### PR TITLE
fix: format withdraw destination amounts to 2 decimal places

### DIFF
--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -139,13 +139,15 @@ class WithdrawViewModel {
         }
     }
 
-    /// Post-fee on-chain token quantity in the destination mint, formatted with
-    /// the mint's decimal scaling (e.g. 297_902_148_685 quarks → "29.7902148685"
-    /// for a 10-decimal Jeffy token; 234_784 quarks → "0.234784" for a 6-decimal
-    /// USDF). Used for both the summary's "Amount in <name>" row and the big
-    /// "You Receive" box — same value, different framing.
+    /// Post-fee on-chain token quantity in the destination mint, formatted to
+    /// exactly two fraction digits for display (e.g. 49_500_000 USDF quarks →
+    /// "49.50"; 297_902_148_685 Jeffy quarks → "29.79"). Used for both the
+    /// summary's "Amount in <name>" row and the big "You Receive" box. The
+    /// wire amount comes from `withdrawableAmount.onChainAmount.quarks` and
+    /// is unaffected by this rounding.
     var youReceiveDisplayValue: String? {
-        withdrawableAmount?.onChainAmount.decimalValue.formatted()
+        withdrawableAmount?.onChainAmount.decimalValue
+            .formatted(.number.precision(.fractionLength(2)))
     }
 
     /// Logo URL for the You Receive box. For both kinds the logo comes from

--- a/FlipcashTests/WithdrawViewModelTests.swift
+++ b/FlipcashTests/WithdrawViewModelTests.swift
@@ -529,7 +529,7 @@ struct WithdrawKindTests {
 @Suite("WithdrawViewModel summary helpers")
 struct WithdrawViewModelSummaryHelpersTests {
 
-    @Test("youReceiveDisplayValue: USDF returns post-fee on-chain token amount")
+    @Test("youReceiveDisplayValue: USDF returns post-fee on-chain token amount, 2 fraction digits")
     func youReceiveDisplayValue_usdf_returnsTokenAmount() throws {
         let usdf = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf, quarks: 100_000_000)
         let viewModel = WithdrawViewModelTestHelpers.createViewModel(withdrawalFeeQuarks: 500_000) // $0.50
@@ -537,9 +537,21 @@ struct WithdrawViewModelSummaryHelpersTests {
         viewModel.enteredAmount = "50.00"
         viewModel.destinationMetadata = WithdrawViewModelTestHelpers.createDestinationMetadata()
 
-        let value = try #require(viewModel.youReceiveDisplayValue)
+        // $50.00 - $0.50 fee = $49.50 → 49_500_000 quarks (6 decimals) → "49.50"
         let withdrawable = try #require(viewModel.withdrawableAmount)
-        #expect(value == withdrawable.onChainAmount.decimalValue.formatted())
+        #expect(withdrawable.onChainAmount.quarks == 49_500_000)
+        #expect(viewModel.youReceiveDisplayValue == "49.50")
+    }
+
+    @Test("youReceiveDisplayValue: whole-number amount pads to 2 fraction digits")
+    func youReceiveDisplayValue_wholeNumber_padsToTwoFractionDigits() throws {
+        let usdf = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf, quarks: 100_000_000)
+        let viewModel = WithdrawViewModelTestHelpers.createViewModel(withdrawalFeeQuarks: 0)
+        viewModel.kind = .usdfToUsdc(usdf)
+        viewModel.enteredAmount = "5"
+        viewModel.destinationMetadata = WithdrawViewModelTestHelpers.createDestinationMetadata()
+
+        #expect(viewModel.youReceiveDisplayValue == "5.00")
     }
 
     /// Regression: WithdrawSummaryScreen wraps the entire amount/fee/net/You-Receive
@@ -585,7 +597,7 @@ struct WithdrawViewModelSummaryHelpersTests {
         return viewModel
     }
 
-    @Test("youReceiveDisplayValue: bonded returns post-fee on-chain token amount")
+    @Test("youReceiveDisplayValue: bonded returns post-fee on-chain token amount, rounded to 2 fraction digits")
     func youReceiveDisplayValue_bonded_returnsTokenCount() throws {
         let bonded = WithdrawViewModelTestHelpers.createBondedBalance()
         let viewModel = WithdrawViewModelTestHelpers.createViewModel()
@@ -595,7 +607,8 @@ struct WithdrawViewModelSummaryHelpersTests {
 
         let value = try #require(viewModel.youReceiveDisplayValue)
         let withdrawable = try #require(viewModel.withdrawableAmount)
-        #expect(value == withdrawable.onChainAmount.decimalValue.formatted())
+        #expect(value == withdrawable.onChainAmount.decimalValue
+            .formatted(.number.precision(.fractionLength(2))))
     }
 
     @Test("destinationLogoURL: usdfToUsdc returns MintMetadata.usdc.imageURL")


### PR DESCRIPTION
## Summary
The withdraw summary's "Amount in <currency>" row and the "You Receive" box were rendering on-chain token amounts with the mint's full decimal precision. This formats the display to exactly two fraction digits while leaving the on-chain wire amount untouched.

## Test plan
- [x] Withdraw a USDF balance and confirm the summary shows two decimals.
- [x] Withdraw a high-decimal bonded token and confirm the summary shows two decimals.
- [x] Confirm the on-chain transfer amount still matches what was entered.