### PR TITLE
fix: restore reactivity in transaction history after cancelling a transfer

### DIFF
--- a/Flipcash/Core/Controllers/HistoryController.swift
+++ b/Flipcash/Core/Controllers/HistoryController.swift
@@ -10,67 +10,124 @@ import FlipcashCore
 
 private let logger = Logger(label: "flipcash.history-controller")
 
-/// Synchronizes transaction history from the server into the local database.
+/// Owns transaction history for the current session.
 ///
-/// On init, fetches any new activities since the last known ID (delta sync)
-/// and resolves pending transactions. Call ``sync()`` to trigger a manual refresh.
+/// Only one transaction-history screen is on display at a time, so the
+/// controller tracks a single "active" mint. Views call ``setActiveMint(_:)``
+/// to declare which mint they're showing, then read from ``activities``; the
+/// controller loads from the local DB and refreshes that slice after each
+/// ``sync()``.
+///
+/// `sync()` is the single entry point for refreshing from the server: it
+/// fetches new activities (delta + pending), writes them to the local DB,
+/// then reloads the active slice so observers see the new state.
 ///
 /// Inject via `@Environment(HistoryController.self)`.
 @MainActor @Observable
 class HistoryController {
 
+    enum LoadingState: Equatable {
+        case loading
+        case loaded([Activity])
+    }
+
+    private(set) var loadingState: LoadingState = .loading
+
     @ObservationIgnored private let client: FlipClient
     @ObservationIgnored private let database: Database
     @ObservationIgnored private let owner: AccountCluster
-    
+    @ObservationIgnored private var activeMint: PublicKey?
+
     private var ownerKeyPair: KeyPair {
         owner.authority.keyPair
     }
-    
+
     // MARK: - Init -
-    
+
     init(container: Container, database: Database, owner: AccountCluster) {
         self.client   = container.flipClient
         self.database = database
         self.owner    = owner
-        
-        sync()
     }
-    
+
+    // MARK: - Observe -
+
+    /// Declare which mint's activities should be exposed via ``loadingState``.
+    /// On a real change of mint, clears the slice and reloads from the local
+    /// DB. Re-calls with the same mint are no-ops; ``sync()`` is the refresh
+    /// path while a mint stays active.
+    func setActiveMint(_ mint: PublicKey) async {
+        guard activeMint != mint else { return }
+        activeMint = mint
+        loadingState = .loading
+        await reload()
+    }
+
+    /// Re-read the active mint's activities from the local DB. Called by
+    /// ``sync()`` after writing new server data and by ``setActiveMint(_:)``.
+    func reload() async {
+        guard let mint = activeMint else {
+            loadingState = .loaded([])
+            return
+        }
+        do {
+            let loaded = try await database.getActivities(mint: mint)
+            guard activeMint == mint else { return }
+            loadingState = .loaded(loaded)
+        } catch is CancellationError {
+            return
+        } catch {
+            logger.error("Failed to reload activities", metadata: [
+                "mint": "\(mint.base58)",
+                "error": "\(error)",
+            ])
+            if activeMint == mint {
+                loadingState = .loaded([])
+            }
+        }
+    }
+
     // MARK: - Fetch -
-    
+
     func sync() {
         Task {
-            try await syncDeltaHistory()
-            try await syncPendingActivities()
-        }
-    }
-    
-    func syncPendingActivities() async throws {
-        let pendingIDs = try database.getPendingActivityIDs()
-        if !pendingIDs.isEmpty {
-            let activities = try await client.fetchTransactionHistoryItemsByID(owner: ownerKeyPair, ids: pendingIDs)
-            try database.transaction {
-                try $0.insertActivities(activities: activities)
+            do {
+                let didDelta = try await syncDeltaHistory()
+                let didPending = try await syncPendingActivities()
+                if didDelta || didPending {
+                    await reload()
+                }
+            } catch {
+                logger.error("Sync failed", metadata: ["error": "\(error)"])
             }
-            
-            logger.info("Inserted pending activities", metadata: ["count": "\(activities.count)"])
-        } else {
-            logger.debug("No pending activities")
         }
     }
-    
-    private func syncDeltaHistory() async throws {
-        let latestID = try database.getLatestActivityID()
-        try await syncHistory(since: latestID)
+
+    func syncPendingActivities() async throws -> Bool {
+        let pendingIDs = try database.getPendingActivityIDs()
+        guard !pendingIDs.isEmpty else {
+            logger.debug("No pending activities")
+            return false
+        }
+        let activities = try await client.fetchTransactionHistoryItemsByID(owner: ownerKeyPair, ids: pendingIDs)
+        try database.transaction {
+            try $0.insertActivities(activities: activities)
+        }
+        logger.info("Inserted pending activities", metadata: ["count": "\(activities.count)"])
+        return true
     }
-    
-    private func syncHistory(since id: PublicKey? = nil) async throws {
+
+    private func syncDeltaHistory() async throws -> Bool {
+        let latestID = try database.getLatestActivityID()
+        return try await syncHistory(since: latestID)
+    }
+
+    private func syncHistory(since id: PublicKey? = nil) async throws -> Bool {
         let pageSize = 1024
         var cursor: PublicKey? = id
-        
+
         var container: [Activity] = []
-        
+
         var hasMore = true
         while hasMore {
             let activities = try await client.fetchTransactionHistory(
@@ -78,24 +135,24 @@ class HistoryController {
                 pageSize: pageSize,
                 since: cursor
             )
-            
+
             if !activities.isEmpty {
                 container.append(contentsOf: activities)
                 cursor = activities.last?.id
             }
-            
+
             hasMore = activities.count == pageSize
         }
 
-        if !container.isEmpty {
-            try database.transaction {
-                try $0.insertActivities(activities: container)
-            }
-            
-            logger.info("Inserted activities", metadata: ["count": "\(container.count)"])
-        } else {
+        guard !container.isEmpty else {
             logger.info("No new activities")
+            return false
         }
+        try database.transaction {
+            try $0.insertActivities(activities: container)
+        }
+        logger.info("Inserted activities", metadata: ["count": "\(container.count)"])
+        return true
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -185,10 +185,7 @@ struct CurrencyInfoScreen: View {
             }
         }
         .navigationDestinationCompat(item: $transactionHistoryMint) { mint in
-            TransactionHistoryScreen(
-                mint: mint,
-                database: sessionContainer.database
-            )
+            TransactionHistoryScreen(mint: mint)
         }
         .fullScreenCover(item: Bindable(walletConnection).processing) { processing in
             NavigationStack {

--- a/Flipcash/Core/Screens/Main/TransactionHistoryScreen.swift
+++ b/Flipcash/Core/Screens/Main/TransactionHistoryScreen.swift
@@ -9,24 +9,19 @@ import SwiftUI
 import FlipcashUI
 import FlipcashCore
 
-private let logger = Logger(label: "flipcash.transaction-history")
-
 struct TransactionHistoryScreen: View {
 
     @Environment(Session.self) private var session
-
-    @State private var activities: [Activity]?
+    @Environment(HistoryController.self) private var historyController
 
     @State private var dialogItem: DialogItem?
 
     private let mint: PublicKey
-    private let database: Database
 
     // MARK: - Init -
 
-    init(mint: PublicKey, database: Database) {
+    init(mint: PublicKey) {
         self.mint = mint
-        self.database = database
     }
 
     // MARK: - Body -
@@ -35,13 +30,14 @@ struct TransactionHistoryScreen: View {
         Background(color: .backgroundMain) {
             List {
                 Section {
-                    if let activities {
+                    switch historyController.loadingState {
+                    case .loaded(let activities):
                         ForEach(activities) { activity in
                             ActivityRow(activity: activity) {
                                 rowAction(activity: activity)
                             }
                         }
-                    } else {
+                    case .loading:
                         ProgressView()
                             .frame(maxWidth: .infinity, minHeight: 200)
                             .listRowBackground(Color.clear)
@@ -57,17 +53,7 @@ struct TransactionHistoryScreen: View {
         }
         .dialog(item: $dialogItem)
         .task(id: mint) {
-            do {
-                activities = try await database.getActivities(mint: mint)
-            } catch is CancellationError {
-                // Superseded by a newer .task — don't clobber `activities`.
-                return
-            } catch {
-                logger.error("Failed to load activities", metadata: [
-                    "mint": "\(mint.base58)",
-                ])
-                activities = []
-            }
+            await historyController.setActiveMint(mint)
         }
     }
 

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -218,6 +218,7 @@ final class SessionAuthenticator {
             database: database,
             owner: owner
         )
+        historyController.sync()
         
         let ratesController = RatesController(
             container: container,

--- a/FlipcashTests/HistoryControllerTests.swift
+++ b/FlipcashTests/HistoryControllerTests.swift
@@ -1,0 +1,152 @@
+//
+//  HistoryControllerTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+struct HistoryControllerTests {
+
+    // MARK: - Helpers
+
+    private static func makeCashLinkActivity(
+        id: PublicKey = .jeffy,
+        state: Activity.State,
+        canCancel: Bool,
+        title: String,
+    ) -> Activity {
+        Activity(
+            id: id,
+            state: state,
+            kind: .cashLink,
+            title: title,
+            exchangedFiat: .mockOne,
+            date: .now,
+            metadata: .cashLink(
+                Activity.CashLinkMetadata(vault: .usdc, canCancel: canCancel)
+            )
+        )
+    }
+
+    private static func makeController(database: Database) -> HistoryController {
+        HistoryController(container: .mock, database: database, owner: .mock)
+    }
+
+    /// Unwrap the controller's loaded slice. Avoids full `Activity` equality —
+    /// `Date` doesn't round-trip through SQLite with full nanosecond precision.
+    private static func loadedActivities(_ controller: HistoryController) throws -> [Activity] {
+        guard case .loaded(let activities) = controller.loadingState else {
+            Issue.record("Expected .loaded state, got \(controller.loadingState)")
+            throw TestFailure.notLoaded
+        }
+        return activities
+    }
+
+    private enum TestFailure: Error { case notLoaded }
+
+    // MARK: - Initial state
+
+    @Test("Initial loadingState is .loading before any mint is active")
+    func initialStateIsLoading() throws {
+        let controller = Self.makeController(database: try Database.makeTemp())
+        #expect(controller.loadingState == .loading)
+    }
+
+    // MARK: - setActiveMint
+
+    @Test("setActiveMint loads the mint's activities from the local DB")
+    func setActiveMintLoadsActivities() async throws {
+        let db = try Database.makeTemp()
+        let pending = Self.makeCashLinkActivity(
+            state: .pending, canCancel: true, title: "Sending $1.00",
+        )
+        try db.insertActivities(activities: [pending])
+
+        let controller = Self.makeController(database: db)
+        await controller.setActiveMint(.usdf)
+
+        let activities = try Self.loadedActivities(controller)
+        #expect(activities.count == 1)
+        #expect(activities[0].id == .jeffy)
+        #expect(activities[0].state == .pending)
+        #expect(activities[0].cancellableCashLinkMetadata != nil)
+    }
+
+    @Test("setActiveMint with the same mint is a no-op — sync() is the refresh path")
+    func setActiveMintSameMintDoesNotReload() async throws {
+        let db = try Database.makeTemp()
+        let pending = Self.makeCashLinkActivity(
+            state: .pending, canCancel: true, title: "Sending $1.00",
+        )
+        try db.insertActivities(activities: [pending])
+
+        let controller = Self.makeController(database: db)
+        await controller.setActiveMint(.usdf)
+        try #require(Self.loadedActivities(controller).first?.state == .pending)
+
+        // Mutate the DB directly. The controller's slice must NOT pick this
+        // up from a same-mint setActiveMint call — that's the re-mount-as-no-op
+        // contract that prevents redundant DB reads.
+        let completed = Self.makeCashLinkActivity(
+            state: .completed, canCancel: false, title: "Cancelled $1.00",
+        )
+        try db.insertActivities(activities: [completed])
+
+        await controller.setActiveMint(.usdf)
+
+        let activities = try Self.loadedActivities(controller)
+        #expect(activities.first?.state == .pending)
+    }
+
+    @Test("setActiveMint with a different mint switches the slice")
+    func setActiveMintSwitchesSlice() async throws {
+        let db = try Database.makeTemp()
+        let usdfActivity = Self.makeCashLinkActivity(
+            state: .pending, canCancel: true, title: "Sending $1.00",
+        )
+        try db.insertActivities(activities: [usdfActivity])
+
+        let controller = Self.makeController(database: db)
+        await controller.setActiveMint(.usdf)
+        try #require(Self.loadedActivities(controller).count == 1)
+
+        // Switch to a mint with no activities.
+        await controller.setActiveMint(.usdc)
+
+        let activities = try Self.loadedActivities(controller)
+        #expect(activities.isEmpty)
+    }
+
+    // MARK: - reload
+
+    @Test("reload picks up DB writes for the active mint — the post-sync refresh path")
+    func reloadReflectsDBWrite() async throws {
+        let db = try Database.makeTemp()
+        let pending = Self.makeCashLinkActivity(
+            state: .pending, canCancel: true, title: "Sending $1.00",
+        )
+        try db.insertActivities(activities: [pending])
+
+        let controller = Self.makeController(database: db)
+        await controller.setActiveMint(.usdf)
+
+        // What HistoryController.sync() writes after the backend confirms a
+        // cancel — same id, terminal state, no longer cancellable.
+        let completed = Self.makeCashLinkActivity(
+            state: .completed, canCancel: false, title: "Cancelled $1.00",
+        )
+        try db.insertActivities(activities: [completed])
+
+        await controller.reload()
+
+        let activities = try Self.loadedActivities(controller)
+        #expect(activities.count == 1)
+        #expect(activities[0].state == .completed)
+        #expect(activities[0].cancellableCashLinkMetadata == nil)
+        #expect(activities[0].title == "Cancelled $1.00")
+    }
+}


### PR DESCRIPTION
## Summary
Cancelling a Sending transfer from the transaction history left the row stuck on the pre-cancel view until the screen was reopened. The history view now updates through normal SwiftUI observation rather than a one-shot DB read, so cancellations and other background sync writes flow through naturally.

## Test plan
- [x] Open the transaction history for a mint with a Sending transfer, cancel it, and verify the row updates without leaving the screen
- [x] Navigate between several currencies' transaction histories and confirm each loads
- [x] Stay on a transaction history screen across an app foreground / push notification and confirm the list stays in sync