### PR TITLE
fix: improve Coinbase onramp error handling

### DIFF
--- a/Flipcash/Core/Controllers/Coinbase.swift
+++ b/Flipcash/Core/Controllers/Coinbase.swift
@@ -255,9 +255,9 @@ public struct OnrampErrorResponse: Error, Decodable, Sendable {
                 case .invalidCard:
                     return "This transaction was declined. Please make sure you are using a debit card and the billing address is correct"
                 case .transactionLimit:
-                    return "You can only add up to $1,800 per week"
+                    return "You can only add up to $1,000 per week"
                 case .transactionCount:
-                    return "Each user is limited to 5 purchases total. To add more funds, please purchase USDC on an exchange and deposit it into your account"
+                    return "Each user is limited to 15 purchases total."
                 case .cardRiskDeclined, .permissionDenied:
                     return "Something went wrong. Please contact support"
                 case .guestRegionMismatch, .guestRegionForbidden, .networkNotTradable:

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -749,7 +749,9 @@ final class OnrampCoordinator {
             }
             presentDestructiveDialog(title: title, subtitle: subtitle)
 
-            ErrorReporting.captureError(kind)
+            ErrorReporting.captureError(kind, id: kind.rawValue, metadata: [
+                "error_code": event.data?.errorCode ?? "nil"
+            ])
         }
 
         switch event.event {


### PR DESCRIPTION
## Summary
Apple Pay error events from the Coinbase onramp web view were being captured to Bugsnag with only the case name, hiding the actual reason. Now the Coinbase error code is attached as metadata, and load, commit, and polling failures group separately so they can be triaged independently. Also refreshes the limit copy to reflect the current weekly cap and per-user purchase count.

## Test plan
- [x] Trigger a Coinbase Apple Pay failure (e.g. unsupported card region) and confirm the resulting Bugsnag report includes the error code.
- [x] Hit the weekly limit and confirm the new copy is shown.
- [x] Hit the per-user purchase count limit and confirm the new copy is shown.