### PR TITLE
refactor: drop entry currency, unify on balance currency

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/Wallet/EnterWalletAmountScreen.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Wallet/EnterWalletAmountScreen.swift
@@ -15,9 +15,7 @@ struct EnterWalletAmountScreen: View {
 
     @State private var actionState: ButtonState = .normal
     @State private var enteredAmount: String = ""
-    
-//    @State private var isShowingCurrencySelection: Bool = false
-    
+
     private var fiat: FiatAmount? {
         guard !enteredAmount.isEmpty else {
             return nil
@@ -53,17 +51,10 @@ struct EnterWalletAmountScreen: View {
                     return EnterAmountCalculator.isWithinDisplayLimit(enteredAmount: enteredAmount, max: maxPerDay)
                 },
                 action: nextAction,
-                currencySelectionAction: nil//showCurrencySelection
+                currencySelectionAction: nil
             )
             .foregroundColor(.textMain)
             .padding(20)
-//            .sheet(isPresented: $isShowingCurrencySelection) {
-//                CurrencySelectionScreen(
-//                    isPresented: $isShowingCurrencySelection,
-//                    kind: .entry,
-//                    ratesController: ratesController
-//                )
-//            }
         }
         .navigationTitle("Amount to Buy")
         .navigationBarTitleDisplayMode(.inline)
@@ -86,8 +77,4 @@ struct EnterWalletAmountScreen: View {
             try await amountEntered(usdc)
         }
     }
-    
-//    private func showCurrencySelection() {
-//        isShowingCurrencySelection.toggle()
-//    }
 }

--- a/Flipcash/Core/Controllers/RatesController.swift
+++ b/Flipcash/Core/Controllers/RatesController.swift
@@ -20,14 +20,6 @@ private let logger = Logger(label: "flipcash.rates-controller")
 /// Inject via `@Environment(RatesController.self)`.
 @MainActor @Observable
 class RatesController {
-    /// The currency used for amount entry (e.g. on the Give screen).
-    /// Persisted to `UserDefaults` on change.
-    var entryCurrency: CurrencyCode = .usd {
-        willSet {
-            LocalDefaults.entryCurrency = newValue
-        }
-    }
-
     /// The currency used for displaying balances.
     /// Persisted to `UserDefaults` on change.
     var balanceCurrency: CurrencyCode = .usd {
@@ -85,22 +77,17 @@ class RatesController {
         self.database = database
         self.verifiedProtoService = VerifiedProtoService(store: database)
 
-        if LocalDefaults.entryCurrency == nil {
-            LocalDefaults.entryCurrency = .local() ?? .usd
-        }
-
         if LocalDefaults.balanceCurrency == nil {
             LocalDefaults.balanceCurrency = .local() ?? .usd
         }
 
-        entryCurrency   = LocalDefaults.entryCurrency!
         balanceCurrency = LocalDefaults.balanceCurrency!
         selectedTokenMint = loadSelectedToken()
 
         // Rehydrate last-known display rates from the database so screens
-        // that read rateFor{Balance,Entry}Currency render in the user's
-        // selected currency on cold launch instead of flashing USD while
-        // waiting for the live mint stream to deliver its first batch.
+        // that read rateForBalanceCurrency render in the user's selected
+        // currency on cold launch instead of flashing USD while waiting for
+        // the live mint stream to deliver its first batch.
         // The stream overwrites these within seconds. Display rates are
         // unsigned and have no validity window — intent submission still
         // goes through the verified-proof path (VerifiedProtoService),
@@ -273,10 +260,6 @@ class RatesController {
         rate(for: balanceCurrency) ?? .oneToOne
     }
 
-    func rateForEntryCurrency() -> Rate {
-        rate(for: entryCurrency) ?? .oneToOne
-    }
-
     func rate(for currency: CurrencyCode) -> Rate? {
         cachedRates[currency]
     }
@@ -358,9 +341,6 @@ extension RatesController {
 // MARK: - LocalDefaults -
 
 private enum LocalDefaults {
-    @Defaults(.entryCurrency)
-    static var entryCurrency: CurrencyCode?
-    
     @Defaults(.balanceCurrency)
     static var balanceCurrency: CurrencyCode?
 

--- a/Flipcash/Core/Screens/Main/BalanceScreen.swift
+++ b/Flipcash/Core/Screens/Main/BalanceScreen.swift
@@ -247,11 +247,7 @@ private struct BalanceHeaderButton: View {
             .frame(maxWidth: .infinity)
             .animation(.default, value: balance)
             .sheet(isPresented: $isShowingCurrencySelection) {
-                CurrencySelectionScreen(
-                    isPresented: $isShowingCurrencySelection,
-                    kind: .balance,
-                    ratesController: ratesController
-                )
+                CurrencySelectionScreen(ratesController: ratesController)
             }
         }
     }

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -205,11 +205,7 @@ struct CurrencyInfoScreen: View {
             CurrencySellAmountScreen(viewModel: sellViewModel)
         }
         .sheet(isPresented: $isShowingCurrencySelection) {
-            CurrencySelectionScreen(
-                isPresented: $isShowingCurrencySelection,
-                kind: .balance,
-                ratesController: ratesController
-            )
+            CurrencySelectionScreen(ratesController: ratesController)
         }
         .sheet(isPresented: $isShowingFundingSelection, onDismiss: {
             // SwiftUI allows only one modal sheet at a time, so we can't set

--- a/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
@@ -10,31 +10,42 @@ import FlipcashUI
 import FlipcashCore
 
 struct CurrencySelectionScreen: View {
-    
+
+    @Environment(\.dismiss) private var dismiss
     @State private var viewModel: CurrencySelectionViewModel
 
     // MARK: - Init -
 
-    init(isPresented: Binding<Bool>, kind: CurrencySelectionType, ratesController: RatesController) {
-        self.viewModel = CurrencySelectionViewModel(
-            isPresented: isPresented,
-            kind: kind,
-            ratesController: ratesController
-        )
+    init(ratesController: RatesController) {
+        self._viewModel = State(initialValue: CurrencySelectionViewModel(ratesController: ratesController))
     }
-    
+
     // MARK: - Body -
-    
+
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Background(color: .backgroundMain) {
                 List {
                     Group {
                         if viewModel.isSearching {
-                            searchingCurrencies()
+                            Section(header: ListHeader("Results")) {
+                                ForEach(viewModel.searchingCurrencies) { description in
+                                    CurrencyRow(description: description, viewModel: viewModel, allowDelete: false, dismiss: dismiss)
+                                }
+                            }
                         } else {
-                            recentCurrencies()
-                            otherCurrencies()
+                            if !viewModel.availableRecentCurrencies.isEmpty {
+                                Section(header: ListHeader("Recent Regions")) {
+                                    ForEach(viewModel.availableRecentCurrencies) { description in
+                                        CurrencyRow(description: description, viewModel: viewModel, allowDelete: true, dismiss: dismiss)
+                                    }
+                                }
+                            }
+                            Section(header: ListHeader("Other Regions")) {
+                                ForEach(viewModel.availableCurrencies) { description in
+                                    CurrencyRow(description: description, viewModel: viewModel, allowDelete: false, dismiss: dismiss)
+                                }
+                            }
                         }
                     }
                     .listRowSeparatorTint(Color.rowSeparator)
@@ -46,7 +57,7 @@ struct CurrencySelectionScreen: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    ToolbarCloseButton(binding: viewModel.isPresented)
+                    ToolbarCloseButton { dismiss() }
                 }
             }
             .searchable(
@@ -56,45 +67,22 @@ struct CurrencySelectionScreen: View {
             )
             .foregroundStyle(Color.textMain)
         }
-        .onAppear {
-//            Analytics.open(screen: .currencySelection)
-//            ErrorReporting.breadcrumb(.currencyScreen)
-        }
     }
-    
-    @ViewBuilder private func searchingCurrencies() -> some View {
-        Section(header: ListHeader("Results")) {
-            ForEach(viewModel.searchingCurrencies) { description in
-                currencyRow(for: description)
-            }
-        }
-    }
-    
-    @ViewBuilder private func recentCurrencies() -> some View {
-        if !viewModel.availableRecentCurrencies.isEmpty {
-            Section(header: ListHeader("Recent Regions")) {
-                ForEach(viewModel.availableRecentCurrencies) { description in
-                    currencyRow(for: description, canDelete: true)
-                }
-            }
-        }
-    }
-    
-    @ViewBuilder private func otherCurrencies() -> some View {
-        Section(header: ListHeader("Other Regions")) {
-            ForEach(viewModel.availableCurrencies) { description in
-                currencyRow(for: description)
-            }
-        }
-    }
-    
-    @ViewBuilder private func currencyRow(for description: CurrencyDescription, canDelete: Bool = false) -> some View {
+}
+
+private struct CurrencyRow: View {
+    let description: CurrencyDescription
+    let viewModel: CurrencySelectionViewModel
+    let allowDelete: Bool
+    let dismiss: DismissAction
+
+    var body: some View {
         Button {
             viewModel.select(currency: description.currency)
+            dismiss()
         } label: {
             HStack(spacing: 15) {
                 Flag(style: description.currency.flagStyle)
-                
                 VStack(alignment: .leading, spacing: 5) {
                     Text(description.localizedName)
                         .foregroundColor(.textMain)
@@ -102,7 +90,6 @@ struct CurrencySelectionScreen: View {
                         .multilineTextAlignment(.leading)
                         .layoutPriority(10)
                 }
-                
                 Spacer()
                 CheckView(active: viewModel.isCurrencyActive(description.currency))
             }
@@ -112,13 +99,11 @@ struct CurrencySelectionScreen: View {
         .opacity(viewModel.opacity(for: description.currency))
         .disabled(viewModel.isSelectionDisabled(for: description.currency))
         .listRowBackground(Color.backgroundMain)
-        .buttonStyle(.plain) // Allows default `Button` highlighting
-        .if(canDelete) { $0
-            .swipeActions {
+        .buttonStyle(.plain)
+        .swipeActions {
+            if allowDelete {
                 Button {
-                    withAnimation {
-                        viewModel.removeRecent(description.currency)
-                    }
+                    withAnimation { viewModel.removeRecent(description.currency) }
                 } label: {
                     Image.asset(.delete)
                 }

--- a/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionViewModel.swift
@@ -18,37 +18,32 @@ class CurrencySelectionViewModel {
     var searchText = ""
     var isFocused = false
 
-    @ObservationIgnored var isPresented: Binding<Bool>
-    
     var isSearching: Bool {
         !searchText.isEmpty
     }
-    
+
     var searchingCurrencies: [CurrencyDescription] {
         let term = searchText.lowercased()
         return currencies.filter {
             $0.currency.rawValue.lowercased().contains(term) || $0.localizedName.lowercased().contains(term)
         }
     }
-    
-    @ObservationIgnored private let kind: CurrencySelectionType
+
     @ObservationIgnored private let ratesController: RatesController
     @ObservationIgnored private let currencies: [CurrencyDescription]
     @ObservationIgnored private var recentCurrencies: Set<CurrencyCode>
-    
+
     // MARK: - Init -
-    
-    init(isPresented: Binding<Bool>, kind: CurrencySelectionType, ratesController: RatesController) {
-        self.isPresented      = isPresented
-        self.kind             = kind
+
+    init(ratesController: RatesController) {
         self.ratesController  = ratesController
         self.currencies       = CurrencyCode.allCurrencies(in: .current)
         self.recentCurrencies = LocalDefaults.storedRecentCurrencies ?? []
-        
+
         addLocalToRecentsIfNeeded()
         updateAvailableCurrencies()
     }
-    
+
     private func addLocalToRecentsIfNeeded() {
         if let isAdded = LocalDefaults.localCurrencyAdded, isAdded {
             // Don't add it again
@@ -57,90 +52,67 @@ class CurrencySelectionViewModel {
             LocalDefaults.localCurrencyAdded = true
         }
     }
-    
+
     // MARK: - Recent Currencies -
-    
+
     private func insertRecent(_ currency: CurrencyCode) {
         recentCurrencies.insert(currency)
         LocalDefaults.storedRecentCurrencies = recentCurrencies
-        
+
         updateAvailableCurrencies()
     }
-    
+
     func removeRecent(_ currency: CurrencyCode) {
         recentCurrencies.remove(currency)
         LocalDefaults.storedRecentCurrencies = recentCurrencies
-        
+
         updateAvailableCurrencies()
     }
-    
+
     private func updateAvailableCurrencies() {
         availableCurrencies = currencies.filter {
             !recentCurrencies.contains($0.currency)
         }
-        
+
         availableRecentCurrencies = currencies.filter {
             recentCurrencies.contains($0.currency)
         }
     }
-    
+
     // MARK: - Selection -
-    
+
     func select(currency: CurrencyCode) {
-        setSelectedCurrency(currency)
-        
+        ratesController.balanceCurrency = currency
         isFocused = false
-        isPresented.wrappedValue = false
-        
+
         Task {
             try await Task.delay(milliseconds: 200)
             insertRecent(currency)
         }
     }
-    
-    private func setSelectedCurrency(_ currency: CurrencyCode) {
-        switch kind {
-        case .entry:
-            ratesController.entryCurrency = currency
-        case .balance:
-            ratesController.balanceCurrency = currency
-        }
-    }
-    
+
     // MARK: - Currency Appearance -
-    
+
     func opacity(for currency: CurrencyCode) -> CGFloat {
         ratesController.rate(for: currency) != nil ? 1.0 : 0.3
     }
-    
+
     func isSelectionDisabled(for currency: CurrencyCode) -> Bool {
         ratesController.rate(for: currency) == nil
     }
-    
+
     func isCurrencyActive(_ currency: CurrencyCode) -> Bool {
-        switch kind {
-        case .entry:
-            return currency == ratesController.entryCurrency
-        case .balance:
-            return currency == ratesController.balanceCurrency
-        }
+        currency == ratesController.balanceCurrency
     }
-}
-
-// MARK: - Kind -
-
-enum CurrencySelectionType {
-    case entry
-    case balance
 }
 
 // MARK: - LocalDefaults -
 
 private enum LocalDefaults {
-    
+
     @Defaults(.recentCurrencies)
     static var storedRecentCurrencies: Set<CurrencyCode>?
-    
+
     @Defaults(.localCurrencyAdded)
     static var localCurrencyAdded: Bool?
 }

--- a/Flipcash/Core/Screens/Main/Currency Swap/CurrencyBuyAmountScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/CurrencyBuyAmountScreen.swift
@@ -59,11 +59,7 @@ struct CurrencyBuyAmountScreen: View {
             }
             .dialog(item: $viewModel.dialogItem)
             .sheet(isPresented: $isShowingCurrencySelection) {
-                CurrencySelectionScreen(
-                    isPresented: $isShowingCurrencySelection,
-                    kind: .entry,
-                    ratesController: ratesController
-                )
+                CurrencySelectionScreen(ratesController: ratesController)
             }
         }
     }

--- a/Flipcash/Core/Screens/Main/Currency Swap/CurrencyBuyViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/CurrencyBuyViewModel.swift
@@ -20,7 +20,7 @@ class CurrencyBuyViewModel: Identifiable {
     var path: [CurrencyBuyPath] = []
 
     var enteredFiat: ExchangedFiat? {
-        computeAmount(using: ratesController.rateForEntryCurrency())
+        computeAmount(using: ratesController.rateForBalanceCurrency())
     }
 
     var canPerformAction: Bool {
@@ -39,10 +39,10 @@ class CurrencyBuyViewModel: Identifiable {
     }
 
     var maxPossibleAmount: ExchangedFiat {
-        let entryRate = ratesController.rateForEntryCurrency()
+        let rate = ratesController.rateForBalanceCurrency()
         let zero = ExchangedFiat.compute(
             onChainAmount: .zero(mint: .usdf),
-            rate: entryRate,
+            rate: rate,
             supplyQuarks: nil
         )
 
@@ -50,7 +50,7 @@ class CurrencyBuyViewModel: Identifiable {
             return zero
         }
 
-        return balance.computeExchangedValue(with: entryRate)
+        return balance.computeExchangedValue(with: rate)
     }
 
     @ObservationIgnored private let session: Session
@@ -80,7 +80,7 @@ class CurrencyBuyViewModel: Identifiable {
     /// Resolves the pin and computes the submission amount against it — one
     /// fetch for both, so quarks can't drift from the submitted pin.
     func prepareSubmission() async -> (amount: ExchangedFiat, pinnedState: VerifiedState)? {
-        let currency = ratesController.entryCurrency
+        let currency = ratesController.balanceCurrency
         guard let pin = await ratesController.currentPinnedState(for: currency, mint: .usdf) else {
             return nil
         }

--- a/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellAmountScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellAmountScreen.swift
@@ -70,11 +70,7 @@ struct CurrencySellAmountScreen: View {
             }
             .dialog(item: $viewModel.dialogItem)
             .sheet(isPresented: $isShowingCurrencySelection) {
-                CurrencySelectionScreen(
-                    isPresented: $isShowingCurrencySelection,
-                    kind: .entry,
-                    ratesController: ratesController
-                )
+                CurrencySelectionScreen(ratesController: ratesController)
             }
         }
     }

--- a/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellViewModel.swift
@@ -17,7 +17,7 @@ class CurrencySellViewModel: Identifiable {
     @ObservationIgnored let currencyMetadata: StoredMintMetadata
 
     var enteredFiat: ExchangedFiat? {
-        computeAmount(using: ratesController.rateForEntryCurrency())
+        computeAmount(using: ratesController.rateForBalanceCurrency())
     }
 
     var canPerformAction: Bool {
@@ -36,10 +36,10 @@ class CurrencySellViewModel: Identifiable {
     }
 
     var maxPossibleAmount: ExchangedFiat {
-        let entryRate = ratesController.rateForEntryCurrency()
+        let rate = ratesController.rateForBalanceCurrency()
         let zero = ExchangedFiat.compute(
             onChainAmount: .zero(mint: currencyMetadata.mint),
-            rate: entryRate,
+            rate: rate,
             supplyQuarks: nil
         )
 
@@ -47,7 +47,7 @@ class CurrencySellViewModel: Identifiable {
             return zero
         }
 
-        return balance.computeExchangedValue(with: entryRate)
+        return balance.computeExchangedValue(with: rate)
     }
 
     @ObservationIgnored private let session: Session
@@ -78,7 +78,7 @@ class CurrencySellViewModel: Identifiable {
     /// Resolves the pin and computes the amount carried into the confirmation
     /// screen — confirmation and `Session.sell` receive the same pin.
     func prepareSubmission() async -> (amount: ExchangedFiat, pinnedState: VerifiedState)? {
-        let currency = ratesController.entryCurrency
+        let currency = ratesController.balanceCurrency
         guard let pin = await ratesController.currentPinnedState(for: currency, mint: currencyMetadata.mint) else {
             return nil
         }

--- a/Flipcash/Core/Screens/Main/GiveScreen.swift
+++ b/Flipcash/Core/Screens/Main/GiveScreen.swift
@@ -34,10 +34,10 @@ struct GiveScreen: View {
     @Environment(\.dismissParentContainer) private var dismissParentContainer
 
     private var maxLimit: ExchangedFiat {
-        let entryRate = ratesController.rateForEntryCurrency()
-        let zero      = ExchangedFiat.compute(
+        let rate = ratesController.rateForBalanceCurrency()
+        let zero = ExchangedFiat.compute(
             onChainAmount: .zero(mint: .usdf),
-            rate: entryRate,
+            rate: rate,
             supplyQuarks: nil
         )
 
@@ -49,7 +49,7 @@ struct GiveScreen: View {
             return zero
         }
 
-        return balance.computeExchangedValue(with: entryRate)
+        return balance.computeExchangedValue(with: rate)
     }
 
     // MARK: - Init -
@@ -78,11 +78,7 @@ struct GiveScreen: View {
             .padding(.bottom, 20)
             .padding(.top, -40)
             .sheet(isPresented: $isShowingCurrencySelection) {
-                CurrencySelectionScreen(
-                    isPresented: $isShowingCurrencySelection,
-                    kind: .entry,
-                    ratesController: ratesController
-                )
+                CurrencySelectionScreen(ratesController: ratesController)
             }
         }
         .ignoresSafeArea(.keyboard)

--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -52,7 +52,7 @@ class GiveViewModel {
                 return nil
             }
 
-            let rate = ratesController.rateForEntryCurrency()
+            let rate = ratesController.rateForBalanceCurrency()
             let entered = FiatAmount(value: amount, currency: rate.currency)
 
             if let viaCurve = ExchangedFiat.compute(
@@ -79,7 +79,7 @@ class GiveViewModel {
             )
 
         } else {
-            let rate = ratesController.rateForEntryCurrency()
+            let rate = ratesController.rateForBalanceCurrency()
             return ExchangedFiat(
                 nativeAmount: FiatAmount(value: amount, currency: rate.currency),
                 rate: rate
@@ -120,7 +120,7 @@ class GiveViewModel {
     }
 
     private func refreshSelectedBalance() {
-        let rate = ratesController.rateForEntryCurrency()
+        let rate = ratesController.rateForBalanceCurrency()
         let availableBalances = session.balances(for: rate)
             .filter { $0.stored.mint != .usdf }
 
@@ -192,7 +192,7 @@ class GiveViewModel {
         let mint = selectedBalance.stored.mint
 
         guard let pin = await ratesController.currentPinnedState(
-            for: ratesController.entryCurrency,
+            for: ratesController.balanceCurrency,
             mint: mint
         ) else { return nil }
 

--- a/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
+++ b/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
@@ -19,7 +19,7 @@ struct SelectCurrencyScreen: View {
     @State private var selectedBalance: ExchangedBalance?
     
     private var balances: [ExchangedBalance] {
-        let allBalances = session.balances(for: fixedRate ?? ratesController.rateForEntryCurrency())
+        let allBalances = session.balances(for: fixedRate ?? ratesController.rateForBalanceCurrency())
         switch kind {
         case .give:
             return allBalances.filter { $0.stored.mint != .usdf }

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawAmountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawAmountScreen.swift
@@ -38,11 +38,7 @@ struct WithdrawAmountScreen: View {
             .foregroundStyle(Color.textMain)
             .padding(20)
             .sheet(isPresented: $isShowingCurrencySelection) {
-                CurrencySelectionScreen(
-                    isPresented: $isShowingCurrencySelection,
-                    kind: .entry,
-                    ratesController: ratesController
-                )
+                CurrencySelectionScreen(ratesController: ratesController)
             }
         }
         .navigationTitle(title)

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -34,10 +34,10 @@ class WithdrawViewModel {
     }
 
     var enteredFiat: ExchangedFiat? {
-        computeAmount(using: ratesController.rateForEntryCurrency(), pinnedSupplyQuarks: nil)
+        computeAmount(using: ratesController.rateForBalanceCurrency(), pinnedSupplyQuarks: nil)
     }
 
-    /// Fee in entry currency for the summary's "Less fee" line. Rounded
+    /// Fee in the user's currency for the summary's "Less fee" line. Rounded
     /// half-up to currency precision so the implied fee on the amount screen
     /// (`minimumWithdrawAmount = displayFee + smallestUnit`) matches the
     /// summary verbatim — no rounding drift between the two screens.
@@ -48,9 +48,9 @@ class WithdrawViewModel {
         return FiatAmount(value: rounded, currency: feeInEntry.currency)
     }
 
-    /// Net in entry currency, derived as `entered − displayFee` so the three
-    /// summary lines (Withdrawal amount, Less fee, Net amount) form a closed
-    /// identity. Falls back to `entered` when there's no fee.
+    /// Net in the user's currency, derived as `entered − displayFee` so the
+    /// three summary lines (Withdrawal amount, Less fee, Net amount) form a
+    /// closed identity. Falls back to `entered` when there's no fee.
     var displayNet: FiatAmount? {
         guard let enteredFiat else { return nil }
         let entered = enteredFiat.nativeAmount
@@ -59,7 +59,7 @@ class WithdrawViewModel {
     }
 
     /// Smallest amount that yields at least one displayable unit of net after
-    /// the fee. `displayFee + smallest_displayable_unit` in the entry currency.
+    /// the fee. `displayFee + smallest_displayable_unit` in the user's currency.
     /// Display and the `isBelowMinimumWithdraw` gate use the same number by
     /// construction.
     var minimumWithdrawAmount: FiatAmount? {
@@ -204,7 +204,7 @@ class WithdrawViewModel {
     }
 
     var maxWithdrawLimit: ExchangedFiat {
-        let rate = ratesController.rateForEntryCurrency()
+        let rate = ratesController.rateForBalanceCurrency()
         let zero = ExchangedFiat.compute(
             onChainAmount: .zero(mint: .usdf),
             rate: rate,
@@ -285,7 +285,7 @@ class WithdrawViewModel {
     /// submission amount against it — one fetch for both.
     func prepareSubmission() async -> (amount: ExchangedFiat, pinnedState: VerifiedState)? {
         guard let mint = kind?.sourceMint else { return nil }
-        let currency = ratesController.entryCurrency
+        let currency = ratesController.balanceCurrency
         guard let pin = await ratesController.currentPinnedState(for: currency, mint: mint) else {
             return nil
         }

--- a/Flipcash/Core/Session/AccountManager.swift
+++ b/Flipcash/Core/Session/AccountManager.swift
@@ -130,7 +130,6 @@ class AccountManager {
         Keychain.historicalAccounts = nil
 
         let currencyKeys: [DefaultsKey] = [
-            .entryCurrency,
             .balanceCurrency,
             .recentCurrencies,
             .localCurrencyAdded,

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -376,8 +376,8 @@ class Session {
             return .insufficient(shortfall: nil)
         }
 
-        let entryRate = ratesController.rateForEntryCurrency()
-        let exchangedBalance = balance.computeExchangedValue(with: entryRate)
+        let rate = ratesController.rateForBalanceCurrency()
+        let exchangedBalance = balance.computeExchangedValue(with: rate)
 
         if exchangedFiat.onChainAmount <= exchangedBalance.onChainAmount {
             // Sufficient funds - send the requested amount

--- a/Flipcash/Keychain/Defaults.swift
+++ b/Flipcash/Keychain/Defaults.swift
@@ -31,7 +31,6 @@ enum DefaultsKey: String {
     case cameraAutoStartDisabled = "com.flipcash.camera.autoStartDisabled"
     case cameraEnabledState      = "com.flipcash.camera.cameraEnabledState"
     
-    case entryCurrency      = "com.flipcash.currency.entryCurrency"
     case balanceCurrency    = "com.flipcash.currency.balanceCurrency"
     case recentCurrencies   = "com.flipcash.currency.recentCurrencies"
     case localCurrencyAdded = "com.flipcash.currency.localCurrencyAdded"

--- a/Flipcash/UI/EnterAmountCalculator.swift
+++ b/Flipcash/UI/EnterAmountCalculator.swift
@@ -15,7 +15,7 @@ struct EnterAmountCalculator {
     // MARK: - Properties
 
     let mode: EnterAmountView.Mode
-    let entryCurrency: CurrencyCode
+    let selectedCurrency: CurrencyCode
     let sendLimitProvider: SendLimitProvider
 
     // MARK: - Computed
@@ -23,11 +23,11 @@ struct EnterAmountCalculator {
     var currency: CurrencyCode {
         switch mode {
         case .currency, .buy, .sell:
-            entryCurrency
+            selectedCurrency
         case .onramp, .walletDeposit, .phantomDeposit:
             .usd
         case .withdraw:
-            entryCurrency
+            selectedCurrency
         }
     }
 
@@ -77,9 +77,9 @@ struct EnterAmountCalculator {
             return balance
         }
 
-        // Server-provided limits are already localized to the entry currency,
-        // and the balance is also in the entry currency, so we can compare
-        // directly. No fx conversion needed.
+        // Server-provided limits are already localized to the user's selected
+        // currency, and the balance is too, so we can compare directly. No fx
+        // conversion needed.
         guard limit.currency == balance.currency else {
             return balance
         }

--- a/Flipcash/UI/EnterAmountView.swift
+++ b/Flipcash/UI/EnterAmountView.swift
@@ -28,7 +28,7 @@ public struct EnterAmountView: View {
     private var calculator: EnterAmountCalculator {
         EnterAmountCalculator(
             mode: mode,
-            entryCurrency: rateController.entryCurrency,
+            selectedCurrency: rateController.balanceCurrency,
             sendLimitProvider: session.sendLimitFor(currency:)
         )
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/ExchangedFiat.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/ExchangedFiat.swift
@@ -130,7 +130,7 @@ public struct ExchangedFiat: Equatable, Hashable, Codable, Sendable {
     ///
     /// - Parameters:
     ///   - amount: User-entered fiat amount (in `rate.currency`).
-    ///   - rate: Fiat FX rate for the entry currency.
+    ///   - rate: Fiat FX rate for the selected currency.
     ///   - mint: Target token mint.
     ///   - supplyQuarks: Current token supply in quarks (10 decimals).
     ///   - balance: Optional USDF-equivalent balance cap. When provided the entered

--- a/FlipcashTests/CurrencyBuyViewModelTests.swift
+++ b/FlipcashTests/CurrencyBuyViewModelTests.swift
@@ -20,12 +20,12 @@ struct CurrencyBuyViewModelTests {
     /// CAD rate: 1 USD = 1.35 CAD
     static let cadRate = Rate(fx: 1.35, currency: .cad)
 
-    /// Helper to create a test view model with CAD as the entry currency.
+    /// Helper to create a test view model with CAD as the selected currency.
     /// Uses the mock SessionContainer which has no seeded balance.
     static func createViewModel() -> CurrencyBuyViewModel {
         let sessionContainer = SessionContainer.mock
 
-        sessionContainer.ratesController.configureTestRates(entryCurrency: .cad, rates: [cadRate])
+        sessionContainer.ratesController.configureTestRates(balanceCurrency: .cad, rates: [cadRate])
 
         return CurrencyBuyViewModel(
             currencyPublicKey: .usdf,
@@ -43,7 +43,7 @@ struct CurrencyBuyViewModelTests {
             .init(mint: MintMetadata.usdf, quarks: 10_000_000)
         ])
 
-        container.ratesController.configureTestRates(entryCurrency: .cad, rates: [cadRate])
+        container.ratesController.configureTestRates(balanceCurrency: .cad, rates: [cadRate])
 
         return CurrencyBuyViewModel(
             currencyPublicKey: .jeffy,

--- a/FlipcashTests/EnterAmountCalculatorTests.swift
+++ b/FlipcashTests/EnterAmountCalculatorTests.swift
@@ -20,7 +20,7 @@ import FlipcashCore
     ///   - usdQuarks: raw USDF quarks (6 decimals) backing the on-chain side.
     ///   - nativeDecimalValue: the native-currency value (already converted). If
     ///     nil, defaults to `usdQuarks / 10^6` at fx 1 — i.e. same value in the
-    ///     entry currency.
+    ///     selected currency.
     static func createExchangedFiat(
         usdQuarks: UInt64,
         nativeDecimalValue: Decimal? = nil,
@@ -50,30 +50,30 @@ import FlipcashCore
 
     // MARK: - Currency Tests
 
-    @Test func currency_whenModeIsCurrency_returnsEntryCurrency() {
+    @Test func currency_whenModeIsCurrency_returnsSelectedCurrency() {
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .cad,
+            selectedCurrency: .cad,
             sendLimitProvider: { _ in return nil }
         )
 
         #expect(calculator.currency == .cad)
     }
 
-    @Test func currency_whenModeIsBuy_returnsEntryCurrency() {
+    @Test func currency_whenModeIsBuy_returnsSelectedCurrency() {
         let calculator = EnterAmountCalculator(
             mode: .buy,
-            entryCurrency: .eur,
+            selectedCurrency: .eur,
             sendLimitProvider: { _ in return nil }
         )
 
         #expect(calculator.currency == .eur)
     }
 
-    @Test func currency_whenModeIsSell_returnsEntryCurrency() {
+    @Test func currency_whenModeIsSell_returnsSelectedCurrency() {
         let calculator = EnterAmountCalculator(
             mode: .sell,
-            entryCurrency: .cad,
+            selectedCurrency: .cad,
             sendLimitProvider: { _ in return nil }
         )
 
@@ -83,17 +83,17 @@ import FlipcashCore
     @Test func currency_whenModeIsOnramp_returnsUSD() {
         let calculator = EnterAmountCalculator(
             mode: .onramp,
-            entryCurrency: .cad,
+            selectedCurrency: .cad,
             sendLimitProvider: { _ in return nil }
         )
 
         #expect(calculator.currency == .usd)
     }
 
-    @Test func currency_whenModeIsWithdraw_returnsEntryCurrency() {
+    @Test func currency_whenModeIsWithdraw_returnsSelectedCurrency() {
         let calculator = EnterAmountCalculator(
             mode: .withdraw,
-            entryCurrency: .cad,
+            selectedCurrency: .cad,
             sendLimitProvider: { _ in return nil }
         )
 
@@ -103,7 +103,7 @@ import FlipcashCore
     @Test func currency_whenModeIsWalletDeposit_returnsUSD() {
         let calculator = EnterAmountCalculator(
             mode: .walletDeposit("Phantom"),
-            entryCurrency: .cad,
+            selectedCurrency: .cad,
             sendLimitProvider: { _ in return nil }
         )
 
@@ -113,7 +113,7 @@ import FlipcashCore
     @Test func currency_whenModeIsPhantomDeposit_returnsUSD() {
         let calculator = EnterAmountCalculator(
             mode: .phantomDeposit,
-            entryCurrency: .cad,
+            selectedCurrency: .cad,
             sendLimitProvider: { _ in return nil }
         )
 
@@ -125,7 +125,7 @@ import FlipcashCore
     @Test func maxTransactionAmount_whenLimitIsNil_returnsNil() {
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in return nil }
         )
 
@@ -136,7 +136,7 @@ import FlipcashCore
         let sendLimit = Self.sendLimit(nextTransaction: 1_000_000, maxPerTransaction: 1_000_000, maxPerDay: 5_000_000)
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in return sendLimit }
         )
 
@@ -153,7 +153,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in sendLimit }
         )
 
@@ -168,7 +168,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in sendLimit }
         )
 
@@ -187,7 +187,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .cad,
+            selectedCurrency: .cad,
             sendLimitProvider: { _ in sendLimit }
         )
 
@@ -211,7 +211,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: mode,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in sendLimit }
         )
 
@@ -231,7 +231,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: mode,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in sendLimit }
         )
 
@@ -245,7 +245,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: mode,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in sendLimit }
         )
 
@@ -305,7 +305,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in return nil }
         )
 
@@ -318,7 +318,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in return sendLimit }
         )
 
@@ -331,7 +331,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in return sendLimit }
         )
 
@@ -356,7 +356,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: .currency,
-            entryCurrency: .cad,
+            selectedCurrency: .cad,
             sendLimitProvider: { _ in return sendLimit }
         )
 
@@ -374,7 +374,7 @@ import FlipcashCore
 
         let calculator = EnterAmountCalculator(
             mode: .buy,
-            entryCurrency: .usd,
+            selectedCurrency: .usd,
             sendLimitProvider: { _ in return sendLimit }
         )
 

--- a/FlipcashTests/RatesControllerTests.swift
+++ b/FlipcashTests/RatesControllerTests.swift
@@ -510,13 +510,13 @@ struct RatesControllerTests {
 
     // MARK: - Helpers -
 
-    /// NOTE: RatesController.init reads `balanceCurrency` / `entryCurrency`
-    /// from `UserDefaults.standard` (via `LocalDefaults`). Tests that
-    /// mutate those values are NOT parallel-safe with each other or with
-    /// any other test on the standard defaults suite. Current tests only
-    /// read the defaults, so parallel execution is fine — but adding any
-    /// test that does `controller.balanceCurrency = .xxx` would require
-    /// `.serialized` on the suite or a proper UserDefaults isolation seam.
+    /// NOTE: RatesController.init reads `balanceCurrency` from
+    /// `UserDefaults.standard` (via `LocalDefaults`). Tests that mutate it
+    /// are NOT parallel-safe with each other or with any other test on the
+    /// standard defaults suite. Current tests only read the defaults, so
+    /// parallel execution is fine — but adding any test that does
+    /// `controller.balanceCurrency = .xxx` would require `.serialized` on
+    /// the suite or a proper UserDefaults isolation seam.
     @MainActor
     private func makeController(database: Database? = nil) -> RatesController {
         RatesController(container: .mock, database: database ?? .mock)

--- a/FlipcashTests/Regressions/Regression_69f39bbb.swift
+++ b/FlipcashTests/Regressions/Regression_69f39bbb.swift
@@ -39,7 +39,7 @@ struct Regression_69f39bbb {
         )
         let rate = Rate(fx: Decimal(fx), currency: currency)
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: currency,
+            balanceCurrency: currency,
             rates: [rate]
         )
         await sessionContainer.ratesController.verifiedProtoService.saveRates([
@@ -68,7 +68,7 @@ struct Regression_69f39bbb {
             )
         ])
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .usd,
+            balanceCurrency: .usd,
             rates: [.oneToOne]
         )
         await sessionContainer.ratesController.verifiedProtoService.saveRates([

--- a/FlipcashTests/Regressions/Regression_native_amount_mismatch.swift
+++ b/FlipcashTests/Regressions/Regression_native_amount_mismatch.swift
@@ -29,7 +29,7 @@ struct Regression_native_amount_mismatch {
         // Pinned rate: 1 USD = 1.35 CAD. Live cache drifted to 1.37 after the pin was captured.
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.37, currency: .cad)]
         )
         await sessionContainer.ratesController.verifiedProtoService.saveRates([
@@ -64,7 +64,7 @@ struct Regression_native_amount_mismatch {
 
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.37, currency: .cad)]
         )
         await sessionContainer.ratesController.verifiedProtoService.saveRates([
@@ -105,7 +105,7 @@ struct Regression_native_amount_mismatch {
         // Pinned CAD rate 1.35; live cache drifted to 1.37.
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.37, currency: .cad)]
         )
         await sessionContainer.ratesController.verifiedProtoService.saveRates([
@@ -136,7 +136,7 @@ struct Regression_native_amount_mismatch {
         // service — the submit path has no pin to use and must bail.
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.35, currency: .cad)]
         )
 
@@ -160,7 +160,7 @@ struct Regression_native_amount_mismatch {
         // Live rate + live metadata supply are present; no pinned proof is.
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.35, currency: .cad)]
         )
 
@@ -186,7 +186,7 @@ struct Regression_native_amount_mismatch {
     func scenarioE_withdrawPrepareSubmissionReturnsNilWhenNoPin() async {
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.35, currency: .cad)]
         )
 
@@ -212,7 +212,7 @@ struct Regression_native_amount_mismatch {
 
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.37, currency: .cad)]
         )
         await sessionContainer.ratesController.verifiedProtoService.saveRates([
@@ -253,7 +253,7 @@ struct Regression_native_amount_mismatch {
         // service — the submit path has no pin to use and must bail.
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.35, currency: .cad)]
         )
 

--- a/FlipcashTests/TestSupport/RatesController+TestSupport.swift
+++ b/FlipcashTests/TestSupport/RatesController+TestSupport.swift
@@ -10,10 +10,10 @@ import FlipcashCore
 @testable import Flipcash
 
 extension RatesController {
-    /// Configure entry currency and inject rates for tests.
-    func configureTestRates(entryCurrency: CurrencyCode? = nil, rates: [Rate]) {
-        if let entryCurrency {
-            self.entryCurrency = entryCurrency
+    /// Configure balance currency and inject rates for tests.
+    func configureTestRates(balanceCurrency: CurrencyCode? = nil, rates: [Rate]) {
+        if let balanceCurrency {
+            self.balanceCurrency = balanceCurrency
         }
 
         updateRates(rates)

--- a/FlipcashTests/TestSupport/WithdrawViewModel+TestSupport.swift
+++ b/FlipcashTests/TestSupport/WithdrawViewModel+TestSupport.swift
@@ -17,7 +17,7 @@ import FlipcashUI
 enum WithdrawViewModelTestHelpers {
 
     static func createViewModel(
-        entryCurrency: CurrencyCode = .usd,
+        balanceCurrency: CurrencyCode = .usd,
         rates: [Rate] = [.oneToOne],
         withdrawalFeeQuarks: UInt64 = 50_000
     ) -> WithdrawViewModel {
@@ -25,7 +25,7 @@ enum WithdrawViewModelTestHelpers {
         let sessionContainer = SessionContainer.mock
 
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: entryCurrency,
+            balanceCurrency: balanceCurrency,
             rates: rates
         )
 
@@ -131,7 +131,7 @@ enum WithdrawViewModelTestHelpers {
             )
         }
         let stored = try #require(container.session.balance(for: .usdf))
-        let rate = container.ratesController.rateForEntryCurrency()
+        let rate = container.ratesController.rateForBalanceCurrency()
         let balance = ExchangedBalance(
             stored: stored,
             exchangedFiat: stored.computeExchangedValue(with: rate)

--- a/FlipcashTests/WithdrawViewModelTests.swift
+++ b/FlipcashTests/WithdrawViewModelTests.swift
@@ -18,7 +18,7 @@ struct WithdrawViewModelTests {
     @Test("Non-USD rate computes correct on-chain amount from entered amount")
     func enteredFiat_cadRate() {
         let cadRate = Rate(fx: 1.4, currency: .cad)
-        let viewModel = WithdrawViewModelTestHelpers.createViewModel(entryCurrency: .cad, rates: [cadRate])
+        let viewModel = WithdrawViewModelTestHelpers.createViewModel(balanceCurrency: .cad, rates: [cadRate])
         viewModel.kind = .sameMint(WithdrawViewModelTestHelpers.createExchangedBalance())
         viewModel.enteredAmount = "7.00" // $7 CAD
 
@@ -170,7 +170,7 @@ struct WithdrawViewModelTests {
     func minimumWithdrawAmount_JPY_158_6() {
         let jpyRate = Rate(fx: 158.6, currency: .jpy)
         let viewModel = WithdrawViewModelTestHelpers.createViewModel(
-            entryCurrency: .jpy,
+            balanceCurrency: .jpy,
             rates: [jpyRate],
             withdrawalFeeQuarks: 500_000 // $0.50
         )
@@ -186,7 +186,7 @@ struct WithdrawViewModelTests {
     func minimumWithdrawAmount_JPY_159_4_displayedFeeRoundsUp() {
         let jpyRate = Rate(fx: 159.4, currency: .jpy)
         let viewModel = WithdrawViewModelTestHelpers.createViewModel(
-            entryCurrency: .jpy,
+            balanceCurrency: .jpy,
             rates: [jpyRate],
             withdrawalFeeQuarks: 500_000
         )
@@ -204,7 +204,7 @@ struct WithdrawViewModelTests {
         // must not fire the gate, even when the device locale uses ",".
         let cadRate = Rate(fx: 1.36, currency: .cad)
         let viewModel = WithdrawViewModelTestHelpers.createViewModel(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [cadRate],
             withdrawalFeeQuarks: 500_000 // $0.50
         )
@@ -224,7 +224,7 @@ struct WithdrawViewModelTests {
         // — useless, so the gate must block it.
         let jpyRate = Rate(fx: 157, currency: .jpy)
         let viewModel = WithdrawViewModelTestHelpers.createViewModel(
-            entryCurrency: .jpy,
+            balanceCurrency: .jpy,
             rates: [jpyRate],
             withdrawalFeeQuarks: 500_000
         )
@@ -330,7 +330,7 @@ struct WithdrawViewModelTests {
             )
         }
         let stored = try #require(container.session.balance(for: mint))
-        let rate = container.ratesController.rateForEntryCurrency()
+        let rate = container.ratesController.rateForBalanceCurrency()
         let balance = ExchangedBalance(
             stored: stored,
             exchangedFiat: stored.computeExchangedValue(with: rate)
@@ -368,7 +368,7 @@ struct WithdrawViewModelTests {
         let cadRate = Rate(fx: 1.4, currency: .cad)
         // Fee comes from userFlags (500_000 quarks = $0.50)
         let viewModel = WithdrawViewModelTestHelpers.createViewModel(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [cadRate],
             withdrawalFeeQuarks: 500_000
         )
@@ -419,7 +419,7 @@ struct WithdrawViewModelTests {
         // Pinned: 1 USD = 1.35 CAD. Live cache drifted to 1.37 after the pin was captured.
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.37, currency: .cad)]
         )
         await sessionContainer.ratesController.verifiedProtoService.saveRates([
@@ -447,7 +447,7 @@ struct WithdrawViewModelTests {
 
         let sessionContainer = SessionContainer.mock
         sessionContainer.ratesController.configureTestRates(
-            entryCurrency: .cad,
+            balanceCurrency: .cad,
             rates: [Rate(fx: 1.37, currency: .cad)]
         )
         await sessionContainer.ratesController.verifiedProtoService.saveRates([


### PR DESCRIPTION
## Summary
Collapses the dual currency preference (one for amount entry, one for balance display) into a single source of truth, so changing the region from the wallet header propagates through Give, Buy, Sell, and Withdraw amount entry. Modernizes the region picker to a current-style navigation stack with environment-driven dismiss, and folds the picker's two roles into one.

## Test plan
- [x] Change the region from US Dollar to Canadian Dollar and confirm both the wallet header and a Give amount entry display the new currency
- [x] Confirm the selection persists across cold launch
- [x] Confirm searching inside the picker selects and dismisses correctly
- [x] Spot check Buy, Sell, Withdraw, and Currency Info amount screens render in the new region
- [x] Confirm the server settings sync receives the new region exactly once