### PR TITLE
fix: round-trip bonded token amounts through server validation direction

### DIFF
--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -639,23 +639,15 @@ class Session {
             throw Error.missingSupply
         }
 
-        // Cap token quarks to the user's actual balance
-        let balance = balance(for: mint)
-        let tokenQuarks: UInt64
-        if let balanceQuarks = balance?.quarks, amount.underlying.quarks > balanceQuarks {
-            tokenQuarks = balanceQuarks
-        } else {
-            tokenQuarks = amount.underlying.quarks
-        }
-
-        // For bonded tokens, derive the server-consistent ExchangedFiat
-        // from the token quarks using computeFromQuarks (which uses
-        // bondingCurve.sell → tokensToValue, matching server validation).
-        // For USDF, the ViewModel's amount is already correct.
+        // Cap to the on-chain balance when rounding pushed quarks above it.
+        // computeFromEntered already round-trips through computeFromQuarks
+        // for server consistency, so we only need to recompute when capping.
         let amountForIntent: ExchangedFiat
-        if mint != .usdf {
+        if let balance = balance(for: mint),
+           amount.underlying.quarks > balance.quarks,
+           mint != .usdf {
             amountForIntent = ExchangedFiat.computeFromQuarks(
-                quarks: tokenQuarks,
+                quarks: balance.quarks,
                 mint: mint,
                 rate: ratesController.rateForEntryCurrency(),
                 supplyQuarks: supply

--- a/FlipcashCore/Sources/FlipcashCore/Models/ExchangedFiat.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/ExchangedFiat.swift
@@ -262,6 +262,18 @@ public struct ExchangedFiat: Equatable, Hashable, Codable, Sendable {
             )
         }
 
+        // For bonded tokens, round-trip through computeFromQuarks so the
+        // fiat side uses the tokens→fiat direction (bondingCurve.sell),
+        // matching the server's intent validation.
+        if mint != .usdf {
+            return computeFromQuarks(
+                quarks: tokenQuarks,
+                mint: mint,
+                rate: rate,
+                supplyQuarks: supplyQuarks
+            )
+        }
+
         let exchanged = ExchangedFiat(
             underlying: Quarks(
                 quarks: tokenQuarks,

--- a/FlipcashCore/Tests/FlipcashCoreTests/ExchangedFiatTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ExchangedFiatTests.swift
@@ -388,6 +388,115 @@ struct ExchangedFiatComputeFromEnteredCapTests {
     }
 }
 
+// MARK: - Server Consistency Tests
+
+@Suite("ExchangedFiat.computeFromEntered - Server Consistency")
+struct ExchangedFiatServerConsistencyTests {
+
+    private let testMint = try! PublicKey(base58: "54ggcQ23uen5b9QXMAns99MQNTKn7iyzq4wvCW6e8r25")
+    private static let quarksPerToken: UInt64 = 10_000_000_000
+
+    /// Asserts that computeFromEntered produces a converted fiat value
+    /// consistent with what computeFromQuarks derives from the same quarks.
+    /// The server validates intents using the tokens→fiat direction
+    /// (bondingCurve.sell), so the client must send values in that direction.
+    private func assertServerConsistency(
+        fiatAmount: Foundation.Decimal,
+        rate: Rate,
+        supplyQuarks: UInt64,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        guard let fromEntered = ExchangedFiat.computeFromEntered(
+            amount: fiatAmount,
+            rate: rate,
+            mint: testMint,
+            supplyQuarks: supplyQuarks
+        ) else {
+            Issue.record("computeFromEntered returned nil", sourceLocation: sourceLocation)
+            return
+        }
+
+        let fromQuarks = ExchangedFiat.computeFromQuarks(
+            quarks: fromEntered.underlying.quarks,
+            mint: testMint,
+            rate: rate,
+            supplyQuarks: supplyQuarks
+        )
+
+        #expect(
+            fromEntered.converted.quarks == fromQuarks.converted.quarks,
+            """
+            computeFromEntered converted (\(fromEntered.converted.quarks)) \
+            ≠ computeFromQuarks converted (\(fromQuarks.converted.quarks)) \
+            for \(fiatAmount) \(rate.currency)
+            """,
+            sourceLocation: sourceLocation
+        )
+    }
+
+    @Test("Bonded token at $326.79 CAD matches server direction (Bugsnag reproduction)")
+    func bondedTokenCAD326() {
+        let supply: UInt64 = 1_000_000 * Self.quarksPerToken
+        assertServerConsistency(
+            fiatAmount: Decimal(string: "326.79")!,
+            rate: Rate(fx: 1.4, currency: .cad),
+            supplyQuarks: supply
+        )
+    }
+
+    @Test("Bonded token at $100 CAD matches server direction")
+    func bondedTokenCAD100() {
+        let supply: UInt64 = 100_000 * Self.quarksPerToken
+        assertServerConsistency(
+            fiatAmount: 100,
+            rate: Rate(fx: 1.4, currency: .cad),
+            supplyQuarks: supply
+        )
+    }
+
+    @Test("Bonded token at $10,000 USD matches server direction")
+    func bondedTokenUSD10000() {
+        let supply: UInt64 = 10_000_000 * Self.quarksPerToken
+        assertServerConsistency(
+            fiatAmount: 10000,
+            rate: .oneToOne,
+            supplyQuarks: supply
+        )
+    }
+
+    @Test("Small amount at small supply matches server direction")
+    func smallAmountSmallSupply() {
+        let supply: UInt64 = 100 * Self.quarksPerToken
+        assertServerConsistency(
+            fiatAmount: Decimal(string: "0.50")!,
+            rate: .oneToOne,
+            supplyQuarks: supply
+        )
+    }
+
+    @Test("USDF bypasses bonding curve, no divergence possible")
+    func usdfNoDivergence() {
+        guard let fromEntered = ExchangedFiat.computeFromEntered(
+            amount: Decimal(string: "326.79")!,
+            rate: .oneToOne,
+            mint: .usdf,
+            supplyQuarks: 0
+        ) else {
+            Issue.record("computeFromEntered returned nil for USDF")
+            return
+        }
+
+        let fromQuarks = ExchangedFiat.computeFromQuarks(
+            quarks: fromEntered.underlying.quarks,
+            mint: .usdf,
+            rate: .oneToOne,
+            supplyQuarks: nil
+        )
+
+        #expect(fromEntered.converted.quarks == fromQuarks.converted.quarks)
+    }
+}
+
 // MARK: - Collection.total Tests
 
 @Suite("ExchangedFiat Collection.total")

--- a/FlipcashCore/Tests/FlipcashCoreTests/ExchangedFiatTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ExchangedFiatTests.swift
@@ -393,98 +393,50 @@ struct ExchangedFiatComputeFromEnteredCapTests {
 @Suite("ExchangedFiat.computeFromEntered - Server Consistency")
 struct ExchangedFiatServerConsistencyTests {
 
-    private let testMint = try! PublicKey(base58: "54ggcQ23uen5b9QXMAns99MQNTKn7iyzq4wvCW6e8r25")
+    private static let testMint = try! PublicKey(base58: "54ggcQ23uen5b9QXMAns99MQNTKn7iyzq4wvCW6e8r25")
     private static let quarksPerToken: UInt64 = 10_000_000_000
 
-    /// Asserts that computeFromEntered produces a converted fiat value
-    /// consistent with what computeFromQuarks derives from the same quarks.
-    /// The server validates intents using the tokens→fiat direction
-    /// (bondingCurve.sell), so the client must send values in that direction.
-    private func assertServerConsistency(
-        fiatAmount: Foundation.Decimal,
-        rate: Rate,
-        supplyQuarks: UInt64,
-        sourceLocation: SourceLocation = #_sourceLocation
-    ) {
-        guard let fromEntered = ExchangedFiat.computeFromEntered(
-            amount: fiatAmount,
+    private static let bondedTokenCases: [(amount: Decimal, rate: Rate, supplyTokens: UInt64)] = [
+        (Decimal(string: "326.79")!, Rate(fx: 1.4, currency: .cad), 1_000_000),
+        (100,                        Rate(fx: 1.4, currency: .cad), 100_000),
+        (10000,                      .oneToOne,                     10_000_000),
+        (Decimal(string: "0.50")!,   .oneToOne,                     100),
+    ]
+
+    @Test(
+        "Bonded token fiat matches server direction",
+        arguments: bondedTokenCases
+    )
+    func bondedTokenServerConsistency(
+        amount: Decimal, rate: Rate, supplyTokens: UInt64
+    ) throws {
+        let supplyQuarks = supplyTokens * Self.quarksPerToken
+
+        let fromEntered = try #require(ExchangedFiat.computeFromEntered(
+            amount: amount,
             rate: rate,
-            mint: testMint,
+            mint: Self.testMint,
             supplyQuarks: supplyQuarks
-        ) else {
-            Issue.record("computeFromEntered returned nil", sourceLocation: sourceLocation)
-            return
-        }
+        ))
 
         let fromQuarks = ExchangedFiat.computeFromQuarks(
             quarks: fromEntered.underlying.quarks,
-            mint: testMint,
+            mint: Self.testMint,
             rate: rate,
             supplyQuarks: supplyQuarks
         )
 
-        #expect(
-            fromEntered.converted.quarks == fromQuarks.converted.quarks,
-            """
-            computeFromEntered converted (\(fromEntered.converted.quarks)) \
-            ≠ computeFromQuarks converted (\(fromQuarks.converted.quarks)) \
-            for \(fiatAmount) \(rate.currency)
-            """,
-            sourceLocation: sourceLocation
-        )
-    }
-
-    @Test("Bonded token at $326.79 CAD matches server direction (Bugsnag reproduction)")
-    func bondedTokenCAD326() {
-        let supply: UInt64 = 1_000_000 * Self.quarksPerToken
-        assertServerConsistency(
-            fiatAmount: Decimal(string: "326.79")!,
-            rate: Rate(fx: 1.4, currency: .cad),
-            supplyQuarks: supply
-        )
-    }
-
-    @Test("Bonded token at $100 CAD matches server direction")
-    func bondedTokenCAD100() {
-        let supply: UInt64 = 100_000 * Self.quarksPerToken
-        assertServerConsistency(
-            fiatAmount: 100,
-            rate: Rate(fx: 1.4, currency: .cad),
-            supplyQuarks: supply
-        )
-    }
-
-    @Test("Bonded token at $10,000 USD matches server direction")
-    func bondedTokenUSD10000() {
-        let supply: UInt64 = 10_000_000 * Self.quarksPerToken
-        assertServerConsistency(
-            fiatAmount: 10000,
-            rate: .oneToOne,
-            supplyQuarks: supply
-        )
-    }
-
-    @Test("Small amount at small supply matches server direction")
-    func smallAmountSmallSupply() {
-        let supply: UInt64 = 100 * Self.quarksPerToken
-        assertServerConsistency(
-            fiatAmount: Decimal(string: "0.50")!,
-            rate: .oneToOne,
-            supplyQuarks: supply
-        )
+        #expect(fromEntered.converted.quarks == fromQuarks.converted.quarks)
     }
 
     @Test("USDF bypasses bonding curve, no divergence possible")
-    func usdfNoDivergence() {
-        guard let fromEntered = ExchangedFiat.computeFromEntered(
+    func usdfNoDivergence() throws {
+        let fromEntered = try #require(ExchangedFiat.computeFromEntered(
             amount: Decimal(string: "326.79")!,
             rate: .oneToOne,
             mint: .usdf,
             supplyQuarks: 0
-        ) else {
-            Issue.record("computeFromEntered returned nil for USDF")
-            return
-        }
+        ))
 
         let fromQuarks = ExchangedFiat.computeFromQuarks(
             quarks: fromEntered.underlying.quarks,


### PR DESCRIPTION
Fixes **"native amount does not match expected sell value"** for bonded token cash links, gives, and withdrawals. `computeFromEntered` now round-trips bonded tokens through `computeFromQuarks` (tokens→fiat) after computing quarks, matching the  server's intent validation direction. 

This was already done in `sell()` now all paths get it at the source.  