### PR TITLE
feat: force logout when primary account timelock leaves locked

### DIFF
--- a/Flipcash/Core/ContainerScreen.swift
+++ b/Flipcash/Core/ContainerScreen.swift
@@ -23,6 +23,9 @@ struct ContainerScreen: View {
             if sessionAuthenticator.requiresUpgrade {
                 ForceUpgradeScreen()
                     .transition(.opacity)
+            } else if sessionAuthenticator.requiresForceLogout {
+                ForceLogoutScreen()
+                    .transition(.opacity)
             } else {
                 switch sessionAuthenticator.state {
                 case .loggedOut:
@@ -47,5 +50,6 @@ struct ContainerScreen: View {
         }
         .animation(.easeOut(duration: 0.3), value: sessionAuthenticator.state.intValue)
         .animation(.easeOut(duration: 0.3), value: sessionAuthenticator.requiresUpgrade)
+        .animation(.easeOut(duration: 0.3), value: sessionAuthenticator.requiresForceLogout)
     }
 }

--- a/Flipcash/Core/Screens/Main/ForceLogoutScreen.swift
+++ b/Flipcash/Core/Screens/Main/ForceLogoutScreen.swift
@@ -1,0 +1,60 @@
+//
+//  ForceLogoutScreen.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+import FlipcashCore
+
+struct ForceLogoutScreen: View {
+
+    @Environment(SessionAuthenticator.self) private var sessionAuthenticator
+
+    // MARK: - Body -
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            VStack(spacing: 0) {
+                VStack(alignment: .center, spacing: 15) {
+                    Spacer()
+
+                    Text("Access Key No Longer Usable in Flipcash")
+                        .font(.appTextLarge)
+                        .foregroundColor(.textMain)
+
+                    Text("Your Access Key has initiated an unlock. As a result, you will no longer be able to use this Access Key in Flipcash.")
+                        .font(.appTextSmall)
+                        .foregroundColor(.textSecondary)
+                        .padding([.leading, .trailing], 20)
+
+                    Spacer()
+                }
+
+                Spacer()
+
+                Button("Log Out") {
+                    sessionAuthenticator.logout()
+                }
+                .buttonStyle(.filled)
+            }
+            .multilineTextAlignment(.center)
+            .padding(20)
+        }
+    }
+}
+
+// MARK: - Previews -
+
+#Preview {
+    ForceLogoutScreen()
+        .environment(SessionAuthenticator.mock)
+}
+
+struct ForceLogoutScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        ForceLogoutScreen()
+            .environment(SessionAuthenticator.mock)
+            .preferredColorScheme(.dark)
+    }
+}

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -35,6 +35,12 @@ final class SessionAuthenticator {
     /// Feature flags available before authentication (e.g. minimum build version).
     private(set) var unauthenticatedUserFlags: UnauthenticatedUserFlags?
 
+    /// Whether any of the user's primary accounts has left the `locked`
+    /// state, meaning the Access Key can no longer be used in Flipcash.
+    /// Drives ``ForceLogoutScreen`` display. One-way latch for the lifetime
+    /// of the login — reset on ``logout()``.
+    private(set) var requiresForceLogout: Bool = false
+
     var isLoggedIn: Bool {
         if case .loggedIn = state {
             return true
@@ -77,8 +83,9 @@ final class SessionAuthenticator {
         UserDefaults.launchCount = (UserDefaults.launchCount ?? 0) + 1
         logger.debug("Launch count", metadata: ["count": "\(UserDefaults.launchCount!)"])
 
-        // Start polling for unauthenticated user flags
-        startPollingUnauthenticatedUserFlags()
+        // Poll server-driven gates that can block app use
+        // (forced upgrade, forced logout on timelock unlock).
+        startPolling()
 
         // During UI testing the deeplink handles login. Skip auto-login
         // to avoid racing with resetForUITesting() and the deeplink's
@@ -155,12 +162,17 @@ final class SessionAuthenticator {
         }
     }
     
-    // MARK: - Unauthenticated User Flags Polling -
+    // MARK: - Polling -
 
-    private func startPollingUnauthenticatedUserFlags() {
+    /// Polls server-driven state that gates app use. Fires immediately and
+    /// then every 30s for the lifetime of the authenticator, covering both
+    /// ``requiresUpgrade`` (always) and ``requiresForceLogout`` (once
+    /// logged in).
+    private func startPolling() {
         poller = Poller(seconds: 30, fireImmediately: true) { [weak self] in
             Task {
                 await self?.fetchUnauthenticatedUserFlags()
+                await self?.checkForUnusableAccount()
             }
         }
     }
@@ -171,6 +183,25 @@ final class SessionAuthenticator {
             self.unauthenticatedUserFlags = flags
         } catch {
             logger.error("Failed to fetch unauthenticated user flags", metadata: ["error": "\(error)"])
+        }
+    }
+
+    /// Checks whether any of the user's primary accounts is in an unusable
+    /// management state and, if so, latches ``requiresForceLogout`` to
+    /// `true`. No-op if not logged in or if already latched. Failures are
+    /// logged but leave the cached value unchanged so transient errors
+    /// don't flip the user into the force-logout modal.
+    private func checkForUnusableAccount() async {
+        guard case .loggedIn(let sessionContainer) = state else { return }
+        guard !requiresForceLogout else { return }
+        let owner = sessionContainer.session.ownerKeyPair
+
+        do {
+            let accounts = try await client.fetchPrimaryAccounts(owner: owner)
+            guard accounts.contains(where: { !$0.managementState.isUsable }) else { return }
+            self.requiresForceLogout = true
+        } catch {
+            logger.error("Failed to check for unusable account", metadata: ["error": "\(error)"])
         }
     }
 
@@ -323,8 +354,10 @@ final class SessionAuthenticator {
         
         state = .loggedIn(session)
         UserDefaults.wasLoggedIn = true
-        
+
         Analytics.setIdentity(initializedAccount.userID)
+
+        Task { await checkForUnusableAccount() }
     }
     
     func switchAccount(to mnemonic: MnemonicPhrase) {
@@ -364,6 +397,7 @@ final class SessionAuthenticator {
         accountManager.resetForLogout()
 
         state = .loggedOut
+        requiresForceLogout = false
         UserDefaults.wasLoggedIn = false
 
         logger.debug("Logged out")

--- a/FlipcashCore/Sources/FlipcashCore/Models/AccountInfo.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/AccountInfo.swift
@@ -152,6 +152,23 @@ extension AccountInfo {
     }
 }
 
+extension AccountInfo.ManagementState {
+
+    /// Whether an account in this state is safe for the user to keep using
+    /// the app. `.unknown` is treated as usable because a transient "server
+    /// couldn't determine state" response shouldn't lock a user out. For
+    /// the stricter operational check (should a transaction be attempted),
+    /// see ``AccountInfo/unuseable``.
+    public var isUsable: Bool {
+        switch self {
+        case .locked, .none, .unknown:
+            return true
+        case .locking, .unlocking, .unlocked, .closing, .closed:
+            return false
+        }
+    }
+}
+
 // MARK: - BlockchainState -
 
 extension AccountInfo {

--- a/FlipcashTests/Models/AccountInfoTests.swift
+++ b/FlipcashTests/Models/AccountInfoTests.swift
@@ -35,3 +35,19 @@ struct AccountInfoSelfClaimTests {
         return proto
     }
 }
+
+@Suite("AccountInfo.ManagementState.isUsable")
+struct ManagementStateIsUsableTests {
+
+    @Test("Covers every case")
+    func isUsableForEveryState() {
+        for state in AccountInfo.ManagementState.allCases {
+            switch state {
+            case .locked, .none, .unknown:
+                #expect(state.isUsable == true, "state=\(state)")
+            case .locking, .unlocking, .unlocked, .closing, .closed:
+                #expect(state.isUsable == false, "state=\(state)")
+            }
+        }
+    }
+}

--- a/FlipcashUITests/Smoke/ForceLogoutSmokeTests.swift
+++ b/FlipcashUITests/Smoke/ForceLogoutSmokeTests.swift
@@ -1,0 +1,52 @@
+//
+//  ForceLogoutSmokeTests.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+final class ForceLogoutSmokeTests: BaseUITestCase {
+
+    /// An Access Key whose primary account has left the `locked` state.
+    /// Logging in with it must land the user on ``ForceLogoutScreen`` and
+    /// block access to the main UI. Safe to distribute — the account is
+    /// already unusable server-side.
+    private static let poisonedMnemonic =
+        "discover gravity refuse faith sick chair dumb magnet mountain repair service ocean"
+
+    func testLogin_withPoisonedAccount_showsForceLogoutScreen() {
+        // IntroScreen
+        waitAndTap(app.buttons["Log In"])
+
+        // If the simulator remembers a prior account, switch to manual entry
+        let enterDifferentKey = app.buttons["Enter a Different Access Key"]
+        if enterDifferentKey.waitForExistence(timeout: 5) {
+            enterDifferentKey.tap()
+        }
+
+        // LoginScreen — type the poisoned mnemonic
+        let textEditor = app.textViews.firstMatch
+        XCTAssertTrue(
+            textEditor.waitForExistence(timeout: 30),
+            "Expected to find the mnemonic text input"
+        )
+        textEditor.tap()
+        textEditor.typeText(Self.poisonedMnemonic)
+
+        // Submit
+        waitAndTap(app.buttons["Log In"])
+
+        // ForceLogoutScreen must appear
+        let forceLogoutTitle = app.staticTexts["Access Key No Longer Usable in Flipcash"]
+        XCTAssertTrue(
+            forceLogoutTitle.waitForExistence(timeout: 30),
+            "Expected ForceLogoutScreen when logging in with an unlocked access key"
+        )
+
+        // Main screen must NOT be reachable
+        XCTAssertFalse(
+            app.buttons["Give"].exists,
+            "Main screen must not be reachable with an unlocked access key"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Detects when any of the user's primary accounts has left the `locked` management state (`locking`, `unlocking`, `unlocked`, `closing`, `closed`) and presents a fullscreen `ForceLogoutScreen` that blocks access to the main UI.
- Check runs at `completeLogin` and every 30s via the existing `SessionAuthenticator` poller (generalized to cover both `requiresUpgrade` and `requiresForceLogout`).
- `requiresForceLogout` is a one-way latch for the lifetime of the login — once set, the poller short-circuits until `logout()` resets it, avoiding observation storms.
- Moved the new `AccountInfo.ManagementState.isUsable` helper into `FlipcashCore` alongside the model.

## Test plan

- [x] `FlipcashTests/Models/AccountInfoTests.swift` — `ManagementStateIsUsableTests` exhaustive switch over every `ManagementState` case
- [x] `FlipcashUITests/Smoke/ForceLogoutSmokeTests.swift` — logs in with a known-poisoned seed phrase, asserts `ForceLogoutScreen` appears and the main screen (`Give`) is unreachable
- [x] Build succeeds for the `Flipcash` scheme
- [x] Manual: log in with a healthy account, confirm normal flow is unchanged