### PR TITLE
fix: persist display rates to fix cold-launch currency flash

### DIFF
--- a/Flipcash/Core/Controllers/Database/Database+Rates.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Rates.swift
@@ -1,0 +1,58 @@
+//
+//  Database+Rates.swift
+//  Flipcash
+//
+//  Created by Claude on 2026-04-09.
+//
+
+import Foundation
+import FlipcashCore
+import SQLite
+
+extension Database {
+
+    // MARK: - Get -
+
+    /// Load all persisted display rates. Used by ``RatesController`` to
+    /// rehydrate its in-memory cache on cold launch so screens render in
+    /// the user's preferred currency before the live mint stream delivers
+    /// its first batch.
+    func getRates() throws -> [Rate] {
+        let table = RateTable()
+
+        let rows = try reader.prepareRowIterator("""
+        SELECT
+            r.data
+        FROM
+            rate r;
+        """)
+
+        return try rows.map { row in
+            try JSONDecoder().decode(Rate.self, from: row[table.data])
+        }
+    }
+
+    // MARK: - Upsert -
+
+    /// Write through a batch of rates from the live mint stream. Each
+    /// row is keyed by currency code, so repeated stream updates for the
+    /// same currency replace the previous row in place.
+    func upsertRates(_ rates: [Rate]) throws {
+        guard !rates.isEmpty else { return }
+
+        let table = RateTable()
+
+        try transaction { _ in
+            for rate in rates {
+                let data = try JSONEncoder().encode(rate)
+                try writer.run(
+                    table.table.upsert(
+                        table.currency <- rate.currency,
+                        table.data     <- data,
+                        onConflictOf: table.currency
+                    )
+                )
+            }
+        }
+    }
+}

--- a/Flipcash/Core/Controllers/Database/Database.swift
+++ b/Flipcash/Core/Controllers/Database/Database.swift
@@ -13,13 +13,16 @@ private let logger = Logger(label: "flipcash.database")
 
 typealias Expression = SQLite.Expression
 
-class Database {
-    
+// SQLite.swift serializes reads/writes through each `Connection`'s own
+// dispatch queue, so concurrent calls into `reader` and `writer` are safe
+// despite Database itself being a reference type. Marking it
+// `@unchecked Sendable` lets background write paths (e.g. RatesController's
+// rate persistence queue) capture it without escaping Swift 6 isolation.
+class Database: @unchecked Sendable {
+
     let reader: Connection
     let writer: Connection
-    
-    var commit: (() -> Void)?
-    
+
     private let storeURL: URL
     
     // MARK: - Init -
@@ -82,7 +85,6 @@ class Database {
                         coalesceMask: .onName,
                         forModes: [.common]
                     )
-                    commit?()
                 } else {
                     print("Transaction detected no changes. Skipping commit...")
                 }

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -86,6 +86,14 @@ struct LimitsTable: Sendable {
     let data  = Expression <Data> ("data")
 }
 
+struct RateTable: Sendable {
+    static let name = "rate"
+
+    let table    = Table(Self.name)
+    let currency = Expression <CurrencyCode> ("currency")
+    let data     = Expression <Data>         ("data")
+}
+
 extension Expression {
     func alias(_ alias: String) -> Expression<Datatype> {
         Expression(alias)
@@ -177,6 +185,15 @@ extension Database {
             try writer.run(limitsTable.table.create(ifNotExists: true, withoutRowid: true) { t in
                 t.column(limitsTable.id, primaryKey: true)
                 t.column(limitsTable.data)
+            })
+        }
+
+        let rateTable = RateTable()
+
+        try writer.transaction {
+            try writer.run(rateTable.table.create(ifNotExists: true, withoutRowid: true) { t in
+                t.column(rateTable.currency, primaryKey: true)
+                t.column(rateTable.data)
             })
         }
 

--- a/Flipcash/Core/Controllers/RatesController.swift
+++ b/Flipcash/Core/Controllers/RatesController.swift
@@ -67,6 +67,17 @@ class RatesController {
     /// Combine cancellables for rate streaming subscription
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
 
+    /// Serial queue for persisting rate updates off the main thread.
+    /// The in-memory `cachedRates` mutation has to stay on main (it's
+    /// `@Observable` and drives SwiftUI re-renders), but the SQLite
+    /// write-through is pure I/O and belongs on a background queue.
+    /// `internal` (not `private`) so tests can sync-wait on it via
+    /// `@testable import Flipcash`.
+    @ObservationIgnored let rateWriteQueue = DispatchQueue(
+        label: "flipcash.rates-controller.db-writes",
+        qos: .utility
+    )
+
     // MARK: - Init -
 
     init(container: Container, database: Database) {
@@ -85,6 +96,35 @@ class RatesController {
         entryCurrency   = LocalDefaults.entryCurrency!
         balanceCurrency = LocalDefaults.balanceCurrency!
         selectedTokenMint = loadSelectedToken()
+
+        // Rehydrate last-known display rates from the database so screens
+        // that read rateFor{Balance,Entry}Currency render in the user's
+        // selected currency on cold launch instead of flashing USD while
+        // waiting for the live mint stream to deliver its first batch.
+        // The stream overwrites these within seconds. Display rates are
+        // unsigned and have no validity window — intent submission still
+        // goes through the verified-proof path (VerifiedProtoService),
+        // which is intentionally untouched because those proofs carry
+        // validity windows that would need a server-team conversation
+        // before being persisted the same way.
+        //
+        // Runs synchronously on the main actor at init so the first
+        // SwiftUI render already has warm data. The duration is logged
+        // below as a regression guardrail — on a real device this is
+        // expected to be a low single-digit millisecond cost for ~200
+        // currencies. If it ever grows past ~20ms the read path should
+        // be reshaped (bulk decode, column-typed storage, etc.) rather
+        // than moved async, because async rehydration would bring the
+        // USD flash back.
+        let rehydrateStart = CFAbsoluteTimeGetCurrent()
+        for rate in (try? database.getRates()) ?? [] {
+            cachedRates[rate.currency] = rate
+        }
+        let rehydrateMs = (CFAbsoluteTimeGetCurrent() - rehydrateStart) * 1000
+        logger.info("Rehydrated cached rates", metadata: [
+            "count": "\(cachedRates.count)",
+            "durationMs": "\(String(format: "%.2f", rehydrateMs))",
+        ])
 
         // Create the streamer using the client factory method
         liveMintDataStreamer = client.createLiveMintDataStreamer(
@@ -230,10 +270,27 @@ class RatesController {
         return exchangedFiat
     }
 
-    /// Called when streaming receives new rates. Updates the cache.
+    /// Called when streaming delivers new rates. `VerifiedProtoService`
+    /// has already deduped the batch against the last-known values, so
+    /// everything in `rates` is a real delta that needs to be mirrored
+    /// to the database. The in-memory mutation stays on main (drives
+    /// SwiftUI via `@Observable`); the SQLite write runs on a
+    /// background queue so it can't stall rendering.
     func updateRates(_ rates: [Rate]) {
         for rate in rates {
             cachedRates[rate.currency] = rate
+        }
+
+        // Capturing `database` across the queue boundary relies on
+        // `Database: @unchecked Sendable`. If that conformance is ever
+        // removed, this closure will fail to compile and the write path
+        // needs to be reshaped (likely moving Database behind an actor).
+        rateWriteQueue.async { [database] in
+            do {
+                try database.upsertRates(rates)
+            } catch {
+                logger.warning("Failed to persist rates", metadata: ["error": "\(error)"])
+            }
         }
     }
     

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -20,7 +20,7 @@
 		</dict>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>8</integer>
+	<integer>9</integer>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/VerifiedProtoService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/VerifiedProtoService.swift
@@ -44,7 +44,11 @@ public actor VerifiedProtoService {
     // MARK: - Save Methods
 
     /// Save verified exchange rates from streaming batch.
-    /// Publishes the parsed rates via `ratesPublisher` for observers.
+    /// Only publishes updates for currencies whose `fx` actually changed,
+    /// avoiding no-op downstream work (SwiftUI re-renders, DB writes).
+    /// The full proto is still stored on every call so intent submission
+    /// always uses the freshest signed rate proof, even when the
+    /// numeric exchange rate is unchanged.
     public func saveRates(_ rates: [Ocp_Currency_V1_VerifiedCoreMintFiatExchangeRate]) {
         var parsedRates: [Rate] = []
         var unknownCodes: [String] = []
@@ -54,11 +58,14 @@ public actor VerifiedProtoService {
                 unknownCodes.append(rate.exchangeRate.currencyCode)
                 continue
             }
+            let fxChanged = exchangeRates[currency]?.exchangeRate.exchangeRate != rate.exchangeRate.exchangeRate
             exchangeRates[currency] = rate
-            parsedRates.append(Rate(
-                fx: Decimal(rate.exchangeRate.exchangeRate),
-                currency: currency
-            ))
+            if fxChanged {
+                parsedRates.append(Rate(
+                    fx: Decimal(rate.exchangeRate.exchangeRate),
+                    currency: currency
+                ))
+            }
         }
 
         if !unknownCodes.isEmpty {
@@ -70,6 +77,10 @@ public actor VerifiedProtoService {
         }
 
         if !parsedRates.isEmpty {
+            logger.info("Exchange rates changed", metadata: [
+                "changed": "\(parsedRates.count)",
+                "total": "\(rates.count)",
+            ])
             ratesPublisher.send(parsedRates)
         }
     }

--- a/FlipcashTests/RatesControllerTests.swift
+++ b/FlipcashTests/RatesControllerTests.swift
@@ -400,10 +400,118 @@ struct RatesControllerTests {
         #expect(controller.streamedMints.count == 2)
     }
 
+    // MARK: - Rate persistence -
+
+    @Test("Rehydrates persisted rates on init")
+    @MainActor
+    func rehydrate_persistedRates_populatesCache() throws {
+        let (database, url) = try makeTempDatabase()
+        defer { removeTempDatabase(at: url) }
+
+        let cad = Rate(fx: Decimal(string: "1.4")!, currency: .cad)
+        let eur = Rate(fx: Decimal(string: "0.92")!, currency: .eur)
+        try database.upsertRates([cad, eur])
+
+        let controller = makeController(database: database)
+
+        #expect(controller.rate(for: .cad) == cad)
+        #expect(controller.rate(for: .eur) == eur)
+    }
+
+    @Test("Fresh database has no persisted rates on init")
+    @MainActor
+    func rehydrate_freshDatabase_noRates() throws {
+        let (database, url) = try makeTempDatabase()
+        defer { removeTempDatabase(at: url) }
+
+        let controller = makeController(database: database)
+
+        #expect(controller.rate(for: .cad) == nil)
+        #expect(controller.rate(for: .eur) == nil)
+    }
+
+    @Test("updateRates writes incoming batch through to database")
+    @MainActor
+    func updateRates_writesBatchThrough() async throws {
+        let (database, url) = try makeTempDatabase()
+        defer { removeTempDatabase(at: url) }
+
+        let controller = makeController(database: database)
+
+        let cad = Rate(fx: Decimal(string: "1.4")!, currency: .cad)
+        let eur = Rate(fx: Decimal(string: "0.92")!, currency: .eur)
+
+        controller.updateRates([cad])
+        controller.updateRates([eur])
+
+        await controller.awaitPendingRateWrites()
+
+        let persisted = try database.getRates()
+        #expect(persisted.count == 2)
+        #expect(persisted.contains(cad))
+        #expect(persisted.contains(eur))
+    }
+
+    @Test("Stream rates overwrite rehydrated stale values in both memory and database")
+    @MainActor
+    func staleRehydration_doesNotBlockStreamUpdate() async throws {
+        let (database, url) = try makeTempDatabase()
+        defer { removeTempDatabase(at: url) }
+
+        let stale = Rate(fx: Decimal(string: "1.3")!, currency: .cad)
+        try database.upsertRates([stale])
+
+        let controller = makeController(database: database)
+        let staleCAD = try #require(controller.rate(for: .cad))
+        #expect(staleCAD.fx == Decimal(string: "1.3"))
+
+        let fresh = Rate(fx: Decimal(string: "1.4")!, currency: .cad)
+        controller.updateRates([fresh])
+
+        let freshCAD = try #require(controller.rate(for: .cad))
+        #expect(freshCAD.fx == Decimal(string: "1.4"))
+
+        await controller.awaitPendingRateWrites()
+
+        let persisted = try database.getRates()
+        let persistedCAD = try #require(persisted.first(where: { $0.currency == .cad }))
+        #expect(persistedCAD.fx == Decimal(string: "1.4"))
+    }
+
     // MARK: - Helpers -
 
+    /// NOTE: RatesController.init reads `balanceCurrency` / `entryCurrency`
+    /// from `UserDefaults.standard` (via `LocalDefaults`). Tests that
+    /// mutate those values are NOT parallel-safe with each other or with
+    /// any other test on the standard defaults suite. Current tests only
+    /// read the defaults, so parallel execution is fine — but adding any
+    /// test that does `controller.balanceCurrency = .xxx` would require
+    /// `.serialized` on the suite or a proper UserDefaults isolation seam.
     @MainActor
     private func makeController(database: Database = .mock) -> RatesController {
         RatesController(container: .mock, database: database)
+    }
+
+    /// Creates an on-disk temp SQLite database. Callers are responsible
+    /// for calling ``removeTempDatabase(at:)`` in a `defer` to clean up
+    /// the `.sqlite` / `-wal` / `-shm` files.
+    private func makeTempDatabase() throws -> (database: Database, url: URL) {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let database = try Database(url: url)
+        return (database, url)
+    }
+
+    /// Removes the temp database file and its SQLite WAL/SHM sidecars.
+    private func removeTempDatabase(at url: URL) {
+        let manager = FileManager.default
+        let paths: [URL] = [
+            url,
+            URL(fileURLWithPath: url.path + "-wal"),
+            URL(fileURLWithPath: url.path + "-shm"),
+        ]
+        for path in paths where manager.fileExists(atPath: path.path) {
+            try? manager.removeItem(at: path)
+        }
     }
 }

--- a/FlipcashTests/TestSupport/RatesController+TestSupport.swift
+++ b/FlipcashTests/TestSupport/RatesController+TestSupport.swift
@@ -18,4 +18,17 @@ extension RatesController {
 
         updateRates(rates)
     }
+
+    /// Block until all pending rate writes on the background queue have
+    /// finished. `updateRates` dispatches the SQLite upsert asynchronously
+    /// to avoid blocking the main thread on I/O, so tests that read from
+    /// the database immediately after calling `updateRates` need to drain
+    /// the queue first.
+    func awaitPendingRateWrites() async {
+        await withCheckedContinuation { continuation in
+            rateWriteQueue.async {
+                continuation.resume()
+            }
+        }
+    }
 }

--- a/FlipcashTests/VerifiedProtoServiceTests.swift
+++ b/FlipcashTests/VerifiedProtoServiceTests.swift
@@ -1,0 +1,137 @@
+//
+//  VerifiedProtoServiceTests.swift
+//  FlipcashTests
+//
+//  Created by Claude on 2026-04-09.
+//
+
+import Foundation
+import Testing
+import Combine
+import FlipcashCore
+import FlipcashAPI
+
+@Suite("VerifiedProtoService")
+struct VerifiedProtoServiceTests {
+
+    // MARK: - saveRates dedupe -
+
+    @Test("saveRates publishes every currency on the first batch")
+    func saveRates_firstBatch_publishesAll() async throws {
+        let service = VerifiedProtoService()
+        let collector = PublishedRateCollector()
+        collector.subscribe(to: service.ratesPublisher)
+
+        await service.saveRates([
+            .makeTest(currencyCode: "usd", rate: 1.0),
+            .makeTest(currencyCode: "cad", rate: 1.4),
+            .makeTest(currencyCode: "eur", rate: 0.92),
+        ])
+
+        try await Task.sleep(for: .milliseconds(20))
+
+        let batches = collector.batches
+        #expect(batches.count == 1)
+        #expect(batches.first?.count == 3)
+    }
+
+    @Test("saveRates drops unchanged rates on subsequent batches")
+    func saveRates_unchangedBatch_publishesNothing() async throws {
+        let service = VerifiedProtoService()
+        let collector = PublishedRateCollector()
+        collector.subscribe(to: service.ratesPublisher)
+
+        await service.saveRates([
+            .makeTest(currencyCode: "usd", rate: 1.0),
+            .makeTest(currencyCode: "cad", rate: 1.4),
+        ])
+
+        // Same rates again — server delivers a full snapshot on every tick,
+        // but dedupe should suppress downstream work when nothing moved.
+        await service.saveRates([
+            .makeTest(currencyCode: "usd", rate: 1.0),
+            .makeTest(currencyCode: "cad", rate: 1.4),
+        ])
+
+        try await Task.sleep(for: .milliseconds(20))
+
+        let batches = collector.batches
+        #expect(batches.count == 1)
+        #expect(batches.first?.count == 2)
+    }
+
+    @Test("saveRates publishes only the currencies whose fx actually changed")
+    func saveRates_partialChange_publishesOnlyDelta() async throws {
+        let service = VerifiedProtoService()
+        let collector = PublishedRateCollector()
+        collector.subscribe(to: service.ratesPublisher)
+
+        await service.saveRates([
+            .makeTest(currencyCode: "usd", rate: 1.0),
+            .makeTest(currencyCode: "cad", rate: 1.4),
+            .makeTest(currencyCode: "eur", rate: 0.92),
+        ])
+
+        // Only CAD moves.
+        await service.saveRates([
+            .makeTest(currencyCode: "usd", rate: 1.0),
+            .makeTest(currencyCode: "cad", rate: 1.41),
+            .makeTest(currencyCode: "eur", rate: 0.92),
+        ])
+
+        try await Task.sleep(for: .milliseconds(20))
+
+        let batches = collector.batches
+        #expect(batches.count == 2)
+
+        let secondBatch = try #require(batches.dropFirst().first)
+        #expect(secondBatch.count == 1)
+        let changed = try #require(secondBatch.first)
+        #expect(changed.currency == .cad)
+        #expect(changed.fx == Decimal(1.41))
+    }
+
+    @Test("saveRates refreshes the stored signed proof even when fx is unchanged")
+    func saveRates_unchangedFx_stillRefreshesProto() async {
+        let service = VerifiedProtoService()
+
+        await service.saveRates([.makeTest(currencyCode: "usd", rate: 1.0)])
+        let first = await service.getVerifiedRate(for: .usd)
+        #expect(first != nil)
+
+        // Re-save with identical fx — the proto object is still replaced so
+        // intent submission always uses the freshest signed rate.
+        await service.saveRates([.makeTest(currencyCode: "usd", rate: 1.0)])
+        let second = await service.getVerifiedRate(for: .usd)
+        #expect(second != nil)
+        #expect(await service.hasVerifiedRate(for: .usd))
+    }
+}
+
+// MARK: - Helpers -
+
+/// Test-only collector for rates arriving on a Combine publisher. State
+/// is protected by an `NSLock` because the sink closure runs on whatever
+/// queue Combine delivers on, which is not the test's @MainActor context.
+/// A lock is the smallest-safe tool here: tests await via `Task.sleep`,
+/// then read `batches` after the sink has drained.
+private final class PublishedRateCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _batches: [[Rate]] = []
+    private var cancellable: AnyCancellable?
+
+    var batches: [[Rate]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _batches
+    }
+
+    func subscribe(to publisher: PassthroughSubject<[Rate], Never>) {
+        cancellable = publisher.sink { [weak self] rates in
+            guard let self else { return }
+            self.lock.lock()
+            self._batches.append(rates)
+            self.lock.unlock()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Force-quit the app and relaunch to the Wallet screen: the total briefly shows USD (`$14.02`) then flashes to the user's preferred currency (`CA$19.60`) within 1–5s. `RatesController.cachedRates` was in-memory only, so the fallback to `Rate.oneToOne` (hardcoded USD) ran until the live mint stream delivered its first batch.

Persist rates in a new `rate` SQLite table (bumps `SQLiteVersion` 8→9), rehydrate synchronously in `RatesController.init`, write through on stream ticks on a background queue. Dedupe unchanged rates in `VerifiedProtoService.saveRates` so steady-state ~60s ticks don't re-publish or re-write.

## Test plan

- [x] Cold launch after first rehydrate: Wallet renders in preferred currency on first frame, no flash
- [x] Log export shows `Rehydrated cached rates count=N durationMs=X.XX` on launch
- [x] Log export shows `Exchange rates changed` only when fx actually moves, not every tick
- [x] `RatesControllerTests` and `VerifiedProtoServiceTests` pass