### PR TITLE
fix: surface underlying swap funding errors in Bugsnag

### DIFF
--- a/Flipcash/Utilities/ErrorReporting.swift
+++ b/Flipcash/Utilities/ErrorReporting.swift
@@ -133,8 +133,8 @@ enum ErrorReporting {
 
         Bugsnag.notifyError(customError) { event in
             if !event.errors.isEmpty {
-                event.errors[0].errorClass = "\(error)"
-                event.errors[0].errorMessage = reason ?? ""
+                event.errors[0].errorClass = reason ?? "\(error)"
+                event.errors[0].errorMessage = "\(error)"
             }
 
             event.addMetadata(

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
@@ -561,6 +561,8 @@ public enum ErrorSwap: Error, CustomStringConvertible, CustomDebugStringConverti
     case grpcStatus(GRPCStatus)
     /// gRPC error
     case grpcError(Error)
+    /// Phase 2 (IntentFundSwap) submission failed; preserves the underlying cause.
+    case fundingIntent(ErrorSubmitIntent)
 
     init(error: Ocp_Transaction_V1_StatefulSwapResponse.Error) {
         switch error.code {
@@ -613,9 +615,11 @@ public enum ErrorSwap: Error, CustomStringConvertible, CustomDebugStringConverti
             return "grpcStatus(\(status.code.rawValue))"
         case .grpcError(let error):
             return "grpcError(\(error.localizedDescription))"
+        case .fundingIntent(let error):
+            return "fundingIntent(\(error))"
         }
     }
-    
+
     public var debugDescription: String {
         description
     }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -226,7 +226,7 @@ class TransactionService: CodeService<Ocp_Transaction_V1_TransactionNIOClient> {
                         completion(.success(swapId))
                     case .failure(let error):
                         logger.error("Failed to fund buy swap", metadata: ["error": "\(error)"])
-                        completion(.failure(.unknown))
+                        completion(.failure(.fundingIntent(error)))
                     }
                 }
 
@@ -298,7 +298,7 @@ class TransactionService: CodeService<Ocp_Transaction_V1_TransactionNIOClient> {
                         completion(.success(swapId))
                     case .failure(let error):
                         logger.error("Failed to fund USDF withdrawal", metadata: ["error": "\(error)"])
-                        completion(.failure(.unknown))
+                        completion(.failure(.fundingIntent(error)))
                     }
                 }
 
@@ -414,7 +414,7 @@ class TransactionService: CodeService<Ocp_Transaction_V1_TransactionNIOClient> {
                         completion(.success(metadata))
                     case .failure(let error):
                         logger.error("Failed to fund new-currency swap", metadata: ["error": "\(error)"])
-                        completion(.failure(.unknown))
+                        completion(.failure(.fundingIntent(error)))
                     }
                 }
 
@@ -478,8 +478,7 @@ class TransactionService: CodeService<Ocp_Transaction_V1_TransactionNIOClient> {
 
                     case .failure(let error):
                         logger.error("Failed to fund sell swap", metadata: ["error": "\(error)"])
-                        // Map ErrorSubmitIntent to ErrorSwap
-                        completion(.failure(.unknown))
+                        completion(.failure(.fundingIntent(error)))
                     }
                 }
 


### PR DESCRIPTION
## Summary

Buy, sell, withdraw, and new-currency-launch flows were collapsing every Phase 2 funding-intent failure into a single generic case before it reached Bugsnag, so dashboard entries read "unknown · ErrorSwap.unknown — Failed to withdraw" with the real gRPC status, denial reason, or signature mismatch already discarded. The funding-intent error is now preserved through the boundary, and the dashboard title now leads with the catch-site reason and surfaces the underlying error as the subtitle.

## Test plan

- [x] Trigger a withdraw (or buy/sell) failure and confirm the Bugsnag event title shows the catch-site reason and the subtitle shows the underlying error.