### PR TITLE
chore(currency-creation): polish the UI and text

### DIFF
--- a/Flipcash/Core/Screens/Main/BalanceFooter.swift
+++ b/Flipcash/Core/Screens/Main/BalanceFooter.swift
@@ -28,7 +28,7 @@ struct BalanceFooter: View {
                 Button("Discover Currencies") {
                     isShowingCurrencyDiscovery = true
                 }
-                .buttonStyle(.filled10)
+                .buttonStyle(.filled)
                 .padding(20)
             }
         }

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationSummaryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationSummaryScreen.swift
@@ -96,7 +96,7 @@ private struct StepRow: View {
     var isLast: Bool = false
 
     var body: some View {
-        HStack(alignment: .top, spacing: 20) {
+        HStack(alignment: .top, spacing: 30) {
             VStack(spacing: 0) {
                 RoundedRectangle(cornerRadius: 6)
                     .fill(.white.opacity(0.16))

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -1025,7 +1025,7 @@ private struct ConfirmationStep: View {
                 if isValidating {
                     ProgressView().progressViewStyle(.circular)
                 } else {
-                    Text("Buy \(totalLaunchCost.nativeAmount.formatted()) to Create Your Currency")
+                    Text("Pay \(totalLaunchCost.nativeAmount.formatted()) to Create")
                 }
             }
             .buttonStyle(.filled)

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingViewModel.swift
@@ -55,7 +55,7 @@ class CurrencyLaunchProcessingViewModel {
 
     var title: String {
         switch displayState {
-        case .processing: "This Will Take a Minute"
+        case .processing: "This Will Take a Few Minutes"
         case .success:    "\(currencyName) Is Live"
         case .failed:     "Something Went Wrong"
         }


### PR DESCRIPTION
## Summary
- Drops "Discover Currencies" button back to the standard filled style.
- Widens the summary step row spacing for better breathing room.
- Shortens the confirmation button label and updates the processing title to set a more realistic expectation.

## Test plan
- [x] Open the main balance screen and confirm the Discover Currencies button looks right.
- [x] Walk through the currency creation wizard and review the summary and confirmation screens.
- [x] Launch a currency and confirm the processing screen title reads "This Will Take a Few Minutes".