### PR TITLE
chore: update success CTA copy on currency launch screen

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingViewModel.swift
@@ -72,7 +72,7 @@ class CurrencyLaunchProcessingViewModel {
     var actionTitle: String {
         switch displayState {
         case .processing: "Notify Me When Complete"
-        case .success:    "Receive My \(currencyName)"
+        case .success:    "Get The First \(launchAmount.nativeAmount.formatted()) of Your Currency Free"
         case .failed:     "OK"
         }
     }

--- a/FlipcashTests/CurrencyLaunchProcessingViewModelTests.swift
+++ b/FlipcashTests/CurrencyLaunchProcessingViewModelTests.swift
@@ -40,7 +40,7 @@ struct CurrencyLaunchProcessingViewModelTests {
         #expect(vm.navigationTitle == "Success")
         #expect(vm.title == "Test Coin Is Live")
         #expect(vm.subtitle == "Your currency is ready to receive and use")
-        #expect(vm.actionTitle == "Receive My Test Coin")
+        #expect(vm.actionTitle == "Get The First $1.00 of Your Currency Free")
     }
 
     @Test("Failed state copy")


### PR DESCRIPTION
## Summary
Updates the success-state button on the currency launch processing screen to match the latest Figma copy, with the dollar amount pulled dynamically from the launch amount.

## Test plan
- [x] Launch a currency and confirm the success button reads "Get The First $X of Your Currency Free" with the correct amount.