### PR TITLE
fix: simulate onchain transactions before server notification

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/Wallet/WalletConnection.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Wallet/WalletConnection.swift
@@ -75,14 +75,7 @@ public final class WalletConnection {
     private let owner: AccountCluster
     private let client: Client
 
-    private let solanaClient = BlockchainClient(
-        apiClient: JSONRPCAPIClient(
-            endpoint: .init(
-                address: "https://api.mainnet-beta.solana.com",
-                network: .mainnetBeta
-            )
-        )
-    )
+    private let rpc: WalletRPC
 
     /// Pending swap info to use when Phantom returns with signed transaction
     private var pendingSwap: PendingSwap?
@@ -92,7 +85,7 @@ public final class WalletConnection {
     private var pendingConnect: CheckedContinuation<Void, Swift.Error>?
 
     /// What the signed-transaction handler should do after the user returns
-    private struct PendingSwap {
+    struct PendingSwap {
         /// Funding-leg swap id (USDC→USDF) — used in the Phantom memo.
         let fundingSwapId: SwapId
         let amount: ExchangedFiat
@@ -109,9 +102,15 @@ public final class WalletConnection {
 
     // MARK: - Init -
 
-    init(owner: AccountCluster, client: Client) {
+    init(owner: AccountCluster, client: Client, rpc: WalletRPC? = nil) {
         self.owner = owner
         self.client = client
+        self.rpc = rpc ?? JSONRPCAPIClient(
+            endpoint: .init(
+                address: "https://api.mainnet-beta.solana.com",
+                network: .mainnetBeta
+            )
+        )
 
         if let connectedWalletSession = Keychain.connectedWalletSession {
             self.session = connectedWalletSession
@@ -260,27 +259,25 @@ public final class WalletConnection {
     }
     
     private func didSignTransaction(_ signedTx: String) {
-        Task { [solanaClient, weak self] in
-            let pending = self?.pendingSwap
-            self?.pendingSwap = nil
+        let pending = pendingSwap
+        pendingSwap = nil
+        completeSwap(signedTx: signedTx, pending: pending)
+    }
 
+    /// `pending` is passed explicitly (rather than read inside the Task) so
+    /// callers read+clear `self.pendingSwap` synchronously before the async
+    /// work begins — avoids a race if a second deep-link callback arrives
+    /// while the first is mid-flight.
+    @discardableResult
+    func completeSwap(
+        signedTx: String,
+        pending: PendingSwap?
+    ) -> Task<Void, Never> {
+        Task { [rpc, weak self] in
             guard let pending, let self else {
                 logger.warning("Received signed transaction but no pending swap context")
                 return
             }
-
-            // Present the generic processing screen immediately. The server callback
-            // below transitions to a launch context when the caller is launching a
-            // new currency; early-exit failures transition back to `.idle` so no
-            // cover presents for a swap the server never recorded.
-            self.state = .buying(
-                ExternalSwapProcessing(
-                    swapId: pending.fundingSwapId,
-                    currencyName: pending.displayName,
-                    amount: pending.amount
-                ),
-                isFailed: false
-            )
 
             let swapMetadata: [String: String] = [
                 "swapId": pending.fundingSwapId.publicKey.base58,
@@ -292,9 +289,33 @@ public final class WalletConnection {
             guard let tx = SolanaTransaction(data: rawData) else {
                 logger.error("Failed to decode signed transaction")
                 ErrorReporting.captureError(Error.invalidURL, reason: "Failed to decode signed transaction", metadata: swapMetadata)
-                self.state = .idle
                 return
             }
+
+            // Preflight before server-notify + chain-submit so a tx that can't
+            // land (stale account state, unpayable fee) surfaces a user dialog
+            // instead of burning through the full flow.
+            let txBase64 = rawData.base64EncodedString()
+            switch await self.simulateSignedTransaction(txBase64, swapMetadata: swapMetadata) {
+            case .proceed:
+                break
+            case .blocked(let dialog):
+                self.dialogItem = dialog
+                return
+            }
+
+            // Present the generic processing screen. The server callback below
+            // transitions to a launch context when the caller is launching a
+            // new currency; early-exit failures transition back to `.idle` so no
+            // cover presents for a swap the server never recorded.
+            self.state = .buying(
+                ExternalSwapProcessing(
+                    swapId: pending.fundingSwapId,
+                    currencyName: pending.displayName,
+                    amount: pending.amount
+                ),
+                isFailed: false
+            )
 
             // Notify server before submitting to chain — if the server rejects,
             // skip chain submission entirely so no USDC is spent without a swap state.
@@ -335,8 +356,7 @@ public final class WalletConnection {
             // server-recorded at this point, so on failure we keep the context
             // and flip `isFailed` so the processing screen surfaces the error.
             do {
-                let txBase64 = rawData.base64EncodedString()
-                let signature = try await solanaClient.apiClient.sendTransaction(
+                let signature = try await rpc.sendTransaction(
                     transaction: txBase64,
                     configs: .init(encoding: "base64")!
                 )
@@ -353,6 +373,80 @@ public final class WalletConnection {
     /// Opens the external wallet via deep link.
     private func openExternalWallet(_ url: URL) {
         url.openWithApplication()
+    }
+
+    /// Transport failures (URL errors, decode errors) pass through as
+    /// `.proceed` — a flaky RPC blip must not block a user with valid funds.
+    /// Only explicit RPC rejections block.
+    func simulateSignedTransaction(
+        _ txBase64: String,
+        swapMetadata: [String: String]
+    ) async -> SimulationOutcome {
+        do {
+            _ = try await rpc.simulateTransaction(
+                transaction: txBase64,
+                configs: RequestConfiguration(
+                    commitment: "confirmed",
+                    encoding: "base64",
+                    replaceRecentBlockhash: true
+                )!
+            )
+            return .proceed
+        } catch APIClientError.transactionSimulationError(let logs) {
+            return blockedOutcome(
+                reason: "Phantom signed transaction failed simulation",
+                logs: logs,
+                extraMetadata: ["kind": "simulationErr"],
+                swapMetadata: swapMetadata
+            )
+        } catch APIClientError.responseError(let response) {
+            var extra: [String: String] = ["kind": "preflightRejection"]
+            if let code = response.code { extra["code"] = "\(code)" }
+            if let message = response.message { extra["message"] = message }
+            return blockedOutcome(
+                reason: "Phantom signed transaction rejected at preflight",
+                logs: response.data?.logs ?? [],
+                extraMetadata: extra,
+                swapMetadata: swapMetadata
+            )
+        } catch {
+            logger.warning("Simulation RPC failed, proceeding to submit", metadata: [
+                "error": "\(error)",
+            ])
+            return .proceed
+        }
+    }
+
+    private func blockedOutcome(
+        reason: String,
+        logs: [String],
+        extraMetadata: [String: String],
+        swapMetadata: [String: String]
+    ) -> SimulationOutcome {
+        logger.error("Blocking signed transaction after RPC rejection", metadata: [
+            "kind": "\(extraMetadata["kind"] ?? "unknown")",
+            "code": "\(extraMetadata["code"] ?? "")",
+            "message": "\(extraMetadata["message"] ?? "")",
+            "logs": "\(logs.suffix(5).joined(separator: " | "))",
+        ])
+        ErrorReporting.captureError(
+            Error.simulationFailed(logs: logs),
+            reason: reason,
+            metadata: swapMetadata.merging(extraMetadata) { current, _ in current }
+        )
+        return .blocked(.init(
+            style: .destructive,
+            title: "Transaction Failed",
+            subtitle: "The Solana network wouldn't accept this transaction from your wallet. No funds were moved. Please try again.",
+            dismissable: true
+        ) {
+            .okay(kind: .destructive)
+        })
+    }
+
+    enum SimulationOutcome {
+        case proceed
+        case blocked(DialogItem)
     }
 
     /// Requests an external swap to fund a buy of an existing launchpad currency.
@@ -482,7 +576,7 @@ public final class WalletConnection {
             )
         }
 
-        let recentBlockhash = try await solanaClient.apiClient.getLatestBlockhash(commitment: "finalized")
+        let recentBlockhash = try await rpc.getLatestBlockhash(commitment: "finalized")
 
         var transaction = Transaction(
             instructions: instructionsConverted,
@@ -668,6 +762,7 @@ extension WalletConnection {
         case noSession
         case missingVerifiedState
         case invalidURL
+        case simulationFailed(logs: [String])
     }
 }
 
@@ -749,3 +844,16 @@ private extension FlipcashCore.Keychain {
 extension WalletConnection {
     static let mock = WalletConnection(owner: .mock, client: .mock)
 }
+
+// MARK: - WalletRPC -
+
+/// The slice of Solana RPC that `WalletConnection` depends on. A narrow
+/// protocol (instead of the full `SolanaAPIClient` surface) keeps test stubs
+/// small and makes the dependency honest at the call site.
+protocol WalletRPC {
+    func getLatestBlockhash(commitment: Commitment?) async throws -> String
+    func sendTransaction(transaction: String, configs: RequestConfiguration) async throws -> TransactionID
+    func simulateTransaction(transaction: String, configs: RequestConfiguration) async throws -> SimulationResult
+}
+
+extension JSONRPCAPIClient: WalletRPC {}

--- a/FlipcashTests/WalletConnectionStateTests.swift
+++ b/FlipcashTests/WalletConnectionStateTests.swift
@@ -3,8 +3,10 @@
 //  FlipcashTests
 //
 
+import Foundation
 import Testing
 import FlipcashCore
+import SolanaSwift
 @testable import Flipcash
 
 @MainActor
@@ -24,8 +26,8 @@ struct WalletConnectionStateTests {
         amount: ExchangedFiat.mockOne
     )
 
-    private func makeConnection() -> WalletConnection {
-        WalletConnection(owner: .mock, client: .mock)
+    private func makeConnection(rpc: WalletRPC? = nil) -> WalletConnection {
+        WalletConnection(owner: .mock, client: .mock, rpc: rpc)
     }
 
     @Test("`.idle` reports no active processing")
@@ -132,4 +134,251 @@ struct WalletConnectionStateTests {
         #expect(conn.dialogItem == nil)
         #expect(conn.state == .idle)
     }
+
+    // MARK: - Simulation outcome -
+
+    @Test("Preflight rejection returns `.blocked` with a user-facing dialog")
+    func simulationRejectionBlocks() async {
+        let conn = makeConnection(rpc: StubRPC(simulate: .failure(
+            APIClientError.transactionSimulationError(logs: [
+                "Program 11111111 invoke [1]",
+                "Transfer: insufficient lamports",
+                "Program 11111111 failed: custom program error: 0x1",
+            ])
+        )))
+
+        let outcome = await conn.simulateSignedTransaction("dummyBase64", swapMetadata: [:])
+
+        switch outcome {
+        case .proceed:
+            Issue.record("Expected .blocked for simulation rejection")
+        case .blocked(let dialog):
+            #expect(dialog.title == "Transaction Failed")
+            #expect(dialog.subtitle?.contains("wouldn't accept") == true)
+        }
+    }
+
+    @Test("Non-simulation errors pass through as `.proceed`")
+    func simulationTransportErrorProceeds() async {
+        let conn = makeConnection(rpc: StubRPC(simulate: .failure(URLError(.timedOut))))
+
+        let outcome = await conn.simulateSignedTransaction("dummyBase64", swapMetadata: [:])
+
+        if case .blocked = outcome {
+            Issue.record("Transport errors must not block — the RPC may just be flaky")
+        }
+    }
+
+    @Test("Successful simulation returns `.proceed`")
+    func simulationSuccessProceeds() async {
+        let conn = makeConnection(rpc: StubRPC(simulate: .succeeds))
+
+        let outcome = await conn.simulateSignedTransaction("dummyBase64", swapMetadata: [:])
+
+        if case .blocked = outcome {
+            Issue.record("Successful simulation must proceed to chain submission")
+        }
+    }
+
+    // MARK: - completeSwap full flow -
+
+    @Test(
+        "Any RPC-reported preflight rejection halts the flow before server + chain submit",
+        arguments: [
+            APIClientError.transactionSimulationError(logs: ["insufficient funds"]),
+            APIClientError.responseError(ResponseError(
+                code: -32002,
+                message: "insufficient funds",
+                data: ResponseErrorData(logs: ["Transfer: insufficient lamports"], numSlotsBehind: nil)
+            )),
+        ]
+    )
+    func completeSwap_preflightRejectionHaltsFlow(_ rpcError: APIClientError) async {
+        let rpc = StubRPC(
+            simulate: .failure(rpcError),
+            send: .failure(TestError.shouldNotBeCalled)
+        )
+        let conn = makeConnection(rpc: rpc)
+        let pending = Self.makePendingSwap(onCompleted: { _, _ in
+            Issue.record("Server notification must not run after preflight rejection")
+            throw TestError.shouldNotBeCalled
+        })
+
+        await conn.completeSwap(signedTx: Self.validSignedTxBase58(), pending: pending).value
+
+        #expect(conn.state == .idle)
+        #expect(conn.dialogItem?.title == "Transaction Failed")
+    }
+
+    @Test("Chain submit failure flips `.buying` to isFailed: true")
+    func completeSwap_chainSubmitFailureMarksFailed() async {
+        let swapId = SwapId.generate()
+        let rpc = StubRPC(simulate: .succeeds, send: .failure(URLError(.networkConnectionLost)))
+        let conn = makeConnection(rpc: rpc)
+        let pending = Self.makePendingSwap(
+            fundingSwapId: swapId,
+            onCompleted: { _, _ in .buyExisting(swapId: swapId) }
+        )
+
+        await conn.completeSwap(signedTx: Self.validSignedTxBase58(), pending: pending).value
+
+        guard case .buying(_, let isFailed) = conn.state else {
+            Issue.record("Expected state to remain `.buying` so the processing screen can surface the failure")
+            return
+        }
+        #expect(isFailed == true)
+    }
+
+    @Test("Chain submit success for `.buyExisting` leaves `.buying` clean")
+    func completeSwap_buyExistingSuccessStaysBuying() async {
+        let swapId = SwapId.generate()
+        let rpc = StubRPC(simulate: .succeeds, send: .succeeds(signature: "sig-1"))
+        let conn = makeConnection(rpc: rpc)
+        let pending = Self.makePendingSwap(
+            fundingSwapId: swapId,
+            onCompleted: { _, _ in .buyExisting(swapId: swapId) }
+        )
+
+        await conn.completeSwap(signedTx: Self.validSignedTxBase58(), pending: pending).value
+
+        guard case .buying(let ctx, let isFailed) = conn.state else {
+            Issue.record("Expected `.buying` state after successful buy-existing flow")
+            return
+        }
+        #expect(isFailed == false)
+        #expect(ctx.swapId == swapId)
+    }
+
+    @Test("Chain submit success for `.launch` transitions state to `.launching`")
+    func completeSwap_launchSuccessTransitionsToLaunching() async {
+        let fundingId = SwapId.generate()
+        let buyId = SwapId.generate()
+        let mint = PublicKey.mock
+        let rpc = StubRPC(simulate: .succeeds, send: .succeeds(signature: "sig-2"))
+        let conn = makeConnection(rpc: rpc)
+        let pending = Self.makePendingSwap(
+            fundingSwapId: fundingId,
+            onCompleted: { _, _ in .launch(swapId: buyId, mint: mint) }
+        )
+
+        await conn.completeSwap(signedTx: Self.validSignedTxBase58(), pending: pending).value
+
+        guard case .launching(let ctx, let isFailed) = conn.state else {
+            Issue.record("Expected `.launching` state after successful launch flow")
+            return
+        }
+        #expect(isFailed == false)
+        #expect(ctx.swapId == buyId)
+        #expect(ctx.launchedMint == mint)
+    }
+
+    @Test("Server notification failure resets to `.idle` without submitting")
+    func completeSwap_serverNotificationFailureResetsToIdle() async {
+        let rpc = StubRPC(simulate: .succeeds, send: .failure(TestError.shouldNotBeCalled))
+        let conn = makeConnection(rpc: rpc)
+        let pending = Self.makePendingSwap(onCompleted: { _, _ in
+            throw TestError.serverRejected
+        })
+
+        await conn.completeSwap(signedTx: Self.validSignedTxBase58(), pending: pending).value
+
+        #expect(conn.state == .idle)
+    }
+
+    @Test("Missing pending is a no-op")
+    func completeSwap_nilPendingIsNoOp() async {
+        let rpc = StubRPC(
+            simulate: .failure(TestError.shouldNotBeCalled),
+            send: .failure(TestError.shouldNotBeCalled)
+        )
+        let conn = makeConnection(rpc: rpc)
+
+        await conn.completeSwap(signedTx: Self.validSignedTxBase58(), pending: nil).value
+
+        #expect(conn.state == .idle)
+        #expect(conn.dialogItem == nil)
+    }
+
+    // MARK: - Helpers -
+
+    private static func makePendingSwap(
+        fundingSwapId: SwapId = .generate(),
+        displayName: String = "Test Coin",
+        amount: ExchangedFiat = .mockOne,
+        onCompleted: @escaping @MainActor @Sendable (FlipcashCore.Signature, ExchangedFiat) async throws -> SignedSwapResult
+    ) -> WalletConnection.PendingSwap {
+        WalletConnection.PendingSwap(
+            fundingSwapId: fundingSwapId,
+            amount: amount,
+            displayName: displayName,
+            onCompleted: onCompleted
+        )
+    }
+
+    /// Produces base58 bytes that round-trip cleanly through
+    /// `SolanaTransaction(data:)` — the decode gate inside `didSignTransaction`.
+    /// The signatures are zero-filled, which is fine because the production
+    /// flow only reads `tx.identifier` (which maps to `signatures[0]`) and
+    /// forwards it to the server-notify closure.
+    private static func validSignedTxBase58() -> String {
+        let tx = SolanaTransaction(
+            payer: PublicKey.mock,
+            recentBlockhash: nil,
+            instructions: [] as [Instruction]
+        )
+        return Base58.fromBytes([UInt8](tx.encode()))
+    }
+}
+
+// MARK: - StubRPC -
+
+/// Minimal `WalletRPC` for tests. Both `simulateTransaction` and
+/// `sendTransaction` are configurable; `getLatestBlockhash` traps because no
+/// current test exercises paths that fetch a blockhash.
+private struct StubRPC: WalletRPC {
+    enum SimulateBehavior {
+        case succeeds
+        case failure(Error)
+    }
+
+    enum SendBehavior {
+        case succeeds(signature: String)
+        case failure(Error)
+    }
+
+    let simulate: SimulateBehavior
+    let send: SendBehavior
+
+    init(simulate: SimulateBehavior, send: SendBehavior = .failure(TestError.shouldNotBeCalled)) {
+        self.simulate = simulate
+        self.send = send
+    }
+
+    func getLatestBlockhash(commitment: Commitment?) async throws -> String {
+        fatalError("getLatestBlockhash not stubbed")
+    }
+
+    func sendTransaction(transaction: String, configs: RequestConfiguration) async throws -> TransactionID {
+        switch send {
+        case .succeeds(let signature):
+            return signature
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func simulateTransaction(transaction: String, configs: RequestConfiguration) async throws -> SimulationResult {
+        switch simulate {
+        case .succeeds:
+            let payload = Data(#"{"err":null,"logs":[]}"#.utf8)
+            return try JSONDecoder().decode(SimulationResult.self, from: payload)
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+private enum TestError: Error {
+    case shouldNotBeCalled
+    case serverRejected
 }


### PR DESCRIPTION
## Summary

Users with insufficient wallet balances were submitting numerous sign requests. Simulate before sending the transaction

## Test plan

- [x] Triggering a buy with insufficient wallet balance shows a dialog and does not notify the server or submit on chain.
- [x] Triggering a buy with sufficient balance proceeds through server notification and chain submission as before.
- [x] Unit tests cover simulation rejection, JSON-RPC preflight rejection, chain submit failure, buy-existing success, launch success, server-notify failure, and missing pending swap.