### PR TITLE
refactor: move logout into My Account

### DIFF
--- a/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
@@ -51,6 +51,20 @@ struct SettingsMyAccountScreen: View {
                 }
             }
 
+            SettingsRow(asset: .logout, title: "Log Out", insets: insets) {
+                dialogItem = .init(
+                    style: .destructive,
+                    title: "Are You Sure You Want To Log Out?",
+                    subtitle: "You can get into this account using your Access Key",
+                    dismissable: true
+                ) {
+                    DialogAction.destructive("Log Out") {
+                        logout()
+                    }
+                    DialogAction.cancel {}
+                }
+            }
+
             SettingsRow(asset: .delete, title: "Delete Account", insets: insets) {
                 dialogItem = .init(
                     style: .destructive,
@@ -70,6 +84,14 @@ struct SettingsMyAccountScreen: View {
     }
 
     private func deleteAccount() {
+        Task {
+            router.dismissSheet()
+            try await Task.delay(milliseconds: 250)
+            sessionAuthenticator.logout()
+        }
+    }
+
+    private func logout() {
         Task {
             router.dismissSheet()
             try await Task.delay(milliseconds: 250)

--- a/Flipcash/Core/Screens/Settings/SettingsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsScreen.swift
@@ -20,14 +20,12 @@ struct SettingsScreen: View {
 
     private let container: Container
     private let sessionContainer: SessionContainer
-    private let session: Session
 
     // MARK: - Init -
 
     init(container: Container, sessionContainer: SessionContainer) {
         self.container = container
         self.sessionContainer = sessionContainer
-        self.session = sessionContainer.session
     }
 
     // MARK: - Body -

--- a/Flipcash/Core/Screens/Settings/SettingsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsScreen.swift
@@ -14,13 +14,11 @@ struct SettingsScreen: View {
     @Environment(AppRouter.self) private var router
     @Environment(BetaFlags.self) private var betaFlags
 
-    @State private var dialogItem: DialogItem?
     @State private var debugTapCount: Int = 0
 
     private let insets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
 
     private let container: Container
-    private let sessionAuthenticator: SessionAuthenticator
     private let sessionContainer: SessionContainer
     private let session: Session
 
@@ -28,7 +26,6 @@ struct SettingsScreen: View {
 
     init(container: Container, sessionContainer: SessionContainer) {
         self.container = container
-        self.sessionAuthenticator = container.sessionAuthenticator
         self.sessionContainer = sessionContainer
         self.session = sessionContainer.session
     }
@@ -83,31 +80,18 @@ struct SettingsScreen: View {
                     .padding(.top, 10)
                 }
                 .safeAreaInset(edge: .bottom) {
-                    VStack(spacing: 0) {
-                        Button {
-                            dialogItem = logoutDialog
-                        } label: {
-                            HStack(spacing: 10) {
-                                Image.asset(.logout)
-                                    .renderingMode(.template)
-                                Text("Log Out")
-                            }
-                        }
-                        .buttonStyle(.subtle)
-
-                        Button {
-                            handleVersionTap()
-                        } label: {
-                            Text("Version \(AppMeta.version) • Build \(AppMeta.build)")
-                                .lineLimit(1)
-                                .font(.appTextHeading)
-                                .foregroundStyle(Color.textSecondary)
-                                .padding(.vertical, 12)
-                                .frame(maxWidth: .infinity)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
+                    Button {
+                        handleVersionTap()
+                    } label: {
+                        Text("Version \(AppMeta.version) • Build \(AppMeta.build)")
+                            .lineLimit(1)
+                            .font(.appTextHeading)
+                            .foregroundStyle(Color.textSecondary)
+                            .padding(.vertical, 12)
+                            .frame(maxWidth: .infinity)
+                            .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                     .padding(.horizontal, 20)
                 }
             }
@@ -120,7 +104,6 @@ struct SettingsScreen: View {
                 }
             }
             .navigationTitle("Settings")
-            .dialog(item: $dialogItem)
             .appRouterDestinations(container: container, sessionContainer: sessionContainer)
         }
     }
@@ -128,20 +111,6 @@ struct SettingsScreen: View {
     // MARK: - Helpers -
 
     private let betaBadge = Badge(decoration: .circle(.textWarning), text: "Beta")
-
-    private var logoutDialog: DialogItem {
-        DialogItem(
-            style: .destructive,
-            title: "Are You Sure You Want To Log Out?",
-            subtitle: "You can get into this account using your Access Key",
-            dismissable: true
-        ) {
-            DialogAction.destructive("Log Out") {
-                logout()
-            }
-            DialogAction.cancel {}
-        }
-    }
 
     // MARK: - Actions -
 
@@ -151,14 +120,6 @@ struct SettingsScreen: View {
             debugTapCount = 0
         } else {
             debugTapCount += 1
-        }
-    }
-
-    private func logout() {
-        Task {
-            router.dismissSheet()
-            try await Task.delay(milliseconds: 250)
-            sessionAuthenticator.logout()
         }
     }
 }

--- a/FlipcashUITests/Smoke/LoginSmokeTests.swift
+++ b/FlipcashUITests/Smoke/LoginSmokeTests.swift
@@ -24,8 +24,9 @@ final class LoginSmokeTests: BaseUITestCase {
         // Verify we're on the main screen
         assertMainScreenReached()
 
-        // Open Settings and log out
+        // Open Settings, go to My Account, and log out
         waitAndTap(app.buttons["Settings"])
+        waitAndTap(app.buttons["My Account"])
         waitAndTap(app.buttons["Log Out"])
 
         // Confirmation dialog — scoped to the dialog container


### PR DESCRIPTION
## Summary

Logging out used to live in a button pinned to the bottom of the Settings screen. It now sits inside My Account as a normal row, between Access Key and Delete Account, so all account-level destructive actions live together. The confirmation dialog is unchanged.

## Test plan

- [x] Open Settings and confirm there is no Log Out button at the bottom, only the version label.
- [x] Open Settings → My Account and confirm Log Out appears between Access Key and Delete Account.
- [ ] Tap Log Out and confirm the same destructive confirmation dialog appears and signs you out on Log Out.