### PR TITLE
refactor: redesign settings screen with deposit/withdraw cards

### DIFF
--- a/Flipcash/Core/Screens/Settings/SettingsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsScreen.swift
@@ -39,119 +39,113 @@ struct SettingsScreen: View {
         @Bindable var router = router
         NavigationStack(path: $router[.settings]) {
             Background(color: .backgroundMain) {
-                VStack(alignment: .center, spacing: 0) {
-                    ScrollView(showsIndicators: false) {
-                        list()
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 20) {
+                        HStack(spacing: 10) {
+                            Button("Deposit") {
+                                router.push(.depositCurrencyList)
+                            }
+                            .buttonStyle(.card(icon: .deposit))
+
+                            Button("Withdraw") {
+                                router.push(.withdraw)
+                            }
+                            .buttonStyle(.card(icon: .withdraw))
+                        }
+
+                        VStack(alignment: .leading, spacing: 0) {
+                            SettingsRow(asset: .myAccount, title: "My Account", insets: insets) {
+                                router.push(.settingsMyAccount)
+                            }
+
+                            SettingsRow(asset: .settings, title: "App Settings", insets: insets) {
+                                router.push(.settingsAppSettings)
+                            }
+
+                            SettingsRow(asset: .sliders, title: "Advanced Features", insets: insets) {
+                                router.push(.settingsAdvancedFeatures)
+                            }
+
+                            if betaFlags.accessGranted {
+                                SettingsRow(asset: .debug, title: "Beta Features", badge: betaBadge, insets: insets) {
+                                    router.push(.settingsBetaFlags)
+                                }
+
+                                SettingsRow(asset: .switchAccounts, title: "Switch Accounts", badge: betaBadge, insets: insets) {
+                                    router.push(.settingsAccountSelection)
+                                }
+                            }
+                        }
+                        .font(.appDisplayXS)
+                        .foregroundStyle(Color.textMain)
                     }
-                    footer()
+                    .padding(.horizontal, 20)
+                    .padding(.top, 10)
                 }
-                .padding(.vertical, 10)
-                .padding(.horizontal, 20)
+                .safeAreaInset(edge: .bottom) {
+                    VStack(spacing: 0) {
+                        Button {
+                            dialogItem = logoutDialog
+                        } label: {
+                            HStack(spacing: 10) {
+                                Image.asset(.logout)
+                                    .renderingMode(.template)
+                                Text("Log Out")
+                            }
+                        }
+                        .buttonStyle(.subtle)
+
+                        Button {
+                            handleVersionTap()
+                        } label: {
+                            Text("Version \(AppMeta.version) • Build \(AppMeta.build)")
+                                .lineLimit(1)
+                                .font(.appTextHeading)
+                                .foregroundStyle(Color.textSecondary)
+                                .padding(.vertical, 12)
+                                .frame(maxWidth: .infinity)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 20)
+                }
             }
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     ToolbarCloseButton {
                         router.dismissSheet()
                     }
                 }
-                ToolbarItem(placement: .principal) {
-                    logoHeader()
-                }
             }
             .navigationTitle("Settings")
+            .dialog(item: $dialogItem)
             .appRouterDestinations(container: container, sessionContainer: sessionContainer)
         }
     }
 
-    // MARK: - Header Components -
+    // MARK: - Helpers -
 
-    @ViewBuilder private func logoHeader() -> some View {
-        Button {
-            handleLogoTap()
-        } label: {
-            Image.asset(.flipcashBrand)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(maxHeight: 34)
+    private let betaBadge = Badge(decoration: .circle(.textWarning), text: "Beta")
+
+    private var logoutDialog: DialogItem {
+        DialogItem(
+            style: .destructive,
+            title: "Are You Sure You Want To Log Out?",
+            subtitle: "You can get into this account using your Access Key",
+            dismissable: true
+        ) {
+            DialogAction.destructive("Log Out") {
+                logout()
+            }
+            DialogAction.cancel {}
         }
-        .buttonStyle(.plain)
-    }
-
-    // MARK: - Lists -
-
-    @ViewBuilder private func list() -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-
-            SettingsRow(asset: .deposit, title: "Deposit Funds", insets: insets) {
-                router.push(.depositCurrencyList)
-            }
-            
-            SettingsRow(asset: .withdraw, title: "Withdraw Funds", insets: insets) {
-                router.push(.withdraw)
-            }
-
-            SettingsRow(asset: .myAccount, title: "My Account", insets: insets) {
-                router.push(.settingsMyAccount)
-            }
-
-            SettingsRow(asset: .settings, title: "App Settings", insets: insets) {
-                router.push(.settingsAppSettings)
-            }
-
-            SettingsRow(asset: .sliders, title: "Advanced Features", insets: insets) {
-                router.push(.settingsAdvancedFeatures)
-            }
-
-            if betaFlags.accessGranted {
-                SettingsRow(asset: .debug, title: "Beta Features", badge: betaBadge(), insets: insets) {
-                    router.push(.settingsBetaFlags)
-                }
-
-                SettingsRow(asset: .switchAccounts, title: "Switch Accounts", badge: betaBadge(), insets: insets) {
-                    router.push(.settingsAccountSelection)
-                }
-            }
-
-            SettingsRow(asset: .logout, title: "Log Out", insets: insets) {
-                dialogItem = .init(
-                    style: .destructive,
-                    title: "Are You Sure You Want To Log Out?",
-                    subtitle: "You can get into this account using your Access Key",
-                    dismissable: true
-                ) {
-                    DialogAction.destructive("Log Out") {
-                        logout()
-                    }
-                    DialogAction.cancel {}
-                }
-            }
-
-            Spacer()
-        }
-        .font(.appDisplayXS)
-        .foregroundColor(.textMain)
-        .dialog(item: $dialogItem)
-    }
-
-    @ViewBuilder private func footer() -> some View {
-        VStack {
-            Text("Version \(AppMeta.version) • Build \(AppMeta.build)")
-                .lineLimit(1)
-                .font(.appTextHeading)
-                .foregroundColor(.textSecondary)
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private func betaBadge() -> Badge {
-        Badge(decoration: .circle(.textWarning), text: "Beta")
     }
 
     // MARK: - Actions -
 
-    private func handleLogoTap() {
+    private func handleVersionTap() {
         if debugTapCount >= 9 {
             betaFlags.setAccessGranted(!betaFlags.accessGranted)
             debugTapCount = 0

--- a/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/CardButtonStyle.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/CardButtonStyle.swift
@@ -1,0 +1,53 @@
+//
+//  CardButtonStyle.swift
+//  FlipcashUI
+//
+//  Created by Raul Riera on 2026-04-30.
+//
+
+import SwiftUI
+
+/// A square card button with a centered icon stacked above its label,
+/// inside a translucent rounded container. Pairs well in horizontal
+/// stacks of two for primary tile-style entry points.
+///
+/// ```swift
+/// Button("Deposit") {
+///     deposit()
+/// }
+/// .buttonStyle(.card(icon: .deposit))
+/// ```
+public struct CardButtonStyle: ButtonStyle {
+    public let icon: Asset
+
+    public init(icon: Asset) {
+        self.icon = icon
+    }
+
+    public func makeBody(configuration: Configuration) -> some View {
+        VStack(spacing: 12) {
+            Image.asset(icon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 28, height: 28)
+
+            configuration.label
+                .lineLimit(1)
+                .font(.appTextMedium)
+                .foregroundStyle(Color.textMain)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 110)
+        .background(.white.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: Metrics.boxRadius))
+        .opacity(configuration.isPressed ? 0.6 : 1.0)
+        .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+extension ButtonStyle where Self == CardButtonStyle {
+    /// A square card button with a centered icon above its label.
+    public static func card(icon: Asset) -> CardButtonStyle {
+        CardButtonStyle(icon: icon)
+    }
+}

--- a/FlipcashUITests/Regression/DepositRegressionTests.swift
+++ b/FlipcashUITests/Regression/DepositRegressionTests.swift
@@ -17,9 +17,9 @@ final class DepositRegressionTests: BaseUITestCase {
 
         assertMainScreenReached()
 
-        // Navigate: Main → Settings → Deposit Funds
+        // Navigate: Main → Settings → Deposit
         settings.open(from: self)
-        waitAndTap(settings.depositFundsRow)
+        waitAndTap(settings.depositButton)
 
         // Select the first currency
         let firstCurrency = app.cells.firstMatch

--- a/FlipcashUITests/Support/Screens/SettingsScreen.swift
+++ b/FlipcashUITests/Support/Screens/SettingsScreen.swift
@@ -19,10 +19,10 @@ struct SettingsUIScreen {
     // MARK: - Elements
 
     var myAccountRow: XCUIElement { app.buttons["My Account"] }
-    var withdrawFundsRow: XCUIElement { app.buttons["Withdraw Funds"] }
+    var withdrawButton: XCUIElement { app.buttons["Withdraw"] }
     var advancedFeaturesRow: XCUIElement { app.buttons["Advanced Features"] }
     var accessKeyRow: XCUIElement { app.buttons["Access Key"] }
-    var depositFundsRow: XCUIElement { app.buttons["Deposit Funds"] }
+    var depositButton: XCUIElement { app.buttons["Deposit"] }
     var applicationLogsRow: XCUIElement { app.buttons["Application Logs"] }
 
     // MARK: - Actions


### PR DESCRIPTION
## Summary

- Redesigns the settings screen to match the new Figma: Deposit and Withdraw become side-by-side card buttons (new `CardButtonStyle`), the Flipcash logo header is replaced with a plain "Settings" title, Log Out is pinned as a subtle button above the version footer, and the multi-tap beta-flags toggle now lives on the version footer with a proper hit area.
- The pinned bottom area uses `safeAreaInset(edge: .bottom)` so the navigation bar gets its default scroll-edge effect back.

## Test plan

- [x] Open Settings and confirm the new layout matches the Figma.
- [x] Tap Deposit and Withdraw — both navigate to the existing flows.
- [x] Tap Log Out and confirm the destructive dialog appears and logs out.
- [x] Tap the version line ten times and confirm beta features appear.
- [x] Run the existing UI suite locally — the Deposit regression test was updated for the renamed button.