### PR TITLE
fix: use USDF PDA as Coinbase onramp destination

### DIFF
--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -678,7 +678,7 @@ final class OnrampCoordinator {
                 paymentCurrency: "USD",
                 purchaseCurrency: "USDF",
                 isQuote: false,
-                destinationAddress: usdfSwapAccounts.ata.publicKey,
+                destinationAddress: usdfSwapAccounts.pda.publicKey,
                 email: email,
                 phoneNumber: phone,
                 partnerOrderRef: orderRef,


### PR DESCRIPTION
## Summary
Coinbase onramp orders were sending the USDF associated token account as the destination, but the server-side swap expects the timelock PDA. Funded buys would settle into an account the swap could not drain.

## Test plan
- [x] Run an Apple Pay onramp purchase and confirm the funds land in the user's USDF balance.