### PR TITLE
fix: scanner crash on out-of-bounds pixel read

### DIFF
--- a/CodeScanner/CodeScanner/src/scanner.cpp
+++ b/CodeScanner/CodeScanner/src/scanner.cpp
@@ -766,8 +766,10 @@ bool detectKikCode(Mat &greyscale, Mat *out_progress, uint32_t device_quality, u
             int x = 0.9 * (point.x - candidate_center.center.x) + candidate_center.center.x;
             int y = 0.9 * (point.y - candidate_center.center.y) + candidate_center.center.y;
 
-            if (whitish.at<char>(y, x) == 0) {
-                ++dark_count;
+            if (x >= 0 && y >= 0 && x < whitish.cols && y < whitish.rows) {
+                if (whitish.at<char>(y, x) == 0) {
+                    ++dark_count;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes random crashes that happened while the scan camera was open and pointed at certain real-world objects. The crash came from reading a pixel position outside the camera frame; the fix adds the same bounds check that already protects two nearby reads in the same scanner routine.

## Test plan
- [x] Open the scanner and point it at varied everyday objects without the app crashing.
- [x] Confirm that scanning a real cash code still detects and accepts the payment.