### PR TITLE
chore: remove feature flag for currency creation

### DIFF
--- a/Flipcash/Core/Controllers/BetaFlags.swift
+++ b/Flipcash/Core/Controllers/BetaFlags.swift
@@ -98,12 +98,11 @@ extension BetaFlags {
         case transactionDetails
         case vibrateOnScan
         case enableCoinbase
-        case currencyCreation
 
         var id: String {
             localizedTitle
         }
-        
+
         var localizedTitle: String {
             switch self {
             case .transactionDetails:
@@ -112,8 +111,6 @@ extension BetaFlags {
                 return "Vibrate on scan"
             case .enableCoinbase:
                 return "Enable Coinbase"
-            case .currencyCreation:
-                return "Currency Creation"
             }
         }
 
@@ -125,8 +122,6 @@ extension BetaFlags {
                 return "If enabled, the device will vibrate to indicate that the camera has registered the code on the bill"
             case .enableCoinbase:
                 return "If enabled, Coinbase onramp will be available regardless of region"
-            case .currencyCreation:
-                return "If enabled, shows a button to create your own currency in the discovery screen"
             }
         }
     }

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryList.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryList.swift
@@ -9,7 +9,6 @@ import FlipcashCore
 struct CurrencyDiscoveryList: View {
     let container: Container
 
-    @Environment(BetaFlags.self) private var betaFlags
     @Binding var mintsByCategory: [DiscoverCategory: [MintMetadata]]
     @Binding var selectedCategory: DiscoverCategory
     @Binding var selectedMint: PublicKey?
@@ -52,12 +51,10 @@ struct CurrencyDiscoveryList: View {
                         .listRowInsets(EdgeInsets())
                     }
 
-                    if betaFlags.hasEnabled(.currencyCreation) {
-                        Color.clear
-                            .frame(height: 80)
-                            .listRowBackground(Color.clear)
-                            .listRowSeparator(.hidden)
-                    }
+                    Color.clear
+                        .frame(height: 80)
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
                 }
             }
             .listSectionSeparator(.hidden)

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryScreen.swift
@@ -12,7 +12,6 @@ struct CurrencyDiscoveryScreen: View {
     let sessionContainer: SessionContainer
 
     @Environment(\.dismiss) private var dismiss
-    @Environment(BetaFlags.self) private var betaFlags
 
     @State private var mintsByCategory: [DiscoverCategory: [MintMetadata]] = [:]
     @State private var selectedCategory: DiscoverCategory = .popular
@@ -29,7 +28,7 @@ struct CurrencyDiscoveryScreen: View {
                     selectedMint: $selectedMint
                 )
 
-                if mintsByCategory[selectedCategory] != nil, betaFlags.hasEnabled(.currencyCreation) {
+                if mintsByCategory[selectedCategory] != nil {
                     CurrencyInfoFooter {
                         NavigationLink("Create Your Own Currency", value: CurrencyCreationStep.summary)
                             .buttonStyle(.filled)


### PR DESCRIPTION
## Summary
Removes the feature flag for currency creation, allowing this feature to be available to everyone.

## Test plan
- Open the currency discovery screen and confirm the "Create Your Own Currency" footer is always visible.
- Tap the footer and confirm the creation wizard opens.
- Open the beta flags screen and confirm the "Currency Creation" toggle is gone.