### PR TITLE
Fix Flip Code scanning performance

### DIFF
--- a/CodeScanner/CodeScanner.xcodeproj/project.pbxproj
+++ b/CodeScanner/CodeScanner.xcodeproj/project.pbxproj
@@ -475,6 +475,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
+				GCC_OPTIMIZATION_LEVEL = 3;
 				INFOPLIST_FILE = CodeScanner/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -486,6 +487,12 @@
 				MACH_O_TYPE = staticlib;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
+				OTHER_CFLAGS = (
+					"-O3",
+					"-ffast-math",
+					"-funsafe-math-optimizations",
+					"-funroll-loops",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kik.CodeScanner;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -597,6 +604,12 @@
 				MACH_O_TYPE = staticlib;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
+				OTHER_CFLAGS = (
+					"-O3",
+					"-ffast-math",
+					"-funsafe-math-optimizations",
+					"-funroll-loops",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kik.CodeScanner;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -758,6 +771,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
+				GCC_OPTIMIZATION_LEVEL = 3;
 				INFOPLIST_FILE = CodeScanner/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -769,6 +783,12 @@
 				MACH_O_TYPE = staticlib;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
+				OTHER_CFLAGS = (
+					"-O3",
+					"-ffast-math",
+					"-funsafe-math-optimizations",
+					"-funroll-loops",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kik.CodeScanner;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -803,6 +823,12 @@
 				MACH_O_TYPE = staticlib;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
+				OTHER_CFLAGS = (
+					"-O3",
+					"-ffast-math",
+					"-funsafe-math-optimizations",
+					"-funroll-loops",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kik.CodeScanner;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/CodeScanner/CodeScanner/src/kikcode_scan.cpp
+++ b/CodeScanner/CodeScanner/src/kikcode_scan.cpp
@@ -48,8 +48,8 @@ int kikCodeScan(
             break;
 
         case SCAN_DEVICE_QUALITY_BEST:
-            if (max_edge_size > 1280) {
-                scale = 1280.0 / max_edge_size;
+            if (max_edge_size > 960.0) {
+                scale = 960.0 / max_edge_size;
             }
             break;
 

--- a/CodeScanner/CodeScanner/src/scanner.cpp
+++ b/CodeScanner/CodeScanner/src/scanner.cpp
@@ -405,7 +405,7 @@ bool detectKikCode(Mat &greyscale, Mat *out_progress, uint32_t device_quality, u
 
     START_DEBUG_TIMING(total);
 
-    double scaling_rate = greyscale.cols / 480.0;
+    double scaling_rate = MIN(greyscale.rows, greyscale.cols) / 480.0;
 
     double finder_deltas[FINDER_POINT_COUNT - 1];
     computeFinderDeltas(finder_deltas);

--- a/CodeScanner/CodeScanner/src/scanner.cpp
+++ b/CodeScanner/CodeScanner/src/scanner.cpp
@@ -526,7 +526,7 @@ bool detectKikCode(Mat &greyscale, Mat *out_progress, uint32_t device_quality, u
         const double minimum_ellipse_convexity = 0.9;
 
         // not too squished
-        const double minimum_ellipse_inertia = 0.6;
+        const double minimum_ellipse_inertia = 0.5;
 
         // perform checks based on the moments already computed
         double area = moment.m00;

--- a/CodeScanner/CodeScanner/src/scanner.cpp
+++ b/CodeScanner/CodeScanner/src/scanner.cpp
@@ -282,10 +282,10 @@ bool extractFinderPoints(int ellipse_id, bool check_high, RotatedRect inner_ring
         // disard small shards that were erroneously picked up
         sort(finder_points.begin(), finder_points.end(), compareFinderPointsSize);
 
-        int median_size = finder_points[finder_points.size() / 2].contourSize;
+        int p90_size = finder_points[finder_points.size() * 0.9].contourSize;
         
         for (int i = 0; i < finder_points.size(); ++i) {
-            if (finder_points[i].contourSize < median_size / 2) {
+            if (finder_points[i].contourSize < p90_size / 5) {
                 finder_points.erase(finder_points.begin() + i);
 
                 --i;

--- a/CodeScanner/CodeScanner/src/scanner.cpp
+++ b/CodeScanner/CodeScanner/src/scanner.cpp
@@ -452,7 +452,7 @@ bool detectKikCode(Mat &greyscale, Mat *out_progress, uint32_t device_quality, u
 
     // determine the light vs. dark areas of the image
     START_DEBUG_TIMING(threshold);
-    adaptiveThreshold(greyscale, whitish, 255, CV_ADAPTIVE_THRESH_MEAN_C, CV_THRESH_BINARY, adaptive_threshold_width, -5);
+    threshold(greyscale, whitish, 170, 255, THRESH_BINARY);
     END_DEBUG_TIMING(timing, threshold);
 
 #if DEBUGGING

--- a/Flipcash/Core/Screens/Main/Bill/Extraction/CodeExtractor.swift
+++ b/Flipcash/Core/Screens/Main/Bill/Extraction/CodeExtractor.swift
@@ -97,17 +97,18 @@ class CodeExtractor: CameraSessionExtractor {
             CVPixelBufferUnlockBaseAddress(buffer, CVPixelBufferLockFlags(rawValue: 0))
         }
         
-        guard let base = CVPixelBufferGetBaseAddress(buffer) else {
+        guard let base = CVPixelBufferGetBaseAddressOfPlane(buffer, 0) else {
             return nil
         }
         
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
         let width = CVPixelBufferGetWidth(buffer)
         let height = CVPixelBufferGetHeight(buffer)
         
         let sample = Sample(
             width: width,
             height: height,
-            data: Data(bytesNoCopy: base, count: width * height, deallocator: .none)
+            data: Data(bytesNoCopy: base, count: bytesPerRow * height, deallocator: .none)
         )
         
         return sample


### PR DESCRIPTION
@dbart01 Since I don't have access to the internal secrets repo, I'd suggest giving this a run and build locally. I've cherry picked these changes from the test build that I created.

1. Performance tweaks for reducing CPU load
2. Bug fix for incorrect frame extraction (the largest issue resolved here)
3. Tweaks to algorithm parameters to improve scanning of the updated code design