### PR TITLE
fix: shrink CapsuleButton content frame on iOS 26

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Views/Buttons/CapsuleButton.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Buttons/CapsuleButton.swift
@@ -96,10 +96,28 @@ public struct CapsuleButton: View {
             }
             .animation(nil, value: state)
             .foregroundStyle(Color.textMain)
-            .frame(height: 57)
-            .padding(.horizontal, title == nil ? 16 : 20)
+            .frame(height: contentHeight)
+            .padding(.horizontal, contentHorizontalPadding)
         }
         .liquidGlassButtonStyle(shape: title == nil ? .circle : .capsule)
+    }
+
+    private var contentHeight: CGFloat {
+        // `.buttonStyle(.glass)` adds ~14pt vertical padding around the label.
+        // Shrink the content on iOS 26 so the rendered button matches the iOS 18 visual.
+        if #available(iOS 26, *) {
+            return 43
+        } else {
+            return 57
+        }
+    }
+
+    private var contentHorizontalPadding: CGFloat {
+        if #available(iOS 26, *) {
+            return title == nil ? 9 : 13
+        } else {
+            return title == nil ? 16 : 20
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The Give-flow Send and Cancel buttons rendered noticeably larger on iOS 26 than on iOS 18, because Apple's native glass button style adds padding around the label that the previous fix only accounted for in the Settings button. This applies the same per-iOS sizing treatment to the shared button so iOS 26 matches the iOS 18 visual.

## Test plan

- [x] On iPhone 17 (iOS 26), open Give, enter an amount, tap Next, and confirm the Send and Cancel buttons match the iOS 18 size
- [x] On iPhone 16 (iOS 18), open Give, enter an amount, tap Next, and confirm the buttons are unchanged