### PR TITLE
refactor: push Discover Currencies instead of presenting as sheet

### DIFF
--- a/Flipcash/Core/Screens/Main/BalanceFooter.swift
+++ b/Flipcash/Core/Screens/Main/BalanceFooter.swift
@@ -12,7 +12,6 @@ struct BalanceFooter: View {
     let showDiscoverCurrencies: Bool
     let isOnlyRow: Bool
     @Binding var selectedMint: PublicKey?
-    @Binding var isShowingCurrencyDiscovery: Bool
 
     var body: some View {
         VStack {
@@ -25,11 +24,9 @@ struct BalanceFooter: View {
             }
 
             if showDiscoverCurrencies {
-                Button("Discover Currencies") {
-                    isShowingCurrencyDiscovery = true
-                }
-                .buttonStyle(.filled10)
-                .padding(20)
+                NavigationLink("Discover Currencies", value: CurrencyDiscoveryRoute.open)
+                    .buttonStyle(.filled10)
+                    .padding(20)
             }
         }
     }

--- a/Flipcash/Core/Screens/Main/BalanceScreen.swift
+++ b/Flipcash/Core/Screens/Main/BalanceScreen.swift
@@ -21,7 +21,6 @@ struct BalanceScreen: View {
     let session: Session
 
     @State private var isShowingCurrencySelection: Bool  = false
-    @State private var isShowingCurrencyDiscovery: Bool = false
     @State private var dialogItem: DialogItem?
     @State private var selectedActivity: Activity?
     @State private var selectedMint: PublicKey?
@@ -119,7 +118,7 @@ struct BalanceScreen: View {
                     sessionContainer: sessionContainer
                 )
             }
-            .navigationDestination(isPresented: $isShowingCurrencyDiscovery) {
+            .navigationDestination(for: CurrencyDiscoveryRoute.self) { _ in
                 CurrencyDiscoveryScreen(
                     container: container,
                     sessionContainer: sessionContainer
@@ -149,8 +148,14 @@ struct BalanceScreen: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity, alignment: .center)
 
-            BubbleButton(text: "Discover Currencies") {
-                isShowingCurrencyDiscovery = true
+            NavigationLink(value: CurrencyDiscoveryRoute.open) {
+                TextBubble(
+                    style: .filled,
+                    font: .appTextMedium,
+                    text: "Discover Currencies",
+                    paddingVertical: 5,
+                    paddingHorizontal: 15
+                )
             }
             .padding(.top, 8)
         }
@@ -192,8 +197,7 @@ struct BalanceScreen: View {
                         reservesBalance: reservesBalance,
                         showDiscoverCurrencies: hasBalances,
                         isOnlyRow: currencyBalances.isEmpty,
-                        selectedMint: $selectedMint,
-                        isShowingCurrencyDiscovery: $isShowingCurrencyDiscovery
+                        selectedMint: $selectedMint
                     )
                 }
                 .listRowInsets(EdgeInsets())
@@ -277,6 +281,10 @@ struct BalanceScreen: View {
             }
         }
     }
+}
+
+enum CurrencyDiscoveryRoute: Hashable {
+    case open
 }
 
 struct ExchangedBalance: Identifiable, Hashable {

--- a/Flipcash/Core/Screens/Main/BalanceScreen.swift
+++ b/Flipcash/Core/Screens/Main/BalanceScreen.swift
@@ -119,6 +119,12 @@ struct BalanceScreen: View {
                     sessionContainer: sessionContainer
                 )
             }
+            .navigationDestination(isPresented: $isShowingCurrencyDiscovery) {
+                CurrencyDiscoveryScreen(
+                    container: container,
+                    sessionContainer: sessionContainer
+                )
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     ToolbarCloseButton(binding: $isPresented)
@@ -130,12 +136,6 @@ struct BalanceScreen: View {
             }
         }
         .dialog(item: $dialogItem)
-        .sheet(isPresented: $isShowingCurrencyDiscovery) {
-            CurrencyDiscoveryScreen(
-                container: container,
-                sessionContainer: sessionContainer
-            )
-        }
     }
     
     @ViewBuilder private func emptyState(geometry: GeometryProxy) -> some View {

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryScreen.swift
@@ -11,7 +11,6 @@ struct CurrencyDiscoveryScreen: View {
     let container: Container
     let sessionContainer: SessionContainer
 
-    @Environment(\.dismiss) private var dismiss
     @Environment(BetaFlags.self) private var betaFlags
 
     @State private var mintsByCategory: [DiscoverCategory: [MintMetadata]] = [:]
@@ -20,54 +19,47 @@ struct CurrencyDiscoveryScreen: View {
     @State private var creationState = CurrencyCreationState()
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                CurrencyDiscoveryList(
-                    container: container,
-                    mintsByCategory: $mintsByCategory,
-                    selectedCategory: $selectedCategory,
-                    selectedMint: $selectedMint
-                )
+        ZStack {
+            CurrencyDiscoveryList(
+                container: container,
+                mintsByCategory: $mintsByCategory,
+                selectedCategory: $selectedCategory,
+                selectedMint: $selectedMint
+            )
 
-                if mintsByCategory[selectedCategory] != nil, betaFlags.hasEnabled(.currencyCreation) {
-                    CurrencyInfoFooter {
-                        NavigationLink("Create Your Own Currency", value: CurrencyCreationStep.summary)
-                            .buttonStyle(.filled)
-                    }
+            if mintsByCategory[selectedCategory] != nil, betaFlags.hasEnabled(.currencyCreation) {
+                CurrencyInfoFooter {
+                    NavigationLink("Create Your Own Currency", value: CurrencyCreationStep.summary)
+                        .buttonStyle(.filled)
                 }
             }
-            .navigationTitle("Currencies")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    ToolbarCloseButton(action: dismiss.callAsFunction)
-                }
+        }
+        .navigationTitle("Currencies")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(for: CurrencyCreationStep.self) { step in
+            switch step {
+            case .summary:
+                CurrencyCreationSummaryScreen()
+            case .wizard:
+                CurrencyCreationWizardScreen(
+                    state: creationState,
+                    sessionContainer: sessionContainer
+                )
             }
-            .navigationDestination(for: CurrencyCreationStep.self) { step in
-                switch step {
-                case .summary:
-                    CurrencyCreationSummaryScreen()
-                case .wizard:
-                    CurrencyCreationWizardScreen(
-                        state: creationState,
-                        sessionContainer: sessionContainer
-                    )
-                }
-            }
-            .navigationDestination(item: $selectedMint) { mintAddress in
-                if let metadata = mintsByCategory[selectedCategory]?.first(where: { $0.address == mintAddress }) {
-                    CurrencyInfoScreen(
-                        metadata: metadata,
-                        container: container,
-                        sessionContainer: sessionContainer
-                    )
-                } else {
-                    CurrencyInfoScreen(
-                        mint: mintAddress,
-                        container: container,
-                        sessionContainer: sessionContainer
-                    )
-                }
+        }
+        .navigationDestination(item: $selectedMint) { mintAddress in
+            if let metadata = mintsByCategory[selectedCategory]?.first(where: { $0.address == mintAddress }) {
+                CurrencyInfoScreen(
+                    metadata: metadata,
+                    container: container,
+                    sessionContainer: sessionContainer
+                )
+            } else {
+                CurrencyInfoScreen(
+                    mint: mintAddress,
+                    container: container,
+                    sessionContainer: sessionContainer
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

Discover Currencies now pushes onto the wallet's navigation stack instead of opening in a sheet, matching the navigation style already used for currency info and creating a more cohesive browsing flow.

## Test plan

- [x] From Wallet, tap Discover Currencies and confirm it pushes (back button, not a close button)
- [ ] Tap a currency row inside Discover and confirm it pushes to the info screen, then back twice returns to Wallet
- [ ] With currency creation beta flag on, tap Create Your Own Currency and confirm the wizard pushes as before
- [ ] From the empty-state Discover Currencies button (no balances), confirm the same push behaviour