### PR TITLE
chore(withdraw): polish UI to add more cross-platform consistency

### DIFF
--- a/Flipcash/Core/Screens/Main/CashReservesRow.swift
+++ b/Flipcash/Core/Screens/Main/CashReservesRow.swift
@@ -25,7 +25,6 @@ struct CashReservesRow: View {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(Color.textSecondary)
-                    .padding(.top, 3)
 
                 Spacer()
 

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
@@ -63,7 +63,7 @@ struct WithdrawScreen: View {
                     .dialog(item: $viewModel.dialogItem)
             case .enterAmount:
                 WithdrawAmountScreen(
-                    title: viewModel.withdrawTitle,
+                    title: "Withdraw",
                     enteredAmount: $viewModel.enteredAmount,
                     subtitle: viewModel.amountSubtitle,
                     canProceed: viewModel.canProceedToAddress,

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawSummaryScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawSummaryScreen.swift
@@ -32,11 +32,10 @@ struct WithdrawSummaryScreen: View {
                                     title: "Net amount",
                                     value: net.formatted()
                                 )
-                                if let amountText = viewModel.amountInTokenText,
-                                   let kind = viewModel.kind {
+                                if let kind = viewModel.kind {
                                     SummaryLineItem(
                                         title: "Amount in \(kind.destinationCurrencyName)",
-                                        value: amountText
+                                        value: display
                                     )
                                 }
                             }

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -81,7 +81,7 @@ class WithdrawViewModel {
     }
 
     var withdrawableAmount: ExchangedFiat? {
-        guard let enteredFiat, destinationMetadata != nil else { return nil }
+        guard let enteredFiat else { return nil }
         guard let fee = resolvedFee, fee.onChain.quarks > 0 else {
             return enteredFiat
         }
@@ -139,43 +139,13 @@ class WithdrawViewModel {
         }
     }
 
-    var withdrawTitle: String {
-        if let balance = kind?.balance {
-            return "Withdraw \(balance.stored.name)"
-        } else {
-            return "Withdraw"
-        }
-    }
-
-    /// Whether the summary's layered card includes the "Amount in <name>" row
-    /// (passes through `kind.showsAmountInTokenLine`, defaulting to false when
-    /// `kind` is nil — e.g., before a balance has been picked).
-    var showsAmountInTokenLine: Bool {
-        kind?.showsAmountInTokenLine ?? false
-    }
-
-    /// On-chain token quantity formatted for the bonded summary's "Amount in <name>" row.
-    /// Uses the mint's decimal scaling (e.g. 297_902_148_685 quarks → "29.7902148685"
-    /// for a 10-decimal Jeffy token). Nil for USDF (1:1 USD peg makes this redundant).
-    var amountInTokenText: String? {
-        guard kind?.showsAmountInTokenLine == true else { return nil }
-        guard let withdrawableAmount else { return nil }
-        return withdrawableAmount.onChainAmount.decimalValue.formatted()
-    }
-
-    /// Single string rendered inside the "You Receive" box on the summary.
-    /// USDF: net fiat (matches the summary's `Net amount` line). Bonded:
-    /// scaled token quantity (matches `amountInTokenText` — same number,
-    /// different framing on screen).
+    /// Post-fee on-chain token quantity in the destination mint, formatted with
+    /// the mint's decimal scaling (e.g. 297_902_148_685 quarks → "29.7902148685"
+    /// for a 10-decimal Jeffy token; 234_784 quarks → "0.234784" for a 6-decimal
+    /// USDF). Used for both the summary's "Amount in <name>" row and the big
+    /// "You Receive" box — same value, different framing.
     var youReceiveDisplayValue: String? {
-        switch kind {
-        case .sameMint:
-            return withdrawableAmount?.onChainAmount.decimalValue.formatted()
-        case .usdfToUsdc:
-            return displayNet?.formatted()
-        case .none:
-            return nil
-        }
+        withdrawableAmount?.onChainAmount.decimalValue.formatted()
     }
 
     /// Logo URL for the You Receive box. For both kinds the logo comes from
@@ -391,7 +361,7 @@ class WithdrawViewModel {
             subtitle: "Withdrawals are irreversible and cannot be undone once initiated",
             dismissable: true,
             actions: {
-                .destructive("Withdraw") { [weak self] in
+                .destructive("Yes, Withdraw") { [weak self] in
                     self?.completeWithdrawal()
                 };
                 .cancel()
@@ -600,14 +570,6 @@ enum WithdrawKind: Equatable {
         switch self {
         case .sameMint:    return false
         case .usdfToUsdc:  return true
-        }
-    }
-
-    /// Whether the summary's layered card includes the "Amount in <name>" line.
-    var showsAmountInTokenLine: Bool {
-        switch self {
-        case .sameMint:    return true
-        case .usdfToUsdc:  return false
         }
     }
 }

--- a/FlipcashTests/WithdrawViewModelTests.swift
+++ b/FlipcashTests/WithdrawViewModelTests.swift
@@ -521,13 +521,6 @@ struct WithdrawKindTests {
         #expect(WithdrawKind.usdfToUsdc(usdf).showsIntroScreen == true)
     }
 
-    @Test("showsAmountInTokenLine: true for sameMint, false for usdfToUsdc")
-    func showsAmountInTokenLine() {
-        let bonded = WithdrawViewModelTestHelpers.createBondedBalance()
-        let usdf = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf)
-        #expect(WithdrawKind.sameMint(bonded).showsAmountInTokenLine == true)
-        #expect(WithdrawKind.usdfToUsdc(usdf).showsAmountInTokenLine == false)
-    }
 }
 
 // MARK: - WithdrawViewModel summary helpers
@@ -536,44 +529,8 @@ struct WithdrawKindTests {
 @Suite("WithdrawViewModel summary helpers")
 struct WithdrawViewModelSummaryHelpersTests {
 
-    @Test("showsAmountInTokenLine: true for sameMint, false for usdfToUsdc (VM passthrough)")
-    func showsAmountInTokenLine_passthrough() {
-        let bonded = WithdrawViewModelTestHelpers.createBondedBalance()
-        let usdf = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf)
-        let vmBonded = WithdrawViewModelTestHelpers.createViewModel()
-        vmBonded.kind = .sameMint(bonded)
-        let vmUsdf = WithdrawViewModelTestHelpers.createViewModel()
-        vmUsdf.kind = .usdfToUsdc(usdf)
-        #expect(vmBonded.showsAmountInTokenLine == true)
-        #expect(vmUsdf.showsAmountInTokenLine == false)
-    }
-
-    @Test("amountInTokenText: nil for usdfToUsdc")
-    func amountInTokenText_usdfToUsdc_isNil() {
-        let usdf = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf, quarks: 100_000_000)
-        let viewModel = WithdrawViewModelTestHelpers.createViewModel()
-        viewModel.kind = .usdfToUsdc(usdf)
-        viewModel.enteredAmount = "5.00"
-        viewModel.destinationMetadata = WithdrawViewModelTestHelpers.createDestinationMetadata()
-
-        #expect(viewModel.amountInTokenText == nil)
-    }
-
-    @Test("amountInTokenText: matches the post-fee on-chain decimal-scaled value for sameMint")
-    func amountInTokenText_sameMint_matchesPostFeeDecimalValue() throws {
-        let bonded = WithdrawViewModelTestHelpers.createBondedBalance()
-        let viewModel = WithdrawViewModelTestHelpers.createViewModel()
-        viewModel.kind = .sameMint(bonded)
-        viewModel.enteredAmount = "10.00"
-        viewModel.destinationMetadata = WithdrawViewModelTestHelpers.createDestinationMetadata()
-
-        let amountText = try #require(viewModel.amountInTokenText)
-        let withdrawable = try #require(viewModel.withdrawableAmount)
-        #expect(amountText == withdrawable.onChainAmount.decimalValue.formatted())
-    }
-
-    @Test("youReceiveDisplayValue: USDF returns fiat-formatted string")
-    func youReceiveDisplayValue_usdf_returnsFiat() throws {
+    @Test("youReceiveDisplayValue: USDF returns post-fee on-chain token amount")
+    func youReceiveDisplayValue_usdf_returnsTokenAmount() throws {
         let usdf = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf, quarks: 100_000_000)
         let viewModel = WithdrawViewModelTestHelpers.createViewModel(withdrawalFeeQuarks: 500_000) // $0.50
         viewModel.kind = .usdfToUsdc(usdf)
@@ -581,11 +538,54 @@ struct WithdrawViewModelSummaryHelpersTests {
         viewModel.destinationMetadata = WithdrawViewModelTestHelpers.createDestinationMetadata()
 
         let value = try #require(viewModel.youReceiveDisplayValue)
-        // $50.00 - $0.50 fee = $49.50; the formatter typically yields "$49.50".
-        #expect(value.contains("49.50"))
+        let withdrawable = try #require(viewModel.withdrawableAmount)
+        #expect(value == withdrawable.onChainAmount.decimalValue.formatted())
     }
 
-    @Test("youReceiveDisplayValue: bonded returns on-chain quark count as numeric string")
+    /// Regression: WithdrawSummaryScreen wraps the entire amount/fee/net/You-Receive
+    /// card in `if let entered, let net, let display`. When any one of those goes
+    /// nil the user sees a near-empty screen with just the address and Withdraw
+    /// button. Locks the three values together for the USDF→USDC flow with and
+    /// without destination metadata, so any future regression to the underlying
+    /// computations fails here instead of silently hiding the card.
+    @Test("summary card values are all non-nil for usdfToUsdc at 1 CAD")
+    func summaryCard_usdfToUsdc_oneCAD_allValuesNonNil() {
+        let viewModel = makeUsdfToUsdcCadViewModel()
+        viewModel.destinationMetadata = WithdrawViewModelTestHelpers.createDestinationMetadata()
+
+        #expect(viewModel.enteredFiat != nil)
+        #expect(viewModel.displayNet != nil)
+        #expect(viewModel.youReceiveDisplayValue != nil)
+    }
+
+    /// Regression: youReceiveDisplayValue and withdrawableAmount must NOT depend on
+    /// destinationMetadata. They feed the summary card; if they vanish whenever
+    /// metadata is briefly nil (initial render before async fetch settles, stale
+    /// state on re-entry, server-failed validation), the user sees a half-blank
+    /// summary. The fee-subtracted token amount is purely a function of the
+    /// entered amount and the static fee — keep it that way.
+    @Test("youReceiveDisplayValue does not depend on destinationMetadata")
+    func youReceiveDisplayValue_noMetadata_stillRenders() {
+        let viewModel = makeUsdfToUsdcCadViewModel()
+
+        #expect(viewModel.destinationMetadata == nil)
+        #expect(viewModel.withdrawableAmount != nil)
+        #expect(viewModel.youReceiveDisplayValue != nil)
+    }
+
+    private func makeUsdfToUsdcCadViewModel() -> WithdrawViewModel {
+        let usdf = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf, quarks: 100_000_000)
+        let viewModel = WithdrawViewModelTestHelpers.createViewModel(
+            balanceCurrency: .cad,
+            rates: [Rate(fx: 1.4, currency: .cad)],
+            withdrawalFeeQuarks: 500_000 // $0.50
+        )
+        viewModel.kind = .usdfToUsdc(usdf)
+        viewModel.enteredAmount = "1"
+        return viewModel
+    }
+
+    @Test("youReceiveDisplayValue: bonded returns post-fee on-chain token amount")
     func youReceiveDisplayValue_bonded_returnsTokenCount() throws {
         let bonded = WithdrawViewModelTestHelpers.createBondedBalance()
         let viewModel = WithdrawViewModelTestHelpers.createViewModel()
@@ -594,9 +594,8 @@ struct WithdrawViewModelSummaryHelpersTests {
         viewModel.destinationMetadata = WithdrawViewModelTestHelpers.createDestinationMetadata()
 
         let value = try #require(viewModel.youReceiveDisplayValue)
-        // Bonded path renders the same quark count as amountInTokenText —
-        // same number, different framing on screen.
-        #expect(value == viewModel.amountInTokenText)
+        let withdrawable = try #require(viewModel.withdrawableAmount)
+        #expect(value == withdrawable.onChainAmount.decimalValue.formatted())
     }
 
     @Test("destinationLogoURL: usdfToUsdc returns MintMetadata.usdc.imageURL")


### PR DESCRIPTION
## Summary

A handful of small polish items on the withdraw flow, plus a regression fix for the summary screen.

The summary card was vanishing in flights where destination metadata hadn't settled yet — the "You Receive" value had picked up a hidden dependency on it that the older path never had. The card and its derived values are now decoupled from metadata, the You Receive amount is a token quantity for both withdrawal paths, and the "Amount in <token>" row is shown consistently. Title and confirmation button copy are also tidied.

## Test plan

- [x] USDF withdrawal shows the updated title, the "Amount in USDC" row, and the matching "You Receive" amount.
- [x] Launchpad token withdrawal shows the updated title, the "Amount in <token>" row, and the matching "You Receive" amount.
- [x] The confirmation dialog reads "Yes, Withdraw".
- [x] The summary card remains visible while destination metadata is being fetched.