### PR TITLE
feat: animate balance value changes across wallet screens

### DIFF
--- a/Flipcash/Core/Screens/Main/BalanceFooter.swift
+++ b/Flipcash/Core/Screens/Main/BalanceFooter.swift
@@ -66,6 +66,8 @@ private struct CashReservesRow: View {
                     Text(reservesBalance.exchangedFiat.converted.formatted())
                         .font(.appTextMedium)
                         .foregroundStyle(Color.textMain)
+                        .contentTransition(.numericText())
+                        .animation(.default, value: reservesBalance.exchangedFiat.converted)
                 }
             }
             .listRowBackground(Color.clear)

--- a/Flipcash/Core/Screens/Main/BalanceScreen.swift
+++ b/Flipcash/Core/Screens/Main/BalanceScreen.swift
@@ -229,9 +229,11 @@ struct BalanceScreen: View {
                 )
                 .font(.appDisplayLarge)
                 .foregroundStyle(Color.textMain)
+                .contentTransition(.numericText())
             }
             .accessibilityIdentifier("balance-header")
             .frame(maxWidth: .infinity)
+            .animation(.default, value: balance)
             .sheet(isPresented: $isShowingCurrencySelection) {
                 CurrencySelectionScreen(
                     isPresented: $isShowingCurrencySelection,

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoHeaderSection.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoHeaderSection.swift
@@ -28,9 +28,11 @@ struct CurrencyInfoHeaderSection: View {
                 )
                 .font(.appDisplayLarge)
                 .foregroundStyle(Color.textMain)
+                .contentTransition(.numericText())
             }
             .frame(height: 60)
             .frame(maxWidth: .infinity)
+            .animation(.default, value: balance)
 
             if !isUSDF && balance.quarks > 0 {
                 ValueAppreciation(amount: appreciation.amount, isPositive: appreciation.isPositive)

--- a/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
+++ b/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
@@ -142,12 +142,14 @@ struct CurrencyLabel: View {
 
             if let amount {
                 Spacer()
-                
+
                 Text(amount.formatted())
                     .font(.appTextMedium)
                     .foregroundStyle(Color.textMain)
+                    .contentTransition(.numericText())
+                    .animation(.default, value: amount)
             }
-            
+
             if let isSelected {
                 CheckView(active: isSelected)
                     .padding(.leading, 12)


### PR DESCRIPTION
## Summary
- Adds `.contentTransition(.numericText())` + `.animation(.default, value:)` to the total balance header in `BalanceScreen` so rate updates morph the digits instead of snapping.
- Mirrors the same treatment on the per-currency balance header in `CurrencyInfoHeaderSection`.
- Adds the numeric content transition to the amount rendered by `CurrencyLabel`, so the per-row balances on the Balance screen (and any other screen using `CurrencyLabel` with an amount) animate when the displayed value changes.

## Test plan
- [x] Open the Wallet screen on a device with rates in flight; confirm the header balance animates smoothly when rates tick.
- [x] Drill into a currency; confirm the `CurrencyInfoScreen` header balance animates on rate/balance changes.
- [x] Return to the Wallet screen; confirm each currency row's amount animates as balances/rates update.
- [x] Confirm no animation regressions in `SelectCurrencyScreen`, `WithdrawScreen`, or `DepositCurrencyListScreen` (they all reuse `CurrencyLabel`).