### PR TITLE
fix: create sender USDC ATA before USDC-to-USDF swap

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+UsdcToUsdf.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+UsdcToUsdf.swift
@@ -17,7 +17,7 @@ extension SwapInstructionBuilder {
     ///   - amount: Amount of USDC to swap (in quarks)
     ///   - pool: The liquidity pool to use for the swap
     ///   - swapId: Unique identifier for the swap (used in memo)
-    /// - Returns: Array of 7 instructions for the USDC→USDF swap
+    /// - Returns: Array of 8 instructions for the USDC→USDF swap
     public static func buildUsdcToUsdfSwapInstructions(
         sender: PublicKey,
         owner: PublicKey,
@@ -35,9 +35,14 @@ extension SwapInstructionBuilder {
             mint: .usdf
         )
 
-        guard let senderUsdcAta = PublicKey.deriveAssociatedAccount(from: sender, mint: .usdc) else {
-            fatalError("Failed to derive USDC ATA")
-        }
+        // Usdf::Swap reads `userOtherToken` as a Token-program account; an
+        // uninitialized canonical USDC ATA causes "Invalid account owner".
+        // CreateIdempotent is a no-op when the account already exists.
+        let senderUsdcAta = AssociatedTokenProgram.CreateIdempotent(
+            subsidizer: sender,
+            owner: sender,
+            mint: .usdc
+        )
 
         var instructions: [Instruction] = []
 
@@ -63,12 +68,15 @@ extension SwapInstructionBuilder {
             ).instruction()
         )
 
-        // 5. Memo::Memo (swap ID for tracking)
+        // 5. AssociatedTokenAccount::CreateIdempotent (USDC ATA for sender)
+        instructions.append(senderUsdcAta.instruction())
+
+        // 6. Memo::Memo (swap ID for tracking)
         instructions.append(
             MemoProgram.Memo(message: swapId.base58).instruction()
         )
 
-        // 6. Usdf::Swap (sender's USDC ATA → sender's USDF ATA)
+        // 7. Usdf::Swap (sender's USDC ATA → sender's USDF ATA)
         instructions.append(
             UsdfProgram.Swap(
                 amount: amount,
@@ -78,11 +86,11 @@ extension SwapInstructionBuilder {
                 usdfVault: pool.usdfVault,
                 otherVault: pool.otherVault,
                 userUsdfToken: senderUsdfAta.address,
-                userOtherToken: senderUsdcAta.publicKey
+                userOtherToken: senderUsdcAta.address
             ).instruction()
         )
 
-        // 7. Token::Transfer (sender's USDF ATA → owner's USDF swap PDA ATA)
+        // 8. Token::Transfer (sender's USDF ATA → owner's USDF swap PDA ATA)
         instructions.append(
             TokenProgram.Transfer(
                 amount: amount,

--- a/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
@@ -12,8 +12,6 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
 
     // MARK: - Fixtures
 
-    /// 32-byte pubkey filled entirely with the seed byte. Mirrors the existing
-    /// UsdfToUsdc test suite.
     private static func testKey(_ seed: Int) -> PublicKey {
         try! PublicKey([UInt8](repeating: UInt8(seed), count: 32))
     }
@@ -58,35 +56,40 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
         #expect(ix.data.first == ComputeBudgetProgram.Command.setComputeUnitPrice.rawValue)
     }
 
-    @Test("Instruction 2 is AssociatedTokenProgram CreateIdempotent for sender's USDF ATA")
-    func instruction2_createsSenderUsdfATA() {
-        let ix = Self.makeInstructions()[2]
+    @Test(
+        "CreateIdempotent at instruction targets the expected payer/owner/mint",
+        arguments: [
+            (
+                index: 2,
+                ataOwner: SwapInstructionBuilderUsdcToUsdfTests.sender,
+                mint: PublicKey.usdf
+            ),
+            (
+                index: 3,
+                ataOwner: MintMetadata.usdf.timelockSwapAccounts(
+                    owner: SwapInstructionBuilderUsdcToUsdfTests.owner
+                )!.pda.publicKey,
+                mint: PublicKey.usdf
+            ),
+            (
+                index: 4,
+                ataOwner: SwapInstructionBuilderUsdcToUsdfTests.sender,
+                mint: PublicKey.usdc
+            ),
+        ]
+    )
+    func createIdempotent_payerOwnerMint(
+        index: Int,
+        ataOwner: PublicKey,
+        mint: PublicKey
+    ) {
+        let ix = Self.makeInstructions()[index]
         // account layout: [payer (w,s), ata (w), owner, mint, system, token, rent]
         #expect(ix.program == AssociatedTokenProgram.address)
         #expect(ix.accounts[0].publicKey == Self.sender)
-        #expect(ix.accounts[0].isSigner == true)
-        #expect(ix.accounts[2].publicKey == Self.sender)
-        #expect(ix.accounts[3].publicKey == .usdf)
-    }
-
-    @Test("Instruction 3 is AssociatedTokenProgram CreateIdempotent for swap PDA's USDF ATA")
-    func instruction3_createsSwapPdaUsdfATA() {
-        let ix = Self.makeInstructions()[3]
-        let pdaPublicKey = MintMetadata.usdf.timelockSwapAccounts(owner: Self.owner)!.pda.publicKey
-        #expect(ix.program == AssociatedTokenProgram.address)
-        #expect(ix.accounts[0].publicKey == Self.sender)
-        #expect(ix.accounts[2].publicKey == pdaPublicKey)
-        #expect(ix.accounts[3].publicKey == .usdf)
-    }
-
-    @Test("Instruction 4 is AssociatedTokenProgram CreateIdempotent for sender's USDC ATA")
-    func instruction4_createsSenderUsdcATA() {
-        let ix = Self.makeInstructions()[4]
-        #expect(ix.program == AssociatedTokenProgram.address)
-        #expect(ix.accounts[0].publicKey == Self.sender)
-        #expect(ix.accounts[0].isSigner == true)
-        #expect(ix.accounts[2].publicKey == Self.sender)
-        #expect(ix.accounts[3].publicKey == .usdc)
+        #expect(ix.accounts[0].isSigner)
+        #expect(ix.accounts[2].publicKey == ataOwner)
+        #expect(ix.accounts[3].publicKey == mint)
     }
 
     @Test("Instruction 5 is Memo carrying the swap id")
@@ -102,16 +105,16 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
     }
 
     @Test("Instruction 7 is TokenProgram Transfer to swap PDA's USDF ATA")
-    func instruction7_isTransferToSwapPdaAta() {
+    func instruction7_isTransferToSwapPdaAta() throws {
         let ix = Self.makeInstructions()[7]
-        let pdaAta = MintMetadata.usdf.timelockSwapAccounts(owner: Self.owner)!.ata.publicKey
-        let senderUsdfAta = PublicKey.deriveAssociatedAccount(from: Self.sender, mint: .usdf)!.publicKey
+        let pdaAta = try #require(MintMetadata.usdf.timelockSwapAccounts(owner: Self.owner)).ata.publicKey
+        let senderUsdfAta = try #require(PublicKey.deriveAssociatedAccount(from: Self.sender, mint: .usdf)).publicKey
         #expect(ix.program == TokenProgram.address)
         // account layout: [source (w), destination (w), owner (s)]
         #expect(ix.accounts[0].publicKey == senderUsdfAta)
         #expect(ix.accounts[1].publicKey == pdaAta)
         #expect(ix.accounts[2].publicKey == Self.sender)
-        #expect(ix.accounts[2].isSigner == true)
+        #expect(ix.accounts[2].isSigner)
     }
 
     // MARK: - Usdf::Swap account verification
@@ -120,7 +123,7 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
     func swap_userIsSender() {
         let ix = Self.makeInstructions()[6]
         #expect(ix.accounts[0].publicKey == Self.sender)
-        #expect(ix.accounts[0].isSigner == true)
+        #expect(ix.accounts[0].isSigner)
     }
 
     @Test("Swap pool, vaults match LiquidityPool.usdf")
@@ -132,9 +135,9 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
     }
 
     @Test("Swap userUsdfToken (account 4) is sender's USDF ATA")
-    func swap_userUsdfToken() {
+    func swap_userUsdfToken() throws {
         let ix = Self.makeInstructions()[6]
-        let expected = PublicKey.deriveAssociatedAccount(from: Self.sender, mint: .usdf)!.publicKey
+        let expected = try #require(PublicKey.deriveAssociatedAccount(from: Self.sender, mint: .usdf)).publicKey
         #expect(ix.accounts[4].publicKey == expected)
     }
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
@@ -1,0 +1,158 @@
+//
+//  SwapInstructionBuilderUsdcToUsdfTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("SwapInstructionBuilder.buildUsdcToUsdfSwapInstructions")
+struct SwapInstructionBuilderUsdcToUsdfTests {
+
+    // MARK: - Fixtures
+
+    /// 32-byte pubkey filled entirely with the seed byte. Mirrors the existing
+    /// UsdfToUsdc test suite.
+    private static func testKey(_ seed: Int) -> PublicKey {
+        try! PublicKey([UInt8](repeating: UInt8(seed), count: 32))
+    }
+
+    private static let sender  = testKey(1)
+    private static let owner   = testKey(2)
+    private static let swapId  = testKey(3)
+    private static let amount: UInt64 = 20_000_000
+
+    private static func makeInstructions(
+        amount: UInt64 = SwapInstructionBuilderUsdcToUsdfTests.amount
+    ) -> [Instruction] {
+        SwapInstructionBuilder.buildUsdcToUsdfSwapInstructions(
+            sender: sender,
+            owner: owner,
+            amount: amount,
+            pool: .usdf,
+            swapId: swapId
+        )
+    }
+
+    // MARK: - Instruction count
+
+    @Test("Produces exactly 8 instructions")
+    func produces8Instructions() {
+        #expect(Self.makeInstructions().count == 8)
+    }
+
+    // MARK: - Instruction order and programs
+
+    @Test("Instruction 0 is ComputeBudget SetComputeUnitLimit")
+    func instruction0_isComputeUnitLimit() {
+        let ix = Self.makeInstructions()[0]
+        #expect(ix.program == ComputeBudgetProgram.address)
+        #expect(ix.data.first == ComputeBudgetProgram.Command.setComputeUnitLimit.rawValue)
+    }
+
+    @Test("Instruction 1 is ComputeBudget SetComputeUnitPrice")
+    func instruction1_isComputeUnitPrice() {
+        let ix = Self.makeInstructions()[1]
+        #expect(ix.program == ComputeBudgetProgram.address)
+        #expect(ix.data.first == ComputeBudgetProgram.Command.setComputeUnitPrice.rawValue)
+    }
+
+    @Test("Instruction 2 is AssociatedTokenProgram CreateIdempotent for sender's USDF ATA")
+    func instruction2_createsSenderUsdfATA() {
+        let ix = Self.makeInstructions()[2]
+        // account layout: [payer (w,s), ata (w), owner, mint, system, token, rent]
+        #expect(ix.program == AssociatedTokenProgram.address)
+        #expect(ix.accounts[0].publicKey == Self.sender)
+        #expect(ix.accounts[0].isSigner == true)
+        #expect(ix.accounts[2].publicKey == Self.sender)
+        #expect(ix.accounts[3].publicKey == .usdf)
+    }
+
+    @Test("Instruction 3 is AssociatedTokenProgram CreateIdempotent for swap PDA's USDF ATA")
+    func instruction3_createsSwapPdaUsdfATA() {
+        let ix = Self.makeInstructions()[3]
+        let pdaPublicKey = MintMetadata.usdf.timelockSwapAccounts(owner: Self.owner)!.pda.publicKey
+        #expect(ix.program == AssociatedTokenProgram.address)
+        #expect(ix.accounts[0].publicKey == Self.sender)
+        #expect(ix.accounts[2].publicKey == pdaPublicKey)
+        #expect(ix.accounts[3].publicKey == .usdf)
+    }
+
+    @Test("Instruction 4 is AssociatedTokenProgram CreateIdempotent for sender's USDC ATA")
+    func instruction4_createsSenderUsdcATA() {
+        let ix = Self.makeInstructions()[4]
+        #expect(ix.program == AssociatedTokenProgram.address)
+        #expect(ix.accounts[0].publicKey == Self.sender)
+        #expect(ix.accounts[0].isSigner == true)
+        #expect(ix.accounts[2].publicKey == Self.sender)
+        #expect(ix.accounts[3].publicKey == .usdc)
+    }
+
+    @Test("Instruction 5 is Memo carrying the swap id")
+    func instruction5_isMemoWithSwapId() {
+        let ix = Self.makeInstructions()[5]
+        #expect(ix.program == MemoProgram.address)
+        #expect(ix.data == Data(Self.swapId.base58.utf8))
+    }
+
+    @Test("Instruction 6 is UsdfProgram Swap")
+    func instruction6_isUsdfSwap() {
+        #expect(Self.makeInstructions()[6].program == UsdfProgram.address)
+    }
+
+    @Test("Instruction 7 is TokenProgram Transfer to swap PDA's USDF ATA")
+    func instruction7_isTransferToSwapPdaAta() {
+        let ix = Self.makeInstructions()[7]
+        let pdaAta = MintMetadata.usdf.timelockSwapAccounts(owner: Self.owner)!.ata.publicKey
+        let senderUsdfAta = PublicKey.deriveAssociatedAccount(from: Self.sender, mint: .usdf)!.publicKey
+        #expect(ix.program == TokenProgram.address)
+        // account layout: [source (w), destination (w), owner (s)]
+        #expect(ix.accounts[0].publicKey == senderUsdfAta)
+        #expect(ix.accounts[1].publicKey == pdaAta)
+        #expect(ix.accounts[2].publicKey == Self.sender)
+        #expect(ix.accounts[2].isSigner == true)
+    }
+
+    // MARK: - Usdf::Swap account verification
+
+    @Test("Swap user (account 0) is sender and isSigner")
+    func swap_userIsSender() {
+        let ix = Self.makeInstructions()[6]
+        #expect(ix.accounts[0].publicKey == Self.sender)
+        #expect(ix.accounts[0].isSigner == true)
+    }
+
+    @Test("Swap pool, vaults match LiquidityPool.usdf")
+    func swap_poolAccounts() {
+        let ix = Self.makeInstructions()[6]
+        #expect(ix.accounts[1].publicKey == LiquidityPool.usdf.address)
+        #expect(ix.accounts[2].publicKey == LiquidityPool.usdf.usdfVault)
+        #expect(ix.accounts[3].publicKey == LiquidityPool.usdf.otherVault)
+    }
+
+    @Test("Swap userUsdfToken (account 4) is sender's USDF ATA")
+    func swap_userUsdfToken() {
+        let ix = Self.makeInstructions()[6]
+        let expected = PublicKey.deriveAssociatedAccount(from: Self.sender, mint: .usdf)!.publicKey
+        #expect(ix.accounts[4].publicKey == expected)
+    }
+
+    @Test("Swap userOtherToken (account 5) is the same USDC ATA address that instruction 4 creates")
+    func swap_userOtherToken() {
+        let instructions = Self.makeInstructions()
+        let createUsdcAta = instructions[4].accounts[1].publicKey
+        #expect(instructions[6].accounts[5].publicKey == createUsdcAta)
+    }
+
+    // MARK: - Discriminator + data layout
+
+    @Test("Swap data: command byte + amount(8 LE) + usdfToOther(1 byte = 0)")
+    func swap_dataLayout() {
+        let ix = Self.makeInstructions(amount: 20_000_000)[6]
+        #expect(ix.data.count == 1 + 8 + 1)
+        #expect(ix.data.first == UsdfProgram.Command.swap.rawValue)
+        #expect(UInt64(bytes: Array(ix.data[1..<9])) == 20_000_000)
+        #expect(ix.data.last == 0) // usdfToOther = false (USDC → USDF direction)
+    }
+}


### PR DESCRIPTION
## Summary

Some USDC-to-USDF swaps were failing simulation with `Invalid account owner` from the Usdf program. The cause is the swap reading the sender's USDC ATA as a Token-program account when that ATA has never been initialized for the connected wallet. The fix adds a `CreateIdempotent` for the USDC ATA before the swap so the account is guaranteed to be a valid Token account; it is a no-op when the ATA already exists.

## Test plan

- [x] Connect a Phantom wallet that has USDC but has never spent it (canonical USDC ATA uninitialized) and confirm a USDC-to-USDF swap now succeeds
- [x] Repeat with a wallet whose USDC ATA already exists and confirm there is no behavior change
- [x] New unit tests in FlipcashCoreTests pass