### PR TITLE
fix: max calculations on newly-minted currencies

### DIFF
--- a/Flipcash/Core/Controllers/Database/Models/StoredBalance.swift
+++ b/Flipcash/Core/Controllers/Database/Models/StoredBalance.swift
@@ -50,12 +50,17 @@ struct StoredBalance: Identifiable, Sendable, Equatable, Hashable {
                 throw Error.missingStoredCoreMintForNonReserveToken
             }
 
+            // Floor — not HALF-UP — so the stored USDF stays ≤ the curve's
+            // exact BigDecimal TVL. Downstream `tokensForValueExchange`
+            // strictly rejects `usdcValue > currentTVL`, and
+            // `Quarks.init(fiatDecimal:)` otherwise rounds HALF-UP and can
+            // push the cap above the TVL for certain residues.
             self.usdf = try! Quarks(
-                fiatDecimal: sellEstimate.netUSDF.asDecimal(),
+                fiatDecimal: sellEstimate.netUSDF.asDecimal().roundedDown(to: PublicKey.usdf.mintDecimals),
                 currencyCode: .usd,
-                decimals: 6
+                decimals: PublicKey.usdf.mintDecimals
             )
-            
+
         } else {
             guard symbol == "USDF" else {
                 throw Error.missingStoredCoreMintForNonReserveToken

--- a/Flipcash/Core/Controllers/Database/Models/StoredBalance.swift
+++ b/Flipcash/Core/Controllers/Database/Models/StoredBalance.swift
@@ -50,11 +50,8 @@ struct StoredBalance: Identifiable, Sendable, Equatable, Hashable {
                 throw Error.missingStoredCoreMintForNonReserveToken
             }
 
-            // Floor — not HALF-UP — so the stored USDF stays ≤ the curve's
-            // exact BigDecimal TVL. Downstream `tokensForValueExchange`
-            // strictly rejects `usdcValue > currentTVL`, and
-            // `Quarks.init(fiatDecimal:)` otherwise rounds HALF-UP and can
-            // push the cap above the TVL for certain residues.
+            // Floor so the stored USDF stays ≤ the curve's
+            // exact BigDecimal TVL.
             self.usdf = try! Quarks(
                 fiatDecimal: sellEstimate.netUSDF.asDecimal().roundedDown(to: PublicKey.usdf.mintDecimals),
                 currencyCode: .usd,

--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -58,9 +58,11 @@ class GiveViewModel {
                 amount: amount,
                 rate: rate,
                 mint: mint,
-                supplyQuarks: supplyQuarks
+                supplyQuarks: supplyQuarks,
+                balance: selectedBalance.stored.usdf,
+                tokenBalanceQuarks: selectedBalance.stored.quarks
             )
-            
+
         } else {
             let rate = ratesController.rateForEntryCurrency()
             return try! ExchangedFiat(

--- a/FlipcashCore/Sources/FlipcashCore/Extensions/Decimal+Operations.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Extensions/Decimal+Operations.swift
@@ -15,6 +15,13 @@ extension Decimal {
         return rounded
     }
 
+    public func roundedDown(to decimalPlaces: Int) -> Decimal {
+        var current = self
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &current, decimalPlaces, .down)
+        return rounded
+    }
+
     func roundedInt() -> Int {
         (rounded(to: 0) as NSDecimalNumber).intValue
     }

--- a/FlipcashTests/Regressions/Regression_give_max_precision.swift
+++ b/FlipcashTests/Regressions/Regression_give_max_precision.swift
@@ -1,0 +1,46 @@
+//
+//  Regression_give_max_precision.swift
+//  Flipcash
+//
+//  Invariant: typing the displayed max on a newly-minted currency through
+//  the Give flow must not disable the Next button. Same root cause as the
+//  sell-max regression; `GiveViewModel.enteredFiat` had to start passing
+//  the `balance:` cap to `ExchangedFiat.computeFromEntered`.
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Regression: give-max precision (newly-minted bonding-curve balance)", .serialized)
+struct Regression_give_max_precision {
+
+    @Test(
+        "Giving the displayed max on a newly-minted currency does not disable Next",
+        arguments: Regression_sell_max_precision.sampledSupplies
+    )
+    func canGive_atDisplayedMax_returnsTrue(tokens: Int) throws {
+        let supply = UInt64(tokens) * UInt64(DiscreteBondingCurve.quarksPerToken)
+
+        let viewModel = GiveViewModelTests.createViewModel()
+        let balance = GiveViewModelTests.createExchangedBalance(
+            mint: .jeffy,
+            quarks: supply,
+            supplyQuarks: supply
+        )
+        viewModel.selectCurrencyAction(exchangedBalance: balance)
+
+        // What the keypad sends after the user taps the displayed max.
+        let displayedMaxString = balance.exchangedFiat.converted.formatted()
+        let parser = NumberFormatter.fiat(
+            currency: balance.exchangedFiat.converted.currencyCode,
+            minimumFractionDigits: balance.exchangedFiat.converted.currencyCode.maximumFractionDigits
+        )
+        let typedAmountDecimal = try #require(parser.number(from: displayedMaxString)?.decimalValue)
+        viewModel.enteredAmount = "\(typedAmountDecimal)"
+
+        #expect(viewModel.canGive == true)
+    }
+}

--- a/FlipcashTests/Regressions/Regression_sell_max_precision.swift
+++ b/FlipcashTests/Regressions/Regression_sell_max_precision.swift
@@ -1,0 +1,105 @@
+//
+//  Regression_sell_max_precision.swift
+//  Flipcash
+//
+//  Invariant: `StoredBalance.usdf.decimalValue` must never exceed the
+//  bonding curve's exact BigDecimal TVL. Violating the invariant causes
+//  the sell-max Next button to be disabled on newly-minted currencies.
+//
+
+import Foundation
+import Testing
+@preconcurrency import BigDecimal
+import FlipcashCore
+@testable import Flipcash
+
+@Suite("Regression: sell-max precision (newly-minted bonding-curve balance)")
+struct Regression_sell_max_precision {
+
+    private let curve = DiscreteBondingCurve()
+    private let mint: PublicKey = .jeffy
+    private let rate: Rate = .oneToOne
+
+    private func makeStoredBalance(supply: UInt64) throws -> StoredBalance {
+        try StoredBalance(
+            quarks: supply,
+            symbol: "TEST",
+            name: "Test",
+            supplyFromBonding: supply,
+            sellFeeBps: 0,
+            mint: mint,
+            vmAuthority: nil,
+            updatedAt: Date(),
+            imageURL: nil,
+            costBasis: 0
+        )
+    }
+
+    /// Sample supplies spanning the early curve. Roughly half of these
+    /// historically triggered the HALF-UP overshoot before the floor fix —
+    /// enough for any regression of the rounding direction to be detected
+    /// by at least one element without looping over thousands of values.
+    static let sampledSupplies: [Int] = [
+        1_013, 2_357, 5_821, 12_347, 37_739, 71_993, 150_001
+    ]
+
+    @Test(
+        "StoredBalance.usdf never exceeds the bonding curve's exact TVL",
+        arguments: sampledSupplies
+    )
+    func storedBalanceUsdf_doesNotOvershootCurveTVL(tokens: Int) throws {
+        let supply = UInt64(tokens) * UInt64(DiscreteBondingCurve.quarksPerToken)
+        let sell = try #require(
+            curve.sell(tokenQuarks: Int(supply), feeBps: 0, supplyQuarks: Int(supply))
+        )
+        let stored = try makeStoredBalance(supply: supply)
+
+        let usdf: Foundation.Decimal = stored.usdf.decimalValue
+        let tvl: Foundation.Decimal = sell.netUSDF.asDecimal()
+
+        #expect(usdf <= tvl)
+    }
+
+    @Test("Selling a fresh currency after a $100 buy does not return nil")
+    func computeFromEntered_afterFreshHundredDollarBuy_returnsNonNil() throws {
+        // Fresh currency + $100 buy is the concrete repro the user reported
+        // as "100% of the time". Sell the exact stored balance and expect
+        // a non-nil ExchangedFiat.
+        let buyEstimate = try #require(
+            curve.buy(
+                usdcQuarks: 100_000_000, // $100 USDF in 6-decimal quarks
+                feeBps: 0,
+                supplyQuarks: 0
+            ),
+            "Curve failed to price a $100 buy on a fresh currency"
+        )
+
+        // Server-side semantics: tokens from the buy, scaled to quarks and
+        // truncated toward zero (cannot mint a fractional quark).
+        let supplyQuarks = try #require(
+            Int(
+                buyEstimate.netTokens
+                    .multiply(BigDecimal(DiscreteBondingCurve.quarksPerToken), DiscreteBondingCurve.rounding)
+                    .round(Rounding(.towardZero, 0))
+                    .asString(.plain)
+            ),
+            "Failed to scale $100 buy tokens into integer quarks"
+        )
+
+        let stored = try makeStoredBalance(supply: UInt64(supplyQuarks))
+
+        let entered = ExchangedFiat.computeFromEntered(
+            amount: stored.usdf.decimalValue,
+            rate: rate,
+            mint: mint,
+            supplyQuarks: UInt64(supplyQuarks),
+            balance: stored.usdf,
+            tokenBalanceQuarks: stored.quarks
+        )
+
+        #expect(
+            entered != nil,
+            "selling exactly the stored balance after a $100 fresh-currency buy must succeed"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Typing the displayed max on Sell or Give for a newly-minted bonding-curve currency left **Next** disabled. `StoredBalance.usdf` was HALF-UP quantized, which could push it a sub-quark above the curve's exact TV

## Test plan

- [x] `Regression_sell_max_precision` — invariant across sampled supplies + \$100 fresh-buy repro
- [x] `Regression_give_max_precision` — typing the displayed max on a probe-found bad supply keeps `canGive == true`
- [x] Verified red → green (reverted the fix, both tests failed; reapplied, both passed)
- [x] `AllTargets` on iPhone 16 (OS 18.6) + iPhone 17
- [x] Manual: fund a fresh currency with \$100, Sell max → Next enabled; Give max → Next enabled