### PR TITLE
fix: hide stale error overlay on currency discovery list

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryList.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryList.swift
@@ -60,7 +60,7 @@ struct CurrencyDiscoveryList: View {
             .listSectionSeparator(.hidden)
         }
         .overlay {
-            if isFailed {
+            if isFailed, mints.isEmpty {
                 VStack(spacing: 10) {
                     Text("Something Went Wrong")
                         .font(.appTextLarge)
@@ -99,7 +99,7 @@ struct CurrencyDiscoveryList: View {
                     mintsByCategory[category] = []
                 }
             } catch {
-                if !Task.isCancelled {
+                if !Task.isCancelled, mintsByCategory[category] == nil {
                     failedCategories.insert(category)
                 }
             }


### PR DESCRIPTION
## Summary
After a long phone lock, the currency discovery list was rendering both its loaded data and the "Something Went Wrong" overlay at the same time. The streaming RPC dropped while the app was suspended, the catch path marked the category as failed, but the cached snapshot stayed in state — so the overlay painted on top of the working list.

This change makes the two states mutually exclusive: the error overlay only shows when there is no data to display, and the failed flag is only recorded when nothing was loaded.

## Test plan
- [x] Open Currencies, wait for the list, lock the phone, return after a few minutes, and confirm only the loaded list is shown.
- [x] Open Currencies offline and confirm the error message still appears when there is nothing to display.