### PR TITLE
fix: use neutral color for negative holder deltas

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
@@ -49,7 +49,7 @@ struct CurrencyDiscoveryRow: View {
                     if let weeklyDelta = metrics.holderDeltas.first(where: { $0.range == .lastWeek }) {
                         Text(Self.formatDelta(weeklyDelta.delta))
                             .font(.appTextSmall)
-                            .foregroundStyle(weeklyDelta.delta < 0 ? Color.Sentiment.negative : Color.Sentiment.positive)
+                            .foregroundStyle(weeklyDelta.delta < 0 ? Color.Sentiment.neutral : Color.Sentiment.positive)
                             .contentTransition(.numericText())
                     }
                 }

--- a/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
@@ -41,6 +41,7 @@ extension Color {
         public static let positiveSecondary = Color(r: 17,  g: 53,  b: 34)
         public static let negative          = Color(r: 228, g: 42,  b: 42)
         public static let negativeSecondary = Color(r: 60,  g: 37,  b: 37)
+        public static let neutral           = Color.textSecondary
     }
 }
 


### PR DESCRIPTION
## Summary
Negative weekly holder counts on currency discovery rows now render in the secondary text color instead of red, matching the muted weight a small dip deserves.

## Test plan
- [x] Open currency discovery and confirm rows with a negative weekly delta show in the neutral color while positive deltas stay green.