### PR TITLE
chore: improve release skill version-bump handling

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -21,7 +21,7 @@ Two-phase workflow with a dogfooding gate. Nothing leaves the machine until the 
 If the pre-flight working tree output is non-empty → STOP. Commit or stash first.
 
 ### 2. Calculate next version
-Derive the current released version from the pre-flight latest tag (strip the `flipcash-` prefix). The `MARKETING_VERSION` in the project file is always bumped ahead for TestFlight builds and must NOT be used.
+Derive the current released version from the pre-flight latest tag (strip the `flipcash-` prefix). Do not infer the version from `MARKETING_VERSION` — it is the version under development, not the version released.
 
 Determine bump type from `$ARGUMENTS` (default: `minor`):
 
@@ -33,14 +33,26 @@ Determine bump type from `$ARGUMENTS` (default: `minor`):
 
 Confirm with user: "Bumping {type}: flipcash-{current} → flipcash-{next} — correct?"
 
-### 3. Determine base
-- **major / minor**: base is HEAD on the current branch. Show the pre-flight latest tag to user. If it picks up a legacy tag, ask for the correct base.
+### 3. Verify MARKETING_VERSION on main (major / minor only)
+Skip for patch — patch bumps the version on the release branch in step 4b.
+
+The bump must already be merged into `origin/main` before cutting the release. Check it:
+```bash
+git fetch origin main
+git show origin/main:Code.xcodeproj/project.pbxproj | grep -c "MARKETING_VERSION = {next-version};"
+```
+
+- **Result is `4`** (Flipcash target's four configurations): proceed.
+- **Result is `0`**: STOP. Tell the user: *"`origin/main` is still at `{current-version}`. Open a `chore/bump-version-{next-version}` PR that flips `MARKETING_VERSION` from `{current-version}` to `{next-version}` (use `replace_all` — only the Flipcash target's four lines should change), merge it, then re-run /release {bump}."* Do not open the bump PR from inside this skill, and do not commit it locally to main.
+
+### 4. Determine base
+- **major / minor**: base is `origin/main`. Show the pre-flight latest tag to user. If it picks up a legacy tag, ask for the correct base.
 - **patch**: base is the `release/flipcash-X.Y.Z` branch (the release being patched). Checkout that branch before proceeding:
   ```bash
   git checkout release/flipcash-{current-version}
   ```
 
-### 3a. Cherry-pick commits (patch only)
+### 4a. Cherry-pick commits (patch only)
 Show commits on `main` that aren't on the release branch yet:
 ```bash
 git log release/flipcash-{current-version}..main --oneline --no-merges
@@ -53,7 +65,7 @@ If a cherry-pick conflicts, STOP and hand off to the user — do not resolve con
 
 Skip this step if the user says there are no commits to pick (rare — usually means the branch already has them applied manually).
 
-### 3b. Bump MARKETING_VERSION (patch only)
+### 4b. Bump MARKETING_VERSION (patch only)
 The release branch's `Code.xcodeproj/project.pbxproj` is still pinned at `{current-version}`. The binary produced from this branch needs the patched version or TestFlight/App Store will reject it as a duplicate. Use the Edit tool with `replace_all: true`:
 
 - **old_string**: `MARKETING_VERSION = {current-version};`
@@ -67,7 +79,7 @@ git add Code.xcodeproj/project.pbxproj
 git commit -m "chore: bump version to {next-version}"
 ```
 
-### 4. What's shipping
+### 5. What's shipping
 ```bash
 git log {base-tag}..HEAD --format="- %s" --no-merges
 ```
@@ -75,7 +87,7 @@ For patch releases, `{base-tag}` is `flipcash-{current-version}` (the tag on the
 
 Display for sanity check.
 
-### 5. Run all tests
+### 6. Run all tests
 ```bash
 xcodebuild test -scheme Flipcash \
   -destination 'platform=iOS Simulator,name=iPhone 17' \
@@ -85,7 +97,7 @@ The `AllTargets` test plan already includes UI tests. Do NOT run UI tests separa
 
 Any failure → STOP.
 
-### 6. Generate changelog
+### 7. Generate changelog
 Use the Agent tool with `model: "haiku"`. Pass the commit list with this prompt:
 
 > Given these git commits (conventional commit format), write user-facing release notes.
@@ -97,13 +109,14 @@ Use the Agent tool with `model: "haiku"`. Pass the commit list with this prompt:
 
 Show to user for approval.
 
-### 7. Branch and tag
-For **major / minor**: the version in `Code.xcodeproj/project.pbxproj` is already bumped ahead for TestFlight — do NOT modify it. Create the branch:
+### 8. Branch and tag
+For **major / minor**: step 3 already verified the bump is on `origin/main`. Pull main locally, then branch:
 ```bash
+git checkout main && git pull --ff-only
 git checkout -b release/flipcash-{next-version}
 ```
 
-For **patch**: already on `release/flipcash-X.Y.Z` from step 3; the version bump commit from step 3b is already on the branch. Skip branch creation.
+For **patch**: already on `release/flipcash-X.Y.Z` from step 4; the version bump commit from step 4b is already on the branch. Skip branch creation.
 
 Then tag:
 ```bash
@@ -129,13 +142,13 @@ Safe to abort. Tell me when you're ready to ship.
 
 After user confirms:
 
-### 8. Push
+### 9. Push
 ```bash
 git push -u origin release/flipcash-{version}
 git push origin flipcash-{version}
 ```
 
-### 9. GitHub Release (draft)
+### 10. GitHub Release (draft)
 Always create the release as a draft. Publish it manually from the GitHub UI once the App Store rollout is live — publishing fires webhooks and "Latest release" badges, so it should reflect what's actually available to users.
 
 ```bash
@@ -149,5 +162,7 @@ Remind the user at the end: *"Release drafted. Promote it in the GitHub UI once 
 - Commit changelog files
 - Skip the dogfooding gate
 - Proceed past the gate without explicit user confirmation
-- Tag a patch without bumping `MARKETING_VERSION` on the release branch (step 3b) — TestFlight rejects duplicate build versions
+- Tag a patch without bumping `MARKETING_VERSION` on the release branch (step 4b) — TestFlight rejects duplicate build versions
+- Open the major/minor bump PR yourself — step 3 stops and asks the user to do it; the bump must descend from a merged `main` commit before /release continues
+- Cut the release branch or tag from a local-only bump commit — always branch from the `main` whose `origin/main` already has the merged bump
 - Resolve cherry-pick conflicts autonomously — stop and hand off to the user


### PR DESCRIPTION
The release skill now verifies that the next `MARKETING_VERSION` is already merged into `origin/main` before cutting the release branch, and stops with instructions if it isn't. The skill never opens the bump PR itself — that stays a user-driven action.

Also clarifies that `MARKETING_VERSION` reflects the version under development, not the released one, and renumbers the steps after inserting the new check.

## Test plan
- [x] Walk through the steps mentally for a major or minor release where the bump is missing — should stop at step 3