### PR TITLE
fix: surface insufficient funds on Give and Withdraw over-balance entries

### DIFF
--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -54,13 +54,29 @@ class GiveViewModel {
             }
 
             let rate = ratesController.rateForEntryCurrency()
-            return ExchangedFiat.compute(
-                fromEntered: FiatAmount(value: amount, currency: rate.currency),
+            let entered = FiatAmount(value: amount, currency: rate.currency)
+
+            if let viaCurve = ExchangedFiat.compute(
+                fromEntered: entered,
                 rate: rate,
                 mint: mint,
-                supplyQuarks: supplyQuarks,
-                balance: selectedBalance.stored.usdf,
-                tokenBalanceQuarks: selectedBalance.stored.quarks
+                supplyQuarks: supplyQuarks
+            ) {
+                return viaCurve
+            }
+
+            // Curve could not price the entered amount (requested > TVL).
+            // Build a synthetic ExchangedFiat so `hasSufficientFunds` sees an
+            // over-balance request and returns `.insufficient` with a shortfall
+            // derived from `nativeAmount`. The onChainAmount is a sentinel —
+            // this ExchangedFiat is never transported.
+            return ExchangedFiat(
+                onChainAmount: TokenAmount(
+                    quarks: selectedBalance.stored.quarks + 1,
+                    mint: mint
+                ),
+                nativeAmount: entered,
+                currencyRate: rate
             )
 
         } else {

--- a/Flipcash/Core/Screens/Settings/WithdrawAmountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/WithdrawAmountScreen.swift
@@ -34,7 +34,7 @@ struct WithdrawAmountScreen: View {
                 subtitle: .balanceWithLimit(viewModel.maxWithdrawLimit),
                 actionState: .constant(.normal),
                 actionEnabled: { _ in
-                    viewModel.enteredFiat != nil
+                    viewModel.canProceedToAddress
                 },
                 action: viewModel.amountEnteredAction,
                 currencySelectionAction: showCurrencySelection

--- a/Flipcash/Core/Screens/Settings/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/WithdrawViewModel.swift
@@ -51,12 +51,27 @@ class WithdrawViewModel {
                 return nil
             }
 
-            return ExchangedFiat.compute(
-                fromEntered: FiatAmount(value: amount, currency: rate.currency),
+            let entered = FiatAmount(value: amount, currency: rate.currency)
+
+            if let viaCurve = ExchangedFiat.compute(
+                fromEntered: entered,
                 rate: rate,
                 mint: mint,
-                supplyQuarks: supplyQuarks,
-                balance: selectedBalance.stored.usdf
+                supplyQuarks: supplyQuarks
+            ) {
+                return viaCurve
+            }
+
+            // Curve could not price the entered amount (requested > TVL).
+            // Synthesize so the amount screen's `canProceedToAddress` flips
+            // false and `EnterAmountView` turns the subtitle red.
+            return ExchangedFiat(
+                onChainAmount: TokenAmount(
+                    quarks: selectedBalance.stored.quarks + 1,
+                    mint: mint
+                ),
+                nativeAmount: entered,
+                currencyRate: rate
             )
         } else {
             return ExchangedFiat(
@@ -119,6 +134,17 @@ class WithdrawViewModel {
         return (onChain: exchangedFee.onChainAmount, usd: exchangedFee.usdfValue)
     }
     
+    /// Gate for the Enter-Amount screen's Next button. Disables when the
+    /// entered amount exceeds the displayed balance cap so `EnterAmountView`
+    /// turns the subtitle red.
+    var canProceedToAddress: Bool {
+        guard enteredFiat != nil else { return false }
+        return EnterAmountCalculator.isWithinDisplayLimit(
+            enteredAmount: enteredAmount,
+            max: maxWithdrawLimit.nativeAmount
+        )
+    }
+
     var canCompleteWithdrawal: Bool {
         guard
             let enteredFiat = enteredFiat,

--- a/FlipcashTests/GiveViewModelTests.swift
+++ b/FlipcashTests/GiveViewModelTests.swift
@@ -468,6 +468,50 @@ struct GiveViewModelTests {
         #expect(container.ratesController.selectedTokenMint == .jeffy)
     }
 
+    // MARK: - Over-balance (insufficient funds)
+
+    @Test("Over-balance bonded entry fires 'Short' dialog with a real shortfall, stays on screen")
+    func giveAction_overBalanceBonded_firesShortDialogWithRealShortfall() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(
+                mint: .makeLaunchpad(
+                    address: .jeffy,
+                    supplyFromBonding: 1_000_000 * 10_000_000_000
+                ),
+                quarks: 10 * 10_000_000_000
+            ),
+        ])
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
+        container.ratesController.selectToken(.jeffy)
+        viewModel.isPresented = true
+
+        let balance = try #require(viewModel.selectedBalance)
+        // 100× the displayed balance — unambiguously over and may exceed curve TVL.
+        let overAmount = balance.exchangedFiat.nativeAmount.value * 100
+        viewModel.enteredAmount = "\(overAmount)"
+
+        // Next must stay tappable so the dialog can fire on tap.
+        #expect(viewModel.canGive == true)
+        #expect(viewModel.dialogItem == nil)
+
+        viewModel.giveAction()
+
+        let dialog = try #require(viewModel.dialogItem)
+        let title = try #require(dialog.title)
+
+        // "You're $X Short" — not "You Need More Cash" and not "Transaction Limit Reached".
+        #expect(title.hasPrefix("You're"))
+        #expect(title.hasSuffix("Short"))
+        // Previous bug rendered the amount as $0.00 — guard against regression.
+        // The `$` anchor avoids a false positive on legitimate shortfalls
+        // like "$10.00 Short", whose "0.00 Short" substring would otherwise
+        // match.
+        #expect(!title.contains("$0.00"))
+
+        // Flow did not proceed to the bill.
+        #expect(viewModel.isPresented == true)
+    }
+
     @Test("Presenting with a stale sub-threshold selection falls back to the highest displayable balance")
     func testPresentation_SubThresholdRememberedMint_FallsBackToHighest() throws {
         let staleHolding = SessionContainer.Holding(

--- a/FlipcashTests/WithdrawViewModelTests.swift
+++ b/FlipcashTests/WithdrawViewModelTests.swift
@@ -72,6 +72,62 @@ struct WithdrawViewModelTests {
         #expect(delta.value <= Decimal(1))
     }
 
+    // MARK: - canProceedToAddress
+
+    @Test("Over-balance bonded entry disables Next via canProceedToAddress")
+    func canProceedToAddress_overBalanceBonded_isFalse() throws {
+        let (viewModel, balance) = try makeBondedSetup()
+        let balanceValue = balance.exchangedFiat.nativeAmount.value
+
+        viewModel.enteredAmount = "\(balanceValue * 100)"
+
+        // enteredFiat stays non-nil so EnterAmountView's isExceedingLimit can
+        // flip the subtitle red.
+        #expect(viewModel.enteredFiat != nil)
+        #expect(viewModel.canProceedToAddress == false)
+    }
+
+    @Test("At-or-below balance leaves canProceedToAddress enabled")
+    func canProceedToAddress_withinBalanceBonded_isTrue() throws {
+        let (viewModel, balance) = try makeBondedSetup()
+        let balanceValue = balance.exchangedFiat.nativeAmount.value
+
+        viewModel.enteredAmount = "\(balanceValue / 10)"
+
+        #expect(viewModel.canProceedToAddress == true)
+    }
+
+    // MARK: - Helpers
+
+    /// Builds a `WithdrawViewModel` backed by an in-memory session whose
+    /// `session.balance(for:)` is populated, so `maxWithdrawLimit` returns a
+    /// real cap rather than zero.
+    private func makeBondedSetup() throws -> (WithdrawViewModel, ExchangedBalance) {
+        let mint: PublicKey = .jeffy
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(
+                mint: .makeLaunchpad(
+                    address: mint,
+                    supplyFromBonding: 1_000_000 * 10_000_000_000
+                ),
+                quarks: 10 * 10_000_000_000
+            ),
+        ])
+        let stored = try #require(container.session.balance(for: mint))
+        let rate = container.ratesController.rateForEntryCurrency()
+        let balance = ExchangedBalance(
+            stored: stored,
+            exchangedFiat: stored.computeExchangedValue(with: rate)
+        )
+        let viewModel = WithdrawViewModel(
+            isPresented: .constant(true),
+            container: .mock,
+            sessionContainer: container
+        )
+        viewModel.selectedBalance = balance
+        return (viewModel, balance)
+    }
+
     @Test("Non-USD rate: subtracts fee in USD and recomputes native amount")
     func withdrawableAmount_withFeeAndCADRate() {
         let cadRate = Rate(fx: 1.4, currency: .cad)


### PR DESCRIPTION
## Summary

Entering an amount above balance on the Give or Withdraw screens was silently clipping the request down to balance for launchpad currencies, so Give produced a bill for the clipped value and Withdraw advanced to the address step instead of rejecting. Give now keeps the Next button tappable and fires the existing "You're $X Short" prompt with the real shortfall, and Withdraw disables Next with a red balance subtitle the same way Sell already does. Buy was not affected.

## Test plan

- [x] Give a launchpad currency with an entry above balance, tap Next, and confirm the Short dialog appears with a non-zero amount.
- [x] Give a launchpad currency with the displayed-max entry, tap Next, and confirm a bill appears for the real balance.
- [x] Withdraw a launchpad currency with an entry above balance and confirm Next disables and the balance subtitle turns red.
- [x] Withdraw a launchpad currency with an entry at or below balance and confirm Next stays enabled.
- [x] Give and Withdraw USDF normally — confirm no change in behavior.