### PR TITLE
fix: red destructive style on notification skip confirmation

### DIFF
--- a/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
@@ -189,7 +189,7 @@ class OnboardingViewModel {
             subtitle: "You won't receive updates when your balance changes",
             dismissable: true
         ) {
-            .standard("OK Allow") { [weak self] in
+            .destructive("OK Allow") { [weak self] in
                 Task {
                     _ = try? await PushController.authorizeAndRegister()
                     self?.completeOnboardingAndLogin()


### PR DESCRIPTION
## Summary

The destructive "Are You Sure?" dialog shown when a user taps "Not Now" on the push notifications onboarding step had no red button. The "OK Allow" call-to-action was using the default style instead of the destructive style used by sibling dialogs (logout, delete account, "Failed to Save").

## Test plan

- Sign out and create a new account.
- On the "Push Notifications Required" screen, tap "Not Now".
- Confirm "OK Allow" appears with red text on a white pill, and "I'm Sure" is a subtle gray button beneath it.