### PR TITLE
fix: hide Give and Sell for balances below display threshold

### DIFF
--- a/Flipcash/Core/Controllers/RatesController.swift
+++ b/Flipcash/Core/Controllers/RatesController.swift
@@ -304,15 +304,6 @@ class RatesController {
         selectedTokenMint = mint
     }
     
-    /// Get the currently selected token, or a default if none is selected
-    /// - Parameter defaultMint: The default mint to return if none is selected. Defaults to USDC.
-    /// - Returns: The selected token or the default
-    func getSelectedToken(default defaultMint: PublicKey = .usdf) -> StoredMintMetadata? {
-        let mint = selectedTokenMint ?? defaultMint
-        
-        return try? database.getMintMetadata(mint: mint)
-    }
-    
     /// Check if a given mint is currently selected
     /// - Parameter mint: The mint to check
     /// - Returns: True if the mint is selected

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -424,7 +424,7 @@ private struct LoadedContent: View {
                     }
                     .buttonStyle(.filled)
 
-                    if balance.isPositive {
+                    if balance.hasDisplayableValue {
                         CodeButton(style: .filledSecondary, title: "Give") {
                             onGive()
                         }

--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -101,23 +101,13 @@ class GiveViewModel {
 
     private func refreshSelectedBalance() {
         let rate = ratesController.rateForEntryCurrency()
-
-        // Resolve from the raw balance list so a sub-display-threshold
-        // holding isn't silently replaced by the top-sorted balance.
-        if let selectedTokenMint = ratesController.selectedTokenMint,
-           selectedTokenMint != .usdf,
-           let stored = session.balance(for: selectedTokenMint) {
-            selectedBalance = ExchangedBalance(
-                stored: stored,
-                exchangedFiat: stored.computeExchangedValue(with: rate)
-            )
-            return
-        }
-
         let availableBalances = session.balances(for: rate)
             .filter { $0.stored.mint != .usdf }
 
-        if let first = availableBalances.first {
+        if let selectedTokenMint = ratesController.selectedTokenMint,
+           let match = availableBalances.first(where: { $0.stored.mint == selectedTokenMint }) {
+            selectedBalance = match
+        } else if let first = availableBalances.first {
             selectedBalance = first
             ratesController.selectToken(first.stored.mint)
         }

--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -101,13 +101,23 @@ class GiveViewModel {
 
     private func refreshSelectedBalance() {
         let rate = ratesController.rateForEntryCurrency()
+
+        // Resolve from the raw balance list so a sub-display-threshold
+        // holding isn't silently replaced by the top-sorted balance.
+        if let selectedTokenMint = ratesController.selectedTokenMint,
+           selectedTokenMint != .usdf,
+           let stored = session.balance(for: selectedTokenMint) {
+            selectedBalance = ExchangedBalance(
+                stored: stored,
+                exchangedFiat: stored.computeExchangedValue(with: rate)
+            )
+            return
+        }
+
         let availableBalances = session.balances(for: rate)
             .filter { $0.stored.mint != .usdf }
 
-        if let selectedTokenMint = ratesController.selectedTokenMint,
-           let match = availableBalances.first(where: { $0.stored.mint == selectedTokenMint }) {
-            selectedBalance = match
-        } else if let first = availableBalances.first {
+        if let first = availableBalances.first {
             selectedBalance = first
             ratesController.selectToken(first.stored.mint)
         }

--- a/FlipcashTests/GiveViewModelTests.swift
+++ b/FlipcashTests/GiveViewModelTests.swift
@@ -468,16 +468,16 @@ struct GiveViewModelTests {
         #expect(container.ratesController.selectedTokenMint == .jeffy)
     }
 
-    @Test("Presenting with a sub-threshold selected mint still resolves that mint, not the fallback")
-    func testPresentation_SubThresholdExplicitMint_StillResolves() throws {
-        let tinyHolding = SessionContainer.Holding(
+    @Test("Presenting with a stale sub-threshold selection falls back to the highest displayable balance")
+    func testPresentation_SubThresholdRememberedMint_FallsBackToHighest() throws {
+        let staleHolding = SessionContainer.Holding(
             mint: .makeLaunchpad(
                 address: .jeffy,
                 supplyFromBonding: 10_000_000 * 10_000_000_000
             ),
             quarks: 100
         )
-        let largerHolding = SessionContainer.Holding(
+        let displayableHolding = SessionContainer.Holding(
             mint: .makeLaunchpad(
                 address: .usdcAuthority,
                 supplyFromBonding: 10_000 * 10_000_000_000
@@ -485,17 +485,16 @@ struct GiveViewModelTests {
             quarks: 1_000_000_000_000
         )
         let container = try SessionContainer.makeTest(holdings: [
-            tinyHolding,
-            largerHolding,
+            staleHolding,
+            displayableHolding,
         ])
-
         let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
 
         container.ratesController.selectToken(.jeffy)
 
         viewModel.isPresented = true
 
-        #expect(viewModel.selectedBalance?.stored.mint == .jeffy)
-        #expect(container.ratesController.selectedTokenMint == .jeffy)
+        #expect(viewModel.selectedBalance?.stored.mint == .usdcAuthority)
+        #expect(container.ratesController.selectedTokenMint == .usdcAuthority)
     }
 }

--- a/FlipcashTests/GiveViewModelTests.swift
+++ b/FlipcashTests/GiveViewModelTests.swift
@@ -400,4 +400,102 @@ struct GiveViewModelTests {
         // Then: Should be able to give
         #expect(canGive == true, "Should allow exchange amount well under max supply value")
     }
+
+    // MARK: - refreshSelectedBalance (presentation) Tests
+
+    @Test("Presenting with a selected token resolves to that mint")
+    func testPresentation_WithSelectedToken_ResolvesRequestedMint() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(
+                mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: 10_000 * 10_000_000_000),
+                quarks: 1_000_000_000_000
+            ),
+        ])
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
+
+        container.ratesController.selectToken(.jeffy)
+
+        viewModel.isPresented = true
+
+        #expect(viewModel.selectedBalance?.stored.mint == .jeffy)
+        #expect(container.ratesController.selectedTokenMint == .jeffy)
+    }
+
+    @Test("Presenting with no prior selection picks highest-value non-USDF and persists it")
+    func testPresentation_FirstTime_PicksHighestAndPersists() throws {
+        // Same supply for both mints (so per-token curve price is equal), but
+        // Jeffy has 100× the holding in quarks → 100× the USDF-equivalent,
+        // putting Jeffy first in the `usdf`-desc sort.
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(
+                mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: 100_000 * 10_000_000_000),
+                quarks: 10_000_000_000_000
+            ),
+            .init(
+                mint: .makeLaunchpad(address: .usdcAuthority, supplyFromBonding: 100_000 * 10_000_000_000),
+                quarks: 100_000_000_000
+            ),
+        ])
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
+
+        container.ratesController.selectedTokenMint = nil
+
+        viewModel.isPresented = true
+
+        #expect(viewModel.selectedBalance?.stored.mint == .jeffy)
+        #expect(container.ratesController.selectedTokenMint == .jeffy)
+    }
+
+    @Test("Presenting with a remembered selection resolves to that mint, not the highest")
+    func testPresentation_Subsequent_UsesRememberedSelection() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(
+                mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: 50_000 * 10_000_000_000),
+                quarks: 100_000_000_000
+            ),
+            .init(
+                mint: .makeLaunchpad(address: .usdcAuthority, supplyFromBonding: 5_000 * 10_000_000_000),
+                quarks: 10_000_000_000_000
+            ),
+        ])
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
+
+        container.ratesController.selectToken(.jeffy)
+
+        viewModel.isPresented = true
+
+        #expect(viewModel.selectedBalance?.stored.mint == .jeffy)
+        #expect(container.ratesController.selectedTokenMint == .jeffy)
+    }
+
+    @Test("Presenting with a sub-threshold selected mint still resolves that mint, not the fallback")
+    func testPresentation_SubThresholdExplicitMint_StillResolves() throws {
+        let tinyHolding = SessionContainer.Holding(
+            mint: .makeLaunchpad(
+                address: .jeffy,
+                supplyFromBonding: 10_000_000 * 10_000_000_000
+            ),
+            quarks: 100
+        )
+        let largerHolding = SessionContainer.Holding(
+            mint: .makeLaunchpad(
+                address: .usdcAuthority,
+                supplyFromBonding: 10_000 * 10_000_000_000
+            ),
+            quarks: 1_000_000_000_000
+        )
+        let container = try SessionContainer.makeTest(holdings: [
+            tinyHolding,
+            largerHolding,
+        ])
+
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
+
+        container.ratesController.selectToken(.jeffy)
+
+        viewModel.isPresented = true
+
+        #expect(viewModel.selectedBalance?.stored.mint == .jeffy)
+        #expect(container.ratesController.selectedTokenMint == .jeffy)
+    }
 }

--- a/FlipcashTests/TestSupport/SessionContainer+TestSupport.swift
+++ b/FlipcashTests/TestSupport/SessionContainer+TestSupport.swift
@@ -1,0 +1,73 @@
+//
+//  SessionContainer+TestSupport.swift
+//  FlipcashTests
+//
+//  Created by Raul Riera on 2026-04-22.
+//
+
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+extension SessionContainer {
+
+    struct Holding {
+        let mint: MintMetadata
+        let quarks: UInt64
+    }
+
+    /// Builds a `SessionContainer` backed by an isolated on-disk SQLite
+    /// database pre-populated with the given holdings via the real
+    /// `Database.insert(mints:date:)` and `Database.insertBalance(...)`
+    /// APIs. `Session.init` reads those balances through `Updateable`
+    /// at construction, so the returned container's `session.balances`
+    /// reflects the seed on the first access.
+    ///
+    /// Each call produces an independent database file so tests don't
+    /// share balance state.
+    @MainActor
+    static func makeTest(holdings: [Holding]) throws -> SessionContainer {
+        let database = try Database(
+            url: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("give-test-\(UUID().uuidString).sqlite")
+        )
+
+        let now = Date.now
+        try database.insert(mints: holdings.map { $0.mint }, date: now)
+        try database.transaction { db in
+            for holding in holdings {
+                try db.insertBalance(
+                    quarks: holding.quarks,
+                    mint: holding.mint.address,
+                    costBasis: 0,
+                    date: now
+                )
+            }
+        }
+
+        let ratesController = RatesController(container: .mock, database: database)
+        let session = Session(
+            container: .mock,
+            historyController: .mock,
+            ratesController: ratesController,
+            database: database,
+            keyAccount: .mock,
+            owner: .init(
+                authority: .derive(using: .primary(), mnemonic: .mock),
+                mint: .mock,
+                timeAuthority: .usdcAuthority
+            ),
+            userID: UUID()
+        )
+
+        return SessionContainer(
+            session: session,
+            database: database,
+            walletConnection: .mock,
+            ratesController: ratesController,
+            historyController: .mock,
+            pushController: .mock,
+            flipClient: Container.mock.flipClient
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Tapping Give on a token with a fraction-of-a-cent balance opened the Give screen with a different token selected — usually the user's highest-balance one — because the tiny token was being filtered out of the Give list and silently substituted.

The fix hides the Give and Sell buttons when the balance is below the displayable threshold. You can't actually give or sell those amounts anyway.

Also removes a dead helper method in the rates controller.

## Test plan

- [x] Build succeeds.
- [x] Give screen tests pass.
- [x] Manually confirm Give and Sell are hidden on a sub-cent balance.
- [x] Manually confirm Give and Sell still show on a normal balance.
- [x] Manually confirm first-time Give on the scan screen still picks the highest balance.