### PR TITLE
fix: use semantic color for negative holder deltas on Discover

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
@@ -49,7 +49,7 @@ struct CurrencyDiscoveryRow: View {
                     if let weeklyDelta = metrics.holderDeltas.first(where: { $0.range == .lastWeek }) {
                         Text(Self.formatDelta(weeklyDelta.delta))
                             .font(.appTextSmall)
-                            .foregroundStyle(.green)
+                            .foregroundStyle(weeklyDelta.delta < 0 ? Color.Sentiment.negative : Color.Sentiment.positive)
                             .contentTransition(.numericText())
                     }
                 }


### PR DESCRIPTION
## Summary

The Discover screen rendered weekly holder deltas in green regardless of sign, so a loss showed up the same as a gain. Negative deltas now use the existing negative sentiment color and positives keep the positive sentiment color.

## Test plan
- Open Wallet, tap Discover Currencies, and confirm negative weekly counts render red while positive counts stay green.