### PR TITLE
chore: raise Bugsnag string value limit to 50,000

### DIFF
--- a/Flipcash/Utilities/ErrorReporting.swift
+++ b/Flipcash/Utilities/ErrorReporting.swift
@@ -12,7 +12,9 @@ import FlipcashCore
 enum ErrorReporting {
     
     static func initialize() {
-        Bugsnag.start()
+        let config = BugsnagConfiguration.loadConfig()
+        config.maxStringValueLength = 50_000
+        Bugsnag.start(with: config)
     }
     
     static func breadcrumb(_ breadcrumb: Breadcrumb) {


### PR DESCRIPTION
## Summary

The default 10,000-character per-field cap was truncating the recent log buffer attached to error events, dropping the most recent (and most diagnostic) lines. Raising it to 50,000 gives the buffer plenty of headroom even when entries carry verbose metadata.

## Test plan

- [x] Trigger an error and confirm the recent log buffer in the resulting Bugsnag event is no longer truncated.