### PR TITLE
feat: open scanner at 1× wide and improve pinch zoom

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraPreviewView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraPreviewView.swift
@@ -216,14 +216,15 @@ public class _CameraPreviewView: UIView {
 
         switch gesture.state {
         case .began:
-            cancelRamp(device: device)
             gestureZoomFactor = device.videoZoomFactor
 
         case .changed:
-            setZoomFactor(gestureZoomFactor * gesture.scale, device: device)
+            // Mild power curve so larger pinches cover more range per finger travel.
+            let amplified = pow(gesture.scale, 1.3)
+            setZoomFactor(gestureZoomFactor * amplified, device: device)
 
         case .ended, .cancelled:
-            rampToOne(device: device)
+            setZoomFactor(wideStartZoomFactor(for: device), device: device)
 
         default:
             break
@@ -237,24 +238,6 @@ public class _CameraPreviewView: UIView {
 
             device.videoZoomFactor = newZoomFactor
 
-            device.unlockForConfiguration()
-        } catch {}
-    }
-
-    private func rampToOne(device: AVCaptureDevice) {
-        do {
-            try device.lockForConfiguration()
-            // Rate is exponential factor/sec — 4.0 yields ~log₂(zoom)/4 s to reach 1×.
-            device.ramp(toVideoZoomFactor: 1.0, withRate: 4.0)
-            device.unlockForConfiguration()
-        } catch {}
-    }
-
-    private func cancelRamp(device: AVCaptureDevice) {
-        guard device.isRampingVideoZoom else { return }
-        do {
-            try device.lockForConfiguration()
-            device.cancelVideoZoomRamp()
             device.unlockForConfiguration()
         } catch {}
     }
@@ -279,9 +262,9 @@ public class _CameraPreviewView: UIView {
 
     private func clamp(_ zoomFactor: CGFloat, device: AVCaptureDevice) -> CGFloat {
         let lower = device.minAvailableVideoZoomFactor
-        // 10× matches Apple's Camera ceiling on single-lens devices and engages
-        // the longest optical lens on every multi-lens model.
-        let upper = min(device.maxAvailableVideoZoomFactor, 10.0)
+        // 20× gives meaningful headroom past the longest optical lens on every
+        // current iPhone, hard-capped by what the device actually reports.
+        let upper = min(device.maxAvailableVideoZoomFactor, 20.0)
         return min(max(zoomFactor, lower), upper)
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraPreviewView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraPreviewView.swift
@@ -224,7 +224,7 @@ public class _CameraPreviewView: UIView {
             setZoomFactor(gestureZoomFactor * amplified, device: device)
 
         case .ended, .cancelled:
-            setZoomFactor(wideStartZoomFactor(for: device), device: device)
+            setZoomFactor(device.wideStartZoomFactor, device: device)
 
         default:
             break

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
@@ -8,10 +8,7 @@
 
 import Foundation
 import Combine
-import FlipcashCore
 @preconcurrency import AVKit
-
-private let logger = Logger(label: "flipcash.camera")
 
 extension AVCaptureDevice {
     /// On a virtual capture device whose first constituent is the ultrawide
@@ -142,15 +139,6 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession where T: Camer
         device.videoZoomFactor = device.wideStartZoomFactor
 
         device.unlockForConfiguration()
-
-        logger.info("Configured capture device", metadata: [
-            "deviceType": "\(device.deviceType.rawValue)",
-            "constituents": "\(device.constituentDevices.map(\.deviceType.rawValue).joined(separator: ","))",
-            "switchovers": "\(device.virtualDeviceSwitchOverVideoZoomFactors)",
-            "startZoom": "\(device.videoZoomFactor)",
-            "minZoom": "\(device.minAvailableVideoZoomFactor)",
-            "maxZoom": "\(device.maxAvailableVideoZoomFactor)",
-        ])
 
         guard let input = try? AVCaptureDeviceInput(device: device) else {
             throw Error.inputCreationFailed

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
@@ -8,7 +8,23 @@
 
 import Foundation
 import Combine
+import FlipcashCore
 @preconcurrency import AVKit
+
+private let logger = Logger(label: "flipcash.camera")
+
+/// On a virtual capture device whose first constituent is the ultrawide lens,
+/// `videoZoomFactor = 1.0` engages the ultrawide (what users perceive as 0.5×).
+/// Returns the zoom factor that engages the wide-angle lens — i.e. the user's
+/// "1×". For non-virtual devices and virtual devices that don't lead with an
+/// ultrawide, returns `1.0` unchanged.
+func wideStartZoomFactor(for device: AVCaptureDevice) -> CGFloat {
+    guard device.constituentDevices.first?.deviceType == .builtInUltraWideCamera,
+          let wideThreshold = device.virtualDeviceSwitchOverVideoZoomFactors.first else {
+        return 1.0
+    }
+    return CGFloat(truncating: wideThreshold)
+}
 
 @MainActor
 public protocol AnyCameraSession {
@@ -119,7 +135,20 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession where T: Camer
             device.automaticallyEnablesLowLightBoostWhenAvailable = true
         }
 
+        // Default to the wide-angle lens on multi-lens devices that lead with
+        // an ultrawide. Without this, iPhone Pro / Plus models open at 0.5×.
+        device.videoZoomFactor = wideStartZoomFactor(for: device)
+
         device.unlockForConfiguration()
+
+        logger.info("Configured capture device", metadata: [
+            "deviceType": "\(device.deviceType.rawValue)",
+            "constituents": "\(device.constituentDevices.map(\.deviceType.rawValue).joined(separator: ","))",
+            "switchovers": "\(device.virtualDeviceSwitchOverVideoZoomFactors)",
+            "startZoom": "\(device.videoZoomFactor)",
+            "minZoom": "\(device.minAvailableVideoZoomFactor)",
+            "maxZoom": "\(device.maxAvailableVideoZoomFactor)",
+        ])
 
         guard let input = try? AVCaptureDeviceInput(device: device) else {
             throw Error.inputCreationFailed

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
@@ -13,17 +13,19 @@ import FlipcashCore
 
 private let logger = Logger(label: "flipcash.camera")
 
-/// On a virtual capture device whose first constituent is the ultrawide lens,
-/// `videoZoomFactor = 1.0` engages the ultrawide (what users perceive as 0.5×).
-/// Returns the zoom factor that engages the wide-angle lens — i.e. the user's
-/// "1×". For non-virtual devices and virtual devices that don't lead with an
-/// ultrawide, returns `1.0` unchanged.
-func wideStartZoomFactor(for device: AVCaptureDevice) -> CGFloat {
-    guard device.constituentDevices.first?.deviceType == .builtInUltraWideCamera,
-          let wideThreshold = device.virtualDeviceSwitchOverVideoZoomFactors.first else {
-        return 1.0
+extension AVCaptureDevice {
+    /// On a virtual capture device whose first constituent is the ultrawide
+    /// lens, `videoZoomFactor = 1.0` engages the ultrawide (what users
+    /// perceive as 0.5×). Returns the zoom factor that engages the wide-angle
+    /// lens — i.e. the user's "1×". For non-virtual devices and virtual
+    /// devices that don't lead with an ultrawide, returns `1.0` unchanged.
+    var wideStartZoomFactor: CGFloat {
+        guard constituentDevices.first?.deviceType == .builtInUltraWideCamera,
+              let wideThreshold = virtualDeviceSwitchOverVideoZoomFactors.first else {
+            return 1.0
+        }
+        return CGFloat(truncating: wideThreshold)
     }
-    return CGFloat(truncating: wideThreshold)
 }
 
 @MainActor
@@ -137,7 +139,7 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession where T: Camer
 
         // Default to the wide-angle lens on multi-lens devices that lead with
         // an ultrawide. Without this, iPhone Pro / Plus models open at 0.5×.
-        device.videoZoomFactor = wideStartZoomFactor(for: device)
+        device.videoZoomFactor = device.wideStartZoomFactor
 
         device.unlockForConfiguration()
 


### PR DESCRIPTION
## Summary

Multi-lens iPhones (Pro and Plus) were opening the scanner at the ultrawide lens, which users perceive as 0.5×. The scanner now opens at the wide-angle lens by default. Pinch zoom is slightly more responsive, the cap is raised from 10× to 20× for more headroom on telephoto-equipped devices, and the gesture now releases instantly back to the start zoom instead of an animated ramp.

## Test plan

- [x] On a single-lens device, the scanner still opens at 1× and pinch behaves the same as before
- [x] On a Pro or Plus device, the scanner opens at 1× wide instead of 0.5× ultrawide
- [x] Pinching in and out feels noticeably snappier than before
- [x] Releasing a pinch immediately returns to the starting zoom with no rubber-band animation
- [x] Zooming all the way in reaches further than the previous cap on devices with a telephoto lens