### PR TITLE
fix: widen leaderboard rank column for 3-digit places

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
@@ -17,7 +17,7 @@ struct CurrencyDiscoveryRow: View {
                 .font(.appTextMedium)
                 .foregroundStyle(Color.textMain)
                 .monospacedDigit()
-                .frame(width: 24, alignment: .center)
+                .frame(width: 32, alignment: .center)
 
             RemoteImage(url: mint.imageURL)
                 .frame(width: 40, height: 40)

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoverySkeletonRow.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoverySkeletonRow.swift
@@ -14,7 +14,7 @@ struct CurrencyDiscoverySkeletonRow: View {
                 .font(.appTextMedium)
                 .foregroundStyle(Color.textMain)
                 .monospacedDigit()
-                .frame(width: 24, alignment: .center)
+                .frame(width: 32, alignment: .center)
                 .unredacted()
 
             Circle()


### PR DESCRIPTION
## Summary
Rank 100+ in the discover-currencies leaderboard wrapped onto two lines because the rank column was sized for two digits. Widened the column from 24pt to 32pt on both the live row and the skeleton row so three-digit ranks fit on a single line.

## Test plan
- Open the app, go to Wallet → Discover Currencies, scroll to rank 100, and confirm it renders on a single line.
- Confirm single- and double-digit ranks still align cleanly.
- Confirm the skeleton placeholder uses the same rank width while loading.