### PR TITLE
fix: locate wallet currency rows by identifier in UI tests

### DIFF
--- a/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
+++ b/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
@@ -114,6 +114,7 @@ struct CurrencyBalanceRow: View {
                 isSelected: showSelected,
             )
         }
+        .accessibilityIdentifier("currency-row")
         .disabled(action == nil)
         .listRowBackground(Color.clear)
         .padding(.horizontal, 20)

--- a/FlipcashUITests/Support/Screens/WalletScreen.swift
+++ b/FlipcashUITests/Support/Screens/WalletScreen.swift
@@ -18,9 +18,12 @@ struct WalletScreen {
 
     // MARK: - Elements
 
-    /// The first actual currency row. Index 0 is the List section header
-    /// (total balance + appreciation); currency rows start at index 1.
-    var firstCurrencyRow: XCUIElement { app.cells.element(boundBy: 1) }
+    /// The first currency row. Identified by the row's accessibility identifier
+    /// rather than `app.cells`, since the wallet uses a `ScrollView` + `LazyVStack`
+    /// rather than a `List`.
+    var firstCurrencyRow: XCUIElement {
+        app.buttons.matching(identifier: "currency-row").firstMatch
+    }
 
     /// The balance header button that shows the flag + total amount + chevron.
     var balanceHeader: XCUIElement { app.buttons["balance-header"] }


### PR DESCRIPTION
## Summary
The wallet recently switched its container from a List to a ScrollView with a LazyVStack, but the page object kept querying `app.cells` — which only matches table or collection cells — so every test that opens the wallet failed at the very first navigation step. The currency row now exposes an accessibility identifier and the page object queries by it.

## Test plan
- [x] Re-run the cash link cancel-from-bill, currency buy, currency sell, and wallet callback UI suites and confirm they get past the wallet open step