### PR TITLE
chore: more text copy changes in UI and tests

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoMarketCapSection.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoMarketCapSection.swift
@@ -18,7 +18,7 @@ struct CurrencyInfoMarketCapSection: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text("Market Cap")
+            Text("Circulating Supply")
                 .foregroundStyle(Color.textSecondary)
                 .font(.appTextMedium)
                 .padding(.horizontal, 20)

--- a/FlipcashTests/CurrencyLaunchProcessingViewModelTests.swift
+++ b/FlipcashTests/CurrencyLaunchProcessingViewModelTests.swift
@@ -28,7 +28,7 @@ struct CurrencyLaunchProcessingViewModelTests {
     func processingCopy() {
         let vm = makeViewModel()
         #expect(vm.navigationTitle == "Creating Test Coin")
-        #expect(vm.title == "This Will Take a Minute")
+        #expect(vm.title == "This Will Take a Few Minutes")
         #expect(vm.subtitle == "This transaction typically takes a few minutes. You may leave the app while it completes")
         #expect(vm.actionTitle == "Notify Me When Complete")
     }


### PR DESCRIPTION
Ports two fixes made on the 1.4.1 release branch back to main so the history stays in sync.

- Market cap text tweak from the release.
- Test expectation update to match the new "This Will Take a Few Minutes" copy on the currency launch processing screen.

## Test plan

- [x] Run the AllTargets test plan locally.