### PR TITLE
feat: force logout when primary account timelock leaves locked

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -3,7 +3,7 @@ name: release
 description: Use when the user wants to cut a release, ship a version, prepare for release, or invokes /release
 disable-model-invocation: true
 argument-hint: [major|minor|patch]
-allowed-tools: Bash(git log *), Bash(git checkout *), Bash(git tag *), Bash(git push *), Bash(git add *), Bash(git commit *), Bash(xcodebuild *), Bash(gh *), Read, Edit, Agent, Grep
+allowed-tools: Bash(git log *), Bash(git checkout *), Bash(git tag *), Bash(git push *), Bash(xcodebuild *), Bash(gh *), Read, Agent, Grep
 ---
 
 # Release
@@ -14,7 +14,6 @@ Two-phase workflow with a dogfooding gate. Nothing leaves the machine until the 
 
 - Working tree: !`git status --porcelain`
 - Latest tag: !`git describe --tags --match 'flipcash-*' --abbrev=0 HEAD 2>/dev/null || echo "no tags found"`
-- Marketing version: !`grep 'MARKETING_VERSION' Code.xcodeproj/project.pbxproj | head -1 | sed 's/.*= //' | tr -d ';\" '`
 
 ## Phase 1: Prepare & Verify
 
@@ -22,7 +21,9 @@ Two-phase workflow with a dogfooding gate. Nothing leaves the machine until the 
 If the pre-flight working tree output is non-empty → STOP. Commit or stash first.
 
 ### 2. Calculate next version
-Parse the pre-flight marketing version as X.Y.Z. Determine bump type from `$ARGUMENTS` (default: `minor`):
+Derive the current released version from the pre-flight latest tag (strip the `flipcash-` prefix). The `MARKETING_VERSION` in the project file is always bumped ahead for TestFlight builds and must NOT be used.
+
+Determine bump type from `$ARGUMENTS` (default: `minor`):
 
 | Argument | Bump | Example |
 |----------|------|---------|
@@ -45,8 +46,6 @@ git log {base-tag}..HEAD --format="- %s" --no-merges
 ```
 For patch releases, `{base-tag}` is `flipcash-{current-version}` (the tag on the branch being patched).
 
-**First run after tag-scheme change:** if the pre-flight "Latest tag" is `no tags found`, no `flipcash-*` tag exists yet. Use `fc1.2.0` (the last legacy tag) as the base for this one-time transition, then ask the user to confirm before running the log command.
-
 Display for sanity check.
 
 ### 5. Run all tests
@@ -55,12 +54,8 @@ xcodebuild test -scheme Flipcash \
   -destination 'platform=iOS Simulator,name=iPhone 17' \
   -testPlan AllTargets
 ```
-```bash
-xcodebuild test -scheme Flipcash \
-  -only-testing:FlipcashUITests \
-  -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' \
-  -destination 'platform=iOS Simulator,name=iPhone 17'
-```
+The `AllTargets` test plan already includes UI tests. Do NOT run UI tests separately.
+
 Any failure → STOP.
 
 ### 6. Generate changelog
@@ -75,20 +70,18 @@ Use the Agent tool with `model: "haiku"`. Pass the commit list with this prompt:
 
 Show to user for approval.
 
-### 7. Branch, bump, and tag
-For **patch**: already on `release/flipcash-X.Y.Z` from step 3.
-```bash
-git checkout -b release/flipcash-{next-version}
-```
+### 7. Branch and tag
+The version in `Code.xcodeproj/project.pbxproj` is already bumped ahead for TestFlight — do NOT modify it.
+
+For **patch**: already on `release/flipcash-X.Y.Z` from step 3 — skip branch creation.
+
 For **major / minor**:
 ```bash
 git checkout -b release/flipcash-{next-version}
 ```
 
-Update `MARKETING_VERSION` in `Code.xcodeproj/project.pbxproj` to `{next-version}` using the Edit tool, then:
+Then tag:
 ```bash
-git add Code.xcodeproj/project.pbxproj
-git commit -m "chore: bump version to {next-version}"
 git tag flipcash-{next-version}
 ```
 

--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -86,6 +86,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         case .active:
             logger.info("scenePhase → active")
             container.client.warmUpChannel()
+            container.flipClient.warmUpChannel()
             sessionContainer?.session.didBecomeActive()
         case .inactive:
             break

--- a/Flipcash/Core/ContainerScreen.swift
+++ b/Flipcash/Core/ContainerScreen.swift
@@ -23,6 +23,9 @@ struct ContainerScreen: View {
             if sessionAuthenticator.requiresUpgrade {
                 ForceUpgradeScreen()
                     .transition(.opacity)
+            } else if sessionAuthenticator.requiresForceLogout {
+                ForceLogoutScreen()
+                    .transition(.opacity)
             } else {
                 switch sessionAuthenticator.state {
                 case .loggedOut:
@@ -47,5 +50,6 @@ struct ContainerScreen: View {
         }
         .animation(.easeOut(duration: 0.3), value: sessionAuthenticator.state.intValue)
         .animation(.easeOut(duration: 0.3), value: sessionAuthenticator.requiresUpgrade)
+        .animation(.easeOut(duration: 0.3), value: sessionAuthenticator.requiresForceLogout)
     }
 }

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryList.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryList.swift
@@ -33,7 +33,13 @@ struct CurrencyDiscoveryList: View {
             Section {
                 if isLoading {
                     ForEach(1...10, id: \.self) { rank in
-                        CurrencyDiscoverySkeletonRow(rank: rank)
+                        Button {
+                            // Intentionally left blank
+                        } label: {
+                            CurrencyDiscoverySkeletonRow(rank: rank)
+                        }
+                        .buttonStyle(.plain)
+                        .listRowInsets(EdgeInsets())
                     }
                 } else {
                     ForEach(mints.indexed(), id: \.element.address) { item in

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoverySkeletonRow.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoverySkeletonRow.swift
@@ -39,8 +39,9 @@ struct CurrencyDiscoverySkeletonRow: View {
                     .font(.appTextSmall)
             }
         }
-        .redacted(reason: .placeholder)
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
+        .contentShape(Rectangle())
+        .redacted(reason: .placeholder)
     }
 }

--- a/Flipcash/Core/Screens/Main/ForceLogoutScreen.swift
+++ b/Flipcash/Core/Screens/Main/ForceLogoutScreen.swift
@@ -1,0 +1,60 @@
+//
+//  ForceLogoutScreen.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+import FlipcashCore
+
+struct ForceLogoutScreen: View {
+
+    @Environment(SessionAuthenticator.self) private var sessionAuthenticator
+
+    // MARK: - Body -
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            VStack(spacing: 0) {
+                VStack(alignment: .center, spacing: 15) {
+                    Spacer()
+
+                    Text("Access Key No Longer Usable in Flipcash")
+                        .font(.appTextLarge)
+                        .foregroundColor(.textMain)
+
+                    Text("Your Access Key has initiated an unlock. As a result, you will no longer be able to use this Access Key in Flipcash.")
+                        .font(.appTextSmall)
+                        .foregroundColor(.textSecondary)
+                        .padding([.leading, .trailing], 20)
+
+                    Spacer()
+                }
+
+                Spacer()
+
+                Button("Log Out") {
+                    sessionAuthenticator.logout()
+                }
+                .buttonStyle(.filled)
+            }
+            .multilineTextAlignment(.center)
+            .padding(20)
+        }
+    }
+}
+
+// MARK: - Previews -
+
+#Preview {
+    ForceLogoutScreen()
+        .environment(SessionAuthenticator.mock)
+}
+
+struct ForceLogoutScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        ForceLogoutScreen()
+            .environment(SessionAuthenticator.mock)
+            .preferredColorScheme(.dark)
+    }
+}

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -35,6 +35,12 @@ final class SessionAuthenticator {
     /// Feature flags available before authentication (e.g. minimum build version).
     private(set) var unauthenticatedUserFlags: UnauthenticatedUserFlags?
 
+    /// Whether any of the user's primary accounts has left the `locked`
+    /// state, meaning the Access Key can no longer be used in Flipcash.
+    /// Drives ``ForceLogoutScreen`` display. One-way latch for the lifetime
+    /// of the login — reset on ``logout()``.
+    private(set) var requiresForceLogout: Bool = false
+
     var isLoggedIn: Bool {
         if case .loggedIn = state {
             return true
@@ -77,8 +83,9 @@ final class SessionAuthenticator {
         UserDefaults.launchCount = (UserDefaults.launchCount ?? 0) + 1
         logger.debug("Launch count", metadata: ["count": "\(UserDefaults.launchCount!)"])
 
-        // Start polling for unauthenticated user flags
-        startPollingUnauthenticatedUserFlags()
+        // Poll server-driven gates that can block app use
+        // (forced upgrade, forced logout on timelock unlock).
+        startPolling()
 
         // During UI testing the deeplink handles login. Skip auto-login
         // to avoid racing with resetForUITesting() and the deeplink's
@@ -155,12 +162,17 @@ final class SessionAuthenticator {
         }
     }
     
-    // MARK: - Unauthenticated User Flags Polling -
+    // MARK: - Polling -
 
-    private func startPollingUnauthenticatedUserFlags() {
+    /// Polls server-driven state that gates app use. Fires immediately and
+    /// then every 30s for the lifetime of the authenticator, covering both
+    /// ``requiresUpgrade`` (always) and ``requiresForceLogout`` (once
+    /// logged in).
+    private func startPolling() {
         poller = Poller(seconds: 30, fireImmediately: true) { [weak self] in
             Task {
                 await self?.fetchUnauthenticatedUserFlags()
+                await self?.checkForUnusableAccount()
             }
         }
     }
@@ -171,6 +183,25 @@ final class SessionAuthenticator {
             self.unauthenticatedUserFlags = flags
         } catch {
             logger.error("Failed to fetch unauthenticated user flags", metadata: ["error": "\(error)"])
+        }
+    }
+
+    /// Checks whether any of the user's primary accounts is in an unusable
+    /// management state and, if so, latches ``requiresForceLogout`` to
+    /// `true`. No-op if not logged in or if already latched. Failures are
+    /// logged but leave the cached value unchanged so transient errors
+    /// don't flip the user into the force-logout modal.
+    private func checkForUnusableAccount() async {
+        guard case .loggedIn(let sessionContainer) = state else { return }
+        guard !requiresForceLogout else { return }
+        let owner = sessionContainer.session.ownerKeyPair
+
+        do {
+            let accounts = try await client.fetchPrimaryAccounts(owner: owner)
+            guard accounts.contains(where: { !$0.managementState.isUsable }) else { return }
+            self.requiresForceLogout = true
+        } catch {
+            logger.error("Failed to check for unusable account", metadata: ["error": "\(error)"])
         }
     }
 
@@ -323,8 +354,10 @@ final class SessionAuthenticator {
         
         state = .loggedIn(session)
         UserDefaults.wasLoggedIn = true
-        
+
         Analytics.setIdentity(initializedAccount.userID)
+
+        Task { await checkForUnusableAccount() }
     }
     
     func switchAccount(to mnemonic: MnemonicPhrase) {
@@ -364,6 +397,7 @@ final class SessionAuthenticator {
         accountManager.resetForLogout()
 
         state = .loggedOut
+        requiresForceLogout = false
         UserDefaults.wasLoggedIn = false
 
         logger.debug("Logged out")

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient.swift
@@ -57,6 +57,26 @@ public class FlipClient: ObservableObject {
     deinit {
         logger.debug("Deallocating FlipClient")
     }
+
+    // MARK: - Channel Lifecycle -
+
+    /// Pre-warm the gRPC channel by triggering a lightweight unauthenticated
+    /// call. Forces TCP+TLS reconnection if the underlying socket died during
+    /// backgrounding. Without this, the first call on the cold channel after
+    /// foregrounding tends to surface as a `GRPCStatus.Code.internalError`
+    /// with an empty message, which the caller can't distinguish from a real
+    /// server error.
+    /// The response is irrelevant — we only need the channel to start connecting.
+    public func warmUpChannel() {
+        accountService.fetchUnauthenticatedUserFlags { result in
+            switch result {
+            case .success:
+                logger.info("Flip channel warm-up succeeded")
+            case .failure:
+                logger.warning("Flip channel warm-up completed (channel reconnecting)")
+            }
+        }
+    }
 }
 
 // MARK: - ConnectivityStateDelegate -

--- a/FlipcashCore/Sources/FlipcashCore/Models/AccountInfo.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/AccountInfo.swift
@@ -152,6 +152,23 @@ extension AccountInfo {
     }
 }
 
+extension AccountInfo.ManagementState {
+
+    /// Whether an account in this state is safe for the user to keep using
+    /// the app. `.unknown` is treated as usable because a transient "server
+    /// couldn't determine state" response shouldn't lock a user out. For
+    /// the stricter operational check (should a transaction be attempted),
+    /// see ``AccountInfo/unuseable``.
+    public var isUsable: Bool {
+        switch self {
+        case .locked, .none, .unknown:
+            return true
+        case .locking, .unlocking, .unlocked, .closing, .closed:
+            return false
+        }
+    }
+}
+
 // MARK: - BlockchainState -
 
 extension AccountInfo {

--- a/FlipcashTests/Models/AccountInfoTests.swift
+++ b/FlipcashTests/Models/AccountInfoTests.swift
@@ -35,3 +35,19 @@ struct AccountInfoSelfClaimTests {
         return proto
     }
 }
+
+@Suite("AccountInfo.ManagementState.isUsable")
+struct ManagementStateIsUsableTests {
+
+    @Test("Covers every case")
+    func isUsableForEveryState() {
+        for state in AccountInfo.ManagementState.allCases {
+            switch state {
+            case .locked, .none, .unknown:
+                #expect(state.isUsable == true, "state=\(state)")
+            case .locking, .unlocking, .unlocked, .closing, .closed:
+                #expect(state.isUsable == false, "state=\(state)")
+            }
+        }
+    }
+}

--- a/FlipcashUITests/Smoke/ForceLogoutSmokeTests.swift
+++ b/FlipcashUITests/Smoke/ForceLogoutSmokeTests.swift
@@ -1,0 +1,52 @@
+//
+//  ForceLogoutSmokeTests.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+final class ForceLogoutSmokeTests: BaseUITestCase {
+
+    /// An Access Key whose primary account has left the `locked` state.
+    /// Logging in with it must land the user on ``ForceLogoutScreen`` and
+    /// block access to the main UI. Safe to distribute — the account is
+    /// already unusable server-side.
+    private static let poisonedMnemonic =
+        "discover gravity refuse faith sick chair dumb magnet mountain repair service ocean"
+
+    func testLogin_withPoisonedAccount_showsForceLogoutScreen() {
+        // IntroScreen
+        waitAndTap(app.buttons["Log In"])
+
+        // If the simulator remembers a prior account, switch to manual entry
+        let enterDifferentKey = app.buttons["Enter a Different Access Key"]
+        if enterDifferentKey.waitForExistence(timeout: 5) {
+            enterDifferentKey.tap()
+        }
+
+        // LoginScreen — type the poisoned mnemonic
+        let textEditor = app.textViews.firstMatch
+        XCTAssertTrue(
+            textEditor.waitForExistence(timeout: 30),
+            "Expected to find the mnemonic text input"
+        )
+        textEditor.tap()
+        textEditor.typeText(Self.poisonedMnemonic)
+
+        // Submit
+        waitAndTap(app.buttons["Log In"])
+
+        // ForceLogoutScreen must appear
+        let forceLogoutTitle = app.staticTexts["Access Key No Longer Usable in Flipcash"]
+        XCTAssertTrue(
+            forceLogoutTitle.waitForExistence(timeout: 30),
+            "Expected ForceLogoutScreen when logging in with an unlocked access key"
+        )
+
+        // Main screen must NOT be reachable
+        XCTAssertFalse(
+            app.buttons["Give"].exists,
+            "Main screen must not be reachable with an unlocked access key"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Detects when any of the user's primary accounts has left the `locked` management state (`locking`, `unlocking`, `unlocked`, `closing`, `closed`) and presents a fullscreen `ForceLogoutScreen` that blocks access to the main UI.
- Check runs at `completeLogin` and every 30s via the existing `SessionAuthenticator` poller (generalized to cover both `requiresUpgrade` and `requiresForceLogout`).
- `requiresForceLogout` is a one-way latch for the lifetime of the login — once set, the poller short-circuits until `logout()` resets it, avoiding observation storms.
- Moved the new `AccountInfo.ManagementState.isUsable` helper into `FlipcashCore` alongside the model.

## Test plan

- [x] `FlipcashTests/Models/AccountInfoTests.swift` — `ManagementStateIsUsableTests` exhaustive switch over every `ManagementState` case
- [x] `FlipcashUITests/Smoke/ForceLogoutSmokeTests.swift` — logs in with a known-poisoned seed phrase, asserts `ForceLogoutScreen` appears and the main screen (`Give`) is unreachable
- [x] Build succeeds for the `Flipcash` scheme
- [x] Manual: log in with a healthy account, confirm normal flow is unchanged