### PR TITLE
refactor: extract OnrampCoordinator from OnrampViewModel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,6 +523,11 @@ Payments & Operations:
 - FlipcashCore/Sources/FlipcashCore/Models/VerifiedState.swift
 - FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/VerifiedProtoService.swift
 
+Onramp & Coinbase:
+- Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+- Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
+- Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift (buy-existing amount entry only)
+
 Multi-Currency:
 - FlipcashCore/Sources/FlipcashCore/Models/Fiat.swift (Quarks)
 - FlipcashCore/Sources/FlipcashCore/Models/ExchangedFiat.swift

--- a/Flipcash/Core/ContainerScreen.swift
+++ b/Flipcash/Core/ContainerScreen.swift
@@ -44,6 +44,7 @@ struct ContainerScreen: View {
                         sessionContainer: sessionContainer
                     )
                     .injectingEnvironment(from: sessionContainer)
+                    .modifier(OnrampHostModifier())
                     .transition(.opacity)
                 }
             }

--- a/Flipcash/Core/ContainerScreen.swift
+++ b/Flipcash/Core/ContainerScreen.swift
@@ -43,8 +43,8 @@ struct ContainerScreen: View {
                         container: container,
                         sessionContainer: sessionContainer
                     )
-                    .injectingEnvironment(from: sessionContainer)
                     .modifier(OnrampHostModifier())
+                    .injectingEnvironment(from: sessionContainer)
                     .transition(.opacity)
                 }
             }

--- a/Flipcash/Core/Controllers/BetaFlags.swift
+++ b/Flipcash/Core/Controllers/BetaFlags.swift
@@ -98,7 +98,6 @@ extension BetaFlags {
         case transactionDetails
         case vibrateOnScan
         case enableCoinbase
-        case coinbaseSandbox
         case currencyCreation
 
         var id: String {
@@ -113,8 +112,6 @@ extension BetaFlags {
                 return "Vibrate on scan"
             case .enableCoinbase:
                 return "Enable Coinbase"
-            case .coinbaseSandbox:
-                return "Coinbase Sandbox"
             case .currencyCreation:
                 return "Currency Creation"
             }
@@ -128,8 +125,6 @@ extension BetaFlags {
                 return "If enabled, the device will vibrate to indicate that the camera has registered the code on the bill"
             case .enableCoinbase:
                 return "If enabled, Coinbase onramp will be available regardless of region"
-            case .coinbaseSandbox:
-                return "If enabled, all Coinbase transactions will go through the sandbox environment"
             case .currencyCreation:
                 return "If enabled, shows a button to create your own currency in the discovery screen"
             }

--- a/Flipcash/Core/Controllers/Onramp/OnrampCompletion.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCompletion.swift
@@ -1,0 +1,21 @@
+//
+//  OnrampCompletion.swift
+//  Flipcash
+//
+
+import Foundation
+import FlipcashCore
+
+enum OnrampCompletion: Identifiable, Hashable {
+    case buyProcessing(swapId: SwapId, currencyName: String, amount: ExchangedFiat)
+    case launchProcessing(swapId: SwapId, launchedMint: PublicKey, currencyName: String, amount: ExchangedFiat)
+
+    var id: String {
+        switch self {
+        case .buyProcessing(let swapId, _, _):
+            "buy-\(swapId.publicKey.base58)"
+        case .launchProcessing(let swapId, _, _, _):
+            "launch-\(swapId.publicKey.base58)"
+        }
+    }
+}

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -14,7 +14,7 @@ private let logger = Logger(label: "flipcash.onramp-coordinator")
 @Observable
 final class OnrampCoordinator {
 
-    // MARK: - Published state -
+    // MARK: - State -
 
     /// Apple Pay order — drives the invisible WebView overlay hosted at root.
     private(set) var coinbaseOrder: OnrampOrderResponse?
@@ -123,7 +123,11 @@ final class OnrampCoordinator {
     @ObservationIgnored private let coinbaseApiKey: String?
     @ObservationIgnored private var coinbase: Coinbase!
 
-    @ObservationIgnored private var pendingOperation: OnrampOperation?
+    /// Set when `start(_:amount:)` is invoked; cleared when the flow resolves
+    /// (success, cancel, or verification-sheet close). Must be observable so
+    /// `isProcessingPayment` propagates the verification-cancel transition
+    /// (no `coinbaseOrder` change) to its callers.
+    private var pendingOperation: OnrampOperation?
     @ObservationIgnored private var pendingAmount: ExchangedFiat?
     @ObservationIgnored private var fundingTask: Task<Void, Never>?
 
@@ -138,7 +142,15 @@ final class OnrampCoordinator {
         self.region = phoneFormatter.currentRegion
         self.coinbaseApiKey = try? InfoPlist.value(for: "coinbase").value(for: "apiKey").string()
 
-        self.coinbase = Coinbase(configuration: .init(bearerTokenProvider: fetchCoinbaseJWT))
+        // Weak capture breaks the retain cycle between the coordinator and
+        // the Coinbase client (which stores this closure for the lifetime of
+        // the session).
+        self.coinbase = Coinbase(configuration: .init(bearerTokenProvider: { [weak self] method, path in
+            guard let self else {
+                throw OnrampError.missingCoinbaseApiKey
+            }
+            return try await self.fetchCoinbaseJWT(method: method, path: path)
+        }))
     }
 
     // MARK: - Verification derived state -
@@ -174,8 +186,10 @@ final class OnrampCoordinator {
             return false
         }
 
-        return e.range(of: #"^[^\s@]+@[^\s@]+\.[^\s@]+$"#, options: .regularExpression) != nil
+        return e.wholeMatch(of: Self.emailRegex) != nil
     }
+
+    private static let emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
     private var isPhoneVerified: Bool {
         session.profile?.isPhoneVerified ?? false
@@ -278,26 +292,8 @@ final class OnrampCoordinator {
 
     // MARK: - Public API -
 
-    func startBuy(
-        amount: ExchangedFiat,
-        mint: PublicKey,
-        displayName: String,
-        onCompleted: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
-    ) {
+    func start(_ operation: OnrampOperation, amount: ExchangedFiat) {
         guard !isProcessingPayment else { return }
-        let operation = OnrampOperation.buy(mint: mint, displayName: displayName, onCompleted: onCompleted)
-        pendingOperation = operation
-        pendingAmount = amount
-        navigateToVerificationOrPurchase(for: operation, amount: amount)
-    }
-
-    func startLaunch(
-        amount: ExchangedFiat,
-        displayName: String,
-        onCompleted: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
-    ) {
-        guard !isProcessingPayment else { return }
-        let operation = OnrampOperation.launch(displayName: displayName, onCompleted: onCompleted)
         pendingOperation = operation
         pendingAmount = amount
         navigateToVerificationOrPurchase(for: operation, amount: amount)

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -57,6 +57,17 @@ final class OnrampCoordinator {
 
     var dialogItem: DialogItem?
 
+    /// True once Coinbase has accepted the order and remains true through the
+    /// full committed flow: Apple Pay commit, on-chain settlement, the poll
+    /// loop, the downstream `buyWithExternalFunding` swap, and while the
+    /// processing screen is presented. Drives the sheet-level dismiss lock —
+    /// the USDF destination is a staging ATA that only `buyWithExternalFunding`
+    /// can drain, so dismissing mid-flight would strand funds with no recovery
+    /// path through normal UI.
+    var isProcessingPayment: Bool {
+        coinbaseOrder != nil || pendingOperation != nil
+    }
+
     let codeLength = 6
 
     // MARK: - Dependencies -
@@ -545,6 +556,20 @@ final class OnrampCoordinator {
         )
     }
 
+    private func showCoinbaseError(title: String, subtitle: String, onDismiss: (() -> Void)? = nil) {
+        presentDestructiveDialog(title: title, subtitle: subtitle) {
+            onDismiss?()
+        }
+    }
+
+    private func showBuyFailedDialog() {
+        coinbaseOrder = nil
+        presentDestructiveDialog(
+            title: "Couldn't Buy Token",
+            subtitle: "Your USDF is in your wallet. Try again from the currency screen."
+        )
+    }
+
     private func showUnsupportedPhoneNumberError() {
         presentDestructiveDialog(
             title: "Unsupported Phone Number",
@@ -642,6 +667,16 @@ final class OnrampCoordinator {
             ErrorReporting.captureError(error)
             pendingOperation = nil
             pendingAmount = nil
+
+            if error.errorType == .guestRegionForbidden {
+                showCoinbaseError(title: error.title, subtitle: error.subtitle) { [weak self] in
+                    Task {
+                        try? await self?.session.unlinkProfile()
+                    }
+                }
+            } else {
+                showCoinbaseError(title: error.title, subtitle: error.subtitle)
+            }
         }
 
         catch {
@@ -666,6 +701,20 @@ final class OnrampCoordinator {
             coinbaseOrder = nil
             pendingOperation = nil
             pendingAmount = nil
+
+            // Prefer the Coinbase-provided reason if we have one — users hitting
+            // a region mismatch or card decline shouldn't see "Something went wrong".
+            let title: String
+            let subtitle: String
+            if let message = event.data?.errorMessage, !message.isEmpty {
+                title = "Payment Failed"
+                subtitle = message
+            } else {
+                title = "Something Went Wrong"
+                subtitle = "Please try again later"
+            }
+            presentDestructiveDialog(title: title, subtitle: subtitle)
+
             ErrorReporting.captureError(kind)
         }
 
@@ -809,6 +858,7 @@ final class OnrampCoordinator {
 
         guard let orderId = coinbaseOrder?.order.orderId else {
             logger.error("pollingSuccess fired with no active Coinbase order")
+            showBuyFailedDialog()
             return
         }
 
@@ -824,6 +874,7 @@ final class OnrampCoordinator {
         } catch {
             logger.error("Coinbase order poll failed", metadata: ["error": "\(error)"])
             ErrorReporting.captureError(error)
+            showBuyFailedDialog()
             return
         }
 
@@ -845,6 +896,7 @@ final class OnrampCoordinator {
                 "order_id": "\(orderId)",
                 "status": "\(order.status)"
             ])
+            showBuyFailedDialog()
             return
         }
 
@@ -853,6 +905,7 @@ final class OnrampCoordinator {
                 "tx_hash": "\(txHash)",
                 "tx_hash_length": "\(txHash.count)"
             ])
+            showBuyFailedDialog()
             return
         }
 
@@ -860,6 +913,7 @@ final class OnrampCoordinator {
             logger.error("Failed to construct swap amount from order", metadata: [
                 "order_id": "\(orderId)"
             ])
+            showBuyFailedDialog()
             return
         }
 
@@ -898,6 +952,7 @@ final class OnrampCoordinator {
         } catch {
             logger.error("Buy failed", metadata: ["error": "\(error)"])
             ErrorReporting.captureError(error)
+            showBuyFailedDialog()
         }
     }
 }

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -1,0 +1,87 @@
+//
+//  OnrampCoordinator.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashCore
+
+private let logger = Logger(label: "flipcash.onramp-coordinator")
+
+@MainActor
+@Observable
+final class OnrampCoordinator {
+
+    // MARK: - Published state -
+
+    /// Apple Pay order — drives the invisible WebView overlay hosted at root.
+    private(set) var coinbaseOrder: OnrampOrderResponse?
+
+    /// Non-nil when a verification sub-flow needs to present at root.
+    var verificationSheet: VerificationSheetContext?
+
+    /// Non-nil once the post-onramp swap succeeds. Drives the calling
+    /// screen's processing-screen cover.
+    var completion: OnrampCompletion?
+
+    // MARK: - Dependencies -
+
+    @ObservationIgnored private let session: Session
+    @ObservationIgnored private let flipClient: FlipClient
+    @ObservationIgnored private let owner: KeyPair
+
+    // MARK: - Init -
+
+    init(session: Session, flipClient: FlipClient) {
+        self.session = session
+        self.flipClient = flipClient
+        self.owner = session.ownerKeyPair
+    }
+
+    // MARK: - Public API (fleshed out in later tasks) -
+
+    func startBuy(
+        amount: ExchangedFiat,
+        mint: PublicKey,
+        displayName: String,
+        onCompleted: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
+    ) {
+        logger.info("startBuy invoked (stub)", metadata: [
+            "currency": "\(amount.converted.currencyCode)",
+            "mint": "\(mint.base58)",
+        ])
+    }
+
+    func startLaunch(
+        amount: ExchangedFiat,
+        displayName: String,
+        onCompleted: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
+    ) {
+        logger.info("startLaunch invoked (stub)", metadata: [
+            "currency": "\(amount.converted.currencyCode)",
+        ])
+    }
+
+    func cancel() {
+        coinbaseOrder = nil
+        verificationSheet = nil
+    }
+}
+
+// MARK: - Supporting types -
+
+struct VerificationSheetContext: Identifiable, Hashable {
+    enum Entry { case info, phone, email }
+
+    let id: UUID = UUID()
+    let entry: Entry
+    let reason: OnrampOperation.LogKindWrapper  // placeholder hashable wrapper
+}
+
+extension OnrampOperation {
+    /// Hashable wrapper so `OnrampOperation` itself (which carries closures)
+    /// doesn't need Hashable conformance.
+    struct LogKindWrapper: Hashable {
+        let value: String
+    }
+}

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -457,6 +457,8 @@ final class OnrampCoordinator {
     }
 
     func applyDeeplinkVerification(_ verification: VerificationDescription) {
+        guard !isEmailVerified else { return }
+
         // If the user isn't already parked on the confirm-code screen, jump
         // them there so the API call's result has somewhere to surface.
         if !isShowingVerificationFlow {
@@ -472,15 +474,13 @@ final class OnrampCoordinator {
             }
 
             do {
-                if !isEmailVerified {
-                    try await flipClient.checkEmailCode(
-                        email: verification.email,
-                        code: verification.code,
-                        owner: owner
-                    )
+                try await flipClient.checkEmailCode(
+                    email: verification.email,
+                    code: verification.code,
+                    owner: owner
+                )
 
-                    try? await session.updateProfile()
-                }
+                try? await session.updateProfile()
 
                 try await Task.delay(milliseconds: 500)
                 confirmEmailButtonState = .success

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -26,6 +26,44 @@ final class OnrampCoordinator {
     /// screen's processing-screen cover.
     var completion: OnrampCompletion?
 
+    /// Binding that surfaces only `.buyProcessing` completions so the
+    /// buy-flow cover does not flash empty content when a `.launchProcessing`
+    /// completion is published.
+    var buyCompletionBinding: Binding<OnrampCompletion?> {
+        Binding(
+            get: {
+                if case .buyProcessing = self.completion {
+                    return self.completion
+                }
+                return nil
+            },
+            set: { newValue in
+                if newValue == nil {
+                    self.completion = nil
+                }
+            }
+        )
+    }
+
+    /// Binding that surfaces only `.launchProcessing` completions so the
+    /// launch-flow cover does not flash empty content when a `.buyProcessing`
+    /// completion is published.
+    var launchCompletionBinding: Binding<OnrampCompletion?> {
+        Binding(
+            get: {
+                if case .launchProcessing = self.completion {
+                    return self.completion
+                }
+                return nil
+            },
+            set: { newValue in
+                if newValue == nil {
+                    self.completion = nil
+                }
+            }
+        )
+    }
+
     // MARK: - Verification state -
 
     /// Drives the verification sheet at the root. `VerifyInfoScreen` binds to

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -64,8 +64,18 @@ final class OnrampCoordinator {
     // MARK: - Verification state -
 
     /// Drives the verification sheet at the root. `VerifyInfoScreen` binds to
-    /// this flag to close itself via the toolbar close button.
-    var isShowingVerificationFlow: Bool = false
+    /// this flag to close itself via the toolbar close button. When the sheet
+    /// dismisses without the user having completed verification (e.g. they
+    /// tapped close), the pending operation is abandoned so callers aren't
+    /// stranded in `isProcessingPayment`.
+    var isShowingVerificationFlow: Bool = false {
+        didSet {
+            if oldValue && !isShowingVerificationFlow && !isAccountVerified {
+                pendingOperation = nil
+                pendingAmount = nil
+            }
+        }
+    }
 
     /// Navigation stack for the verification sub-flow sheet. When the path
     /// transitions from non-empty to empty (sheet dismissed mid-flight),

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -3,7 +3,9 @@
 //  Flipcash
 //
 
+import UIKit
 import SwiftUI
+import FlipcashUI
 import FlipcashCore
 
 private let logger = Logger(label: "flipcash.onramp-coordinator")
@@ -24,6 +26,39 @@ final class OnrampCoordinator {
     /// screen's processing-screen cover.
     var completion: OnrampCompletion?
 
+    // MARK: - Verification state -
+
+    /// Drives the verification sheet at the root. `VerifyInfoScreen` binds to
+    /// this flag to close itself via the toolbar close button.
+    var isShowingVerificationFlow: Bool = false
+
+    /// Navigation stack for the verification sub-flow sheet. When the path
+    /// transitions from non-empty to empty (sheet dismissed mid-flight),
+    /// the coordinator resets the transient verification state.
+    var verificationPath: [OnrampVerificationPath] = [] {
+        didSet {
+            if verificationPath.isEmpty && !oldValue.isEmpty {
+                resetVerificationState()
+            }
+        }
+    }
+
+    var enteredPhone: String = ""
+    var enteredCode: String = ""
+    var enteredEmail: String = ""
+
+    private(set) var region: Region
+    private(set) var isResending: Bool = false
+
+    var sendCodeButtonState: ButtonState = .normal
+    var sendEmailCodeState: ButtonState = .normal
+    var confirmCodeButtonState: ButtonState = .normal
+    var confirmEmailButtonState: ButtonState = .normal
+
+    var dialogItem: DialogItem?
+
+    let codeLength = 6
+
     // MARK: - Dependencies -
 
     @ObservationIgnored private let session: Session
@@ -36,15 +71,138 @@ final class OnrampCoordinator {
     @ObservationIgnored private var pendingAmount: ExchangedFiat?
     @ObservationIgnored private var fundingTask: Task<Void, Never>?
 
+    @ObservationIgnored private let phoneFormatter = PhoneFormatter()
+
     // MARK: - Init -
 
     init(session: Session, flipClient: FlipClient) {
         self.session = session
         self.flipClient = flipClient
         self.owner = session.ownerKeyPair
+        self.region = phoneFormatter.currentRegion
         self.coinbaseApiKey = try? InfoPlist.value(for: "coinbase").value(for: "apiKey").string()
 
         self.coinbase = Coinbase(configuration: .init(bearerTokenProvider: fetchCoinbaseJWT))
+    }
+
+    // MARK: - Verification derived state -
+
+    var regionFlagStyle: Flag.Style {
+        .fiat(region)
+    }
+
+    var countryCode: String {
+        "+\(phoneFormatter.countryCode(for: region)!)"
+    }
+
+    var phone: Phone? {
+        Phone(enteredPhone)
+    }
+
+    var canSendVerificationCode: Bool {
+        phone != nil
+    }
+
+    var canSendEmailVerification: Bool {
+        isEmailValid
+    }
+
+    var isCodeComplete: Bool {
+        enteredCode.count >= codeLength
+    }
+
+    var isEmailValid: Bool {
+        let e = enteredEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !e.isEmpty, e.utf8.count <= 254 else {
+            return false
+        }
+
+        return e.range(of: #"^[^\s@]+@[^\s@]+\.[^\s@]+$"#, options: .regularExpression) != nil
+    }
+
+    private var isPhoneVerified: Bool {
+        session.profile?.isPhoneVerified ?? false
+    }
+
+    private var isEmailVerified: Bool {
+        session.profile?.isEmailVerified ?? false
+    }
+
+    private var isAccountVerified: Bool {
+        isPhoneVerified && isEmailVerified
+    }
+
+    // MARK: - Verification setters & bindings -
+
+    private func resetVerificationState() {
+        enteredPhone = ""
+        enteredCode = ""
+        enteredEmail = ""
+        isResending = false
+    }
+
+    func setRegion(_ region: Region) {
+        self.region = region
+    }
+
+    var adjustingPhoneNumberBinding: Binding<String> {
+        Binding { [weak self] in
+            guard let self = self else { return "" }
+            return self.enteredPhone
+
+        } set: { [weak self] newValue in
+            guard let self = self else { return }
+            let cleanPhoneNumber = newValue.filter { character in
+                CharacterSet.numbers.contains(character.unicodeScalars.first!)
+            }
+
+            let countryCode = self.phoneFormatter.countryCode(for: self.region)!
+            self.enteredPhone = self.phoneFormatter.format("+\(countryCode)\(cleanPhoneNumber)")
+        }
+    }
+
+    var adjustingCodeBinding: Binding<String> {
+        Binding { [weak self] in
+            guard let self = self else { return "" }
+            return self.enteredCode
+
+        } set: { [weak self] newValue in
+            guard let self = self else { return }
+
+            if newValue.count > self.codeLength {
+                self.enteredCode = String(newValue.prefix(self.codeLength))
+            } else {
+                self.enteredCode = newValue
+            }
+        }
+    }
+
+    // MARK: - Clipboard -
+
+    func pasteCodeFromClipboardIfPossible() {
+        guard let code = codeFromClipboard() else {
+            return
+        }
+
+        enteredCode = code
+    }
+
+    private func codeFromClipboard() -> String? {
+        if let codeString = UIPasteboard.general.string, codeString.count == codeLength {
+            let digits: [Int] = codeString.utf8.compactMap { char in
+                let digit = Int(char)
+                if digit >= 48 && digit <= 57 {
+                    return digit
+                }
+                return nil
+            }
+
+            if digits.count == codeLength {
+                return codeString
+            }
+        }
+        return nil
     }
 
     // MARK: - Coinbase JWT -
@@ -73,7 +231,7 @@ final class OnrampCoordinator {
         let operation = OnrampOperation.buy(mint: mint, displayName: displayName, onCompleted: onCompleted)
         pendingOperation = operation
         pendingAmount = amount
-        Task { await createOrder(amount: amount, operation: operation) }
+        navigateToVerificationOrPurchase(for: operation, amount: amount)
     }
 
     func startLaunch(
@@ -84,7 +242,7 @@ final class OnrampCoordinator {
         let operation = OnrampOperation.launch(displayName: displayName, onCompleted: onCompleted)
         pendingOperation = operation
         pendingAmount = amount
-        Task { await createOrder(amount: amount, operation: operation) }
+        navigateToVerificationOrPurchase(for: operation, amount: amount)
     }
 
     func cancel() {
@@ -94,6 +252,334 @@ final class OnrampCoordinator {
         pendingAmount = nil
         coinbaseOrder = nil
         verificationSheet = nil
+    }
+
+    // MARK: - Verification navigation -
+
+    /// Entry point invoked by `VerifyInfoScreen`'s Next button.
+    func navigateToInitialVerification() {
+        navigateToAmount(from: .info)
+    }
+
+    private func navigateToAmount(from origin: Origin) {
+        if origin.rawValue < Origin.info.rawValue, (!isPhoneVerified || !isEmailVerified) {
+            verificationPath.append(.info)
+            return
+        }
+
+        if origin.rawValue < Origin.phone.rawValue, !isPhoneVerified {
+            Analytics.track(event: Analytics.OnrampEvent.showEnterPhone)
+            verificationPath.append(.enterPhoneNumber)
+            return
+        }
+
+        if origin.rawValue < Origin.email.rawValue, !isEmailVerified {
+            Analytics.track(event: Analytics.OnrampEvent.showEnterEmail)
+            verificationPath.append(.enterEmail)
+            return
+        }
+
+        // Verification complete — drop the sheet and kick off the order.
+        guard let operation = pendingOperation, let amount = pendingAmount else {
+            logger.warning("Verification completed without a pending operation")
+            isShowingVerificationFlow = false
+            return
+        }
+        isShowingVerificationFlow = false
+        Task { await createOrder(amount: amount, operation: operation) }
+    }
+
+    private func navigateToVerificationOrPurchase(for operation: OnrampOperation, amount: ExchangedFiat) {
+        if isAccountVerified {
+            Task { await createOrder(amount: amount, operation: operation) }
+        } else {
+            Analytics.track(event: Analytics.OnrampEvent.showVerificationInfo)
+            isShowingVerificationFlow = true
+        }
+    }
+
+    // MARK: - Verification actions -
+
+    func sendPhoneNumberCodeAction() {
+        guard let phone else {
+            return
+        }
+
+        Task {
+            sendCodeButtonState = .loading
+            defer {
+                sendCodeButtonState = .normal
+            }
+
+            do {
+                try await flipClient.sendVerificationCode(
+                    phone: phone.e164,
+                    owner: owner
+                )
+                try await Task.delay(milliseconds: 500)
+                sendCodeButtonState = .success
+
+                try await Task.delay(milliseconds: 500)
+                verificationPath.append(.confirmPhoneNumberCode)
+
+                Analytics.track(event: Analytics.OnrampEvent.showConfirmPhone)
+
+                try await Task.delay(milliseconds: 500)
+            }
+
+            catch
+                ErrorSendVerificationCode.invalidPhoneNumber,
+                ErrorSendVerificationCode.unsupportedPhoneType
+            {
+                showUnsupportedPhoneNumberError()
+            }
+
+            catch {
+                ErrorReporting.captureError(error)
+                showGenericError()
+            }
+        }
+    }
+
+    func resendCodeAction() async throws {
+        guard let phone else {
+            return
+        }
+
+        isResending = true
+        defer {
+            isResending = false
+        }
+
+        do {
+            try await flipClient.sendVerificationCode(
+                phone: phone.e164,
+                owner: owner
+            )
+        } catch {
+            ErrorReporting.captureError(error)
+        }
+    }
+
+    func confirmPhoneNumberCodeAction() {
+        guard let phone else {
+            return
+        }
+
+        guard isCodeComplete else {
+            return
+        }
+
+        Task {
+            confirmCodeButtonState = .loading
+            defer {
+                confirmCodeButtonState = .normal
+            }
+
+            do {
+                try await flipClient.checkVerificationCode(
+                    phone: phone.e164,
+                    code: enteredCode,
+                    owner: owner
+                )
+
+                try? await session.updateProfile()
+
+                try await Task.delay(milliseconds: 500)
+                confirmCodeButtonState = .success
+
+                try await Task.delay(milliseconds: 500)
+                navigateToAmount(from: .phone)
+
+                try await Task.delay(milliseconds: 500)
+            } catch ErrorCheckVerificationCode.invalidCode {
+                showInvalidCodeError()
+            } catch ErrorCheckVerificationCode.noVerification {
+                showGenericError()
+            } catch {
+                ErrorReporting.captureError(error)
+            }
+        }
+    }
+
+    func sendEmailCodeAction() {
+        guard isEmailValid else {
+            return
+        }
+
+        Task {
+            sendEmailCodeState = .loading
+            defer {
+                sendEmailCodeState = .normal
+            }
+
+            do {
+                try await flipClient.sendEmailVerification(
+                    email: enteredEmail,
+                    owner: owner
+                )
+                try await Task.delay(milliseconds: 500)
+                sendEmailCodeState = .success
+
+                try await Task.delay(milliseconds: 500)
+                verificationPath.append(.confirmEmailCode)
+
+                Analytics.track(event: Analytics.OnrampEvent.showConfirmEmail)
+
+                try await Task.delay(milliseconds: 500)
+            } catch ErrorSendEmailCode.invalidEmailAddress {
+                showInvalidEmailError()
+            } catch {
+                ErrorReporting.captureError(error)
+                showGenericError()
+            }
+        }
+    }
+
+    func resendEmailCodeAction() async throws {
+        guard isEmailValid else {
+            return
+        }
+
+        isResending = true
+        defer {
+            isResending = false
+        }
+
+        do {
+            try await flipClient.sendEmailVerification(
+                email: enteredEmail,
+                owner: owner
+            )
+        } catch {
+            ErrorReporting.captureError(error)
+        }
+    }
+
+    func applyDeeplinkVerification(_ verification: VerificationDescription) {
+        // If the user isn't already parked on the confirm-code screen, jump
+        // them there so the API call's result has somewhere to surface.
+        if !isShowingVerificationFlow {
+            verificationPath = [.confirmEmailCode]
+            enteredEmail = verification.email
+            isShowingVerificationFlow = true
+        }
+
+        Task {
+            confirmEmailButtonState = .loading
+            defer {
+                confirmEmailButtonState = .normal
+            }
+
+            do {
+                if !isEmailVerified {
+                    try await flipClient.checkEmailCode(
+                        email: verification.email,
+                        code: verification.code,
+                        owner: owner
+                    )
+
+                    try? await session.updateProfile()
+                }
+
+                try await Task.delay(milliseconds: 500)
+                confirmEmailButtonState = .success
+
+                try await Task.delay(milliseconds: 500)
+                navigateToAmount(from: .email)
+            } catch ErrorCheckEmailCode.invalidCode {
+                showInvalidVerificationLinkError { [weak self] in
+                    Task {
+                        try await self?.resendEmailCodeAction()
+                    }
+                }
+            } catch ErrorCheckEmailCode.noVerification {
+                showExpiredVerificationLinkError { [weak self] in
+                    Task {
+                        try await self?.resendEmailCodeAction()
+                    }
+                }
+            } catch {
+                ErrorReporting.captureError(error)
+                showGenericError()
+            }
+        }
+    }
+
+    // MARK: - Dialog factories -
+
+    private func presentDestructiveDialog(
+        title: String,
+        subtitle: String,
+        action: @escaping DialogAction.DialogActionHandler = {}
+    ) {
+        dialogItem = .init(
+            style: .destructive,
+            title: title,
+            subtitle: subtitle,
+            dismissable: true,
+        ) {
+            .okay(kind: .destructive, action: action)
+        }
+    }
+
+    private func presentResendOrCancelDialog(title: String, subtitle: String, resendAction: @escaping () -> Void) {
+        dialogItem = .init(
+            style: .destructive,
+            title: title,
+            subtitle: subtitle,
+            dismissable: true,
+        ) {
+            .destructive("Resend Verification Code") {
+                resendAction()
+            };
+            .cancel()
+        }
+    }
+
+    private func showGenericError(action: @escaping DialogAction.DialogActionHandler = {}) {
+        presentDestructiveDialog(
+            title: "Something Went Wrong",
+            subtitle: "Please try again later",
+            action: action
+        )
+    }
+
+    private func showUnsupportedPhoneNumberError() {
+        presentDestructiveDialog(
+            title: "Unsupported Phone Number",
+            subtitle: "Please use a different phone number and try again"
+        )
+    }
+
+    private func showInvalidEmailError() {
+        presentDestructiveDialog(
+            title: "Invalid Email",
+            subtitle: "Please enter a different email and try again"
+        )
+    }
+
+    private func showInvalidCodeError() {
+        presentDestructiveDialog(
+            title: "Invalid Code",
+            subtitle: "Please enter the verification code that was sent to your phone number or request a new code"
+        )
+    }
+
+    private func showInvalidVerificationLinkError(resendAction: @escaping () -> Void) {
+        presentResendOrCancelDialog(
+            title: "Verification Link Invalid",
+            subtitle: "This verification link is invalid. Please try again",
+            resendAction: resendAction
+        )
+    }
+
+    private func showExpiredVerificationLinkError(resendAction: @escaping () -> Void) {
+        presentResendOrCancelDialog(
+            title: "Verification Link Expired",
+            subtitle: "This verification link has expired. Please try again",
+            resendAction: resendAction
+        )
     }
 
     // MARK: - Coinbase order -
@@ -432,4 +918,16 @@ extension OnrampOperation {
     struct LogKindWrapper: Hashable {
         let value: String
     }
+}
+
+private enum Origin: Int {
+    case root
+    case info
+    case phone
+    case email
+    case payment
+}
+
+private extension CharacterSet {
+    static let numbers: CharacterSet = CharacterSet(charactersIn: "0123456789")
 }

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -32,6 +32,10 @@ final class OnrampCoordinator {
     @ObservationIgnored private let coinbaseApiKey: String?
     @ObservationIgnored private var coinbase: Coinbase!
 
+    @ObservationIgnored private var pendingOperation: OnrampOperation?
+    @ObservationIgnored private var pendingAmount: ExchangedFiat?
+    @ObservationIgnored private var fundingTask: Task<Void, Never>?
+
     // MARK: - Init -
 
     init(session: Session, flipClient: FlipClient) {
@@ -58,7 +62,7 @@ final class OnrampCoordinator {
         )
     }
 
-    // MARK: - Public API (fleshed out in later tasks) -
+    // MARK: - Public API -
 
     func startBuy(
         amount: ExchangedFiat,
@@ -66,10 +70,10 @@ final class OnrampCoordinator {
         displayName: String,
         onCompleted: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
     ) {
-        logger.info("startBuy invoked (stub)", metadata: [
-            "currency": "\(amount.converted.currencyCode)",
-            "mint": "\(mint.base58)",
-        ])
+        let operation = OnrampOperation.buy(mint: mint, displayName: displayName, onCompleted: onCompleted)
+        pendingOperation = operation
+        pendingAmount = amount
+        Task { await createOrder(amount: amount, operation: operation) }
     }
 
     func startLaunch(
@@ -77,14 +81,338 @@ final class OnrampCoordinator {
         displayName: String,
         onCompleted: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
     ) {
-        logger.info("startLaunch invoked (stub)", metadata: [
-            "currency": "\(amount.converted.currencyCode)",
-        ])
+        let operation = OnrampOperation.launch(displayName: displayName, onCompleted: onCompleted)
+        pendingOperation = operation
+        pendingAmount = amount
+        Task { await createOrder(amount: amount, operation: operation) }
     }
 
     func cancel() {
+        fundingTask?.cancel()
+        fundingTask = nil
+        pendingOperation = nil
+        pendingAmount = nil
         coinbaseOrder = nil
         verificationSheet = nil
+    }
+
+    // MARK: - Coinbase order -
+
+    private func createOrder(amount: ExchangedFiat, operation: OnrampOperation) async {
+        guard let profile = session.profile, profile.canCreateCoinbaseOrder else {
+            logger.warning("createOrder invoked without a Coinbase-capable profile")
+            return
+        }
+
+        guard let email = profile.email, let phone = profile.phone?.e164 else {
+            logger.warning("createOrder invoked with incomplete profile")
+            return
+        }
+
+        Analytics.onrampInvokePayment(amount: amount.underlying)
+
+        let id       = UUID()
+        let userRef  = "\(email):\(phone)"
+        let orderRef = "\(userRef):\(id)"
+        let ref = BetaFlags.shared.hasEnabled(.coinbaseSandbox) ? "sandbox-\(userRef)" : userRef
+
+        do {
+            logger.info("Creating Coinbase order", metadata: [
+                "currency": "\(amount.converted.currencyCode)",
+                "purchase_quarks": "\(amount.underlying.quarks)",
+                "sandbox": "\(BetaFlags.shared.hasEnabled(.coinbaseSandbox))",
+                "destination_kind": "\(operation.logKind)",
+            ])
+
+            guard let usdfSwapAccounts = MintMetadata.usdf.timelockSwapAccounts(owner: session.owner.authorityPublicKey) else {
+                fatalError("Failed to derive USDF swap accounts")
+            }
+
+            let response = try await coinbase.createOrder(request: .init(
+                purchaseAmount: "\(amount.underlying.decimalValue)",
+                paymentCurrency: "USD",
+                purchaseCurrency: "USDF",
+                isQuote: false,
+                destinationAddress: usdfSwapAccounts.ata.publicKey,
+                email: email,
+                phoneNumber: phone,
+                partnerOrderRef: orderRef,
+                partnerUserRef: ref,
+                phoneNumberVerifiedAt: .now,
+                agreementAcceptedAt: .now
+            ))
+
+            coinbaseOrder = response
+            logger.info("Coinbase order created", metadata: [
+                "order_id": "\(response.id)"
+            ])
+        }
+
+        catch let error as OnrampErrorResponse {
+            logger.error("Coinbase order failed", metadata: [
+                "error_type": "\(error.errorType)",
+                "error_title": "\(error.title)"
+            ])
+            ErrorReporting.captureError(error)
+            pendingOperation = nil
+            pendingAmount = nil
+        }
+
+        catch {
+            logger.error("Coinbase order failed with unexpected error", metadata: [
+                "error": "\(error)"
+            ])
+            ErrorReporting.captureError(error)
+            pendingOperation = nil
+            pendingAmount = nil
+        }
+    }
+
+    func receiveApplePayEvent(_ event: ApplePayEvent) {
+        func errorMetadata() -> Logger.Metadata {
+            [
+                "error_code": "\(event.data?.errorCode ?? "nil")",
+                "error_message": "\(event.data?.errorMessage ?? "nil")"
+            ]
+        }
+
+        func handleEventError(_ kind: ApplePayEvent.Event) {
+            coinbaseOrder = nil
+            pendingOperation = nil
+            pendingAmount = nil
+            ErrorReporting.captureError(kind)
+        }
+
+        switch event.event {
+        case .loadPending:
+            logger.info("Apple Pay load pending")
+        case .loadSuccess:
+            logger.info("Apple Pay loaded")
+        case .loadError:
+            logger.error("Apple Pay load failed", metadata: errorMetadata())
+            handleEventError(.loadError)
+
+        case .applePayButtonPressed:
+            logger.info("Apple Pay button pressed")
+        case .pendingPaymentAuth:
+            logger.info("Apple Pay pending payment auth")
+
+        case .commitSuccess:
+            logger.info("Apple Pay commit succeeded")
+        case .commitError:
+            logger.error("Apple Pay commit failed", metadata: errorMetadata())
+            handleEventError(.commitError)
+        case .pollingStart:
+            logger.info("Apple Pay polling started")
+        case .pollingSuccess:
+            fundingTask?.cancel()
+            fundingTask = Task { [weak self] in
+                await self?.handleCoinbaseFundingSuccess()
+            }
+        case .pollingError:
+            logger.error("Apple Pay polling failed", metadata: errorMetadata())
+            Analytics.onrampCompleted(
+                amount: nil,
+                successful: false,
+                error: nil
+            )
+            handleEventError(.pollingError)
+        case .cancelled:
+            logger.info("Apple Pay cancelled")
+            coinbaseOrder = nil
+            pendingOperation = nil
+            pendingAmount = nil
+        case .none:
+            logger.warning("Apple Pay received unknown event", metadata: ["raw_event": "\(event.name)"])
+        }
+    }
+
+    // MARK: - Poll + settle -
+
+    /// Polls `GET /v2/onramp/orders/{id}` until the order reaches a terminal state
+    /// (COMPLETED or FAILED) or the timeout expires. Returns the final order on
+    /// success. Throws on timeout, FAILED status, or repeated network errors.
+    private func pollCoinbaseOrderUntilComplete(orderId: String) async throws -> OnrampOrderResponse.Order {
+        let start = Date()
+        let deadline = start.addingTimeInterval(60) // sandbox completes in 250ms; 60s is generous for production
+        var pollCount = 0
+        var lastError: Error?
+
+        while Date() < deadline {
+            try Task.checkCancellation()
+            pollCount += 1
+            do {
+                let response = try await coinbase.fetchOrder(orderId: orderId)
+                let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
+                let status = response.order.status.uppercased()
+
+                logger.info("Coinbase order poll", metadata: [
+                    "poll": "\(pollCount)",
+                    "elapsed_ms": "\(elapsedMs)",
+                    "status": "\(response.order.status)",
+                    "tx_hash": "\(response.order.txHash ?? "nil")"
+                ])
+
+                if status.contains("COMPLETED") {
+                    return response.order
+                }
+                if status.contains("FAILED") {
+                    throw OnrampError.coinbaseOrderFailed(status: response.order.status)
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let error as OnrampError {
+                throw error
+            } catch {
+                lastError = error
+                logger.warning("Coinbase order poll error, retrying", metadata: [
+                    "poll": "\(pollCount)",
+                    "error": "\(error)"
+                ])
+            }
+
+            // Backoff: start at 500ms, +200ms every 5 polls
+            let delayMs = 500 + (200 * (pollCount / 5))
+            try await Task.delay(milliseconds: delayMs)
+        }
+
+        throw lastError ?? OnrampError.coinbaseOrderPollTimeout
+    }
+
+    /// Builds an ExchangedFiat for the buyWithExternalFunding call. The Coinbase
+    /// `purchaseAmount` is a string-encoded decimal in USDF units (e.g. "5" for $5).
+    /// Returns nil if the order didn't actually purchase USDF (defense against future
+    /// Coinbase API changes — we always request USDF, so a mismatch indicates a server
+    /// behavior change worth failing closed on).
+    private func makeUsdfSwapAmount(from order: OnrampOrderResponse.Order) -> ExchangedFiat? {
+        guard let purchaseCurrency = order.purchaseCurrency,
+              purchaseCurrency.uppercased() == "USDF" else {
+            return nil
+        }
+
+        guard let purchaseAmountString = order.purchaseAmount,
+              let decimal = NumberFormatter.decimal(from: purchaseAmountString) else {
+            return nil
+        }
+
+        guard let underlying = try? Quarks(
+            fiatDecimal: decimal,
+            currencyCode: .usd,
+            decimals: PublicKey.usdf.mintDecimals
+        ) else {
+            return nil
+        }
+
+        return try? ExchangedFiat(
+            underlying: underlying,
+            rate: .oneToOne,
+            mint: .usdf
+        )
+    }
+
+    private func handleCoinbaseFundingSuccess() async {
+        guard let operation = pendingOperation else {
+            logger.error("pollingSuccess fired with no pending operation")
+            return
+        }
+
+        logger.info("Coinbase funding succeeded", metadata: [
+            "destination_kind": "\(operation.logKind)",
+            "destination_name": "\(operation.displayName)"
+        ])
+
+        guard let orderId = coinbaseOrder?.order.orderId else {
+            logger.error("pollingSuccess fired with no active Coinbase order")
+            return
+        }
+
+        // Poll Coinbase for the completed order. This runs in sandbox too — it
+        // validates the full Coinbase integration (JWT scoping, GET endpoint,
+        // status transitions, txHash field parsing) end-to-end on every run.
+        let order: OnrampOrderResponse.Order
+        do {
+            order = try await pollCoinbaseOrderUntilComplete(orderId: orderId)
+        } catch is CancellationError {
+            logger.info("Coinbase order poll cancelled")
+            return
+        } catch {
+            logger.error("Coinbase order poll failed", metadata: ["error": "\(error)"])
+            ErrorReporting.captureError(error)
+            return
+        }
+
+        // Sandbox short-circuits the on-chain settlement — Coinbase returns a
+        // placeholder tx_hash that isn't a real Solana signature. We skip the
+        // buy (`buyWithExternalFunding` would reject the placeholder) but only
+        // AFTER exercising the full Coinbase order polling pipeline above.
+        if BetaFlags.shared.hasEnabled(.coinbaseSandbox) {
+            logger.info("Sandbox order — skipping buy", metadata: [
+                "order_id": "\(orderId)",
+                "status": "\(order.status)",
+                "tx_hash": "\(order.txHash ?? "nil")"
+            ])
+            return
+        }
+
+        guard let txHash = order.txHash, !txHash.isEmpty else {
+            logger.error("Coinbase order completed with no txHash", metadata: [
+                "order_id": "\(orderId)",
+                "status": "\(order.status)"
+            ])
+            return
+        }
+
+        guard let signature = try? Signature(base58: txHash) else {
+            logger.error("Failed to decode txHash as Solana signature", metadata: [
+                "tx_hash": "\(txHash)",
+                "tx_hash_length": "\(txHash.count)"
+            ])
+            return
+        }
+
+        guard let amount = makeUsdfSwapAmount(from: order) else {
+            logger.error("Failed to construct swap amount from order", metadata: [
+                "order_id": "\(orderId)"
+            ])
+            return
+        }
+
+        let onCompletedClosure: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
+        switch operation {
+        case .buy(_, _, let cb):    onCompletedClosure = cb
+        case .launch(_, let cb):    onCompletedClosure = cb
+        }
+
+        do {
+            switch try await onCompletedClosure(signature, amount) {
+            case .buyExisting(let swapId):
+                self.completion = .buyProcessing(
+                    swapId: swapId,
+                    currencyName: operation.displayName,
+                    amount: amount
+                )
+            case .launch(let swapId, let mint):
+                self.completion = .launchProcessing(
+                    swapId: swapId,
+                    launchedMint: mint,
+                    currencyName: operation.displayName,
+                    amount: amount
+                )
+            }
+
+            Analytics.onrampCompleted(
+                amount: amount.underlying,
+                successful: true,
+                error: nil
+            )
+
+            pendingOperation = nil
+            pendingAmount = nil
+            coinbaseOrder = nil
+        } catch {
+            logger.error("Buy failed", metadata: ["error": "\(error)"])
+            ErrorReporting.captureError(error)
+        }
     }
 }
 

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -661,13 +661,11 @@ final class OnrampCoordinator {
         let id       = UUID()
         let userRef  = "\(email):\(phone)"
         let orderRef = "\(userRef):\(id)"
-        let ref = BetaFlags.shared.hasEnabled(.coinbaseSandbox) ? "sandbox-\(userRef)" : userRef
 
         do {
             logger.info("Creating Coinbase order", metadata: [
                 "currency": "\(amount.converted.currencyCode)",
                 "purchase_quarks": "\(amount.underlying.quarks)",
-                "sandbox": "\(BetaFlags.shared.hasEnabled(.coinbaseSandbox))",
                 "destination_kind": "\(operation.logKind)",
             ])
 
@@ -684,7 +682,7 @@ final class OnrampCoordinator {
                 email: email,
                 phoneNumber: phone,
                 partnerOrderRef: orderRef,
-                partnerUserRef: ref,
+                partnerUserRef: userRef,
                 phoneNumberVerifiedAt: .now,
                 agreementAcceptedAt: .now
             ))
@@ -922,19 +920,6 @@ final class OnrampCoordinator {
             logger.error("Coinbase order poll failed", metadata: ["error": "\(error)"])
             ErrorReporting.captureError(error)
             showBuyFailedDialog()
-            return
-        }
-
-        // Sandbox short-circuits the on-chain settlement — Coinbase returns a
-        // placeholder tx_hash that isn't a real Solana signature. We skip the
-        // buy (`buyWithExternalFunding` would reject the placeholder) but only
-        // AFTER exercising the full Coinbase order polling pipeline above.
-        if BetaFlags.shared.hasEnabled(.coinbaseSandbox) {
-            logger.info("Sandbox order — skipping buy", metadata: [
-                "order_id": "\(orderId)",
-                "status": "\(order.status)",
-                "tx_hash": "\(order.txHash ?? "nil")"
-            ])
             return
         }
 

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -19,9 +19,6 @@ final class OnrampCoordinator {
     /// Apple Pay order — drives the invisible WebView overlay hosted at root.
     private(set) var coinbaseOrder: OnrampOrderResponse?
 
-    /// Non-nil when a verification sub-flow needs to present at root.
-    var verificationSheet: VerificationSheetContext?
-
     /// Non-nil once the post-onramp swap succeeds. Drives the calling
     /// screen's processing-screen cover.
     var completion: OnrampCompletion?
@@ -300,7 +297,6 @@ final class OnrampCoordinator {
         pendingOperation = nil
         pendingAmount = nil
         coinbaseOrder = nil
-        verificationSheet = nil
     }
 
     // MARK: - Verification navigation -
@@ -594,12 +590,6 @@ final class OnrampCoordinator {
         )
     }
 
-    private func showCoinbaseError(title: String, subtitle: String, onDismiss: (() -> Void)? = nil) {
-        presentDestructiveDialog(title: title, subtitle: subtitle) {
-            onDismiss?()
-        }
-    }
-
     private func showBuyFailedDialog() {
         coinbaseOrder = nil
         presentDestructiveDialog(
@@ -707,13 +697,13 @@ final class OnrampCoordinator {
             pendingAmount = nil
 
             if error.errorType == .guestRegionForbidden {
-                showCoinbaseError(title: error.title, subtitle: error.subtitle) { [weak self] in
+                presentDestructiveDialog(title: error.title, subtitle: error.subtitle) { [weak self] in
                     Task {
                         try? await self?.session.unlinkProfile()
                     }
                 }
             } else {
-                showCoinbaseError(title: error.title, subtitle: error.subtitle)
+                presentDestructiveDialog(title: error.title, subtitle: error.subtitle)
             }
         }
 
@@ -996,22 +986,6 @@ final class OnrampCoordinator {
 }
 
 // MARK: - Supporting types -
-
-struct VerificationSheetContext: Identifiable, Hashable {
-    enum Entry { case info, phone, email }
-
-    let id: UUID = UUID()
-    let entry: Entry
-    let reason: OnrampOperation.LogKindWrapper  // placeholder hashable wrapper
-}
-
-extension OnrampOperation {
-    /// Hashable wrapper so `OnrampOperation` itself (which carries closures)
-    /// doesn't need Hashable conformance.
-    struct LogKindWrapper: Hashable {
-        let value: String
-    }
-}
 
 private enum Origin: Int {
     case root

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -29,6 +29,8 @@ final class OnrampCoordinator {
     @ObservationIgnored private let session: Session
     @ObservationIgnored private let flipClient: FlipClient
     @ObservationIgnored private let owner: KeyPair
+    @ObservationIgnored private let coinbaseApiKey: String?
+    @ObservationIgnored private var coinbase: Coinbase!
 
     // MARK: - Init -
 
@@ -36,6 +38,24 @@ final class OnrampCoordinator {
         self.session = session
         self.flipClient = flipClient
         self.owner = session.ownerKeyPair
+        self.coinbaseApiKey = try? InfoPlist.value(for: "coinbase").value(for: "apiKey").string()
+
+        self.coinbase = Coinbase(configuration: .init(bearerTokenProvider: fetchCoinbaseJWT))
+    }
+
+    // MARK: - Coinbase JWT -
+
+    private func fetchCoinbaseJWT(method: String, path: String) async throws -> String {
+        guard let coinbaseApiKey else {
+            throw OnrampError.missingCoinbaseApiKey
+        }
+
+        return try await flipClient.fetchCoinbaseOnrampJWT(
+            apiKey: coinbaseApiKey,
+            owner: owner,
+            method: method,
+            path: path
+        )
     }
 
     // MARK: - Public API (fleshed out in later tasks) -

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -274,6 +274,7 @@ final class OnrampCoordinator {
         displayName: String,
         onCompleted: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
     ) {
+        guard !isProcessingPayment else { return }
         let operation = OnrampOperation.buy(mint: mint, displayName: displayName, onCompleted: onCompleted)
         pendingOperation = operation
         pendingAmount = amount
@@ -285,6 +286,7 @@ final class OnrampCoordinator {
         displayName: String,
         onCompleted: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
     ) {
+        guard !isProcessingPayment else { return }
         let operation = OnrampOperation.launch(displayName: displayName, onCompleted: onCompleted)
         pendingOperation = operation
         pendingAmount = amount
@@ -874,6 +876,17 @@ final class OnrampCoordinator {
     }
 
     private func handleCoinbaseFundingSuccess() async {
+        // Always release the transient onramp state when this method exits,
+        // regardless of success / error / sandbox short-circuit. Without this
+        // the user is stranded with `isProcessingPayment == true` and no way
+        // to retry.
+        defer {
+            pendingOperation = nil
+            pendingAmount = nil
+            coinbaseOrder = nil
+            fundingTask = nil
+        }
+
         guard let operation = pendingOperation else {
             logger.error("pollingSuccess fired with no pending operation")
             return
@@ -973,10 +986,6 @@ final class OnrampCoordinator {
                 successful: true,
                 error: nil
             )
-
-            pendingOperation = nil
-            pendingAmount = nil
-            coinbaseOrder = nil
         } catch {
             logger.error("Buy failed", metadata: ["error": "\(error)"])
             ErrorReporting.captureError(error)

--- a/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
@@ -7,25 +7,28 @@ import SwiftUI
 import FlipcashCore
 
 /// Root-level host for the invisible Coinbase Apple Pay WebView and the
-/// Onramp verification sheet. Attach once on the logged-in branch so any
-/// screen can drive a Coinbase onramp without owning the Apple Pay plumbing
-/// or the verification flow.
+/// email-verification deeplink subscription. Attach once on the logged-in
+/// branch so the Apple Pay plumbing is reachable from any screen without
+/// each screen having to own it.
+///
+/// The verification sheet is NOT hosted here — SwiftUI only allows one modal
+/// sheet per presentation context, and when the user is several sheets deep
+/// (Wallet → Discovery → Wizard → FundingSelection) the root-level sheet slot
+/// is already taken. Screens that initiate an onramp (`OnrampAmountScreen`,
+/// `CurrencyCreationWizardScreen`) host the verification sheet themselves so
+/// it presents on top of whatever sheet stack the user is already in.
 struct OnrampHostModifier: ViewModifier {
 
     @Environment(OnrampCoordinator.self) private var onrampCoordinator
     @Environment(OnrampDeeplinkInbox.self) private var deeplinkInbox
 
     func body(content: Content) -> some View {
-        @Bindable var onrampCoordinator = onrampCoordinator
         @Bindable var deeplinkInbox = deeplinkInbox
         return content
             .overlay {
                 ApplePayOverlay(order: onrampCoordinator.coinbaseOrder) { event in
                     onrampCoordinator.receiveApplePayEvent(event)
                 }
-            }
-            .sheet(isPresented: $onrampCoordinator.isShowingVerificationFlow) {
-                VerifyInfoScreen(onrampCoordinator: onrampCoordinator)
             }
             .onChange(of: deeplinkInbox.pendingEmailVerification, initial: true) { _, verification in
                 if let verification {

--- a/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
@@ -23,8 +23,7 @@ struct OnrampHostModifier: ViewModifier {
     @Environment(OnrampDeeplinkInbox.self) private var deeplinkInbox
 
     func body(content: Content) -> some View {
-        @Bindable var deeplinkInbox = deeplinkInbox
-        return content
+        content
             .overlay {
                 ApplePayOverlay(order: onrampCoordinator.coinbaseOrder) { event in
                     onrampCoordinator.receiveApplePayEvent(event)

--- a/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
@@ -6,19 +6,24 @@
 import SwiftUI
 import FlipcashCore
 
-/// Root-level host for the invisible Coinbase Apple Pay WebView. Attach once
-/// on the logged-in branch so any screen can drive a Coinbase onramp without
-/// owning the Apple Pay plumbing.
+/// Root-level host for the invisible Coinbase Apple Pay WebView and the
+/// Onramp verification sheet. Attach once on the logged-in branch so any
+/// screen can drive a Coinbase onramp without owning the Apple Pay plumbing
+/// or the verification flow.
 struct OnrampHostModifier: ViewModifier {
 
     @Environment(OnrampCoordinator.self) private var coordinator
 
     func body(content: Content) -> some View {
-        content
+        @Bindable var coordinator = coordinator
+        return content
             .overlay {
                 ApplePayOverlay(order: coordinator.coinbaseOrder) { event in
                     coordinator.receiveApplePayEvent(event)
                 }
+            }
+            .sheet(isPresented: $coordinator.isShowingVerificationFlow) {
+                VerifyInfoScreen(coordinator: coordinator)
             }
     }
 }

--- a/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
@@ -12,24 +12,24 @@ import FlipcashCore
 /// or the verification flow.
 struct OnrampHostModifier: ViewModifier {
 
-    @Environment(OnrampCoordinator.self) private var coordinator
+    @Environment(OnrampCoordinator.self) private var onrampCoordinator
     @Environment(OnrampDeeplinkInbox.self) private var deeplinkInbox
 
     func body(content: Content) -> some View {
-        @Bindable var coordinator = coordinator
+        @Bindable var onrampCoordinator = onrampCoordinator
         @Bindable var deeplinkInbox = deeplinkInbox
         return content
             .overlay {
-                ApplePayOverlay(order: coordinator.coinbaseOrder) { event in
-                    coordinator.receiveApplePayEvent(event)
+                ApplePayOverlay(order: onrampCoordinator.coinbaseOrder) { event in
+                    onrampCoordinator.receiveApplePayEvent(event)
                 }
             }
-            .sheet(isPresented: $coordinator.isShowingVerificationFlow) {
-                VerifyInfoScreen(coordinator: coordinator)
+            .sheet(isPresented: $onrampCoordinator.isShowingVerificationFlow) {
+                VerifyInfoScreen(onrampCoordinator: onrampCoordinator)
             }
             .onChange(of: deeplinkInbox.pendingEmailVerification, initial: true) { _, verification in
                 if let verification {
-                    coordinator.applyDeeplinkVerification(verification)
+                    onrampCoordinator.applyDeeplinkVerification(verification)
                     deeplinkInbox.pendingEmailVerification = nil
                 }
             }

--- a/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
@@ -4,7 +4,6 @@
 //
 
 import SwiftUI
-import FlipcashUI
 import FlipcashCore
 
 /// Root-level host for the invisible Coinbase Apple Pay WebView. Attach once

--- a/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
@@ -13,9 +13,11 @@ import FlipcashCore
 struct OnrampHostModifier: ViewModifier {
 
     @Environment(OnrampCoordinator.self) private var coordinator
+    @Environment(OnrampDeeplinkInbox.self) private var deeplinkInbox
 
     func body(content: Content) -> some View {
         @Bindable var coordinator = coordinator
+        @Bindable var deeplinkInbox = deeplinkInbox
         return content
             .overlay {
                 ApplePayOverlay(order: coordinator.coinbaseOrder) { event in
@@ -24,6 +26,12 @@ struct OnrampHostModifier: ViewModifier {
             }
             .sheet(isPresented: $coordinator.isShowingVerificationFlow) {
                 VerifyInfoScreen(coordinator: coordinator)
+            }
+            .onChange(of: deeplinkInbox.pendingEmailVerification, initial: true) { _, verification in
+                if let verification {
+                    coordinator.applyDeeplinkVerification(verification)
+                    deeplinkInbox.pendingEmailVerification = nil
+                }
             }
     }
 }

--- a/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampHostModifier.swift
@@ -1,0 +1,25 @@
+//
+//  OnrampHostModifier.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+import FlipcashCore
+
+/// Root-level host for the invisible Coinbase Apple Pay WebView. Attach once
+/// on the logged-in branch so any screen can drive a Coinbase onramp without
+/// owning the Apple Pay plumbing.
+struct OnrampHostModifier: ViewModifier {
+
+    @Environment(OnrampCoordinator.self) private var coordinator
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                ApplePayOverlay(order: coordinator.coinbaseOrder) { event in
+                    coordinator.receiveApplePayEvent(event)
+                }
+            }
+    }
+}

--- a/Flipcash/Core/Controllers/Onramp/OnrampOperation.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampOperation.swift
@@ -1,0 +1,33 @@
+//
+//  OnrampOperation.swift
+//  Flipcash
+//
+
+import Foundation
+import FlipcashCore
+
+enum OnrampOperation {
+    case buy(
+        mint: PublicKey,
+        displayName: String,
+        onCompleted: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
+    )
+    case launch(
+        displayName: String,
+        onCompleted: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
+    )
+
+    var displayName: String {
+        switch self {
+        case .buy(_, let displayName, _): displayName
+        case .launch(let displayName, _): displayName
+        }
+    }
+
+    var logKind: String {
+        switch self {
+        case .buy:    "buy_existing"
+        case .launch: "launch_new"
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -22,7 +22,7 @@ struct CurrencyCreationWizardScreen: View {
     @Environment(Session.self) private var session
     @Environment(RatesController.self) private var ratesController
     @Environment(WalletConnection.self) private var walletConnection
-    @Environment(OnrampCoordinator.self) private var coordinator
+    @Environment(OnrampCoordinator.self) private var onrampCoordinator
 
     @State private var step: WizardStep = .name
     @State private var direction: Direction = .forward
@@ -169,7 +169,7 @@ struct CurrencyCreationWizardScreen: View {
         }
         .dialog(item: $errorDialog)
         .dialog(item: Bindable(walletConnection).dialogItem)
-        .dialog(item: Bindable(coordinator).dialogItem)
+        .dialog(item: Bindable(onrampCoordinator).dialogItem)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled()
@@ -217,7 +217,7 @@ struct CurrencyCreationWizardScreen: View {
                 onSelectCoinbase: {
                     isShowingFundingSheet = false
                     isValidating = true
-                    coordinator.startLaunch(
+                    onrampCoordinator.startLaunch(
                         amount: launchAmount,
                         displayName: state.currencyName,
                         onCompleted: { signature, amount in
@@ -247,11 +247,11 @@ struct CurrencyCreationWizardScreen: View {
                 })
             }
         }
-        // Coinbase launch flow: coordinator publishes `.launchProcessing`
+        // Coinbase launch flow: the onrampCoordinator publishes `.launchProcessing`
         // once the post-onramp swap has been submitted. The cover presents
         // `CurrencyLaunchProcessingScreen` and its Done button tears down
         // the wizard so the user lands back in the discovery stack.
-        .fullScreenCover(item: coordinator.launchCompletionBinding) { completion in
+        .fullScreenCover(item: onrampCoordinator.launchCompletionBinding) { completion in
             if case .launchProcessing(let swapId, let launchedMint, let name, let amount) = completion {
                 NavigationStack {
                     CurrencyLaunchProcessingScreen(
@@ -262,7 +262,7 @@ struct CurrencyCreationWizardScreen: View {
                         fundingMethod: .coinbase
                     )
                     .environment(\.dismissParentContainer, {
-                        coordinator.completion = nil
+                        onrampCoordinator.completion = nil
                         isValidating = false
                         dismiss()
                     })
@@ -292,13 +292,13 @@ struct CurrencyCreationWizardScreen: View {
         .onAppear {
             if step == .name { focusedField = .name }
         }
-        // On a coordinator error the Coinbase flow resets to idle without
+        // On an onrampCoordinator error the Coinbase flow resets to idle without
         // publishing a completion. Mirror that by clearing `isValidating`
         // so the confirmation screen becomes interactive again. The success
         // path runs through the `.launchProcessing` cover, whose
         // `dismissParentContainer` already resets `isValidating`.
-        .onChange(of: coordinator.isProcessingPayment) { _, isProcessing in
-            if !isProcessing && coordinator.completion == nil {
+        .onChange(of: onrampCoordinator.isProcessingPayment) { _, isProcessing in
+            if !isProcessing && onrampCoordinator.completion == nil {
                 isValidating = false
             }
         }

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -29,6 +29,7 @@ struct CurrencyCreationWizardScreen: View {
     @State private var compressTask: Task<Void, Never>?
     @State private var validationTask: Task<Void, Never>?
     @State private var isValidating: Bool = false
+    @State private var pendingCoinbaseLaunch: Bool = false
     @State private var errorDialog: DialogItem?
     @FocusState private var focusedField: Field?
 
@@ -206,7 +207,21 @@ struct CurrencyCreationWizardScreen: View {
         ) { result in
             handleFileImport(result)
         }
-        .sheet(isPresented: $isShowingFundingSheet) {
+        .sheet(isPresented: $isShowingFundingSheet, onDismiss: {
+            // SwiftUI allows only one modal sheet at a time. If the user picked
+            // Coinbase and they're unverified, the coordinator needs to present
+            // its own verification sheet — defer the kickoff until the funding
+            // sheet has fully dismissed so the two sheets don't collide.
+            guard pendingCoinbaseLaunch else { return }
+            pendingCoinbaseLaunch = false
+            onrampCoordinator.startLaunch(
+                amount: launchAmount,
+                displayName: state.currencyName,
+                onCompleted: { signature, amount in
+                    try await launchAfterOnramp(signature: signature, amount: amount)
+                }
+            )
+        }) {
             FundingSelectionSheet(
                 reserveBalance: reserveBalance,
                 isCoinbaseAvailable: session.hasCoinbaseOnramp,
@@ -215,15 +230,9 @@ struct CurrencyCreationWizardScreen: View {
                     launchAndBuyWithReserves()
                 },
                 onSelectCoinbase: {
-                    isShowingFundingSheet = false
+                    pendingCoinbaseLaunch = true
                     isValidating = true
-                    onrampCoordinator.startLaunch(
-                        amount: launchAmount,
-                        displayName: state.currencyName,
-                        onCompleted: { signature, amount in
-                            try await launchAfterOnramp(signature: signature, amount: amount)
-                        }
-                    )
+                    isShowingFundingSheet = false
                 },
                 onSelectPhantom: {
                     isShowingFundingSheet = false

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -218,12 +218,14 @@ struct CurrencyCreationWizardScreen: View {
             // sheet has fully dismissed so the two sheets don't collide.
             guard pendingCoinbaseLaunch else { return }
             pendingCoinbaseLaunch = false
-            onrampCoordinator.startLaunch(
-                amount: launchAmount,
-                displayName: state.currencyName,
-                onCompleted: { signature, amount in
-                    try await launchAfterOnramp(signature: signature, amount: amount)
-                }
+            onrampCoordinator.start(
+                .launch(
+                    displayName: state.currencyName,
+                    onCompleted: { signature, amount in
+                        try await launchAfterOnramp(signature: signature, amount: amount)
+                    }
+                ),
+                amount: launchAmount
             )
         }) {
             FundingSelectionSheet(
@@ -260,10 +262,6 @@ struct CurrencyCreationWizardScreen: View {
                 })
             }
         }
-        // Coinbase launch flow: the onrampCoordinator publishes `.launchProcessing`
-        // once the post-onramp swap has been submitted. The cover presents
-        // `CurrencyLaunchProcessingScreen` and its Done button tears down
-        // the wizard so the user lands back in the discovery stack.
         .fullScreenCover(item: onrampCoordinator.launchCompletionBinding) { completion in
             if case .launchProcessing(let swapId, let launchedMint, let name, let amount) = completion {
                 NavigationStack {
@@ -282,10 +280,8 @@ struct CurrencyCreationWizardScreen: View {
                 }
             }
         }
-        // Phantom launch flow: `WalletConnection.launchProcessing` is set
-        // inside `didSignTransaction` after the user returns from signing.
-        // The wizard only ever hosts launches here — buy-existing Phantom
-        // flows present their own cover from `CurrencyInfoScreen`.
+        // The wizard only hosts launch covers — buy-existing Phantom flows
+        // present their own cover from `CurrencyInfoScreen`.
         .fullScreenCover(item: Bindable(walletConnection).launchProcessing) { processing in
             NavigationStack {
                 CurrencyLaunchProcessingScreen(

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -171,6 +171,9 @@ struct CurrencyCreationWizardScreen: View {
         .dialog(item: $errorDialog)
         .dialog(item: Bindable(walletConnection).dialogItem)
         .dialog(item: Bindable(onrampCoordinator).dialogItem)
+        .sheet(isPresented: Bindable(onrampCoordinator).isShowingVerificationFlow) {
+            VerifyInfoScreen(onrampCoordinator: onrampCoordinator)
+        }
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled()

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -22,6 +22,7 @@ struct CurrencyCreationWizardScreen: View {
     @Environment(Session.self) private var session
     @Environment(RatesController.self) private var ratesController
     @Environment(WalletConnection.self) private var walletConnection
+    @Environment(OnrampCoordinator.self) private var coordinator
 
     @State private var step: WizardStep = .name
     @State private var direction: Direction = .forward
@@ -34,10 +35,6 @@ struct CurrencyCreationWizardScreen: View {
     @State private var isShowingPhotoPicker = false
     @State private var isShowingFilePicker = false
     @State private var isShowingFundingSheet = false
-    /// Non-nil while the Coinbase onramp sheet is presented for a launch flow.
-    /// Carries the user-chosen currency name (used as the sheet identity and
-    /// for SwapProcessing's display label).
-    @State private var launchOnrampName: LaunchSheetIdentity?
     /// Non-nil while the Reserves-funded launch is in flight. Drives a
     /// `fullScreenCover` that presents `CurrencyLaunchProcessingScreen`.
     @State private var reservesLaunchContext: ReservesLaunchContext?
@@ -49,11 +46,6 @@ struct CurrencyCreationWizardScreen: View {
     private struct CreatedMintRecord {
         let mint: PublicKey
         let name: String
-    }
-
-    private struct LaunchSheetIdentity: Identifiable, Hashable {
-        let displayName: String
-        var id: String { displayName }
     }
 
     private struct ReservesLaunchContext: Identifiable, Hashable {
@@ -177,6 +169,7 @@ struct CurrencyCreationWizardScreen: View {
         }
         .dialog(item: $errorDialog)
         .dialog(item: Bindable(walletConnection).dialogItem)
+        .dialog(item: Bindable(coordinator).dialogItem)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled()
@@ -224,7 +217,13 @@ struct CurrencyCreationWizardScreen: View {
                 onSelectCoinbase: {
                     isShowingFundingSheet = false
                     isValidating = true
-                    launchOnrampName = LaunchSheetIdentity(displayName: state.currencyName)
+                    coordinator.startLaunch(
+                        amount: launchAmount,
+                        displayName: state.currencyName,
+                        onCompleted: { signature, amount in
+                            try await launchAfterOnramp(signature: signature, amount: amount)
+                        }
+                    )
                 },
                 onSelectPhantom: {
                     isShowingFundingSheet = false
@@ -248,27 +247,27 @@ struct CurrencyCreationWizardScreen: View {
                 })
             }
         }
-        .sheet(item: $launchOnrampName) { identity in
-            OnrampAmountScreen.forLaunching(
-                displayName: identity.displayName,
-                session: sessionContainer.session,
-                flipClient: sessionContainer.flipClient,
-                deeplinkInbox: sessionContainer.onrampDeeplinkInbox,
-                onDismiss: {
-                    launchOnrampName = nil
-                    isValidating = false
-                },
-                onUsdfReady: { signature, amount in
-                    try await launchAfterOnramp(signature: signature, amount: amount)
+        // Coinbase launch flow: coordinator publishes `.launchProcessing`
+        // once the post-onramp swap has been submitted. The cover presents
+        // `CurrencyLaunchProcessingScreen` and its Done button tears down
+        // the wizard so the user lands back in the discovery stack.
+        .fullScreenCover(item: Bindable(coordinator).completion) { completion in
+            if case .launchProcessing(let swapId, let launchedMint, let name, let amount) = completion {
+                NavigationStack {
+                    CurrencyLaunchProcessingScreen(
+                        swapId: swapId,
+                        launchedMint: launchedMint,
+                        currencyName: name,
+                        launchAmount: amount,
+                        fundingMethod: .coinbase
+                    )
+                    .environment(\.dismissParentContainer, {
+                        coordinator.completion = nil
+                        isValidating = false
+                        dismiss()
+                    })
                 }
-            )
-            // Done button on SwapProcessingScreen tears down both the onramp
-            // sheet and the wizard so the user lands back in the discovery stack.
-            .environment(\.dismissParentContainer, {
-                launchOnrampName = nil
-                isValidating = false
-                dismiss()
-            })
+            }
         }
         // Phantom launch flow: `WalletConnection.launchProcessing` is set
         // inside `didSignTransaction` after the user returns from signing.
@@ -292,6 +291,16 @@ struct CurrencyCreationWizardScreen: View {
         }
         .onAppear {
             if step == .name { focusedField = .name }
+        }
+        // On a coordinator error the Coinbase flow resets to idle without
+        // publishing a completion. Mirror that by clearing `isValidating`
+        // so the confirmation screen becomes interactive again. The success
+        // path runs through the `.launchProcessing` cover, whose
+        // `dismissParentContainer` already resets `isValidating`.
+        .onChange(of: coordinator.isProcessingPayment) { _, isProcessing in
+            if !isProcessing && coordinator.completion == nil {
+                isValidating = false
+            }
         }
         .onChange(of: step) { _, newStep in
             switch newStep {

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -251,7 +251,7 @@ struct CurrencyCreationWizardScreen: View {
         // once the post-onramp swap has been submitted. The cover presents
         // `CurrencyLaunchProcessingScreen` and its Done button tears down
         // the wizard so the user lands back in the discovery stack.
-        .fullScreenCover(item: Bindable(coordinator).completion) { completion in
+        .fullScreenCover(item: coordinator.launchCompletionBinding) { completion in
             if case .launchProcessing(let swapId, let launchedMint, let name, let amount) = completion {
                 NavigationStack {
                     CurrencyLaunchProcessingScreen(

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -162,6 +162,7 @@ struct CurrencyCreationWizardScreen: View {
                         state: state,
                         previewFiat: previewFiat,
                         launchAmount: launchAmount,
+                        isValidating: isValidating,
                         onBuy: { isShowingFundingSheet = true }
                     )
                     .transition(direction.slide)
@@ -969,6 +970,7 @@ private struct ConfirmationStep: View {
     let state: CurrencyCreationState
     let previewFiat: Quarks
     let launchAmount: ExchangedFiat
+    let isValidating: Bool
     let onBuy: () -> Void
 
     var body: some View {
@@ -996,10 +998,17 @@ private struct ConfirmationStep: View {
             .padding(.top, 32)
             .padding(.horizontal, 20)
 
-            Button("Buy \(launchAmount.converted.formatted()) to Create Your Currency", action: onBuy)
-                .buttonStyle(.filled)
-                .padding(.top, 20)
-                .padding(.bottom, 20)
+            Button(action: onBuy) {
+                if isValidating {
+                    ProgressView().progressViewStyle(.circular)
+                } else {
+                    Text("Buy \(launchAmount.converted.formatted()) to Create Your Currency")
+                }
+            }
+            .buttonStyle(.filled)
+            .disabled(isValidating)
+            .padding(.top, 20)
+            .padding(.bottom, 20)
         }
         .padding(.horizontal, 20)
     }

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -201,7 +201,7 @@ struct CurrencyInfoScreen: View {
                 })
             }
         }
-        .fullScreenCover(item: Bindable(coordinator).completion) { completion in
+        .fullScreenCover(item: coordinator.buyCompletionBinding) { completion in
             if case .buyProcessing(let swapId, let name, let amount) = completion {
                 NavigationStack {
                     SwapProcessingScreen(

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -289,9 +289,7 @@ struct CurrencyInfoScreen: View {
                 mint: target.mint,
                 displayName: target.displayName,
                 session: sessionContainer.session,
-                flipClient: sessionContainer.flipClient,
                 coordinator: coordinator,
-                deeplinkInbox: sessionContainer.onrampDeeplinkInbox,
                 onUsdfReady: { signature, amount in
                     let swapId = try await sessionContainer.session.buyWithExternalFunding(
                         amount: amount,

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -201,6 +201,21 @@ struct CurrencyInfoScreen: View {
                 })
             }
         }
+        .fullScreenCover(item: Bindable(coordinator).completion) { completion in
+            if case .buyProcessing(let swapId, let name, let amount) = completion {
+                NavigationStack {
+                    SwapProcessingScreen(
+                        swapId: swapId,
+                        swapType: .buyWithCoinbase,
+                        currencyName: name,
+                        amount: amount
+                    )
+                    .environment(\.dismissParentContainer, {
+                        coordinator.completion = nil
+                    })
+                }
+            }
+        }
         .navigationDestination(isPresented: $isShowingGive) {
             GiveScreen(viewModel: giveViewModel)
         }

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -47,6 +47,7 @@ struct CurrencyInfoScreen: View {
     }
 
     @Environment(WalletConnection.self) private var walletConnection
+    @Environment(OnrampCoordinator.self) private var coordinator
 
     private let mint: PublicKey
     private let container: Container
@@ -274,7 +275,16 @@ struct CurrencyInfoScreen: View {
                 displayName: target.displayName,
                 session: sessionContainer.session,
                 flipClient: sessionContainer.flipClient,
+                coordinator: coordinator,
                 deeplinkInbox: sessionContainer.onrampDeeplinkInbox,
+                onUsdfReady: { signature, amount in
+                    let swapId = try await sessionContainer.session.buyWithExternalFunding(
+                        amount: amount,
+                        of: target.mint,
+                        transactionSignature: signature
+                    )
+                    return .buyExisting(swapId: swapId)
+                },
                 onDismiss: { onrampDestination = nil }
             )
         }

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -28,6 +28,7 @@ struct CurrencyInfoScreen: View {
     /// Non-nil while the Onramp sheet is presented. Setting it presents the
     /// sheet with a fresh `OnrampViewModel`; nil'ing it dismisses.
     @State private var onrampDestination: BuyTarget?
+    @State private var pendingOnrampTarget: BuyTarget?
 
     /// Identifying data for the Coinbase onramp sheet trigger.
     private struct BuyTarget: Identifiable, Hashable {
@@ -250,7 +251,15 @@ struct CurrencyInfoScreen: View {
                 ratesController: ratesController
             )
         }
-        .sheet(isPresented: $isShowingFundingSelection) {
+        .sheet(isPresented: $isShowingFundingSelection, onDismiss: {
+            // SwiftUI allows only one modal sheet at a time, so we can't set
+            // `onrampDestination` in the same frame as dismissing the funding
+            // sheet — the second sheet gets swallowed. Defer the handoff until
+            // the funding sheet has fully dismissed.
+            guard let target = pendingOnrampTarget else { return }
+            pendingOnrampTarget = nil
+            onrampDestination = target
+        }) {
             if let metadata = viewModel.mintMetadata {
                 FundingSelectionSheet(
                     reserveBalance: viewModel.reserveBalance,
@@ -267,7 +276,7 @@ struct CurrencyInfoScreen: View {
                     },
                     onSelectCoinbase: {
                         Analytics.buttonTapped(name: .buyWithCoinbase)
-                        onrampDestination = BuyTarget(
+                        pendingOnrampTarget = BuyTarget(
                             mint: metadata.mint,
                             displayName: metadata.name
                         )

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -47,7 +47,7 @@ struct CurrencyInfoScreen: View {
     }
 
     @Environment(WalletConnection.self) private var walletConnection
-    @Environment(OnrampCoordinator.self) private var coordinator
+    @Environment(OnrampCoordinator.self) private var onrampCoordinator
 
     private let mint: PublicKey
     private let container: Container
@@ -201,7 +201,7 @@ struct CurrencyInfoScreen: View {
                 })
             }
         }
-        .fullScreenCover(item: coordinator.buyCompletionBinding) { completion in
+        .fullScreenCover(item: onrampCoordinator.buyCompletionBinding) { completion in
             if case .buyProcessing(let swapId, let name, let amount) = completion {
                 NavigationStack {
                     SwapProcessingScreen(
@@ -211,7 +211,7 @@ struct CurrencyInfoScreen: View {
                         amount: amount
                     )
                     .environment(\.dismissParentContainer, {
-                        coordinator.completion = nil
+                        onrampCoordinator.completion = nil
                     })
                 }
             }
@@ -289,7 +289,7 @@ struct CurrencyInfoScreen: View {
                 mint: target.mint,
                 displayName: target.displayName,
                 session: sessionContainer.session,
-                coordinator: coordinator,
+                onrampCoordinator: onrampCoordinator,
                 onUsdfReady: { signature, amount in
                     let swapId = try await sessionContainer.session.buyWithExternalFunding(
                         amount: amount,

--- a/Flipcash/Core/Screens/Onramp/ConfirmEmailScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/ConfirmEmailScreen.swift
@@ -13,12 +13,12 @@ struct ConfirmEmailScreen: View {
 
     @State private var countdownEnd: Date?
 
-    @Bindable private var coordinator: OnrampCoordinator
+    @Bindable private var onrampCoordinator: OnrampCoordinator
 
     // MARK: - Init -
 
-    init(coordinator: OnrampCoordinator) {
-        self.coordinator = coordinator
+    init(onrampCoordinator: OnrampCoordinator) {
+        self.onrampCoordinator = onrampCoordinator
     }
 
     // MARK: - Body -
@@ -48,7 +48,7 @@ struct ConfirmEmailScreen: View {
                     VStack {
                         Text("Tap the link we sent to")
                             .foregroundStyle(Color.textSecondary)
-                        Text(coordinator.enteredEmail)
+                        Text(onrampCoordinator.enteredEmail)
                             .foregroundStyle(Color.textMain)
                     }
                     .font(.appTextSmall)
@@ -69,11 +69,11 @@ struct ConfirmEmailScreen: View {
                             Button {
                                 Task {
                                     do {
-                                        try await coordinator.resendEmailCodeAction()
+                                        try await onrampCoordinator.resendEmailCodeAction()
                                     }
                                 }
                             } label: {
-                                Loadable(isLoading: coordinator.isResending, color: .textSecondary) {
+                                Loadable(isLoading: onrampCoordinator.isResending, color: .textSecondary) {
                                     VStack(spacing: 0) {
                                         Text("Didn't get an email? Resend")
                                         Text(" ") // Offset to match the two line layout above
@@ -92,7 +92,7 @@ struct ConfirmEmailScreen: View {
                 Spacer()
 
                 CodeButton(
-                    state: coordinator.confirmEmailButtonState,
+                    state: onrampCoordinator.confirmEmailButtonState,
                     style: .filled,
                     title: "Open Mail",
                     disabled: false
@@ -103,7 +103,7 @@ struct ConfirmEmailScreen: View {
             .padding(20)
             .foregroundColor(.textMain)
         }
-        .dialog(item: $coordinator.dialogItem)
+        .dialog(item: $onrampCoordinator.dialogItem)
         .navigationTitle("Verify Email")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
@@ -121,7 +121,7 @@ struct ConfirmEmailScreen: View {
                 self.countdownEnd = nil
             }
         }
-        .onChange(of: coordinator.isResending) { _, isResending in
+        .onChange(of: onrampCoordinator.isResending) { _, isResending in
             if !isResending {
                 countdownEnd = Date.now.addingTimeInterval(60)
             }

--- a/Flipcash/Core/Screens/Onramp/ConfirmEmailScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/ConfirmEmailScreen.swift
@@ -12,50 +12,50 @@ import FlipcashCore
 struct ConfirmEmailScreen: View {
 
     @State private var countdownEnd: Date?
-    
-    @Bindable private var viewModel: OnrampViewModel
-    
+
+    @Bindable private var coordinator: OnrampCoordinator
+
     // MARK: - Init -
-    
-    init(viewModel: OnrampViewModel) {
-        self.viewModel = viewModel
+
+    init(coordinator: OnrampCoordinator) {
+        self.coordinator = coordinator
     }
-    
+
     // MARK: - Body -
-    
+
     var body: some View {
         Background(color: .backgroundMain) {
             VStack(spacing: 5) {
-                
+
                 Spacer()
-                
+
                 // Placeholder to offset the bottom part
                 VStack(spacing: 0) {
                     Text(" ")
                     Text(" ")
                 }
                 .font(.appTextSmall)
-                
+
                 Spacer()
-                
+
                 VStack(spacing: 30) {
                     Image.asset(.emailSent)
-                    
+
                     Text("Check your inbox")
                         .font(.appDisplaySmall)
                         .foregroundStyle(Color.textMain)
-                    
+
                     VStack {
                         Text("Tap the link we sent to")
                             .foregroundStyle(Color.textSecondary)
-                        Text(viewModel.enteredEmail)
+                        Text(coordinator.enteredEmail)
                             .foregroundStyle(Color.textMain)
                     }
                     .font(.appTextSmall)
                 }
-                
+
                 Spacer()
-                
+
                 Group {
                     if let countdownEnd, countdownEnd > .now {
                         VStack(spacing: 0) {
@@ -69,11 +69,11 @@ struct ConfirmEmailScreen: View {
                             Button {
                                 Task {
                                     do {
-                                        try await viewModel.resendEmailCodeAction()
+                                        try await coordinator.resendEmailCodeAction()
                                     }
                                 }
                             } label: {
-                                Loadable(isLoading: viewModel.isResending, color: .textSecondary) {
+                                Loadable(isLoading: coordinator.isResending, color: .textSecondary) {
                                     VStack(spacing: 0) {
                                         Text("Didn't get an email? Resend")
                                         Text(" ") // Offset to match the two line layout above
@@ -90,9 +90,9 @@ struct ConfirmEmailScreen: View {
                 .padding(20)
 
                 Spacer()
-                
+
                 CodeButton(
-                    state: viewModel.confirmEmailButtonState,
+                    state: coordinator.confirmEmailButtonState,
                     style: .filled,
                     title: "Open Mail",
                     disabled: false
@@ -103,7 +103,7 @@ struct ConfirmEmailScreen: View {
             .padding(20)
             .foregroundColor(.textMain)
         }
-        .dialog(item: $viewModel.dialogItem)
+        .dialog(item: $coordinator.dialogItem)
         .navigationTitle("Verify Email")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
@@ -121,7 +121,7 @@ struct ConfirmEmailScreen: View {
                 self.countdownEnd = nil
             }
         }
-        .onChange(of: viewModel.isResending) { _, isResending in
+        .onChange(of: coordinator.isResending) { _, isResending in
             if !isResending {
                 countdownEnd = Date.now.addingTimeInterval(60)
             }

--- a/Flipcash/Core/Screens/Onramp/ConfirmPhoneScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/ConfirmPhoneScreen.swift
@@ -10,20 +10,20 @@ import FlipcashUI
 import FlipcashCore
 
 struct ConfirmPhoneScreen: View {
-    
+
     @Environment(NotificationController.self) private var notificationController
     @State private var countdownEnd: Date?
-    @Bindable private var viewModel: OnrampViewModel
+    @Bindable private var coordinator: OnrampCoordinator
     @FocusState private var isFocused: Bool
-    
+
     // MARK: - Init -
-    
-    init(viewModel: OnrampViewModel) {
-        self.viewModel = viewModel
+
+    init(coordinator: OnrampCoordinator) {
+        self.coordinator = coordinator
     }
-    
+
     // MARK: - Body -
-    
+
     var body: some View {
         Background(color: .backgroundMain) {
             VStack(spacing: 5) {
@@ -32,8 +32,8 @@ struct ConfirmPhoneScreen: View {
                     isFocused = true
                 } label: {
                     ZStack {
-                        TwoFactorCodeView(digitCount: viewModel.codeLength, content: $viewModel.enteredCode)
-                        TextField("", text: viewModel.adjustingCodeBinding)
+                        TwoFactorCodeView(digitCount: coordinator.codeLength, content: $coordinator.enteredCode)
+                        TextField("", text: coordinator.adjustingCodeBinding)
                             .foregroundColor(.backgroundMain)
                             .keyboardType(.numberPad)
                             .textContentType(.oneTimeCode)
@@ -41,15 +41,15 @@ struct ConfirmPhoneScreen: View {
                             .focused($isFocused)
                     }
                 }
-                
+
                 let text = "An SMS message was sent to your phone number with a verification code. Please enter the verification code above."
-                
+
                 Group {
                     if let countdownEnd, countdownEnd > .now {
                         VStack(spacing: 15) {
                             Text(text)
                             VStack(spacing: 0) {
-                                Text("Didn't get an SMS at \(viewModel.phone?.national ?? "")?")
+                                Text("Didn't get an SMS at \(coordinator.phone?.national ?? "")?")
                                 (Text("Request a new one in ") + Text(timerInterval: .now...countdownEnd, countsDown: true))
                                     .contentTransition(.numericText())
                             }
@@ -61,12 +61,12 @@ struct ConfirmPhoneScreen: View {
                             Button {
                                 Task {
                                     do {
-                                        try await viewModel.resendCodeAction()
+                                        try await coordinator.resendCodeAction()
                                         countdownEnd = Date.now.addingTimeInterval(60)
                                     }
                                 }
                             } label: {
-                                Loadable(isLoading: viewModel.isResending, color: .textSecondary) {
+                                Loadable(isLoading: coordinator.isResending, color: .textSecondary) {
                                     VStack(spacing: 0) {
                                         Text("Didn't get an SMS? Resend")
                                         Text(" ") // Offset to match the two line layout above
@@ -84,18 +84,18 @@ struct ConfirmPhoneScreen: View {
 
                 Spacer()
                 CodeButton(
-                    state: viewModel.confirmCodeButtonState,
+                    state: coordinator.confirmCodeButtonState,
                     style: .filled,
                     title: "Confirm",
-                    disabled: !viewModel.isCodeComplete
+                    disabled: !coordinator.isCodeComplete
                 ) {
-                    viewModel.confirmPhoneNumberCodeAction()
+                    coordinator.confirmPhoneNumberCodeAction()
                 }
             }
             .padding(20)
             .foregroundColor(.textMain)
         }
-        .dialog(item: $viewModel.dialogItem)
+        .dialog(item: $coordinator.dialogItem)
         .navigationTitle("Verify Phone Number")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
@@ -114,13 +114,13 @@ struct ConfirmPhoneScreen: View {
                 self.countdownEnd = nil
             }
         }
-        .onChange(of: viewModel.enteredCode) { _, _ in
-            if viewModel.isCodeComplete {
-                viewModel.confirmPhoneNumberCodeAction()
+        .onChange(of: coordinator.enteredCode) { _, _ in
+            if coordinator.isCodeComplete {
+                coordinator.confirmPhoneNumberCodeAction()
             }
         }
         .onChange(of: notificationController.didBecomeActive) { _, _ in
-            viewModel.pasteCodeFromClipboardIfPossible()
+            coordinator.pasteCodeFromClipboardIfPossible()
         }
     }
 }

--- a/Flipcash/Core/Screens/Onramp/ConfirmPhoneScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/ConfirmPhoneScreen.swift
@@ -13,13 +13,13 @@ struct ConfirmPhoneScreen: View {
 
     @Environment(NotificationController.self) private var notificationController
     @State private var countdownEnd: Date?
-    @Bindable private var coordinator: OnrampCoordinator
+    @Bindable private var onrampCoordinator: OnrampCoordinator
     @FocusState private var isFocused: Bool
 
     // MARK: - Init -
 
-    init(coordinator: OnrampCoordinator) {
-        self.coordinator = coordinator
+    init(onrampCoordinator: OnrampCoordinator) {
+        self.onrampCoordinator = onrampCoordinator
     }
 
     // MARK: - Body -
@@ -32,8 +32,8 @@ struct ConfirmPhoneScreen: View {
                     isFocused = true
                 } label: {
                     ZStack {
-                        TwoFactorCodeView(digitCount: coordinator.codeLength, content: $coordinator.enteredCode)
-                        TextField("", text: coordinator.adjustingCodeBinding)
+                        TwoFactorCodeView(digitCount: onrampCoordinator.codeLength, content: $onrampCoordinator.enteredCode)
+                        TextField("", text: onrampCoordinator.adjustingCodeBinding)
                             .foregroundColor(.backgroundMain)
                             .keyboardType(.numberPad)
                             .textContentType(.oneTimeCode)
@@ -49,7 +49,7 @@ struct ConfirmPhoneScreen: View {
                         VStack(spacing: 15) {
                             Text(text)
                             VStack(spacing: 0) {
-                                Text("Didn't get an SMS at \(coordinator.phone?.national ?? "")?")
+                                Text("Didn't get an SMS at \(onrampCoordinator.phone?.national ?? "")?")
                                 (Text("Request a new one in ") + Text(timerInterval: .now...countdownEnd, countsDown: true))
                                     .contentTransition(.numericText())
                             }
@@ -61,12 +61,12 @@ struct ConfirmPhoneScreen: View {
                             Button {
                                 Task {
                                     do {
-                                        try await coordinator.resendCodeAction()
+                                        try await onrampCoordinator.resendCodeAction()
                                         countdownEnd = Date.now.addingTimeInterval(60)
                                     }
                                 }
                             } label: {
-                                Loadable(isLoading: coordinator.isResending, color: .textSecondary) {
+                                Loadable(isLoading: onrampCoordinator.isResending, color: .textSecondary) {
                                     VStack(spacing: 0) {
                                         Text("Didn't get an SMS? Resend")
                                         Text(" ") // Offset to match the two line layout above
@@ -84,18 +84,18 @@ struct ConfirmPhoneScreen: View {
 
                 Spacer()
                 CodeButton(
-                    state: coordinator.confirmCodeButtonState,
+                    state: onrampCoordinator.confirmCodeButtonState,
                     style: .filled,
                     title: "Confirm",
-                    disabled: !coordinator.isCodeComplete
+                    disabled: !onrampCoordinator.isCodeComplete
                 ) {
-                    coordinator.confirmPhoneNumberCodeAction()
+                    onrampCoordinator.confirmPhoneNumberCodeAction()
                 }
             }
             .padding(20)
             .foregroundColor(.textMain)
         }
-        .dialog(item: $coordinator.dialogItem)
+        .dialog(item: $onrampCoordinator.dialogItem)
         .navigationTitle("Verify Phone Number")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
@@ -114,13 +114,13 @@ struct ConfirmPhoneScreen: View {
                 self.countdownEnd = nil
             }
         }
-        .onChange(of: coordinator.enteredCode) { _, _ in
-            if coordinator.isCodeComplete {
-                coordinator.confirmPhoneNumberCodeAction()
+        .onChange(of: onrampCoordinator.enteredCode) { _, _ in
+            if onrampCoordinator.isCodeComplete {
+                onrampCoordinator.confirmPhoneNumberCodeAction()
             }
         }
         .onChange(of: notificationController.didBecomeActive) { _, _ in
-            coordinator.pasteCodeFromClipboardIfPossible()
+            onrampCoordinator.pasteCodeFromClipboardIfPossible()
         }
     }
 }

--- a/Flipcash/Core/Screens/Onramp/EnterEmailScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/EnterEmailScreen.swift
@@ -32,7 +32,7 @@ struct EnterEmailScreen: View {
                         .font(.appTextXL)
                         .keyboardType(.emailAddress)
                         .textContentType(.emailAddress)
-                        .autocapitalization(.none)
+                        .textInputAutocapitalization(.never)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .multilineTextAlignment(.leading)
                         .padding([.leading, .trailing], 15)
@@ -63,7 +63,7 @@ struct EnterEmailScreen: View {
         .navigationTitle("Verify Email")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            isFocused.toggle()
+            isFocused = true
         }
     }
 }

--- a/Flipcash/Core/Screens/Onramp/EnterEmailScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/EnterEmailScreen.swift
@@ -11,14 +11,14 @@ import FlipcashCore
 
 struct EnterEmailScreen: View {
 
-    @Bindable private var coordinator: OnrampCoordinator
+    @Bindable private var onrampCoordinator: OnrampCoordinator
 
     @FocusState private var isFocused: Bool
 
     // MARK: - Init -
 
-    init(coordinator: OnrampCoordinator) {
-        self.coordinator = coordinator
+    init(onrampCoordinator: OnrampCoordinator) {
+        self.onrampCoordinator = onrampCoordinator
     }
 
     // MARK: - Body -
@@ -28,7 +28,7 @@ struct EnterEmailScreen: View {
             VStack(alignment: .center, spacing: 15) {
                 Spacer()
                 InputContainer(size: .regular) {
-                    TextField("Email", text: $coordinator.enteredEmail)
+                    TextField("Email", text: $onrampCoordinator.enteredEmail)
                         .font(.appTextXL)
                         .keyboardType(.emailAddress)
                         .textContentType(.emailAddress)
@@ -47,19 +47,19 @@ struct EnterEmailScreen: View {
                 Spacer()
 
                 CodeButton(
-                    state: coordinator.sendEmailCodeState,
+                    state: onrampCoordinator.sendEmailCodeState,
                     style: .filled,
                     title: "Next",
-                    disabled: !coordinator.canSendEmailVerification
+                    disabled: !onrampCoordinator.canSendEmailVerification
                 ) {
                     isFocused = false
-                    coordinator.sendEmailCodeAction()
+                    onrampCoordinator.sendEmailCodeAction()
                 }
             }
             .padding(20)
             .foregroundColor(.textMain)
         }
-        .dialog(item: $coordinator.dialogItem)
+        .dialog(item: $onrampCoordinator.dialogItem)
         .navigationTitle("Verify Email")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {

--- a/Flipcash/Core/Screens/Onramp/EnterEmailScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/EnterEmailScreen.swift
@@ -10,25 +10,25 @@ import FlipcashUI
 import FlipcashCore
 
 struct EnterEmailScreen: View {
-    
-    @Bindable private var viewModel: OnrampViewModel
-    
+
+    @Bindable private var coordinator: OnrampCoordinator
+
     @FocusState private var isFocused: Bool
-    
+
     // MARK: - Init -
-    
-    init(viewModel: OnrampViewModel) {
-        self.viewModel = viewModel
+
+    init(coordinator: OnrampCoordinator) {
+        self.coordinator = coordinator
     }
-    
+
     // MARK: - Body -
-    
+
     var body: some View {
         Background(color: .backgroundMain) {
             VStack(alignment: .center, spacing: 15) {
                 Spacer()
                 InputContainer(size: .regular) {
-                    TextField("Email", text: $viewModel.enteredEmail)
+                    TextField("Email", text: $coordinator.enteredEmail)
                         .font(.appTextXL)
                         .keyboardType(.emailAddress)
                         .textContentType(.emailAddress)
@@ -38,28 +38,28 @@ struct EnterEmailScreen: View {
                         .padding([.leading, .trailing], 15)
                         .focused($isFocused)
                 }
-                
+
                 Text("Please enter your email to continue")
                     .foregroundColor(.textSecondary)
                     .font(.appTextSmall)
                     .multilineTextAlignment(.center)
-                
+
                 Spacer()
-                
+
                 CodeButton(
-                    state: viewModel.sendEmailCodeState,
+                    state: coordinator.sendEmailCodeState,
                     style: .filled,
                     title: "Next",
-                    disabled: !viewModel.canSendEmailVerification
+                    disabled: !coordinator.canSendEmailVerification
                 ) {
                     isFocused = false
-                    viewModel.sendEmailCodeAction()
+                    coordinator.sendEmailCodeAction()
                 }
             }
             .padding(20)
             .foregroundColor(.textMain)
         }
-        .dialog(item: $viewModel.dialogItem)
+        .dialog(item: $coordinator.dialogItem)
         .navigationTitle("Verify Email")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {

--- a/Flipcash/Core/Screens/Onramp/EnterPhoneScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/EnterPhoneScreen.swift
@@ -10,21 +10,21 @@ import FlipcashUI
 import FlipcashCore
 
 struct EnterPhoneScreen: View {
-    
+
     @State private var isShowingRegionSelection = false
-    
-    @Bindable private var viewModel: OnrampViewModel
-    
+
+    @Bindable private var coordinator: OnrampCoordinator
+
     @FocusState private var isFocused: Bool
-    
+
     // MARK: - Init -
-    
-    init(viewModel: OnrampViewModel) {
-        self.viewModel = viewModel
+
+    init(coordinator: OnrampCoordinator) {
+        self.coordinator = coordinator
     }
-    
+
     // MARK: - Body -
-    
+
     var body: some View {
         Background(color: .backgroundMain) {
             VStack(alignment: .center, spacing: 15) {
@@ -35,8 +35,8 @@ struct EnterPhoneScreen: View {
                             isShowingRegionSelection = true
                         } label: {
                             HStack(spacing: 10) {
-                                Flag(style: viewModel.regionFlagStyle)
-                                Text(viewModel.countryCode)
+                                Flag(style: coordinator.regionFlagStyle)
+                                Text(coordinator.countryCode)
                                     .font(.appTextXL)
                             }
                             .padding([.leading, .trailing], 15)
@@ -52,8 +52,8 @@ struct EnterPhoneScreen: View {
                                 didSelectRegion: didSelectRegion
                             )
                         }
-                        
-                        TextField("Phone Number", text: viewModel.adjustingPhoneNumberBinding)
+
+                        TextField("Phone Number", text: coordinator.adjustingPhoneNumberBinding)
                             .font(.appTextXL)
                             .keyboardType(.phonePad)
                             .textContentType(.telephoneNumber)
@@ -63,39 +63,39 @@ struct EnterPhoneScreen: View {
                             .focused($isFocused)
                     }
                 }
-                
+
                 Text("Please enter your phone number to continue")
                     .foregroundColor(.textSecondary)
                     .font(.appTextSmall)
                     .multilineTextAlignment(.center)
-                
+
                 Spacer()
-                
+
                 CodeButton(
-                    state: viewModel.sendCodeButtonState,
+                    state: coordinator.sendCodeButtonState,
                     style: .filled,
                     title: "Next",
-                    disabled: !viewModel.canSendVerificationCode
+                    disabled: !coordinator.canSendVerificationCode
                 ) {
                     isFocused = false
-                    viewModel.sendPhoneNumberCodeAction()
+                    coordinator.sendPhoneNumberCodeAction()
                 }
             }
             .padding(20)
             .foregroundColor(.textMain)
         }
-        .dialog(item: $viewModel.dialogItem)
+        .dialog(item: $coordinator.dialogItem)
         .navigationTitle("Verify Phone Number")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             isFocused = true
         }
     }
-    
+
     // MARK: - Actions -
-    
+
     private func didSelectRegion(region: Region) {
-        viewModel.setRegion(region)
+        coordinator.setRegion(region)
         isShowingRegionSelection = false
     }
 }

--- a/Flipcash/Core/Screens/Onramp/EnterPhoneScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/EnterPhoneScreen.swift
@@ -13,14 +13,14 @@ struct EnterPhoneScreen: View {
 
     @State private var isShowingRegionSelection = false
 
-    @Bindable private var coordinator: OnrampCoordinator
+    @Bindable private var onrampCoordinator: OnrampCoordinator
 
     @FocusState private var isFocused: Bool
 
     // MARK: - Init -
 
-    init(coordinator: OnrampCoordinator) {
-        self.coordinator = coordinator
+    init(onrampCoordinator: OnrampCoordinator) {
+        self.onrampCoordinator = onrampCoordinator
     }
 
     // MARK: - Body -
@@ -35,8 +35,8 @@ struct EnterPhoneScreen: View {
                             isShowingRegionSelection = true
                         } label: {
                             HStack(spacing: 10) {
-                                Flag(style: coordinator.regionFlagStyle)
-                                Text(coordinator.countryCode)
+                                Flag(style: onrampCoordinator.regionFlagStyle)
+                                Text(onrampCoordinator.countryCode)
                                     .font(.appTextXL)
                             }
                             .padding([.leading, .trailing], 15)
@@ -53,7 +53,7 @@ struct EnterPhoneScreen: View {
                             )
                         }
 
-                        TextField("Phone Number", text: coordinator.adjustingPhoneNumberBinding)
+                        TextField("Phone Number", text: onrampCoordinator.adjustingPhoneNumberBinding)
                             .font(.appTextXL)
                             .keyboardType(.phonePad)
                             .textContentType(.telephoneNumber)
@@ -72,19 +72,19 @@ struct EnterPhoneScreen: View {
                 Spacer()
 
                 CodeButton(
-                    state: coordinator.sendCodeButtonState,
+                    state: onrampCoordinator.sendCodeButtonState,
                     style: .filled,
                     title: "Next",
-                    disabled: !coordinator.canSendVerificationCode
+                    disabled: !onrampCoordinator.canSendVerificationCode
                 ) {
                     isFocused = false
-                    coordinator.sendPhoneNumberCodeAction()
+                    onrampCoordinator.sendPhoneNumberCodeAction()
                 }
             }
             .padding(20)
             .foregroundColor(.textMain)
         }
-        .dialog(item: $coordinator.dialogItem)
+        .dialog(item: $onrampCoordinator.dialogItem)
         .navigationTitle("Verify Phone Number")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
@@ -95,7 +95,7 @@ struct EnterPhoneScreen: View {
     // MARK: - Actions -
 
     private func didSelectRegion(region: Region) {
-        coordinator.setRegion(region)
+        onrampCoordinator.setRegion(region)
         isShowingRegionSelection = false
     }
 }

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -79,6 +79,7 @@ struct OnrampAmountScreen: View {
 
     var body: some View {
         @Bindable var viewModel = viewModel
+        @Bindable var coordinator = coordinator
         NavigationStack {
             Background(color: .backgroundMain) {
                 EnterAmountView(
@@ -105,6 +106,7 @@ struct OnrampAmountScreen: View {
             .interactiveDismissDisabled(coordinator.isProcessingPayment)
         }
         .dialog(item: $viewModel.dialogItem)
+        .dialog(item: $coordinator.dialogItem)
         .onChange(of: coordinator.completion) { _, completion in
             guard case .buyProcessing = completion else { return }
             onDismiss()

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -57,8 +57,8 @@ struct OnrampAmountScreen: View {
                     mode: .onramp,
                     enteredAmount: $viewModel.enteredAmount,
                     subtitle: .singleTransactionLimit,
-                    actionState: $viewModel.payButtonState,
-                    actionEnabled: { _ in viewModel.enteredFiat != nil },
+                    actionState: .constant(onrampCoordinator.isProcessingPayment ? .loading : .normal),
+                    actionEnabled: { _ in viewModel.enteredFiat != nil && !onrampCoordinator.isProcessingPayment },
                     action: viewModel.customAmountEnteredAction,
                     currencySelectionAction: nil,
                 )

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -12,7 +12,7 @@ import FlipcashCore
 struct OnrampAmountScreen: View {
 
     @State private var viewModel: OnrampViewModel
-    @Environment(OnrampCoordinator.self) private var coordinator
+    @Environment(OnrampCoordinator.self) private var onrampCoordinator
 
     private let onDismiss: () -> Void
 
@@ -22,7 +22,7 @@ struct OnrampAmountScreen: View {
         mint: PublicKey,
         displayName: String,
         session: Session,
-        coordinator: OnrampCoordinator,
+        onrampCoordinator: OnrampCoordinator,
         onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult,
         onDismiss: @escaping () -> Void
     ) -> OnrampAmountScreen {
@@ -31,7 +31,7 @@ struct OnrampAmountScreen: View {
                 mint: mint,
                 displayName: displayName,
                 session: session,
-                coordinator: coordinator,
+                onrampCoordinator: onrampCoordinator,
                 onUsdfReady: onUsdfReady
             ),
             onDismiss: onDismiss
@@ -50,7 +50,7 @@ struct OnrampAmountScreen: View {
 
     var body: some View {
         @Bindable var viewModel = viewModel
-        @Bindable var coordinator = coordinator
+        @Bindable var onrampCoordinator = onrampCoordinator
         NavigationStack {
             Background(color: .backgroundMain) {
                 EnterAmountView(
@@ -68,17 +68,17 @@ struct OnrampAmountScreen: View {
             .navigationTitle("Amount to Add")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                if !coordinator.isProcessingPayment {
+                if !onrampCoordinator.isProcessingPayment {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         ToolbarCloseButton { onDismiss() }
                     }
                 }
             }
-            .interactiveDismissDisabled(coordinator.isProcessingPayment)
+            .interactiveDismissDisabled(onrampCoordinator.isProcessingPayment)
         }
         .dialog(item: $viewModel.dialogItem)
-        .dialog(item: $coordinator.dialogItem)
-        .onChange(of: coordinator.completion) { _, completion in
+        .dialog(item: $onrampCoordinator.dialogItem)
+        .onChange(of: onrampCoordinator.completion) { _, completion in
             guard case .buyProcessing = completion else { return }
             onDismiss()
         }

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -124,9 +124,6 @@ struct OnrampAmountScreen: View {
                 }
             }
         }
-        .sheet(isPresented: $viewModel.isShowingVerificationFlow) {
-            VerifyInfoScreen(viewModel: viewModel)
-        }
         .dialog(item: $viewModel.dialogItem)
         .onChange(of: deeplinkInbox.pendingEmailVerification, initial: true) { _, verification in
             if let verification {

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -58,7 +58,7 @@ struct OnrampAmountScreen: View {
                     enteredAmount: $viewModel.enteredAmount,
                     subtitle: .singleTransactionLimit,
                     actionState: .constant(onrampCoordinator.isProcessingPayment ? .loading : .normal),
-                    actionEnabled: { _ in viewModel.enteredFiat != nil && !onrampCoordinator.isProcessingPayment },
+                    actionEnabled: { _ in viewModel.enteredFiat != nil },
                     action: viewModel.customAmountEnteredAction,
                     currencySelectionAction: nil,
                 )

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -15,7 +15,6 @@ struct OnrampAmountScreen: View {
     @Environment(OnrampCoordinator.self) private var coordinator
 
     private let onDismiss: () -> Void
-    private let deeplinkInbox: OnrampDeeplinkInbox
 
     // MARK: - Init -
 
@@ -23,9 +22,7 @@ struct OnrampAmountScreen: View {
         mint: PublicKey,
         displayName: String,
         session: Session,
-        flipClient: FlipClient,
         coordinator: OnrampCoordinator,
-        deeplinkInbox: OnrampDeeplinkInbox,
         onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult,
         onDismiss: @escaping () -> Void
     ) -> OnrampAmountScreen {
@@ -34,24 +31,19 @@ struct OnrampAmountScreen: View {
                 mint: mint,
                 displayName: displayName,
                 session: session,
-                flipClient: flipClient,
                 coordinator: coordinator,
-                onUsdfReady: onUsdfReady,
-                onDismiss: onDismiss
+                onUsdfReady: onUsdfReady
             ),
-            onDismiss: onDismiss,
-            deeplinkInbox: deeplinkInbox
+            onDismiss: onDismiss
         )
     }
 
     private init(
         viewModel: OnrampViewModel,
-        onDismiss: @escaping () -> Void,
-        deeplinkInbox: OnrampDeeplinkInbox
+        onDismiss: @escaping () -> Void
     ) {
         _viewModel = State(wrappedValue: viewModel)
         self.onDismiss = onDismiss
-        self.deeplinkInbox = deeplinkInbox
     }
 
     // MARK: - Body -

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -24,7 +24,9 @@ struct OnrampAmountScreen: View {
         displayName: String,
         session: Session,
         flipClient: FlipClient,
+        coordinator: OnrampCoordinator,
         deeplinkInbox: OnrampDeeplinkInbox,
+        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult,
         onDismiss: @escaping () -> Void
     ) -> OnrampAmountScreen {
         OnrampAmountScreen(
@@ -33,6 +35,8 @@ struct OnrampAmountScreen: View {
                 displayName: displayName,
                 session: session,
                 flipClient: flipClient,
+                coordinator: coordinator,
+                onUsdfReady: onUsdfReady,
                 onDismiss: onDismiss
             ),
             onDismiss: onDismiss,

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -142,7 +142,7 @@ struct OnrampAmountScreen: View {
 /// flow in the background) and explicitly excluded from hit testing and
 /// accessibility so the covered region of the amount keypad remains tappable
 /// and VoiceOver users don't land on a silent 300×300 zone.
-private struct ApplePayOverlay: View {
+struct ApplePayOverlay: View {
 
     let order: OnrampOrderResponse?
     let onEvent: (ApplePayEvent) -> Void

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -125,12 +125,6 @@ struct OnrampAmountScreen: View {
             }
         }
         .dialog(item: $viewModel.dialogItem)
-        .onChange(of: deeplinkInbox.pendingEmailVerification, initial: true) { _, verification in
-            if let verification {
-                viewModel.applyDeeplinkVerification(verification)
-                deeplinkInbox.pendingEmailVerification = nil
-            }
-        }
     }
 }
 

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -12,6 +12,7 @@ import FlipcashCore
 struct OnrampAmountScreen: View {
 
     @State private var viewModel: OnrampViewModel
+    @Environment(OnrampCoordinator.self) private var coordinator
 
     private let onDismiss: () -> Void
     private let deeplinkInbox: OnrampDeeplinkInbox
@@ -73,58 +74,37 @@ struct OnrampAmountScreen: View {
     // MARK: - Body -
 
     var body: some View {
-        NavigationStack(path: $viewModel.amountPath) {
+        @Bindable var viewModel = viewModel
+        NavigationStack {
             Background(color: .backgroundMain) {
                 EnterAmountView(
                     mode: .onramp,
                     enteredAmount: $viewModel.enteredAmount,
                     subtitle: .singleTransactionLimit,
                     actionState: $viewModel.payButtonState,
-                    actionEnabled: { _ in
-                        viewModel.enteredFiat != nil
-                    },
+                    actionEnabled: { _ in viewModel.enteredFiat != nil },
                     action: viewModel.customAmountEnteredAction,
                     currencySelectionAction: nil,
                 )
                 .foregroundColor(.textMain)
                 .padding(20)
-                .overlay {
-                    ApplePayOverlay(order: viewModel.coinbaseOrder) { event in
-                        viewModel.receiveApplePayEvent(event)
-                    }
-                }
             }
             .navigationTitle("Amount to Add")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                if !viewModel.isProcessingPayment {
+                if !coordinator.isProcessingPayment {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         ToolbarCloseButton { onDismiss() }
                     }
                 }
             }
-            .interactiveDismissDisabled(viewModel.isProcessingPayment)
-            .navigationDestination(for: OnrampAmountPath.self) { path in
-                switch path {
-                case .swapProcessing(let swapId, let currencyName, let amount):
-                    SwapProcessingScreen(
-                        swapId: swapId,
-                        swapType: .buyWithCoinbase,
-                        currencyName: currencyName,
-                        amount: amount
-                    )
-                case .launchProcessing(let swapId, let launchedMint, let currencyName, let amount):
-                    CurrencyLaunchProcessingScreen(
-                        swapId: swapId,
-                        launchedMint: launchedMint,
-                        currencyName: currencyName,
-                        launchAmount: amount,
-                        fundingMethod: .coinbase
-                    )
-                }
-            }
+            .interactiveDismissDisabled(coordinator.isProcessingPayment)
         }
         .dialog(item: $viewModel.dialogItem)
+        .onChange(of: coordinator.completion) { _, completion in
+            guard case .buyProcessing = completion else { return }
+            onDismiss()
+        }
     }
 }
 

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -78,6 +78,9 @@ struct OnrampAmountScreen: View {
         }
         .dialog(item: $viewModel.dialogItem)
         .dialog(item: $onrampCoordinator.dialogItem)
+        .sheet(isPresented: $onrampCoordinator.isShowingVerificationFlow) {
+            VerifyInfoScreen(onrampCoordinator: onrampCoordinator)
+        }
         .onChange(of: onrampCoordinator.completion) { _, completion in
             guard case .buyProcessing = completion else { return }
             onDismiss()

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -44,27 +44,6 @@ struct OnrampAmountScreen: View {
         )
     }
 
-    static func forLaunching(
-        displayName: String,
-        session: Session,
-        flipClient: FlipClient,
-        deeplinkInbox: OnrampDeeplinkInbox,
-        onDismiss: @escaping () -> Void,
-        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
-    ) -> OnrampAmountScreen {
-        OnrampAmountScreen(
-            viewModel: .forLaunching(
-                displayName: displayName,
-                session: session,
-                flipClient: flipClient,
-                onDismiss: onDismiss,
-                onUsdfReady: onUsdfReady
-            ),
-            onDismiss: onDismiss,
-            deeplinkInbox: deeplinkInbox
-        )
-    }
-
     private init(
         viewModel: OnrampViewModel,
         onDismiss: @escaping () -> Void,

--- a/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
@@ -27,8 +27,6 @@ class OnrampViewModel {
 
     var enteredAmount: String = ""
 
-    var payButtonState: ButtonState = .normal
-
     var dialogItem: DialogItem?
 
     /// Display name forwarded to the onrampCoordinator when a buy is kicked off.

--- a/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
@@ -29,7 +29,6 @@ class OnrampViewModel {
 
     var dialogItem: DialogItem?
 
-    /// Display name forwarded to the onrampCoordinator when a buy is kicked off.
     let displayName: String
 
     var enteredFiat: ExchangedFiat? {
@@ -53,14 +52,7 @@ class OnrampViewModel {
     }
 
     @ObservationIgnored private let session: Session
-
-    /// Target mint for the buy. Captured at init time by `forBuying`.
     @ObservationIgnored private let mint: PublicKey
-
-    /// Coordinator that drives the Coinbase order and Apple Pay flow at root.
-    /// The VM hands off the validated amount via `startBuy`; the onrampCoordinator
-    /// publishes a `.buyProcessing` completion once the post-onramp swap is
-    /// submitted.
     @ObservationIgnored private let onrampCoordinator: OnrampCoordinator
     @ObservationIgnored private let onUsdfReady: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
 
@@ -122,11 +114,9 @@ class OnrampViewModel {
             return
         }
 
-        onrampCoordinator.startBuy(
-            amount: exchangedFiat,
-            mint: mint,
-            displayName: displayName,
-            onCompleted: onUsdfReady
+        onrampCoordinator.start(
+            .buy(mint: mint, displayName: displayName, onCompleted: onUsdfReady),
+            amount: exchangedFiat
         )
     }
 

--- a/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
@@ -124,16 +124,14 @@ class OnrampViewModel {
     @ObservationIgnored private let onDismiss: () -> Void
 
     /// Internal dispatch for the post-onramp step. Paired with the matching
-    /// factory init (see `forBuying` / `forLaunching`), so cases carry exactly
-    /// the data they need.
+    /// factory init (see `forBuying`), so cases carry exactly the data they
+    /// need.
     private enum Mode {
         case buyExistingCurrency(mint: PublicKey)
-        case launchNewCurrency(onUsdfReady: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult)
 
         var logKind: String {
             switch self {
             case .buyExistingCurrency: "buy_existing"
-            case .launchNewCurrency:   "launch_new"
             }
         }
     }
@@ -185,24 +183,6 @@ class OnrampViewModel {
             flipClient: flipClient,
             coordinator: coordinator,
             onUsdfReady: onUsdfReady,
-            onDismiss: onDismiss
-        )
-    }
-
-    static func forLaunching(
-        displayName: String,
-        session: Session,
-        flipClient: FlipClient,
-        onDismiss: @escaping () -> Void,
-        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
-    ) -> OnrampViewModel {
-        OnrampViewModel(
-            displayName: displayName,
-            mode: .launchNewCurrency(onUsdfReady: onUsdfReady),
-            session: session,
-            flipClient: flipClient,
-            coordinator: nil,
-            onUsdfReady: nil,
             onDismiss: onDismiss
         )
     }
@@ -369,14 +349,6 @@ class OnrampViewModel {
                 displayName: displayName,
                 onCompleted: onUsdfReady
             )
-
-        case .launchNewCurrency:
-            // `reset()` clears `enteredAmount` along with verification fields,
-            // so stash and restore it.
-            let amount = enteredAmount
-            reset()
-            enteredAmount = amount
-            navigateToVerificationOrPurchase()
         }
     }
     
@@ -974,27 +946,6 @@ class OnrampViewModel {
                     currencyName: displayName,
                     amount: exchangedFiat
                 )
-
-            case .launchNewCurrency(let onUsdfReady):
-                let result = try await onUsdfReady(signature, exchangedFiat)
-                switch result {
-                case .launch(let swapId, let mint):
-                    appendPath = .launchProcessing(
-                        swapId: swapId,
-                        launchedMint: mint,
-                        currencyName: displayName,
-                        amount: exchangedFiat
-                    )
-                case .buyExisting(let swapId):
-                    // Launch callers should always return .launch; fall back to
-                    // the generic processing path if they don't.
-                    logger.warning("Launch onUsdfReady returned .buyExisting result")
-                    appendPath = .swapProcessing(
-                        swapId: swapId,
-                        currencyName: displayName,
-                        amount: exchangedFiat
-                    )
-                }
             }
             coinbaseOrder = nil
             Analytics.onrampCompleted(
@@ -1142,7 +1093,6 @@ class OnrampViewModel {
 /// never bind the same `[Path]` array.
 enum OnrampAmountPath: Hashable {
     case swapProcessing(swapId: SwapId, currencyName: String, amount: ExchangedFiat)
-    case launchProcessing(swapId: SwapId, launchedMint: PublicKey, currencyName: String, amount: ExchangedFiat)
 }
 
 /// Navigation path for `VerifyInfoScreen`'s NavigationStack.

--- a/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
@@ -42,9 +42,7 @@ class OnrampViewModel {
     var dialogItem: DialogItem?
 
     /// Display name shown on the SwapProcessing step and surfaced in logs.
-    /// For buy-existing flows this is the target currency's name; for
-    /// launch-new flows it's the user-chosen name of the currency being
-    /// created. Fixed at init time.
+    /// The target currency's name. Fixed at init time.
     let displayName: String
 
     var enteredCode: String = ""
@@ -123,26 +121,15 @@ class OnrampViewModel {
     @ObservationIgnored private let owner: KeyPair
     @ObservationIgnored private let onDismiss: () -> Void
 
-    /// Internal dispatch for the post-onramp step. Paired with the matching
-    /// factory init (see `forBuying`), so cases carry exactly the data they
-    /// need.
-    private enum Mode {
-        case buyExistingCurrency(mint: PublicKey)
+    /// Target mint for the buy. Captured at init time by `forBuying`.
+    @ObservationIgnored private let mint: PublicKey
 
-        var logKind: String {
-            switch self {
-            case .buyExistingCurrency: "buy_existing"
-            }
-        }
-    }
-
-    @ObservationIgnored private let mode: Mode
-
-    /// Set only when created via `forBuying`. The buy flow hands the validated
-    /// amount to the coordinator, which drives the Coinbase order and Apple Pay
-    /// flow at root. Launch flows still use the VM-internal path through `mode`.
-    @ObservationIgnored private let coordinator: OnrampCoordinator?
-    @ObservationIgnored private let onUsdfReady: (@MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult)?
+    /// Coordinator that drives the Coinbase order and Apple Pay flow at root.
+    /// The VM hands off the validated amount via `startBuy`; the coordinator
+    /// publishes a `.buyProcessing` completion once the post-onramp swap is
+    /// submitted.
+    @ObservationIgnored private let coordinator: OnrampCoordinator
+    @ObservationIgnored private let onUsdfReady: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
 
     @ObservationIgnored private var coinbase: Coinbase!
 
@@ -178,7 +165,7 @@ class OnrampViewModel {
     ) -> OnrampViewModel {
         OnrampViewModel(
             displayName: displayName,
-            mode: .buyExistingCurrency(mint: mint),
+            mint: mint,
             session: session,
             flipClient: flipClient,
             coordinator: coordinator,
@@ -189,15 +176,15 @@ class OnrampViewModel {
 
     private init(
         displayName: String,
-        mode: Mode,
+        mint: PublicKey,
         session: Session,
         flipClient: FlipClient,
-        coordinator: OnrampCoordinator?,
-        onUsdfReady: (@MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult)?,
+        coordinator: OnrampCoordinator,
+        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult,
         onDismiss: @escaping () -> Void
     ) {
         self.displayName = displayName
-        self.mode = mode
+        self.mint = mint
         self.session = session
         self.flipClient = flipClient
         self.coordinator = coordinator
@@ -340,16 +327,12 @@ class OnrampViewModel {
             return
         }
 
-        switch mode {
-        case .buyExistingCurrency(let mint):
-            guard let coordinator, let onUsdfReady else { return }
-            coordinator.startBuy(
-                amount: exchangedFiat,
-                mint: mint,
-                displayName: displayName,
-                onCompleted: onUsdfReady
-            )
-        }
+        coordinator.startBuy(
+            amount: exchangedFiat,
+            mint: mint,
+            displayName: displayName,
+            onCompleted: onUsdfReady
+        )
     }
     
     func sendPhoneNumberCodeAction() {
@@ -864,7 +847,6 @@ class OnrampViewModel {
 
     private func handleCoinbaseFundingSuccess() async {
         logger.info("Coinbase funding succeeded", metadata: [
-            "destination_kind": "\(mode.logKind)",
             "destination_name": "\(displayName)"
         ])
 
@@ -933,27 +915,22 @@ class OnrampViewModel {
         }
 
         do {
-            let appendPath: OnrampAmountPath
-            switch mode {
-            case .buyExistingCurrency(let mint):
-                let swapId = try await session.buyWithExternalFunding(
-                    amount: exchangedFiat,
-                    of: mint,
-                    transactionSignature: signature
-                )
-                appendPath = .swapProcessing(
-                    swapId: swapId,
-                    currencyName: displayName,
-                    amount: exchangedFiat
-                )
-            }
+            let swapId = try await session.buyWithExternalFunding(
+                amount: exchangedFiat,
+                of: mint,
+                transactionSignature: signature
+            )
             coinbaseOrder = nil
             Analytics.onrampCompleted(
                 amount: exchangedFiat.underlying,
                 successful: true,
                 error: nil
             )
-            amountPath.append(appendPath)
+            amountPath.append(.swapProcessing(
+                swapId: swapId,
+                currencyName: displayName,
+                amount: exchangedFiat
+            ))
         } catch {
             logger.error("Buy failed", metadata: ["error": "\(error)"])
             ErrorReporting.captureError(error)

--- a/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
@@ -140,6 +140,12 @@ class OnrampViewModel {
 
     @ObservationIgnored private let mode: Mode
 
+    /// Set only when created via `forBuying`. The buy flow hands the validated
+    /// amount to the coordinator, which drives the Coinbase order and Apple Pay
+    /// flow at root. Launch flows still use the VM-internal path through `mode`.
+    @ObservationIgnored private let coordinator: OnrampCoordinator?
+    @ObservationIgnored private let onUsdfReady: (@MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult)?
+
     @ObservationIgnored private var coinbase: Coinbase!
 
     @ObservationIgnored private let coinbaseApiKey: String?
@@ -168,6 +174,8 @@ class OnrampViewModel {
         displayName: String,
         session: Session,
         flipClient: FlipClient,
+        coordinator: OnrampCoordinator,
+        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult,
         onDismiss: @escaping () -> Void
     ) -> OnrampViewModel {
         OnrampViewModel(
@@ -175,6 +183,8 @@ class OnrampViewModel {
             mode: .buyExistingCurrency(mint: mint),
             session: session,
             flipClient: flipClient,
+            coordinator: coordinator,
+            onUsdfReady: onUsdfReady,
             onDismiss: onDismiss
         )
     }
@@ -191,6 +201,8 @@ class OnrampViewModel {
             mode: .launchNewCurrency(onUsdfReady: onUsdfReady),
             session: session,
             flipClient: flipClient,
+            coordinator: nil,
+            onUsdfReady: nil,
             onDismiss: onDismiss
         )
     }
@@ -200,12 +212,16 @@ class OnrampViewModel {
         mode: Mode,
         session: Session,
         flipClient: FlipClient,
+        coordinator: OnrampCoordinator?,
+        onUsdfReady: (@MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult)?,
         onDismiss: @escaping () -> Void
     ) {
         self.displayName = displayName
         self.mode = mode
         self.session = session
         self.flipClient = flipClient
+        self.coordinator = coordinator
+        self.onUsdfReady = onUsdfReady
         self.owner = session.ownerKeyPair
         self.onDismiss = onDismiss
         self.region = phoneFormatter.currentRegion
@@ -344,12 +360,24 @@ class OnrampViewModel {
             return
         }
 
-        // `reset()` clears `enteredAmount` along with verification fields,
-        // so stash and restore it.
-        let amount = enteredAmount
-        reset()
-        enteredAmount = amount
-        navigateToVerificationOrPurchase()
+        switch mode {
+        case .buyExistingCurrency(let mint):
+            guard let coordinator, let onUsdfReady else { return }
+            coordinator.startBuy(
+                amount: exchangedFiat,
+                mint: mint,
+                displayName: displayName,
+                onCompleted: onUsdfReady
+            )
+
+        case .launchNewCurrency:
+            // `reset()` clears `enteredAmount` along with verification fields,
+            // so stash and restore it.
+            let amount = enteredAmount
+            reset()
+            enteredAmount = amount
+            navigateToVerificationOrPurchase()
+        }
     }
     
     func sendPhoneNumberCodeAction() {

--- a/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
@@ -31,7 +31,7 @@ class OnrampViewModel {
 
     var dialogItem: DialogItem?
 
-    /// Display name forwarded to the coordinator when a buy is kicked off.
+    /// Display name forwarded to the onrampCoordinator when a buy is kicked off.
     let displayName: String
 
     var enteredFiat: ExchangedFiat? {
@@ -60,10 +60,10 @@ class OnrampViewModel {
     @ObservationIgnored private let mint: PublicKey
 
     /// Coordinator that drives the Coinbase order and Apple Pay flow at root.
-    /// The VM hands off the validated amount via `startBuy`; the coordinator
+    /// The VM hands off the validated amount via `startBuy`; the onrampCoordinator
     /// publishes a `.buyProcessing` completion once the post-onramp swap is
     /// submitted.
-    @ObservationIgnored private let coordinator: OnrampCoordinator
+    @ObservationIgnored private let onrampCoordinator: OnrampCoordinator
     @ObservationIgnored private let onUsdfReady: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
 
     // MARK: - Init -
@@ -72,14 +72,14 @@ class OnrampViewModel {
         mint: PublicKey,
         displayName: String,
         session: Session,
-        coordinator: OnrampCoordinator,
+        onrampCoordinator: OnrampCoordinator,
         onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
     ) -> OnrampViewModel {
         OnrampViewModel(
             displayName: displayName,
             mint: mint,
             session: session,
-            coordinator: coordinator,
+            onrampCoordinator: onrampCoordinator,
             onUsdfReady: onUsdfReady
         )
     }
@@ -88,13 +88,13 @@ class OnrampViewModel {
         displayName: String,
         mint: PublicKey,
         session: Session,
-        coordinator: OnrampCoordinator,
+        onrampCoordinator: OnrampCoordinator,
         onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
     ) {
         self.displayName = displayName
         self.mint = mint
         self.session = session
-        self.coordinator = coordinator
+        self.onrampCoordinator = onrampCoordinator
         self.onUsdfReady = onUsdfReady
     }
 
@@ -124,7 +124,7 @@ class OnrampViewModel {
             return
         }
 
-        coordinator.startBuy(
+        onrampCoordinator.startBuy(
             amount: exchangedFiat,
             mint: mint,
             displayName: displayName,

--- a/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
@@ -12,11 +12,11 @@ import FlipcashCore
 private let logger = Logger(label: "flipcash.onramp")
 
 /// Long-lived store for Onramp email verification deeplinks. `DeepLinkController`
-/// drops incoming verifications here; `OnrampAmountScreen` observes the value
-/// with `.onChange(initial: true)`, so whether the link arrived before or
-/// after the sheet opened the verification is picked up through the same
-/// entry point. Lives on `SessionContainer` so it survives sheet dismissal
-/// but not logout.
+/// drops incoming verifications here; `OnrampHostModifier` observes the value
+/// with `.onChange(initial: true)` and hands it off to `OnrampCoordinator`, so
+/// whether the link arrived before or after the sheet opened the verification
+/// is picked up through the same entry point. Lives on `SessionContainer` so
+/// it survives sheet dismissal but not logout.
 @MainActor @Observable
 final class OnrampDeeplinkInbox {
     var pendingEmailVerification: VerificationDescription?
@@ -25,43 +25,15 @@ final class OnrampDeeplinkInbox {
 @MainActor @Observable
 class OnrampViewModel {
 
-    var isShowingVerificationFlow: Bool = false
+    var enteredAmount: String = ""
 
-    var amountPath: [OnrampAmountPath] = []
-
-    var verificationPath: [OnrampVerificationPath] = [] {
-        didSet {
-            if verificationPath.isEmpty && !oldValue.isEmpty {
-                reset()
-            }
-        }
-    }
-
-    var coinbaseOrder: OnrampOrderResponse?
+    var payButtonState: ButtonState = .normal
 
     var dialogItem: DialogItem?
 
-    /// Display name shown on the SwapProcessing step and surfaced in logs.
-    /// The target currency's name. Fixed at init time.
+    /// Display name forwarded to the coordinator when a buy is kicked off.
     let displayName: String
 
-    var enteredCode: String = ""
-    var enteredEmail: String = ""
-    var enteredAmount: String = ""
-
-    private(set) var isResending: Bool = false
-
-    private(set) var region: Region
-    private(set) var enteredPhone: String = ""
-
-    var payButtonState: ButtonState = .normal
-    private(set) var sendCodeButtonState: ButtonState = .normal
-    private(set) var sendEmailCodeState: ButtonState = .normal
-    private(set) var confirmCodeButtonState: ButtonState = .normal
-    private(set) var confirmEmailButtonState: ButtonState = .normal
-    
-    let codeLength = 6
-    
     var enteredFiat: ExchangedFiat? {
         guard !enteredAmount.isEmpty else {
             return nil
@@ -81,45 +53,8 @@ class OnrampViewModel {
             mint: .usdf
         )
     }
-    
-    var regionFlagStyle: Flag.Style {
-        .fiat(region)
-    }
-    
-    var countryCode: String {
-        "+\(phoneFormatter.countryCode(for: region)!)"
-    }
-    
-    var phone: Phone? {
-        Phone(enteredPhone)
-    }
-    
-    var canSendVerificationCode: Bool {
-        phone != nil
-    }
-    
-    var canSendEmailVerification: Bool {
-        isEmailValid
-    }
-    
-    var isCodeComplete: Bool {
-        enteredCode.count >= codeLength
-    }
-    
-    var isEmailValid: Bool {
-        let e = enteredEmail.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        guard !e.isEmpty, e.utf8.count <= 254 else {
-            return false
-        }
-        
-        return e.range(of: #"^[^\s@]+@[^\s@]+\.[^\s@]+$"#, options: .regularExpression) != nil
-    }
-    
+
     @ObservationIgnored private let session: Session
-    @ObservationIgnored private let flipClient: FlipClient
-    @ObservationIgnored private let owner: KeyPair
-    @ObservationIgnored private let onDismiss: () -> Void
 
     /// Target mint for the buy. Captured at init time by `forBuying`.
     @ObservationIgnored private let mint: PublicKey
@@ -131,46 +66,21 @@ class OnrampViewModel {
     @ObservationIgnored private let coordinator: OnrampCoordinator
     @ObservationIgnored private let onUsdfReady: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
 
-    @ObservationIgnored private var coinbase: Coinbase!
-
-    @ObservationIgnored private let coinbaseApiKey: String?
-
-    @ObservationIgnored private var fundingTask: Task<Void, Never>?
-
-    @ObservationIgnored private let phoneFormatter = PhoneFormatter()
-
-
-    private var isPhoneVerified: Bool {
-        session.profile?.isPhoneVerified ?? false
-    }
-
-    private var isEmailVerified: Bool {
-        session.profile?.isEmailVerified ?? false
-    }
-
-    private var isAccountVerified: Bool {
-        isPhoneVerified && isEmailVerified
-    }
-
     // MARK: - Init -
 
     static func forBuying(
         mint: PublicKey,
         displayName: String,
         session: Session,
-        flipClient: FlipClient,
         coordinator: OnrampCoordinator,
-        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult,
-        onDismiss: @escaping () -> Void
+        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
     ) -> OnrampViewModel {
         OnrampViewModel(
             displayName: displayName,
             mint: mint,
             session: session,
-            flipClient: flipClient,
             coordinator: coordinator,
-            onUsdfReady: onUsdfReady,
-            onDismiss: onDismiss
+            onUsdfReady: onUsdfReady
         )
     }
 
@@ -178,129 +88,16 @@ class OnrampViewModel {
         displayName: String,
         mint: PublicKey,
         session: Session,
-        flipClient: FlipClient,
         coordinator: OnrampCoordinator,
-        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult,
-        onDismiss: @escaping () -> Void
+        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
     ) {
         self.displayName = displayName
         self.mint = mint
         self.session = session
-        self.flipClient = flipClient
         self.coordinator = coordinator
         self.onUsdfReady = onUsdfReady
-        self.owner = session.ownerKeyPair
-        self.onDismiss = onDismiss
-        self.region = phoneFormatter.currentRegion
-        self.coinbaseApiKey = try? InfoPlist.value(for: "coinbase").value(for: "apiKey").string()
-
-        self.coinbase = Coinbase(configuration: .init(bearerTokenProvider: fetchCoinbaseJWT))
     }
 
-    deinit {
-        fundingTask?.cancel()
-    }
-    
-    // MARK: - Setters -
-    
-    private func reset() {
-        enteredPhone  = ""
-        enteredCode   = ""
-        enteredEmail  = ""
-        enteredAmount = ""
-        
-        isResending = false
-
-        coinbaseOrder = nil
-
-        payButtonState = .normal
-
-        navigateToRoot()
-    }
-    
-    func setRegion(_ region: Region) {
-        self.region = region
-    }
-    
-    // MARK: - Bindings -
-    
-    var adjustingPhoneNumberBinding: Binding<String> {
-        Binding { [weak self] in
-            guard let self = self else { return "" }
-            return self.enteredPhone
-            
-        } set: { [weak self] newValue in
-            guard let self = self else { return }
-            let cleanPhoneNumber = newValue.filter { character in
-                CharacterSet.numbers.contains(character.unicodeScalars.first!)
-            }
-            
-            let countryCode = self.phoneFormatter.countryCode(for: self.region)!
-            self.enteredPhone = self.phoneFormatter.format("+\(countryCode)\(cleanPhoneNumber)")
-        }
-    }
-    
-    var adjustingCodeBinding: Binding<String> {
-        Binding { [weak self] in
-            guard let self = self else { return "" }
-            return self.enteredCode
-            
-        } set: { [weak self] newValue in
-            guard let self = self else { return }
-            
-            if newValue.count > self.codeLength {
-                self.enteredCode = String(newValue.prefix(self.codeLength))
-            } else {
-                self.enteredCode = newValue
-            }
-        }
-    }
-    
-    // MARK: - Navigation -
-    
-    func navigateToRoot() {
-        amountPath = []
-        verificationPath = []
-    }
-
-    func navigateToInitialVerification() {
-        navigateToAmount(from: .info)
-    }
-
-    private func navigateToAmount(from origin: Origin) {
-        if origin.rawValue < Origin.info.rawValue, (!isPhoneVerified || !isEmailVerified) {
-            verificationPath.append(.info)
-            return
-        }
-
-        if origin.rawValue < Origin.phone.rawValue, !isPhoneVerified {
-            Analytics.track(event: Analytics.OnrampEvent.showEnterPhone)
-            verificationPath.append(.enterPhoneNumber)
-            return
-        }
-
-        if origin.rawValue < Origin.email.rawValue, !isEmailVerified {
-            Analytics.track(event: Analytics.OnrampEvent.showEnterEmail)
-            verificationPath.append(.enterEmail)
-            return
-        }
-
-        navigateToVerificationOrPurchase()
-    }
-
-    private func navigateToVerificationOrPurchase() {
-        // If we need to verify the phone or
-        // email, we'll need to open up the
-        // verification flow, otherwise, we
-        // can jump straight to the purchase
-        if isAccountVerified {
-            createOrder()
-        } else {
-            Analytics.track(event: Analytics.OnrampEvent.showVerificationInfo)
-            isShowingVerificationFlow = true
-        }
-    }
-    
     // MARK: - Actions -
 
     func customAmountEnteredAction() {
@@ -334,609 +131,6 @@ class OnrampViewModel {
             onCompleted: onUsdfReady
         )
     }
-    
-    func sendPhoneNumberCodeAction() {
-        guard let phone else {
-            return
-        }
-        
-        Task {
-            sendCodeButtonState = .loading
-            defer {
-                sendCodeButtonState = .normal
-            }
-            
-            do {
-                try await flipClient.sendVerificationCode(
-                    phone: phone.e164,
-                    owner: owner
-                )
-                try await Task.delay(milliseconds: 500)
-                sendCodeButtonState = .success
-                
-                try await Task.delay(milliseconds: 500)
-                verificationPath.append(.confirmPhoneNumberCode)
-
-                Analytics.track(event: Analytics.OnrampEvent.showConfirmPhone)
-                
-                try await Task.delay(milliseconds: 500)
-            }
-            
-            catch
-                ErrorSendVerificationCode.invalidPhoneNumber,
-                ErrorSendVerificationCode.unsupportedPhoneType
-            {
-                showUnsupportedPhoneNumberError()
-            }
-
-            catch {
-                ErrorReporting.captureError(error)
-                showGenericError()
-            }
-        }
-    }
-    
-    func resendCodeAction() async throws {
-        guard let phone else {
-            return
-        }
-        
-        isResending = true
-        defer {
-            isResending = false
-        }
-        
-        do {
-            try await flipClient.sendVerificationCode(
-                phone: phone.e164,
-                owner: owner
-            )
-        } catch {
-            ErrorReporting.captureError(error)
-        }
-    }
-    
-    func confirmPhoneNumberCodeAction() {
-        guard let phone else {
-            return
-        }
-        
-        guard isCodeComplete else {
-            return
-        }
-        
-        Task {
-            confirmCodeButtonState = .loading
-            defer {
-                confirmCodeButtonState = .normal
-            }
-            
-            do {
-                try await flipClient.checkVerificationCode(
-                    phone: phone.e164,
-                    code: enteredCode,
-                    owner: owner
-                )
-                
-                try? await session.updateProfile()
-
-                try await Task.delay(milliseconds: 500)
-                confirmCodeButtonState = .success
-
-                try await Task.delay(milliseconds: 500)
-                navigateToAmount(from: .phone)
-                
-                try await Task.delay(milliseconds: 500)
-            } catch ErrorCheckVerificationCode.invalidCode {
-                showInvalidCodeError()
-            } catch ErrorCheckVerificationCode.noVerification {
-                showGenericError()
-            } catch {
-                ErrorReporting.captureError(error)
-            }
-        }
-    }
-    
-    func sendEmailCodeAction() {
-        guard isEmailValid else {
-            return
-        }
-        
-        Task {
-            sendEmailCodeState = .loading
-            defer {
-                sendEmailCodeState = .normal
-            }
-            
-            do {
-                try await flipClient.sendEmailVerification(
-                    email: enteredEmail,
-                    owner: owner
-                )
-                try await Task.delay(milliseconds: 500)
-                sendEmailCodeState = .success
-                
-                try await Task.delay(milliseconds: 500)
-                verificationPath.append(.confirmEmailCode)
-
-                Analytics.track(event: Analytics.OnrampEvent.showConfirmEmail)
-                
-                try await Task.delay(milliseconds: 500)
-            } catch ErrorSendEmailCode.invalidEmailAddress {
-                showInvalidEmailError()
-            } catch {
-                ErrorReporting.captureError(error)
-                showGenericError()
-            }
-        }
-    }
-
-    func resendEmailCodeAction() async throws {
-        guard isEmailValid else {
-            return
-        }
-        
-        isResending = true
-        defer {
-            isResending = false
-        }
-        
-        do {
-            try await flipClient.sendEmailVerification(
-                email: enteredEmail,
-                owner: owner
-            )
-        } catch {
-            ErrorReporting.captureError(error)
-        }
-    }
-    
-    func applyDeeplinkVerification(_ verification: VerificationDescription) {
-        // If the user isn't already parked on the confirm-code screen, jump
-        // them there so the API call's result has somewhere to surface.
-        if !isShowingVerificationFlow {
-            verificationPath = [.confirmEmailCode]
-            enteredEmail = verification.email
-        }
-
-        Task {
-            confirmEmailButtonState = .loading
-            defer {
-                confirmEmailButtonState = .normal
-            }
-
-            do {
-                if !isEmailVerified {
-                    try await flipClient.checkEmailCode(
-                        email: verification.email,
-                        code: verification.code,
-                        owner: owner
-                    )
-
-                    try? await session.updateProfile()
-                }
-
-                try await Task.delay(milliseconds: 500)
-                confirmEmailButtonState = .success
-
-                try await Task.delay(milliseconds: 500)
-                navigateToAmount(from: .email)
-            } catch ErrorCheckEmailCode.invalidCode {
-                showInvalidVerificationLinkError { [weak self] in
-                    Task {
-                        try await self?.resendEmailCodeAction()
-                    }
-                }
-            } catch ErrorCheckEmailCode.noVerification {
-                showExpiredVerificationLinkError { [weak self] in
-                    Task {
-                        try await self?.resendEmailCodeAction()
-                    }
-                }
-            } catch {
-                ErrorReporting.captureError(error)
-                showGenericError()
-            }
-        }
-    }
-    
-    // MARK: - Coinbase -
-    
-    private func createOrder() {
-        guard let exchangedFiat = enteredFiat else {
-            return
-        }
-
-        guard let profile = session.profile, profile.canCreateCoinbaseOrder else {
-            return
-        }
-
-        Analytics.onrampInvokePayment(amount: exchangedFiat.underlying)
-
-        Task {
-            try await createOnrampOrder(
-                profile: profile,
-                exchangedFiat: exchangedFiat
-            )
-        }
-    }
-    
-    private func createOnrampOrder(profile: Profile, exchangedFiat: ExchangedFiat) async throws {
-        guard let email = profile.email, let phone = profile.phone?.e164 else {
-            logger.warning("createOnrampOrder invoked with incomplete profile")
-            return
-        }
-
-        let id       = UUID()
-        let userRef  = "\(email):\(phone)"
-        let orderRef = "\(userRef):\(id)"
-        
-        payButtonState = .loading
-        
-        let ref = BetaFlags.shared.hasEnabled(.coinbaseSandbox) ? "sandbox-\(userRef)" : userRef
-        
-        do {
-            logger.info("Creating Coinbase order", metadata: [
-                "currency": "\(exchangedFiat.converted.currencyCode)",
-                "purchase_quarks": "\(exchangedFiat.underlying.quarks)",
-                "sandbox": "\(BetaFlags.shared.hasEnabled(.coinbaseSandbox))"
-            ])
-            
-            guard let usdfSwapAccounts = MintMetadata.usdf.timelockSwapAccounts(owner: session.owner.authorityPublicKey) else {
-                fatalError("Failed to derive USDF swap accounts")
-            }
-                        
-            let response = try await coinbase.createOrder(request: .init(
-                purchaseAmount: "\(exchangedFiat.underlying.decimalValue)",
-                paymentCurrency: "USD",
-                purchaseCurrency: "USDF",
-                isQuote: false,
-                destinationAddress: usdfSwapAccounts.ata.publicKey,
-                email: email,
-                phoneNumber: phone,
-                partnerOrderRef: orderRef,
-                partnerUserRef: ref,
-                phoneNumberVerifiedAt: .now,
-                agreementAcceptedAt: .now
-            ))
-            
-            isShowingVerificationFlow = false
-            coinbaseOrder = response
-            logger.info("Coinbase order created", metadata: [
-                "order_id": "\(response.id)"
-            ])
-        }
-
-        catch let error as OnrampErrorResponse {
-            if error.errorType == .guestRegionForbidden {
-                showCoinbaseError(
-                    title: error.title,
-                    subtitle: error.subtitle
-                ) { [weak self] in
-                    Task {
-                        try? await self?.session.unlinkProfile()
-                    }
-                }
-            } else {
-                showCoinbaseError(
-                    title: error.title,
-                    subtitle: error.subtitle
-                )
-            }
-
-            logger.error("Coinbase order failed", metadata: [
-                "error_type": "\(error.errorType)",
-                "error_title": "\(error.title)"
-            ])
-            ErrorReporting.captureError(error)
-            payButtonState = .normal
-        }
-
-        catch {
-            logger.error("Coinbase order failed with unexpected error", metadata: [
-                "error": "\(error)"
-            ])
-            ErrorReporting.captureError(error)
-            payButtonState = .normal
-        }
-    }
-    
-    func receiveApplePayEvent(_ event: ApplePayEvent) {
-        func errorMetadata() -> Logger.Metadata {
-            [
-                "error_code": "\(event.data?.errorCode ?? "nil")",
-                "error_message": "\(event.data?.errorMessage ?? "nil")"
-            ]
-        }
-
-        func handleEventError(_ kind: ApplePayEvent.Event) {
-            payButtonState = .normal
-            coinbaseOrder = nil
-
-            // Prefer the Coinbase-provided reason if we have one — users hitting
-            // a region mismatch or card decline shouldn't see "Something went wrong".
-            let title: String
-            let subtitle: String
-            if let message = event.data?.errorMessage, !message.isEmpty {
-                title = "Payment Failed"
-                subtitle = message
-            } else {
-                title = "Something Went Wrong"
-                subtitle = "Please try again later"
-            }
-
-            dialogItem = .init(
-                style: .destructive,
-                title: title,
-                subtitle: subtitle,
-                dismissable: true,
-            ) {
-                .okay(kind: .destructive) { [weak self] in
-                    self?.onDismiss()
-                }
-            }
-
-            ErrorReporting.captureError(kind)
-        }
-
-        switch event.event {
-        case .loadPending:
-            logger.info("Apple Pay load pending")
-        case .loadSuccess:
-            logger.info("Apple Pay loaded")
-        case .loadError:
-            logger.error("Apple Pay load failed", metadata: errorMetadata())
-            handleEventError(.loadError)
-
-        case .applePayButtonPressed:
-            logger.info("Apple Pay button pressed")
-        case .pendingPaymentAuth:
-            logger.info("Apple Pay pending payment auth")
-
-        case .commitSuccess:
-            logger.info("Apple Pay commit succeeded")
-        case .commitError:
-            logger.error("Apple Pay commit failed", metadata: errorMetadata())
-            handleEventError(.commitError)
-        case .pollingStart:
-            logger.info("Apple Pay polling started")
-        case .pollingSuccess:
-            fundingTask?.cancel()
-            fundingTask = Task { [weak self] in
-                await self?.handleCoinbaseFundingSuccess()
-            }
-        case .pollingError:
-            logger.error("Apple Pay polling failed", metadata: errorMetadata())
-            Analytics.onrampCompleted(
-                amount: nil,
-                successful: false,
-                error: nil
-            )
-            handleEventError(.pollingError)
-        case .cancelled:
-            logger.info("Apple Pay cancelled")
-            coinbaseOrder = nil
-            payButtonState = .normal
-        case .none:
-            logger.warning("Apple Pay received unknown event", metadata: ["raw_event": "\(event.name)"])
-        }
-    }
-    
-    private func fetchCoinbaseJWT(method: String, path: String) async throws -> String {
-        guard let coinbaseApiKey else {
-            throw OnrampError.missingCoinbaseApiKey
-        }
-
-        return try await flipClient.fetchCoinbaseOnrampJWT(
-            apiKey: coinbaseApiKey,
-            owner: owner,
-            method: method,
-            path: path
-        )
-    }
-
-    // MARK: - Clipboard -
-    
-    func pasteCodeFromClipboardIfPossible() {
-        guard let code = codeFromClipboard() else {
-            return
-        }
-        
-        enteredCode = code
-    }
-    
-    private func codeFromClipboard() -> String? {
-        if let codeString = UIPasteboard.general.string, codeString.count == codeLength {
-            let digits: [Int] = codeString.utf8.compactMap { char in
-                let digit = Int(char)
-                if digit >= 48 && digit <= 57 {
-                    return digit
-                }
-                return nil
-            }
-            
-            if digits.count == codeLength {
-                return codeString
-            }
-        }
-        return nil
-    }
-    
-    // MARK: - Buy -
-
-    /// Polls `GET /v2/onramp/orders/{id}` until the order reaches a terminal state
-    /// (COMPLETED or FAILED) or the timeout expires. Returns the final order on
-    /// success. Throws on timeout, FAILED status, or repeated network errors.
-    private func pollCoinbaseOrderUntilComplete(orderId: String) async throws -> OnrampOrderResponse.Order {
-        let start = Date()
-        let deadline = start.addingTimeInterval(60) // sandbox completes in 250ms; 60s is generous for production
-        var pollCount = 0
-        var lastError: Error?
-
-        while Date() < deadline {
-            try Task.checkCancellation()
-            pollCount += 1
-            do {
-                let response = try await coinbase.fetchOrder(orderId: orderId)
-                let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
-                let status = response.order.status.uppercased()
-
-                logger.info("Coinbase order poll", metadata: [
-                    "poll": "\(pollCount)",
-                    "elapsed_ms": "\(elapsedMs)",
-                    "status": "\(response.order.status)",
-                    "tx_hash": "\(response.order.txHash ?? "nil")"
-                ])
-
-                if status.contains("COMPLETED") {
-                    return response.order
-                }
-                if status.contains("FAILED") {
-                    throw OnrampError.coinbaseOrderFailed(status: response.order.status)
-                }
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch let error as OnrampError {
-                throw error
-            } catch {
-                lastError = error
-                logger.warning("Coinbase order poll error, retrying", metadata: [
-                    "poll": "\(pollCount)",
-                    "error": "\(error)"
-                ])
-            }
-
-            // Backoff: start at 500ms, +200ms every 5 polls
-            let delayMs = 500 + (200 * (pollCount / 5))
-            try await Task.delay(milliseconds: delayMs)
-        }
-
-        throw lastError ?? OnrampError.coinbaseOrderPollTimeout
-    }
-
-    /// Builds an ExchangedFiat for the buyWithExternalFunding call. The Coinbase
-    /// `purchaseAmount` is a string-encoded decimal in USDF units (e.g. "5" for $5).
-    /// Returns nil if the order didn't actually purchase USDF (defense against future
-    /// Coinbase API changes — we always request USDF, so a mismatch indicates a server
-    /// behavior change worth failing closed on).
-    private func makeUsdfSwapAmount(from order: OnrampOrderResponse.Order) -> ExchangedFiat? {
-        guard let purchaseCurrency = order.purchaseCurrency,
-              purchaseCurrency.uppercased() == "USDF" else {
-            return nil
-        }
-
-        guard let purchaseAmountString = order.purchaseAmount,
-              let decimal = NumberFormatter.decimal(from: purchaseAmountString) else {
-            return nil
-        }
-
-        guard let underlying = try? Quarks(
-            fiatDecimal: decimal,
-            currencyCode: .usd,
-            decimals: PublicKey.usdf.mintDecimals
-        ) else {
-            return nil
-        }
-
-        return try? ExchangedFiat(
-            underlying: underlying,
-            rate: .oneToOne,
-            mint: .usdf
-        )
-    }
-
-    private func handleCoinbaseFundingSuccess() async {
-        logger.info("Coinbase funding succeeded", metadata: [
-            "destination_name": "\(displayName)"
-        ])
-
-        guard let orderId = coinbaseOrder?.order.orderId else {
-            logger.error("pollingSuccess fired with no active Coinbase order")
-            showBuyFailedDialog()
-            return
-        }
-
-        // Poll Coinbase for the completed order. This runs in sandbox too — it
-        // validates the full Coinbase integration (JWT scoping, GET endpoint,
-        // status transitions, txHash field parsing) end-to-end on every run.
-        let order: OnrampOrderResponse.Order
-        do {
-            order = try await pollCoinbaseOrderUntilComplete(orderId: orderId)
-        } catch is CancellationError {
-            // View model was deallocated or task was cancelled mid-poll. The user
-            // already navigated away — no UI update needed.
-            logger.info("Coinbase order poll cancelled")
-            return
-        } catch {
-            logger.error("Coinbase order poll failed", metadata: ["error": "\(error)"])
-            ErrorReporting.captureError(error)
-            showBuyFailedDialog()
-            return
-        }
-
-        // Sandbox short-circuits the on-chain settlement — Coinbase returns a
-        // placeholder tx_hash that isn't a real Solana signature. We skip the
-        // buy (`buyWithExternalFunding` would reject the placeholder) but only
-        // AFTER exercising the full Coinbase order polling pipeline above.
-        if BetaFlags.shared.hasEnabled(.coinbaseSandbox) {
-            logger.info("Sandbox order — skipping buy", metadata: [
-                "order_id": "\(orderId)",
-                "status": "\(order.status)",
-                "tx_hash": "\(order.txHash ?? "nil")"
-            ])
-            showSandboxOrderCompleted()
-            return
-        }
-
-        guard let txHash = order.txHash, !txHash.isEmpty else {
-            logger.error("Coinbase order completed with no txHash", metadata: [
-                "order_id": "\(orderId)",
-                "status": "\(order.status)"
-            ])
-            showBuyFailedDialog()
-            return
-        }
-
-        guard let signature = try? Signature(base58: txHash) else {
-            logger.error("Failed to decode txHash as Solana signature", metadata: [
-                "tx_hash": "\(txHash)",
-                "tx_hash_length": "\(txHash.count)"
-            ])
-            showBuyFailedDialog()
-            return
-        }
-
-        guard let exchangedFiat = makeUsdfSwapAmount(from: order) else {
-            logger.error("Failed to construct swap amount from order", metadata: [
-                "order_id": "\(orderId)"
-            ])
-            showBuyFailedDialog()
-            return
-        }
-
-        do {
-            let swapId = try await session.buyWithExternalFunding(
-                amount: exchangedFiat,
-                of: mint,
-                transactionSignature: signature
-            )
-            coinbaseOrder = nil
-            Analytics.onrampCompleted(
-                amount: exchangedFiat.underlying,
-                successful: true,
-                error: nil
-            )
-            amountPath.append(.swapProcessing(
-                swapId: swapId,
-                currencyName: displayName,
-                amount: exchangedFiat
-            ))
-        } catch {
-            logger.error("Buy failed", metadata: ["error": "\(error)"])
-            ErrorReporting.captureError(error)
-            showBuyFailedDialog()
-        }
-    }
 
     // MARK: - Dialog Factories -
 
@@ -955,35 +149,7 @@ class OnrampViewModel {
         }
     }
 
-    private func presentResendOrCancelDialog(title: String, subtitle: String, resendAction: @escaping () -> Void) {
-        dialogItem = .init(
-            style: .destructive,
-            title: title,
-            subtitle: subtitle,
-            dismissable: true,
-        ) {
-            .destructive("Resend Verification Code") {
-                resendAction()
-            };
-            .cancel()
-        }
-    }
-
     // MARK: - Errors -
-
-    private func showCoinbaseError(title: String, subtitle: String, onDismiss: (() -> Void)? = nil) {
-        presentDestructiveDialog(title: title, subtitle: subtitle) {
-            onDismiss?()
-        }
-    }
-
-    private func showGenericError(action: @escaping DialogAction.DialogActionHandler = {}) {
-        presentDestructiveDialog(
-            title: "Something Went Wrong",
-            subtitle: "Please try again later",
-            action: action
-        )
-    }
 
     private func showAmountTooSmallError() {
         presentDestructiveDialog(
@@ -998,79 +164,9 @@ class OnrampViewModel {
             subtitle: "Please enter a smaller amount"
         )
     }
-
-    private func showUnsupportedPhoneNumberError() {
-        presentDestructiveDialog(
-            title: "Unsupported Phone Number",
-            subtitle: "Please use a different phone number and try again"
-        )
-    }
-
-    private func showInvalidEmailError() {
-        presentDestructiveDialog(
-            title: "Invalid Email",
-            subtitle: "Please enter a different email and try again"
-        )
-    }
-
-    private func showInvalidCodeError() {
-        presentDestructiveDialog(
-            title: "Invalid Code",
-            subtitle: "Please enter the verification code that was sent to your phone number or request a new code"
-        )
-    }
-
-    private func showInvalidVerificationLinkError(resendAction: @escaping () -> Void) {
-        presentResendOrCancelDialog(
-            title: "Verification Link Invalid",
-            subtitle: "This verification link is invalid. Please try again",
-            resendAction: resendAction
-        )
-    }
-
-    private func showExpiredVerificationLinkError(resendAction: @escaping () -> Void) {
-        presentResendOrCancelDialog(
-            title: "Verification Link Expired",
-            subtitle: "This verification link has expired. Please try again",
-            resendAction: resendAction
-        )
-    }
-
-    private func showSandboxOrderCompleted() {
-        payButtonState = .normal
-        coinbaseOrder = nil
-        dialogItem = .init(
-            style: .success,
-            title: "Sandbox Order Completed",
-            subtitle: "The buy is skipped in sandbox mode.",
-            dismissable: true,
-        ) {
-            .okay(kind: .standard) { [weak self] in
-                self?.onDismiss()
-            }
-        }
-    }
-
-    private func showBuyFailedDialog() {
-        payButtonState = .normal
-        coinbaseOrder = nil
-        presentDestructiveDialog(
-            title: "Couldn't Buy Token",
-            subtitle: "Your USDF is in your wallet. Try again from the currency screen."
-        ) { [weak self] in
-            self?.onDismiss()
-        }
-    }
 }
 
 // MARK: - Paths -
-
-/// Navigation path for `OnrampAmountScreen`'s NavigationStack. Exhaustive on
-/// its own — the verification flow has its own path type so the two stacks
-/// never bind the same `[Path]` array.
-enum OnrampAmountPath: Hashable {
-    case swapProcessing(swapId: SwapId, currencyName: String, amount: ExchangedFiat)
-}
 
 /// Navigation path for `VerifyInfoScreen`'s NavigationStack.
 enum OnrampVerificationPath: Hashable {
@@ -1081,14 +177,6 @@ enum OnrampVerificationPath: Hashable {
     case confirmEmailCode
 }
 
-private enum Origin: Int {
-    case root
-    case info
-    case phone
-    case email
-    case payment
-}
-
 // MARK: - Profile -
 
 extension Profile {
@@ -1096,13 +184,6 @@ extension Profile {
         phone != nil && email?.isEmpty == false
     }
 }
-
-// MARK: - CharacterSet -
-
-private extension CharacterSet {
-    static let numbers: CharacterSet = CharacterSet(charactersIn: "0123456789")
-}
-
 
 // MARK: - OnrampError -
 

--- a/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
@@ -39,17 +39,6 @@ class OnrampViewModel {
 
     var coinbaseOrder: OnrampOrderResponse?
 
-    /// True once Coinbase has accepted the order and remains true through the
-    /// full committed flow: Apple Pay commit, on-chain settlement, the poll
-    /// loop, the downstream `buyWithExternalFunding` swap, and while
-    /// `SwapProcessingScreen` is on the nav stack. Drives the sheet-level
-    /// dismiss lock — the USDF destination is a VM-owned staging ATA that only
-    /// `buyWithExternalFunding` can drain, so dismissing mid-flight would
-    /// strand funds with no recovery path through normal UI.
-    var isProcessingPayment: Bool {
-        coinbaseOrder != nil || !amountPath.isEmpty
-    }
-
     var dialogItem: DialogItem?
 
     /// Display name shown on the SwapProcessing step and surfaced in logs.

--- a/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
@@ -10,19 +10,19 @@ import FlipcashUI
 import FlipcashCore
 
 struct VerifyInfoScreen: View {
-    
-    @Bindable private var viewModel: OnrampViewModel
-    
+
+    @Bindable private var coordinator: OnrampCoordinator
+
     // MARK: - Init -
-    
-    init(viewModel: OnrampViewModel) {
-        self.viewModel = viewModel
+
+    init(coordinator: OnrampCoordinator) {
+        self.coordinator = coordinator
     }
-    
+
     // MARK: - Body -
-    
+
     var body: some View {
-        NavigationStack(path: $viewModel.verificationPath) {
+        NavigationStack(path: $coordinator.verificationPath) {
             Background(color: .backgroundMain) {
                 VStack(alignment: .center, spacing: 20) {
                     Spacer()
@@ -44,7 +44,7 @@ struct VerifyInfoScreen: View {
                     Spacer()
 
                     Button("Next") {
-                        viewModel.navigateToInitialVerification()
+                        coordinator.navigateToInitialVerification()
                     }
                     .buttonStyle(.filled)
                 }
@@ -55,24 +55,24 @@ struct VerifyInfoScreen: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    ToolbarCloseButton(binding: $viewModel.isShowingVerificationFlow)
+                    ToolbarCloseButton(binding: $coordinator.isShowingVerificationFlow)
                 }
             }
             .navigationDestination(for: OnrampVerificationPath.self) { path in
                 switch path {
                 case .info:
-                    VerifyInfoScreen(viewModel: viewModel)
+                    VerifyInfoScreen(coordinator: coordinator)
                 case .enterPhoneNumber:
-                    EnterPhoneScreen(viewModel: viewModel)
+                    EnterPhoneScreen(coordinator: coordinator)
                         .interactiveDismissDisabled()
                 case .confirmPhoneNumberCode:
-                    ConfirmPhoneScreen(viewModel: viewModel)
+                    ConfirmPhoneScreen(coordinator: coordinator)
                         .interactiveDismissDisabled()
                 case .enterEmail:
-                    EnterEmailScreen(viewModel: viewModel)
+                    EnterEmailScreen(coordinator: coordinator)
                         .interactiveDismissDisabled()
                 case .confirmEmailCode:
-                    ConfirmEmailScreen(viewModel: viewModel)
+                    ConfirmEmailScreen(coordinator: coordinator)
                         .interactiveDismissDisabled()
                 }
             }

--- a/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
@@ -11,18 +11,18 @@ import FlipcashCore
 
 struct VerifyInfoScreen: View {
 
-    @Bindable private var coordinator: OnrampCoordinator
+    @Bindable private var onrampCoordinator: OnrampCoordinator
 
     // MARK: - Init -
 
-    init(coordinator: OnrampCoordinator) {
-        self.coordinator = coordinator
+    init(onrampCoordinator: OnrampCoordinator) {
+        self.onrampCoordinator = onrampCoordinator
     }
 
     // MARK: - Body -
 
     var body: some View {
-        NavigationStack(path: $coordinator.verificationPath) {
+        NavigationStack(path: $onrampCoordinator.verificationPath) {
             Background(color: .backgroundMain) {
                 VStack(alignment: .center, spacing: 20) {
                     Spacer()
@@ -44,7 +44,7 @@ struct VerifyInfoScreen: View {
                     Spacer()
 
                     Button("Next") {
-                        coordinator.navigateToInitialVerification()
+                        onrampCoordinator.navigateToInitialVerification()
                     }
                     .buttonStyle(.filled)
                 }
@@ -55,24 +55,24 @@ struct VerifyInfoScreen: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    ToolbarCloseButton(binding: $coordinator.isShowingVerificationFlow)
+                    ToolbarCloseButton(binding: $onrampCoordinator.isShowingVerificationFlow)
                 }
             }
             .navigationDestination(for: OnrampVerificationPath.self) { path in
                 switch path {
                 case .info:
-                    VerifyInfoScreen(coordinator: coordinator)
+                    VerifyInfoScreen(onrampCoordinator: onrampCoordinator)
                 case .enterPhoneNumber:
-                    EnterPhoneScreen(coordinator: coordinator)
+                    EnterPhoneScreen(onrampCoordinator: onrampCoordinator)
                         .interactiveDismissDisabled()
                 case .confirmPhoneNumberCode:
-                    ConfirmPhoneScreen(coordinator: coordinator)
+                    ConfirmPhoneScreen(onrampCoordinator: onrampCoordinator)
                         .interactiveDismissDisabled()
                 case .enterEmail:
-                    EnterEmailScreen(coordinator: coordinator)
+                    EnterEmailScreen(onrampCoordinator: onrampCoordinator)
                         .interactiveDismissDisabled()
                 case .confirmEmailCode:
-                    ConfirmEmailScreen(coordinator: coordinator)
+                    ConfirmEmailScreen(onrampCoordinator: onrampCoordinator)
                         .interactiveDismissDisabled()
                 }
             }

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -447,6 +447,7 @@ struct SessionContainer {
             .environment(pushController)
             .environment(walletConnection)
             .environment(onrampCoordinator)
+            .environment(onrampDeeplinkInbox)
     }
 
     @MainActor

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -416,6 +416,7 @@ struct SessionContainer {
     let pushController: PushController
     let flipClient: FlipClient
     let onrampDeeplinkInbox: OnrampDeeplinkInbox
+    let onrampCoordinator: OnrampCoordinator
 
     @MainActor
     init(
@@ -435,6 +436,7 @@ struct SessionContainer {
         self.pushController = pushController
         self.flipClient = flipClient
         self.onrampDeeplinkInbox = OnrampDeeplinkInbox()
+        self.onrampCoordinator = OnrampCoordinator(session: session, flipClient: flipClient)
     }
 
     fileprivate func injectingEnvironment<SomeView>(into view: SomeView) -> some View where SomeView: View {
@@ -444,6 +446,7 @@ struct SessionContainer {
             .environment(historyController)
             .environment(pushController)
             .environment(walletConnection)
+            .environment(onrampCoordinator)
     }
 
     @MainActor

--- a/FlipcashTests/OnrampCoordinatorTests.swift
+++ b/FlipcashTests/OnrampCoordinatorTests.swift
@@ -19,4 +19,34 @@ struct OnrampCoordinatorTests {
         #expect(coordinator.verificationSheet == nil)
         #expect(coordinator.completion == nil)
     }
+
+    @Test("startLaunch with a verified user does not open the verification sheet")
+    func startLaunch_verified_doesNotOpenVerification() {
+        let coordinator = OnrampCoordinator(session: .verifiedMock, flipClient: .mock)
+        coordinator.startLaunch(
+            amount: .mockOne,
+            displayName: "Test",
+            onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
+        )
+        #expect(coordinator.isShowingVerificationFlow == false)
+    }
+
+    @Test("startLaunch with an unverified user opens the verification sheet")
+    func startLaunch_unverified_opensVerification() {
+        let coordinator = OnrampCoordinator(session: .unverifiedMock, flipClient: .mock)
+        coordinator.startLaunch(
+            amount: .mockOne,
+            displayName: "Test",
+            onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
+        )
+        #expect(coordinator.isShowingVerificationFlow == true)
+    }
+
+    @Test("applyDeeplinkVerification sets the confirm-email path and stashes the email")
+    func applyDeeplinkVerification_setsConfirmEmailPath() {
+        let coordinator = OnrampCoordinator(session: .unverifiedMock, flipClient: .mock)
+        coordinator.applyDeeplinkVerification(VerificationDescription(email: "a@b.c", code: "123456"))
+        #expect(coordinator.verificationPath == [.confirmEmailCode])
+        #expect(coordinator.enteredEmail == "a@b.c")
+    }
 }

--- a/FlipcashTests/OnrampCoordinatorTests.swift
+++ b/FlipcashTests/OnrampCoordinatorTests.swift
@@ -1,0 +1,22 @@
+//
+//  OnrampCoordinatorTests.swift
+//  FlipcashTests
+//
+
+import Testing
+@testable import Flipcash
+import FlipcashCore
+
+@MainActor
+@Suite("OnrampCoordinator")
+struct OnrampCoordinatorTests {
+
+    @Test("cancel clears order and verification state")
+    func cancelClearsState() {
+        let coordinator = OnrampCoordinator(session: .mock, flipClient: .mock)
+        coordinator.cancel()
+        #expect(coordinator.coinbaseOrder == nil)
+        #expect(coordinator.verificationSheet == nil)
+        #expect(coordinator.completion == nil)
+    }
+}

--- a/FlipcashTests/OnrampCoordinatorTests.swift
+++ b/FlipcashTests/OnrampCoordinatorTests.swift
@@ -13,39 +13,39 @@ struct OnrampCoordinatorTests {
 
     @Test("cancel clears order and verification state")
     func cancelClearsState() {
-        let coordinator = OnrampCoordinator(session: .mock, flipClient: .mock)
-        coordinator.cancel()
-        #expect(coordinator.coinbaseOrder == nil)
-        #expect(coordinator.completion == nil)
+        let onrampCoordinator = OnrampCoordinator(session: .mock, flipClient: .mock)
+        onrampCoordinator.cancel()
+        #expect(onrampCoordinator.coinbaseOrder == nil)
+        #expect(onrampCoordinator.completion == nil)
     }
 
     @Test("startLaunch with a verified user does not open the verification sheet")
     func startLaunch_verified_doesNotOpenVerification() {
-        let coordinator = OnrampCoordinator(session: .verifiedMock, flipClient: .mock)
-        coordinator.startLaunch(
+        let onrampCoordinator = OnrampCoordinator(session: .verifiedMock, flipClient: .mock)
+        onrampCoordinator.startLaunch(
             amount: .mockOne,
             displayName: "Test",
             onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
         )
-        #expect(coordinator.isShowingVerificationFlow == false)
+        #expect(onrampCoordinator.isShowingVerificationFlow == false)
     }
 
     @Test("startLaunch with an unverified user opens the verification sheet")
     func startLaunch_unverified_opensVerification() {
-        let coordinator = OnrampCoordinator(session: .unverifiedMock, flipClient: .mock)
-        coordinator.startLaunch(
+        let onrampCoordinator = OnrampCoordinator(session: .unverifiedMock, flipClient: .mock)
+        onrampCoordinator.startLaunch(
             amount: .mockOne,
             displayName: "Test",
             onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
         )
-        #expect(coordinator.isShowingVerificationFlow == true)
+        #expect(onrampCoordinator.isShowingVerificationFlow == true)
     }
 
     @Test("applyDeeplinkVerification sets the confirm-email path and stashes the email")
     func applyDeeplinkVerification_setsConfirmEmailPath() {
-        let coordinator = OnrampCoordinator(session: .unverifiedMock, flipClient: .mock)
-        coordinator.applyDeeplinkVerification(VerificationDescription(email: "a@b.c", code: "123456"))
-        #expect(coordinator.verificationPath == [.confirmEmailCode])
-        #expect(coordinator.enteredEmail == "a@b.c")
+        let onrampCoordinator = OnrampCoordinator(session: .unverifiedMock, flipClient: .mock)
+        onrampCoordinator.applyDeeplinkVerification(VerificationDescription(email: "a@b.c", code: "123456"))
+        #expect(onrampCoordinator.verificationPath == [.confirmEmailCode])
+        #expect(onrampCoordinator.enteredEmail == "a@b.c")
     }
 }

--- a/FlipcashTests/OnrampCoordinatorTests.swift
+++ b/FlipcashTests/OnrampCoordinatorTests.swift
@@ -19,24 +19,28 @@ struct OnrampCoordinatorTests {
         #expect(onrampCoordinator.completion == nil)
     }
 
-    @Test("startLaunch with a verified user does not open the verification sheet")
-    func startLaunch_verified_doesNotOpenVerification() {
+    @Test("start with a verified user does not open the verification sheet")
+    func start_verified_doesNotOpenVerification() {
         let onrampCoordinator = OnrampCoordinator(session: .verifiedMock, flipClient: .mock)
-        onrampCoordinator.startLaunch(
-            amount: .mockOne,
-            displayName: "Test",
-            onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
+        onrampCoordinator.start(
+            .launch(
+                displayName: "Test",
+                onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
+            ),
+            amount: .mockOne
         )
         #expect(onrampCoordinator.isShowingVerificationFlow == false)
     }
 
-    @Test("startLaunch with an unverified user opens the verification sheet")
-    func startLaunch_unverified_opensVerification() {
+    @Test("start with an unverified user opens the verification sheet")
+    func start_unverified_opensVerification() {
         let onrampCoordinator = OnrampCoordinator(session: .unverifiedMock, flipClient: .mock)
-        onrampCoordinator.startLaunch(
-            amount: .mockOne,
-            displayName: "Test",
-            onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
+        onrampCoordinator.start(
+            .launch(
+                displayName: "Test",
+                onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
+            ),
+            amount: .mockOne
         )
         #expect(onrampCoordinator.isShowingVerificationFlow == true)
     }

--- a/FlipcashTests/OnrampCoordinatorTests.swift
+++ b/FlipcashTests/OnrampCoordinatorTests.swift
@@ -16,7 +16,6 @@ struct OnrampCoordinatorTests {
         let coordinator = OnrampCoordinator(session: .mock, flipClient: .mock)
         coordinator.cancel()
         #expect(coordinator.coinbaseOrder == nil)
-        #expect(coordinator.verificationSheet == nil)
         #expect(coordinator.completion == nil)
     }
 

--- a/FlipcashTests/TestSupport/ExchangedFiat+TestSupport.swift
+++ b/FlipcashTests/TestSupport/ExchangedFiat+TestSupport.swift
@@ -1,0 +1,19 @@
+//
+//  ExchangedFiat+TestSupport.swift
+//  FlipcashTests
+//
+
+import Foundation
+import FlipcashCore
+
+extension ExchangedFiat {
+
+    /// A simple fixture representing a small USDF amount. Use in tests that
+    /// only need a well-formed amount — coordinator routing, enum case checks,
+    /// and similar tests that do not exercise amount math.
+    static let mockOne = ExchangedFiat(
+        underlying: 1_000_000,
+        converted: 1_000_000,
+        mint: .usdf
+    )
+}

--- a/FlipcashTests/TestSupport/ExchangedFiat+TestSupport.swift
+++ b/FlipcashTests/TestSupport/ExchangedFiat+TestSupport.swift
@@ -8,9 +8,9 @@ import FlipcashCore
 
 extension ExchangedFiat {
 
-    /// A simple fixture representing a small USDF amount. Use in tests that
-    /// only need a well-formed amount — coordinator routing, enum case checks,
-    /// and similar tests that do not exercise amount math.
+    /// A $1 USDF fixture (USDF uses 6 decimals, so $1 == 1_000_000 quarks).
+    /// Use in tests that only need a well-formed amount — coordinator routing,
+    /// enum case checks, and similar tests that do not exercise amount math.
     static let mockOne = ExchangedFiat(
         underlying: 1_000_000,
         converted: 1_000_000,

--- a/FlipcashTests/TestSupport/Session+TestSupport.swift
+++ b/FlipcashTests/TestSupport/Session+TestSupport.swift
@@ -1,0 +1,58 @@
+//
+//  Session+TestSupport.swift
+//  FlipcashTests
+//
+
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+extension Session {
+
+    /// A session whose profile is `nil`, so both `isPhoneVerified` and
+    /// `isEmailVerified` read as `false`. Use when a test needs to drive
+    /// a flow that branches on unverified state.
+    @MainActor
+    static func makeUnverifiedMock() -> Session {
+        Session(
+            container: .mock,
+            historyController: .mock,
+            ratesController: .mock,
+            database: .mock,
+            keyAccount: .mock,
+            owner: .init(
+                authority: .derive(using: .primary(), mnemonic: .mock),
+                mint: .mock,
+                timeAuthority: .usdcAuthority
+            ),
+            userID: UUID()
+        )
+    }
+
+    /// A session with a fully-verified profile (both phone and email set).
+    /// Use when a test needs to drive a flow that branches on verified state.
+    @MainActor
+    static func makeVerifiedMock() -> Session {
+        let session = makeUnverifiedMock()
+        session.profile = Profile(
+            displayName: "Test User",
+            phone: .mock,
+            email: "test@example.com"
+        )
+        return session
+    }
+
+    /// Alias for `makeUnverifiedMock()` — exposes the session as a property so
+    /// tests read as `.unverifiedMock` at the call site.
+    @MainActor
+    static var unverifiedMock: Session {
+        makeUnverifiedMock()
+    }
+
+    /// Alias for `makeVerifiedMock()` — exposes the session as a property so
+    /// tests read as `.verifiedMock` at the call site.
+    @MainActor
+    static var verifiedMock: Session {
+        makeVerifiedMock()
+    }
+}

--- a/FlipcashTests/TestSupport/Session+TestSupport.swift
+++ b/FlipcashTests/TestSupport/Session+TestSupport.swift
@@ -13,7 +13,7 @@ extension Session {
     /// `isEmailVerified` read as `false`. Use when a test needs to drive
     /// a flow that branches on unverified state.
     @MainActor
-    static func makeUnverifiedMock() -> Session {
+    static var unverifiedMock: Session {
         Session(
             container: .mock,
             historyController: .mock,
@@ -32,27 +32,13 @@ extension Session {
     /// A session with a fully-verified profile (both phone and email set).
     /// Use when a test needs to drive a flow that branches on verified state.
     @MainActor
-    static func makeVerifiedMock() -> Session {
-        let session = makeUnverifiedMock()
+    static var verifiedMock: Session {
+        let session = unverifiedMock
         session.profile = Profile(
             displayName: "Test User",
             phone: .mock,
             email: "test@example.com"
         )
         return session
-    }
-
-    /// Alias for `makeUnverifiedMock()` — exposes the session as a property so
-    /// tests read as `.unverifiedMock` at the call site.
-    @MainActor
-    static var unverifiedMock: Session {
-        makeUnverifiedMock()
-    }
-
-    /// Alias for `makeVerifiedMock()` — exposes the session as a property so
-    /// tests read as `.verifiedMock` at the call site.
-    @MainActor
-    static var verifiedMock: Session {
-        makeVerifiedMock()
     }
 }


### PR DESCRIPTION
## Summary
Hoist the ApplePayWebView into the Container, update the Coordinate to orchestrate all the new callsites

## Test plan
- [x] Buy existing currency via Coinbase (verified user): amount entry → Apple Pay → processing screen
- [ ] Launch new currency via Coinbase (verified user): wizard → confirmation → processing screen
- [x] Buy or launch with unverified user: verification sheet, phone + email round-trip, order resumes after verification
- [x] Email verification deeplink while the sheet is up and while it isn't
- [x] `OnrampCoordinatorTests` pass