### PR TITLE
refactor: modernize SendCashOperation and ScanCashOperation

### DIFF
--- a/Flipcash/Core/Screens/Main/Operations/ScanCashOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/ScanCashOperation.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import FlipcashCore
-import Combine
 
 private let logger = Logger(label: "flipcash.scan-cash")
 
@@ -19,10 +18,11 @@ private let logger = Logger(label: "flipcash.scan-cash")
 /// - Listens for a grab request on the same channel
 ///
 /// ## Device B (Receiver — this class)
-/// 1. **Listen for mint** — Poll the rendezvous channel until the sender's
-///    `requestToGiveBill` message arrives. Extract the mint address,
+/// 1. **Listen for mint** — Subscribe to the rendezvous stream and wait for
+///    the sender's `requestToGiveBill` message. Extract the mint address,
 ///    `VerifiedState` (exchange rate + reserve state proofs), and
-///    `MintMetadata` (server-provided via `additionalContext`) from the message.
+///    `MintMetadata` (server-provided via `additionalContext`) from the
+///    message.
 /// 2. **Resolve VM authority** — Use the mint metadata from the message
 ///    when available (zero network cost). Falls back to a database lookup
 ///    or `fetchMints()` call for older servers that don't populate
@@ -38,17 +38,17 @@ private let logger = Logger(label: "flipcash.scan-cash")
 /// when Device B has never synced this currency.
 @MainActor
 class ScanCashOperation {
-    
+
     private let client: Client
     private let flipClient: FlipClient
     private let database: Database
     private let owner: AccountCluster
     private let payload: CashCode.Payload
-    
-    private var messageStream: AnyCancellable? = nil
-    
+
+    private var runTask: Task<PaymentMetadata, Swift.Error>?
+
     // MARK: - Init -
-    
+
     init(client: Client, flipClient: FlipClient, database: Database, owner: AccountCluster, payload: CashCode.Payload) {
         self.client     = client
         self.flipClient = flipClient
@@ -60,146 +60,128 @@ class ScanCashOperation {
 
     deinit {
         logger.info("ScanCashOperation closed", metadata: ["rendezvous": "\(payload.rendezvous.publicKey.base58)"])
-        messageStream?.cancel()
-        messageStream = nil
+        runTask?.cancel()
     }
-    
+
+    // MARK: - Lifecycle -
+
     func start() async throws -> PaymentMetadata {
+        let task = Task { try await self.run() }
+        runTask = task
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    func cancel() {
+        runTask?.cancel()
+    }
+
+    // MARK: - Run -
+
+    private func run() async throws -> PaymentMetadata {
         let rendezvous = payload.rendezvous
         let owner = owner
 
-        let (mint, verifiedState, mintMetadata) = try await listenForMint(
-            rendezvous: rendezvous
-        )
+        logger.info("Polling for give request", metadata: ["rendezvous": "\(rendezvous.publicKey.base58)"])
+        let giveRequest = try await client.awaitGiveRequest(rendezvous: rendezvous)
+
+        logger.info("Received give request", metadata: [
+            "rendezvous": "\(rendezvous.publicKey.base58)",
+            "mint": "\(giveRequest.mint.base58)",
+            "hasVerifiedState": "\(giveRequest.verifiedState != nil)",
+            "hasMintMetadata": "\(giveRequest.mintMetadata != nil)",
+        ])
 
         let vmAuthority: PublicKey
-        if let mintMetadata, let authority = mintMetadata.vmMetadata?.authority {
+        if let mintMetadata = giveRequest.mintMetadata, let authority = mintMetadata.vmMetadata?.authority {
             // Persist the metadata so downstream operations (e.g.
             // SendCashOperation for the quick give-and-grab chain)
             // can look it up from the database immediately.
             try? database.insert(mints: [mintMetadata], date: .now)
+            logger.debug("VM authority resolved from give-request metadata", metadata: ["mint": "\(giveRequest.mint.base58)"])
             vmAuthority = authority
         } else {
-            vmAuthority = try await pullMintIfNeeded(for: mint)
+            vmAuthority = try await pullMintIfNeeded(for: giveRequest.mint)
         }
 
         let mintCurrencyCluster = AccountCluster(
             authority: owner.authority,
-            mint: mint,
+            mint: giveRequest.mint,
             timeAuthority: vmAuthority
         )
-        
-        // We need to ensure the accounts for this mint
-        // are created. This call is a no-op is the
-        // account already exists
+
+        // No-op when the account already exists.
         try await client.createAccounts(
             owner: owner.authority.keyPair,
-            mint: mint,
+            mint: giveRequest.mint,
             cluster: mintCurrencyCluster,
             kind: .primary,
             derivationIndex: 0
         )
-        
+
         return try await completePayment(
             destination: mintCurrencyCluster.vaultPublicKey,
             rendezvous: rendezvous,
-            verifiedState: verifiedState
+            verifiedState: giveRequest.verifiedState
         )
     }
-    
+
+    // MARK: - Helpers -
+
     private func pullMintIfNeeded(for mint: PublicKey) async throws -> PublicKey {
         if let vmAuthority = try database.getVMAuthority(mint: mint) {
+            logger.debug("VM authority resolved from database", metadata: ["mint": "\(mint.base58)"])
             return vmAuthority
-        } else {
-            let mints = try await client.fetchMints(mints: [mint])
-            guard let mintMetadata = mints[mint] else {
-                throw Error.failedToFetchMint
-            }
-            
-            try database.insert(mints: [mintMetadata], date: .now)
-            
-            guard let authority = mintMetadata.vmMetadata?.authority else {
-                throw Error.failedToFetchMint
-            }
-            
-            return authority
-        }
-    }
-    
-    private func listenForMint(rendezvous: KeyPair) async throws -> (PublicKey, VerifiedState?, MintMetadata?) {
-        let maxAttempts = 10
-
-        for i in 0..<maxAttempts {
-            if i > 0 {
-                try await Task.delay(milliseconds: 300)
-            }
-
-            do {
-                let messages = try await client.fetchMessages(rendezvous: rendezvous)
-                let result = messages.compactMap { message -> (PublicKey, VerifiedState?, MintMetadata?)? in
-                    if case .requestToGiveBill(let mint, _, _) = message.kind {
-                        return (mint, message.giveVerifiedState, message.giveMintMetadata)
-                    }
-                    return nil
-                }.first
-
-                if let result {
-                    return result
-                }
-            } catch {
-                logger.warning("Failed to fetch messages", metadata: ["attempt": "\(i + 1)/\(maxAttempts)", "error": "\(error)"])
-                throw Error.connectionFailed
-            }
         }
 
-        throw Error.mintMessageNotFound
+        logger.info("Fetching mint metadata from server", metadata: ["mint": "\(mint.base58)"])
+        let mints = try await client.fetchMints(mints: [mint])
+        guard let mintMetadata = mints[mint] else {
+            throw Error.failedToFetchMint
+        }
+
+        try database.insert(mints: [mintMetadata], date: .now)
+
+        guard let authority = mintMetadata.vmMetadata?.authority else {
+            throw Error.failedToFetchMint
+        }
+
+        return authority
     }
-    
+
     private func completePayment(destination: PublicKey, rendezvous: KeyPair, verifiedState: VerifiedState?) async throws -> PaymentMetadata {
-        do {
-            let isStreamOpen = try await client.sendRequestToGrabBill(
-                destination: destination,
-                rendezvous: rendezvous
-            )
+        let isStreamOpen = try await client.sendRequestToGrabBill(
+            destination: destination,
+            rendezvous: rendezvous
+        )
 
-            guard isStreamOpen else {
-                throw Error.noOpenStreamForRendezvous
-            }
-
-            let metadata = try await client.pollIntentMetadata(
-                owner: owner.authority.keyPair,
-                intentID: rendezvous.publicKey
-            )
-
-            if case .sendPayment(let paymentMetadata) = metadata {
-                return PaymentMetadata(
-                    exchangedFiat: paymentMetadata.exchangedFiat,
-                    verifiedState: verifiedState
-                )
-            }
-
-            if case .receivePayment(let paymentMetadata) = metadata {
-                return PaymentMetadata(
-                    exchangedFiat: paymentMetadata.exchangedFiat,
-                    verifiedState: verifiedState
-                )
-            }
-
-            throw Error.sendPaymentMetadataNotFound
-            
-        } catch Error.noOpenStreamForRendezvous {
-            throw Error.noOpenStreamForRendezvous // Avoid capture
-
-        } catch ClientError.pollLimitReached {
-            throw ClientError.pollLimitReached // Avoid capture
-
-        } catch ClientError.denied {
-            throw ClientError.denied // Avoid capture
-
-        } catch {
-//            ErrorReporting.captureError(error)
-            throw error
+        guard isStreamOpen else {
+            throw Error.noOpenStreamForRendezvous
         }
+
+        let metadata = try await client.pollIntentMetadata(
+            owner: owner.authority.keyPair,
+            intentID: rendezvous.publicKey
+        )
+
+        if case .sendPayment(let paymentMetadata) = metadata {
+            return PaymentMetadata(
+                exchangedFiat: paymentMetadata.exchangedFiat,
+                verifiedState: verifiedState
+            )
+        }
+
+        if case .receivePayment(let paymentMetadata) = metadata {
+            return PaymentMetadata(
+                exchangedFiat: paymentMetadata.exchangedFiat,
+                verifiedState: verifiedState
+            )
+        }
+
+        throw Error.sendPaymentMetadataNotFound
     }
 }
 
@@ -208,11 +190,5 @@ extension ScanCashOperation {
         case noOpenStreamForRendezvous
         case sendPaymentMetadataNotFound
         case failedToFetchMint
-        case missingVMAuthority
-        case mintMessageNotFound
-
-        /// A network error prevented fetching messages from the
-        /// rendezvous channel (e.g. no internet connection).
-        case connectionFailed
     }
 }

--- a/Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import FlipcashCore
-import Combine
 
 private let logger = Logger(label: "flipcash.send-cash")
 
@@ -32,54 +31,40 @@ private let logger = Logger(label: "flipcash.send-cash")
 ///
 /// ## Lifecycle
 ///
-/// Calling ``start(completion:)`` kicks off two concurrent paths:
-///
-/// **Path 1 — Advertise (fire-and-forget Task)**
-/// 1. Resolve the exchange-rate proof (`VerifiedState`), preferring the
-///    value provided at init over the `RatesController` cache.
-/// 2. Publish the bill on the rendezvous channel so the receiver knows
-///    which mint and exchange data to expect.
-///
-/// **Path 2 — Listen (message stream)**
-/// 1. Open a persistent gRPC stream on the rendezvous channel.
-/// 2. When the receiver's grab request arrives, verify the destination
-///    signature to prevent tampering.
-/// 3. Transfer funds to the verified destination.
-/// 4. Poll until on-chain settlement is confirmed.
-///
-/// Both paths share the resolved `VerifiedState` through
-/// ``resolvedVerifiedState``. Path 2 reads this value when it's time to
-/// transfer, falling back to the `RatesController` cache if Path 1 hasn't
-/// written it yet. For brand-new currencies whose rate isn't cached, the
-/// provided `verifiedState` at init is the only source of truth.
-///
-/// ## Completion Guarantee
-///
-/// The ``complete(with:completion:)`` method ensures the completion handler
-/// fires exactly once. This guards against double-delivery from gRPC stream
-/// reconnections (see `MessagingService.openMessageStream`) or overlapping
-/// error paths (e.g. advertisement failure racing with a stream disconnect).
+/// ``start()`` runs the whole flow imperatively — advertise, await grab,
+/// verify, transfer, poll settlement. The operation owns a `Task` internally
+/// so callers can invoke ``cancel()`` to tear it down without having to
+/// track the outer Task themselves.
 ///
 /// ## Not Recoverable
 ///
 /// If ``sendRequestToGiveBill`` fails (network error, server down), the
 /// operation terminates immediately. There is no retry — the receiver never
 /// got the advertisement, so the stream will never deliver a grab request.
-/// The bill is dismissed and the user sees an error.
 ///
 /// ## Owned By
 ///
 /// `Session` creates, stores (`sendOperation`), and tears down this
 /// operation. The `ignoresStream` flag is toggled by Session when presenting
-/// a share sheet to prevent stream events from dismissing the bill.
+/// a share sheet to suppress grab-request processing underneath it.
 @MainActor
 class SendCashOperation {
 
+    /// Submitting a proof older than this is rejected as stale, so we pre-flight the check
+    /// to fail fast and surface a specific error in logs and Bugsnag.
+    static let maxReserveAge: TimeInterval = 15 * 60
+
+    enum FailurePath: String {
+        case advertisement
+        case stream
+        case transfer
+    }
+
     let payload: CashCode.Payload
 
-    /// When `true`, incoming stream messages are silently dropped. Session
-    /// sets this while a share sheet is presented to prevent the bill from
-    /// being dismissed underneath it.
+    /// When `true`, incoming rendezvous-stream messages are silently dropped.
+    /// Session sets this while a share sheet is presented to prevent a grab
+    /// request from being processed while the user is mid-share-sheet.
     var ignoresStream = false
 
     private let client: Client
@@ -87,30 +72,9 @@ class SendCashOperation {
     private let ratesController: RatesController
     private let owner: AccountCluster
     private let exchangedFiat: ExchangedFiat
-
-    /// The exchange-rate proof passed at init. Preferred over the
-    /// `RatesController` cache because new currencies may not have a
-    /// cached rate yet.
     private let providedVerifiedState: VerifiedState?
 
-    private var messageStream: AnyCancellable? = nil
-
-    /// Guards against processing more than one grab request per operation.
-    private var hasProcessedPayment = false
-
-    /// Guards against delivering the completion handler more than once.
-    /// See ``complete(with:completion:)`` for details.
-    private var hasCompleted = false
-
-    /// Which path failed — used for error reporting to distinguish
-    /// advertisement failures (Path 1) from transfer failures (Path 2).
-    private(set) var failurePath: String?
-
-    /// The verified state resolved during Path 1 (advertisement). Path 2
-    /// (transfer) reads this to avoid a redundant cache lookup. For new
-    /// currencies this may be the only available source since the cache
-    /// can be empty.
-    private(set) var resolvedVerifiedState: VerifiedState?
+    private var runTask: Task<Void, Swift.Error>?
 
     // MARK: - Init -
 
@@ -131,159 +95,197 @@ class SendCashOperation {
 
     deinit {
         logger.info("SendCashOperation closed", metadata: ["rendezvous": "\(payload.rendezvous.publicKey.base58)"])
-        messageStream?.cancel()
-        messageStream = nil
+        runTask?.cancel()
     }
-    
-    func start(completion: @escaping (Result<Void, Swift.Error>) -> Void) {
+
+    // MARK: - Lifecycle -
+
+    func start() async throws {
+        let task = Task { try await self.run() }
+        runTask = task
+        try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    func cancel() {
+        runTask?.cancel()
+    }
+
+    // MARK: - Run -
+    //
+    // 1. Resolve verified state (one proof used for the whole op)
+    // 2. Advertise bill on rendezvous channel
+    // 3. Await grab request from receiver
+    // 4. Verify destination signature
+    // 5. Transfer funds + poll settlement
+    //
+    // The same proof is used for advertise and transfer on purpose. `exchangedFiat`
+    // bakes in (quarks, nativeAmount) at bill creation time; switching to a
+    // different-rate proof for transfer would make the server's
+    // `quarks × rate ≈ nativeAmount` check fail with
+    // `invalidIntent(native amount does not match expected sell value)`.
+
+    private func run() async throws {
         let rendezvous = payload.rendezvous
         let exchangedFiat = exchangedFiat
         var owner = owner
-        
-        // Ensure that our outgoing (source) account mint
-        // matches the mint of the funds being sent
+
         if owner.timelock.mint != exchangedFiat.mint {
             guard let vmAuthority = try? database.getVMAuthority(mint: exchangedFiat.mint) else {
-                completion(.failure(Error.missingMintMetadata))
-                return
+                throw Error.missingMintMetadata
             }
-            
-            owner = owner.use(
+            owner = owner.use(mint: exchangedFiat.mint, timeAuthority: vmAuthority)
+        }
+
+        let resolution = await resolveAndLogVerifiedState(
+            currency: exchangedFiat.nativeAmount.currency,
+            mint: exchangedFiat.mint
+        )
+
+        do {
+            _ = try await client.sendRequestToGiveBill(
                 mint: exchangedFiat.mint,
-                timeAuthority: vmAuthority
+                exchangedFiat: exchangedFiat,
+                verifiedState: resolution.state,
+                rendezvous: rendezvous
             )
-        }
-        
-        // Send a message to the receiver with the mint and exchange
-        // data so they can create the correct incoming accounts
-        // on their end
-        Task {
-            do {
-                let verifiedState: VerifiedState?
-                if let provided = self.providedVerifiedState {
-                    verifiedState = provided
-                } else {
-                    verifiedState = await self.ratesController.getVerifiedState(
-                        for: exchangedFiat.nativeAmount.currency,
-                        mint: exchangedFiat.mint
-                    )
-                }
-
-                self.resolvedVerifiedState = verifiedState
-
-                _ = try await client.sendRequestToGiveBill(
-                    mint: exchangedFiat.mint,
-                    exchangedFiat: exchangedFiat,
-                    verifiedState: verifiedState,
-                    rendezvous: rendezvous
-                )
-            } catch {
-                logger.error("Advertisement failed", metadata: ["rendezvous": "\(rendezvous.publicKey.base58)", "error": "\(error)"])
-                self.failurePath = "advertisement"
-                self.complete(with: .failure(error), completion: completion)
-            }
+        } catch {
+            try Task.checkCancellation()
+            handleFailure(error, path: .advertisement, resolution: resolution)
+            throw error
         }
 
-        messageStream = self.client.openMessageStream(rendezvous: rendezvous) { [weak self] result in
-            guard let self = self else { return }
-
-            guard !self.ignoresStream else {
-                return
-            }
-
-            // Prevent processing duplicate payment requests
-            guard !self.hasProcessedPayment else {
-                logger.warning("Ignoring duplicate payment request", metadata: ["rendezvous": "\(rendezvous.publicKey.base58)"])
-                return
-            }
-
-            switch result {
-            case .success(let messages):
-                // Ignore non-payment metadata messages
-                guard let paymentMetadata = messages.compactMap({ $0.paymentRequest }).first else {
-                    return
+        let paymentRequest: PaymentRequest
+        do {
+            paymentRequest = try await client.awaitGrabRequest(
+                rendezvous: rendezvous,
+                shouldIgnore: { [weak self] in
+                    // Hops to MainActor to read the flag safely — this closure
+                    // is invoked from the cooperative executor inside the
+                    // stream wait, not from the owning actor.
+                    await self?.ignoresStream ?? false
                 }
+            )
+        } catch {
+            try Task.checkCancellation()
+            handleFailure(error, path: .stream, resolution: resolution)
+            throw error
+        }
 
-                // 1. Validate that destination hasn't been tampered with by
-                // verifying the signature matches one that has been signed
-                // with the rendezvous key.
+        // Rejects tampered grab requests by checking the rendezvous signature.
+        let isValid = client.verifyRequestToGrabBill(
+            destination: paymentRequest.account,
+            rendezvous: rendezvous.publicKey,
+            signature: paymentRequest.signature
+        )
 
-                let isValid = client.verifyRequestToGrabBill(
-                    destination: paymentMetadata.account,
-                    rendezvous: rendezvous.publicKey,
-                    signature: paymentMetadata.signature
-                )
+        guard isValid else {
+            let error = Error.invalidPaymentDestinationSignature
+            handleFailure(error, path: .transfer, resolution: resolution)
+            throw error
+        }
 
-                guard isValid else {
-                    self.complete(with: .failure(Error.invalidPaymentDestinationSignature), completion: completion)
-                    return
-                }
+        guard let transferState = resolution.state else {
+            let error = Error.missingVerifiedState
+            handleFailure(error, path: .transfer, resolution: resolution)
+            throw error
+        }
 
-                // Mark payment as processed to prevent duplicate submissions
-                self.hasProcessedPayment = true
-
-                // 2. Send the funds to destination
-                Task {
-                    do {
-                        // Use the verified state already resolved when the bill
-                        // was created, falling back to the cache only if needed.
-                        // New currencies may not be in the cache yet.
-                        let verifiedState: VerifiedState
-                        if let resolved = self.resolvedVerifiedState {
-                            verifiedState = resolved
-                        } else if let cached = await self.ratesController.getVerifiedState(
-                            for: exchangedFiat.nativeAmount.currency,
-                            mint: exchangedFiat.mint
-                        ) {
-                            verifiedState = cached
-                        } else {
-                            throw Error.missingVerifiedState
-                        }
-
-                        try await self.client.transfer(
-                            exchangedFiat: exchangedFiat,
-                            verifiedState: verifiedState,
-                            owner: owner,
-                            destination: paymentMetadata.account,
-                            rendezvous: rendezvous.publicKey
-                        )
-
-                        _ = try await self.client.pollIntentMetadata(
-                            owner: owner.authority.keyPair,
-                            intentID: rendezvous.publicKey
-                        )
-
-                        self.complete(with: .success(()), completion: completion)
-
-                    } catch {
-                        logger.error("Transfer failed", metadata: ["rendezvous": "\(rendezvous.publicKey.base58)", "error": "\(error)"])
-                        self.failurePath = "transfer"
-                        self.complete(with: .failure(error), completion: completion)
-                    }
-                }
-
-            case .failure(let error):
-                logger.error("Stream failed", metadata: ["rendezvous": "\(rendezvous.publicKey.base58)", "error": "\(error)"])
-                self.failurePath = "stream"
-                self.complete(with: .failure(error), completion: completion)
+        if let reserveTimestamp = transferState.reserveTimestamp {
+            let reserveAge = Date().timeIntervalSince(reserveTimestamp)
+            if reserveAge >= Self.maxReserveAge {
+                let error = Error.reserveProofStale(ageSeconds: reserveAge)
+                handleFailure(error, path: .transfer, resolution: resolution)
+                throw error
             }
+        }
+
+        do {
+            try await client.transfer(
+                exchangedFiat: exchangedFiat,
+                verifiedState: transferState,
+                owner: owner,
+                destination: paymentRequest.account,
+                rendezvous: rendezvous.publicKey
+            )
+
+            _ = try await client.pollIntentMetadata(
+                owner: owner.authority.keyPair,
+                intentID: rendezvous.publicKey
+            )
+        } catch {
+            try Task.checkCancellation()
+            handleFailure(error, path: .transfer, resolution: resolution)
+            throw error
         }
     }
-    
-    /// Delivers a result to the caller exactly once. Subsequent calls are
-    /// no-ops, preventing double-completion from stream reconnections or
-    /// overlapping error paths.
-    private func complete(with result: Result<Void, Swift.Error>, completion: @escaping (Result<Void, Swift.Error>) -> Void) {
-        guard !hasCompleted else { return }
-        hasCompleted = true
-        invalidateMessageStream()
-        completion(result)
+
+    // MARK: - Helpers -
+
+    /// Resolves verified state via the shared helper and logs the source +
+    /// rate proof age. Logging the source is the primary diagnostic for the
+    /// recurring `invalidIntent(native amount does not match expected sell value)`
+    /// error — it lets us see where the submitted proof came from on any
+    /// given recurrence.
+    private func resolveAndLogVerifiedState(currency: CurrencyCode, mint: PublicKey) async -> VerifiedStateResolution {
+        let resolution = await resolveVerifiedState(
+            provided: providedVerifiedState,
+            currency: currency,
+            mint: mint,
+            cacheLookup: { [ratesController] c, m in
+                await ratesController.getVerifiedState(for: c, mint: m)
+            }
+        )
+
+        var metadata: Logger.Metadata = [
+            "source": "\(resolution.sourceLabel)",
+            "currency": "\(currency.rawValue)",
+            "mint": "\(mint.base58)",
+        ]
+        if let state = resolution.state {
+            let rateAge = Date().timeIntervalSince(state.timestamp)
+            metadata["rate"] = "\(state.exchangeRate)"
+            metadata["rateAgeSec"] = "\(String(format: "%.1f", rateAge))"
+            metadata["hasReserveProof"] = "\(state.reserveProto != nil)"
+            if let reserveTimestamp = state.reserveTimestamp {
+                let reserveAge = Date().timeIntervalSince(reserveTimestamp)
+                metadata["reserveAgeSec"] = "\(String(format: "%.1f", reserveAge))"
+            }
+        }
+
+        switch resolution {
+        case .cacheMiss:
+            // TODO: Fall back to `RatesController.ensureMintSubscribed` +
+            // `awaitVerifiedState` to recover when a brand-new currency
+            // hasn't populated the cache yet.
+            logger.warning("Verified state resolution failed", metadata: metadata)
+        case .provided, .cacheHit:
+            logger.info("Resolved verified state", metadata: metadata)
+        }
+
+        return resolution
     }
 
-    private func invalidateMessageStream() {
-        logger.info("Closed message stream")
-        messageStream?.cancel()
-        messageStream = nil
+    private func handleFailure(_ error: Swift.Error, path: FailurePath, resolution: VerifiedStateResolution) {
+        // Log before capturing so the entry lands in the trace buffer
+        // Bugsnag attaches to the report.
+        logger.error("SendCashOperation failed", metadata: [
+            "rendezvous": "\(payload.rendezvous.publicKey.base58)",
+            "path": "\(path.rawValue)",
+            "verifiedStateSource": "\(resolution.sourceLabel)",
+            "error": "\(error)",
+        ])
+
+        ErrorReporting.capturePayment(
+            error: error,
+            rendezvous: payload.rendezvous.publicKey,
+            exchangedFiat: exchangedFiat,
+            verifiedState: resolution.state,
+            reason: path.rawValue
+        )
     }
 }
 
@@ -301,5 +303,10 @@ extension SendCashOperation {
         /// value at init or the `RatesController` cache. Common for
         /// brand-new currencies that haven't been rate-cached yet.
         case missingVerifiedState
+
+        /// The resolved `VerifiedState` has a reserve-state proof older than
+        /// the server tolerates. Submitting it would be rejected — we reject
+        /// client-side to surface a specific error.
+        case reserveProofStale(ageSeconds: TimeInterval)
     }
 }

--- a/Flipcash/Core/Screens/Main/Operations/VerifiedStateResolution.swift
+++ b/Flipcash/Core/Screens/Main/Operations/VerifiedStateResolution.swift
@@ -1,0 +1,53 @@
+//
+//  VerifiedStateResolution.swift
+//  Flipcash
+//
+
+import Foundation
+import FlipcashCore
+
+/// Outcome of a verified-state resolution attempt.
+///
+/// Encoded as an enum rather than `(VerifiedState?, source: Source)` so the
+/// "state is nil iff cacheMiss" invariant holds at the type level — callers
+/// can't accidentally consume `.cacheMiss` as if it had a value.
+enum VerifiedStateResolution: Equatable, Sendable {
+    case provided(VerifiedState)
+    case cacheHit(VerifiedState)
+    case cacheMiss
+
+    /// Stable identifier suitable for log metadata.
+    var sourceLabel: String {
+        switch self {
+        case .provided: return "provided"
+        case .cacheHit: return "cache-hit"
+        case .cacheMiss: return "cache-miss"
+        }
+    }
+
+    var state: VerifiedState? {
+        switch self {
+        case .provided(let state), .cacheHit(let state):
+            return state
+        case .cacheMiss:
+            return nil
+        }
+    }
+}
+
+/// Resolve a `VerifiedState`, preferring `provided` and falling back to
+/// `cacheLookup`. Returns `.cacheMiss` when neither yields a proof.
+func resolveVerifiedState(
+    provided: VerifiedState?,
+    currency: CurrencyCode,
+    mint: PublicKey,
+    cacheLookup: (CurrencyCode, PublicKey) async -> VerifiedState?
+) async -> VerifiedStateResolution {
+    if let provided {
+        return .provided(provided)
+    }
+    if let cached = await cacheLookup(currency, mint) {
+        return .cacheHit(cached)
+    }
+    return .cacheMiss
+}

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -902,9 +902,10 @@ class Session {
                 // so the user can retry by scanning again.
                 completion(.failed)
 
-            } catch ScanCashOperation.Error.connectionFailed {
-                // Network error while fetching the bill's mint data.
-                showCashLinkConnectionError()
+            } catch MessagingWaitError.timedOut {
+                // No advertisement arrived on the rendezvous stream within
+                // the wait window — the bill is stale or the sender is gone.
+                // Silently reset so the user can retry by scanning again.
                 completion(.failed)
 
             } catch {
@@ -944,8 +945,8 @@ class Session {
         
         var primaryAction: BillState.PrimaryAction? = .init(asset: .airplane, title: "Send as a Link") { [weak self, weak operation] in
             if let operation, let self {
-                // Disable scanning of the bill
-                // while the share sheet is up
+                // Suppress grab-request processing on the rendezvous stream
+                // while the share sheet is up (keeps the bill alive underneath).
                 operation.ignoresStream = true
                 
                 let payload       = operation.payload
@@ -1033,19 +1034,20 @@ class Session {
             Analytics.transferStart(event: .giveBillStart)
         }
 
-        operation.start { [weak self] result in
-            switch result {
-            case .success:
+        Task { [weak self] in
+            do {
+                try await operation.start()
+
                 // Toast: someone grabbed the user's bill (-amount)
                 self?.enqueue(toast: .init(
                     amount: billDescription.exchangedFiat.nativeAmount,
                     isDeposit: false
                 ))
-                
+
                 self?.updatePostTransaction()
-                
+
                 self?.dismissCashBill(style: .pop)
-                
+
                 Analytics.transfer(
                     event: .giveBill,
                     exchangedFiat: billDescription.exchangedFiat,
@@ -1053,28 +1055,14 @@ class Session {
                     successful: true,
                     error: nil
                 )
-                
-            case .failure(let error):
-                let verifiedState = self?.sendOperation?.resolvedVerifiedState
-                let failurePath = self?.sendOperation?.failurePath
-
-                logger.error("SendCashOperation failed", metadata: [
-                    "rendezvous": "\(payload.rendezvous.publicKey.base58)",
-                    "path": "\(failurePath ?? "unknown")",
-                    "error": "\(error)"
-                ])
-
-                ErrorReporting.capturePayment(
-                    error: error,
-                    rendezvous: payload.rendezvous.publicKey,
-                    exchangedFiat: billDescription.exchangedFiat,
-                    verifiedState: verifiedState,
-                    reason: failurePath
-                )
-
+            } catch is CancellationError {
+                // Cancelled by dismissCashBill — no error UI, no analytics.
+                return
+            } catch {
+                // Diagnostics + ErrorReporting happen inside SendCashOperation.
                 self?.dismissCashBill(style: .slide)
                 self?.showCashReturnedError()
-                
+
                 Analytics.transfer(
                     event: .giveBill,
                     exchangedFiat: billDescription.exchangedFiat,
@@ -1159,6 +1147,7 @@ class Session {
     }
     
     func dismissCashBill(style: PresentationState.Style) {
+        sendOperation?.cancel()
         sendOperation = nil
         presentationState = .hidden(style)
         billState = .default()

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Messaging.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Messaging.swift
@@ -10,30 +10,141 @@ import Foundation
 import Combine
 
 extension Client {
-    
+
     public func openMessageStream(rendezvous: KeyPair, completion: @MainActor @Sendable @escaping (Result<[StreamMessage], Error>) -> Void) -> AnyCancellable {
         messagingService.openMessageStream(rendezvous: rendezvous, completion: completion)
     }
-    
+
+    /// Async-stream overload of ``openMessageStream(rendezvous:completion:)``.
+    /// Each yielded element is a batch of `StreamMessage`s delivered by the
+    /// gRPC subscription. Breaking out of the `for try await` loop (or
+    /// cancelling the consuming task) tears down the underlying subscription.
+    public func openMessageStream(rendezvous: KeyPair) -> AsyncThrowingStream<[StreamMessage], Error> {
+        nonisolated(unsafe) let service = messagingService
+        return asyncThrowingStream { callback in
+            service.openMessageStream(rendezvous: rendezvous) { result in
+                callback(result)
+            }
+        }
+    }
+
     public func fetchMessages(rendezvous: KeyPair) async throws -> [StreamMessage] {
         try await withCheckedThrowingContinuation { c in
             messagingService.fetchMessages(rendezvous: rendezvous) { c.resume(with: $0) }
         }
     }
-    
+
     public func verifyRequestToGrabBill(destination: PublicKey, rendezvous: PublicKey, signature: Signature) -> Bool {
         messagingService.verifyRequestToGrabBill(destination: destination, rendezvous: rendezvous, signature: signature)
     }
-    
+
     public func sendRequestToGrabBill(destination: PublicKey, rendezvous: KeyPair) async throws -> Bool {
         try await withCheckedThrowingContinuation { c in
             messagingService.sendRequestToGrabBill(destination: destination, rendezvous: rendezvous) { c.resume(with: $0) }
         }
     }
-    
+
     public func sendRequestToGiveBill(mint: PublicKey, exchangedFiat: ExchangedFiat, verifiedState: VerifiedState?, rendezvous: KeyPair) async throws -> Bool {
         try await withCheckedThrowingContinuation { c in
             messagingService.sendRequestToGiveBill(mint: mint, exchangedFiat: exchangedFiat, verifiedState: verifiedState, rendezvous: rendezvous) { c.resume(with: $0) }
         }
     }
+
+    // MARK: - Higher-level waits -
+
+    /// Waits for the first grab request (i.e. a `paymentRequest` message) to
+    /// arrive on the rendezvous channel. Messages are silently skipped while
+    /// `shouldIgnore` returns `true`, so callers can pause processing when
+    /// a share sheet or other modal is in front of the bill. `shouldIgnore`
+    /// is `async` so callers can read actor-isolated state safely — this
+    /// method runs on the generic executor, not the caller's actor.
+    ///
+    /// Throws ``MessagingWaitError/streamClosedBeforeRequest`` if the stream
+    /// terminates before any matching message arrives.
+    public func awaitGrabRequest(
+        rendezvous: KeyPair,
+        shouldIgnore: @escaping @Sendable () async -> Bool = { false }
+    ) async throws -> PaymentRequest {
+        try await firstPaymentRequest(
+            in: openMessageStream(rendezvous: rendezvous),
+            shouldIgnore: shouldIgnore
+        )
+    }
+
+    /// Waits for a give request to be present on the rendezvous channel,
+    /// polling `pollMessages` up to `maxAttempts` times spaced by
+    /// `pollInterval`. Polling — not streaming — is required here because
+    /// the give request is typically published *before* the receiver starts
+    /// listening, and the streaming endpoint only delivers messages to
+    /// already-connected subscribers. The poll endpoint returns the
+    /// currently-queued set, so we see the request whether it was published
+    /// before or after we started waiting.
+    ///
+    /// Throws ``MessagingWaitError/timedOut`` if no give request is
+    /// observed within `maxAttempts` × `pollInterval`.
+    public func awaitGiveRequest(
+        rendezvous: KeyPair,
+        maxAttempts: Int = 10,
+        pollInterval: Duration = .milliseconds(300)
+    ) async throws -> GiveRequest {
+        let rendezvous = rendezvous
+        return try await pollForGiveRequest(
+            maxAttempts: maxAttempts,
+            pollInterval: pollInterval,
+            fetch: { try await self.fetchMessages(rendezvous: rendezvous) }
+        )
+    }
+}
+
+// MARK: - Stream-consuming helpers (testable) -
+
+/// Consumes `stream` and returns the first `paymentRequest` seen, skipping
+/// batches for which `shouldIgnore` returns `true`. Throws
+/// ``MessagingWaitError/streamClosedBeforeRequest`` if the stream terminates
+/// without a match.
+func firstPaymentRequest(
+    in stream: AsyncThrowingStream<[StreamMessage], Error>,
+    shouldIgnore: @Sendable () async -> Bool
+) async throws -> PaymentRequest {
+    for try await messages in stream {
+        if await shouldIgnore() { continue }
+        if let request = messages.compactMap(\.paymentRequest).first {
+            return request
+        }
+    }
+    throw MessagingWaitError.streamClosedBeforeRequest
+}
+
+/// Polls `fetch` for a rendezvous-channel message batch up to `maxAttempts`
+/// times (with `pollInterval` between attempts), returning on the first
+/// batch that contains a give request. Throws
+/// ``MessagingWaitError/timedOut`` when the budget is exhausted without a
+/// match.
+func pollForGiveRequest(
+    maxAttempts: Int,
+    pollInterval: Duration,
+    fetch: @Sendable () async throws -> [StreamMessage]
+) async throws -> GiveRequest {
+    for attempt in 0..<maxAttempts {
+        if attempt > 0 {
+            try await Task.sleep(for: pollInterval)
+        }
+        try Task.checkCancellation()
+        let messages = try await fetch()
+        if let request = messages.compactMap(\.giveRequest).first {
+            return request
+        }
+    }
+    throw MessagingWaitError.timedOut
+}
+
+// MARK: - Errors -
+
+public enum MessagingWaitError: Swift.Error, Equatable {
+    /// The rendezvous stream terminated before the requested message type
+    /// arrived.
+    case streamClosedBeforeRequest
+
+    /// The bounded wait expired without the requested message type arriving.
+    case timedOut
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Utilities/AsyncStreamBridge.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Utilities/AsyncStreamBridge.swift
@@ -1,0 +1,39 @@
+//
+//  AsyncStreamBridge.swift
+//  FlipcashCore
+//
+
+import Foundation
+import Combine
+
+/// Converts a Combine-style `Result`-callback subscription into an
+/// `AsyncThrowingStream`. When the consumer stops iterating — via `break`,
+/// `return`, cancellation, or an early `finish(throwing:)` — `onTermination`
+/// calls `cancel()` on the returned `AnyCancellable`, tearing down the
+/// underlying subscription.
+///
+/// This is the shared shape the stream-returning `Client` overloads rely on,
+/// and keeps the bridge testable in isolation from gRPC.
+///
+/// `AnyCancellable` is not `Sendable` and `onTermination` is `@Sendable`,
+/// so we use `nonisolated(unsafe)` to cross the boundary. The cancellable
+/// is only read after the stream has finished, so there is no concurrent
+/// access to protect against.
+public func asyncThrowingStream<Value: Sendable>(
+    from subscribe: (@escaping @Sendable (Result<Value, Error>) -> Void) -> AnyCancellable
+) -> AsyncThrowingStream<Value, Error> {
+    AsyncThrowingStream { continuation in
+        let cancellable = subscribe { result in
+            switch result {
+            case .success(let value):
+                continuation.yield(value)
+            case .failure(let error):
+                continuation.finish(throwing: error)
+            }
+        }
+        nonisolated(unsafe) let unsafeCancellable = cancellable
+        continuation.onTermination = { @Sendable _ in
+            unsafeCancellable.cancel()
+        }
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Models/StreamMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/StreamMessage.swift
@@ -13,13 +13,40 @@ public struct StreamMessage: Sendable {
         case paymentRequest(PaymentRequest)
         case requestToGiveBill(PublicKey, Ocp_Transaction_V1_VerifiedExchangeData?, MintMetadata?)
     }
-    
+
     public let id: ID
     public let kind: Kind
-    
+
     public init(id: ID, kind: Kind) {
         self.id = id
         self.kind = kind
+    }
+}
+
+/// Decoded contents of a `requestToGiveBill` stream message — the
+/// sender-side advertisement that a receiver scans for.
+public struct GiveRequest: Sendable {
+    public let mint: PublicKey
+    public let verifiedState: VerifiedState?
+    public let mintMetadata: MintMetadata?
+
+    public init(mint: PublicKey, verifiedState: VerifiedState?, mintMetadata: MintMetadata?) {
+        self.mint = mint
+        self.verifiedState = verifiedState
+        self.mintMetadata = mintMetadata
+    }
+}
+
+extension StreamMessage {
+    /// Extracts the decoded `GiveRequest` if this message is a give-bill
+    /// advertisement, otherwise `nil`.
+    public var giveRequest: GiveRequest? {
+        guard case .requestToGiveBill(let mint, _, _) = kind else { return nil }
+        return GiveRequest(
+            mint: mint,
+            verifiedState: giveVerifiedState,
+            mintMetadata: giveMintMetadata
+        )
     }
 }
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/VerifiedState.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/VerifiedState.swift
@@ -44,6 +44,10 @@ extension VerifiedState {
         rateProto.exchangeRate.timestamp.date
     }
 
+    public var reserveTimestamp: Date? {
+        reserveProto?.reserveState.timestamp.date
+    }
+
     public var supplyFromBonding: UInt64? {
         reserveProto?.reserveState.supplyFromBonding
     }

--- a/FlipcashCore/Tests/FlipcashCoreTests/AsyncStreamBridgeTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/AsyncStreamBridgeTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+import Combine
+@testable import FlipcashCore
+
+@Suite("asyncThrowingStream bridge")
+struct AsyncStreamBridgeTests {
+
+    @Test("Yields successive values to the consumer")
+    func yieldsValues() async throws {
+        let stream = asyncThrowingStream(from: { callback in
+            callback(.success(1))
+            callback(.success(2))
+            callback(.success(3))
+            return AnyCancellable { }
+        }) as AsyncThrowingStream<Int, Error>
+
+        var received: [Int] = []
+        for try await value in stream {
+            received.append(value)
+            if received.count == 3 { break }
+        }
+
+        #expect(received == [1, 2, 3])
+    }
+
+    @Test("Consumer throws when subscription delivers an error")
+    func propagatesFailure() async {
+        struct BridgeError: Error, Equatable {}
+
+        let stream = asyncThrowingStream(from: { callback in
+            callback(.failure(BridgeError()))
+            return AnyCancellable { }
+        }) as AsyncThrowingStream<Int, Error>
+
+        await #expect(throws: BridgeError.self) {
+            for try await _ in stream {
+                Issue.record("Expected throw before any yield")
+            }
+        }
+    }
+
+    @Test("Subscription is cancelled when consumer breaks out of the loop")
+    func cancelsSubscriptionOnBreak() async throws {
+        let cancelled = Cancelled()
+
+        // Inline the stream so its only strong reference is the `for` loop's
+        // iterator. Dropping to the outer scope releases the stream and fires
+        // `onTermination`. Assigning to a `let` would keep it alive until the
+        // function returns and break this test's timing.
+        func consume() async throws {
+            let stream: AsyncThrowingStream<Int, Error> = asyncThrowingStream { callback in
+                callback(.success(42))
+                return AnyCancellable { cancelled.set() }
+            }
+            for try await _ in stream {
+                break
+            }
+        }
+        try await consume()
+
+        for _ in 0..<100 {
+            if cancelled.value { break }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+
+        #expect(cancelled.value)
+    }
+
+    @Test("Subscription is cancelled when the outer Task is cancelled")
+    func cancelsSubscriptionOnTaskCancel() async throws {
+        let cancelled = Cancelled()
+
+        let task = Task {
+            let stream = asyncThrowingStream(from: { _ in
+                AnyCancellable { cancelled.set() }
+            }) as AsyncThrowingStream<Int, Error>
+
+            for try await _ in stream { }
+        }
+
+        // Give the stream a moment to attach, then cancel the consumer.
+        try await Task.sleep(for: .milliseconds(5))
+        task.cancel()
+        _ = try? await task.value
+
+        for _ in 0..<100 {
+            if cancelled.value { break }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+
+        #expect(cancelled.value)
+    }
+
+    private final class Cancelled: @unchecked Sendable {
+        private let lock = NSLock()
+        private var flag = false
+        var value: Bool {
+            lock.lock(); defer { lock.unlock() }
+            return flag
+        }
+        func set() {
+            lock.lock(); defer { lock.unlock() }
+            flag = true
+        }
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/MessagingWaitsTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/MessagingWaitsTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("Messaging waits")
+struct MessagingWaitsTests {
+
+    private let testMint = try! PublicKey(base58: "54ggcQ23uen5b9QXMAns99MQNTKn7iyzq4wvCW6e8r25")
+    private let testAccount = try! PublicKey(base58: "54ggcQ23uen5b9QXMAns99MQNTKn7iyzq4wvCW6e8r25")
+    private let testSignature = try! Signature(Array(repeating: Byte(0), count: 64))
+
+    private func messageID() -> ID {
+        ID(data: Data([UInt8.random(in: 0...255)]))
+    }
+
+    private func paymentRequestMessage() -> StreamMessage {
+        StreamMessage(
+            id: messageID(),
+            kind: .paymentRequest(
+                PaymentRequest(account: testAccount, signature: testSignature)
+            )
+        )
+    }
+
+    private func giveRequestMessage() -> StreamMessage {
+        StreamMessage(
+            id: messageID(),
+            kind: .requestToGiveBill(testMint, nil, nil)
+        )
+    }
+
+    // MARK: - firstPaymentRequest -
+
+    @Test("Returns first payment request and leaves the stream alone")
+    func firstPaymentRequest_returnsMatch() async throws {
+        let (stream, continuation) = AsyncThrowingStream<[StreamMessage], Error>.makeStream()
+
+        let consumer = Task {
+            try await firstPaymentRequest(in: stream, shouldIgnore: { false })
+        }
+
+        continuation.yield([paymentRequestMessage()])
+
+        let request = try await consumer.value
+        #expect(request.account == testAccount)
+    }
+
+    @Test("Skips batches while shouldIgnore is true, then returns on the next match")
+    func firstPaymentRequest_respectsIgnore() async throws {
+        let (stream, continuation) = AsyncThrowingStream<[StreamMessage], Error>.makeStream()
+        let ignoreFlag = ToggleFlag(initial: true)
+
+        let consumer = Task {
+            try await firstPaymentRequest(in: stream, shouldIgnore: { ignoreFlag.value })
+        }
+
+        // First batch arrives while ignored — dropped.
+        continuation.yield([paymentRequestMessage()])
+        try await Task.sleep(for: .milliseconds(10))
+
+        // Flip the flag and deliver another batch — consumer should take this one.
+        ignoreFlag.set(false)
+        continuation.yield([paymentRequestMessage()])
+
+        let request = try await consumer.value
+        #expect(request.account == testAccount)
+    }
+
+    @Test("Throws streamClosedBeforeRequest when the stream finishes without a match")
+    func firstPaymentRequest_streamClosedEmpty() async throws {
+        let (stream, continuation) = AsyncThrowingStream<[StreamMessage], Error>.makeStream()
+
+        let consumer = Task {
+            try await firstPaymentRequest(in: stream, shouldIgnore: { false })
+        }
+
+        continuation.finish()
+
+        await #expect(throws: MessagingWaitError.streamClosedBeforeRequest) {
+            _ = try await consumer.value
+        }
+    }
+
+    // MARK: - pollForGiveRequest -
+
+    @Test("Returns decoded GiveRequest from the first matching poll batch")
+    func pollForGiveRequest_returnsMatch() async throws {
+        let mint = testMint
+        let request = try await pollForGiveRequest(
+            maxAttempts: 3,
+            pollInterval: .milliseconds(10),
+            fetch: { [giveRequestMessage()] }
+        )
+
+        #expect(request.mint == mint)
+        #expect(request.verifiedState == nil)
+        #expect(request.mintMetadata == nil)
+    }
+
+    @Test("Skips empty batches and returns on the first non-empty batch that contains a match")
+    func pollForGiveRequest_skipsEmptyBatches() async throws {
+        let attemptLog = AttemptLog()
+        let target = giveRequestMessage()
+
+        let request = try await pollForGiveRequest(
+            maxAttempts: 5,
+            pollInterval: .milliseconds(5),
+            fetch: {
+                let n = attemptLog.incrementAndGet()
+                return n < 3 ? [] : [target]
+            }
+        )
+
+        #expect(request.mint == testMint)
+        #expect(attemptLog.count == 3)
+    }
+
+    @Test("Times out after maxAttempts when no give-bill message ever appears")
+    func pollForGiveRequest_timesOut() async throws {
+        let attemptLog = AttemptLog()
+
+        await #expect(throws: MessagingWaitError.timedOut) {
+            _ = try await pollForGiveRequest(
+                maxAttempts: 3,
+                pollInterval: .milliseconds(5),
+                fetch: {
+                    _ = attemptLog.incrementAndGet()
+                    return []
+                }
+            )
+        }
+        #expect(attemptLog.count == 3)
+    }
+
+    // MARK: - Test helper -
+
+    private final class ToggleFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var flag: Bool
+        init(initial: Bool) { self.flag = initial }
+        var value: Bool {
+            lock.lock(); defer { lock.unlock() }
+            return flag
+        }
+        func set(_ newValue: Bool) {
+            lock.lock(); defer { lock.unlock() }
+            flag = newValue
+        }
+    }
+
+    private final class AttemptLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var counter = 0
+        var count: Int {
+            lock.lock(); defer { lock.unlock() }
+            return counter
+        }
+        func incrementAndGet() -> Int {
+            lock.lock(); defer { lock.unlock() }
+            counter += 1
+            return counter
+        }
+    }
+}

--- a/FlipcashTests/VerifiedStateResolutionTests.swift
+++ b/FlipcashTests/VerifiedStateResolutionTests.swift
@@ -1,0 +1,96 @@
+//
+//  VerifiedStateResolutionTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+@testable import Flipcash
+import FlipcashCore
+
+@Suite("VerifiedStateResolution")
+struct VerifiedStateResolutionTests {
+
+    private let currency: CurrencyCode = .usd
+    private let mint: PublicKey = .jeffy
+
+    private func makeState(rate: Double = 1.0) -> VerifiedState {
+        VerifiedState(
+            rateProto: .makeTest(currencyCode: currency.rawValue, rate: rate)
+        )
+    }
+
+    @Test("Provided state is returned without consulting the cache")
+    func provided_short_circuitsCache() async {
+        let provided = makeState(rate: 1.23)
+        var cacheCalls = 0
+
+        let result = await resolveVerifiedState(
+            provided: provided,
+            currency: currency,
+            mint: mint,
+            cacheLookup: { _, _ in
+                cacheCalls += 1
+                return self.makeState(rate: 9.99)
+            }
+        )
+
+        #expect(result == .provided(provided))
+        #expect(cacheCalls == 0)
+    }
+
+    @Test("Cache-hit returned when nothing is provided")
+    func cacheHit_returnedWhenProvidedNil() async {
+        let cached = makeState(rate: 7.5)
+
+        let result = await resolveVerifiedState(
+            provided: nil,
+            currency: currency,
+            mint: mint,
+            cacheLookup: { _, _ in cached }
+        )
+
+        #expect(result == .cacheHit(cached))
+    }
+
+    @Test("Cache-miss when provided is nil and cache yields nil")
+    func cacheMiss_whenBothSourcesEmpty() async {
+        let result = await resolveVerifiedState(
+            provided: nil,
+            currency: currency,
+            mint: mint,
+            cacheLookup: { _, _ in nil }
+        )
+
+        #expect(result == .cacheMiss)
+        #expect(result.state == nil)
+    }
+
+    @Test("Cache lookup receives the requested currency and mint")
+    func cacheLookup_receivesCorrectArguments() async {
+        var receivedCurrency: CurrencyCode?
+        var receivedMint: PublicKey?
+
+        _ = await resolveVerifiedState(
+            provided: nil,
+            currency: currency,
+            mint: mint,
+            cacheLookup: { c, m in
+                receivedCurrency = c
+                receivedMint = m
+                return nil
+            }
+        )
+
+        #expect(receivedCurrency == currency)
+        #expect(receivedMint == mint)
+    }
+
+    @Test("sourceLabel produces stable log strings")
+    func sourceLabel_stableStrings() {
+        let state = makeState()
+        #expect(VerifiedStateResolution.provided(state).sourceLabel == "provided")
+        #expect(VerifiedStateResolution.cacheHit(state).sourceLabel == "cache-hit")
+        #expect(VerifiedStateResolution.cacheMiss.sourceLabel == "cache-miss")
+    }
+}


### PR DESCRIPTION
## Summary

- Reworks the give and scan flows into linear async/await operations that each own their own lifecycle, so cancellation and error handling are consistent and the call sites in Session don't juggle callback state.
- Moves the rendezvous message waits (wait-for-grab on the sender side, poll-for-give on the receiver side) into the messaging layer so they are reusable and covered by unit tests.
- Adds visibility around verified-state resolution — the source of the proof, its age, and the reserve age — so when the recurring "native amount does not match expected sell value" error shows up again we have enough context to diagnose it.
- Adds a client-side pre-flight that rejects a reserve proof older than 15 minutes before submitting, since the server won't honor it anyway.

## Test plan

- [x] Give a bill on iOS, grab it on another device. Bill should dismiss on successful grab.
- [x] Scan a bill advertised by another device. Should grab within a couple of seconds; if the sender never advertised, the scanner should give up after a short bounded wait instead of hanging.
- [x] Quick give-and-grab chain (scan a bill, then immediately let someone else scan the received bill from your screen). Should complete without losing the verified state.
- [x] Present the share sheet while a bill is live. Incoming grabs should be suppressed until the sheet closes, and the bill should survive backgrounding the app.
- [x] Log out, log in on a different account, and repeat the give/scan flow. Verified-state cache should repopulate correctly per account.