### PR TITLE
feat: restore bill designer with palette paste

### DIFF
--- a/Flipcash/Core/Screens/Main/Bill Designer/BillDesigner.swift
+++ b/Flipcash/Core/Screens/Main/Bill Designer/BillDesigner.swift
@@ -1,0 +1,64 @@
+//
+//  BillDesigner.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+public struct BillDesigner: View {
+
+    @Binding public var backgroundColors: [Color]
+
+    public init(backgroundColors: Binding<[Color]>) {
+        self._backgroundColors = backgroundColors
+    }
+
+    /// The view is intentionally transparent above the bottom gradient so the
+    /// underlying camera viewport on `ScanScreen` remains visible behind the
+    /// bill preview. Anything that should be hidden while the designer is up
+    /// (e.g. `ScanScreen`'s top/bottom bars) needs to be faded out by the
+    /// caller — don't add a background here.
+    public var body: some View {
+        VStack(spacing: 0) {
+            GeometryReader { geometry in
+                BillView(
+                    fiat: FiatAmount(value: 10, currency: .usd),
+                    data: .placeholder35,
+                    canvasSize: CGSize(
+                        width: geometry.size.width,
+                        height: geometry.size.height
+                    ),
+                    backgroundColors: backgroundColors
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .padding(.top, 20)
+
+            ColorEditorControl(colors: $backgroundColors)
+                .padding(.bottom, 20)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .ignoresSafeArea(.container, edges: .bottom)
+        .background(alignment: .bottom) {
+            LinearGradient(
+                gradient: Gradient(
+                    colors: [
+                        .init(white: 0),
+                        .clear,
+                    ]
+                ),
+                startPoint: .bottom,
+                endPoint: .top
+            )
+            .ignoresSafeArea(.container, edges: .bottom)
+        }
+    }
+}
+
+#Preview {
+    BillDesigner(
+        backgroundColors: .constant(ColorEditorControl.deriveColors(fromHue: 0.6))
+    )
+}

--- a/Flipcash/Core/Screens/Main/Bill Designer/BillDesignerOverlay.swift
+++ b/Flipcash/Core/Screens/Main/Bill Designer/BillDesignerOverlay.swift
@@ -1,0 +1,62 @@
+//
+//  BillDesignerOverlay.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+struct BillDesignerOverlay: View {
+
+    @Environment(Session.self) private var session
+
+    @Binding var colors: [Color]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Spacer()
+
+                Button(action: copyHexCodes) {
+                    ButtonIcon(systemName: "doc.on.doc")
+                }
+                .liquidGlassButtonStyle(shape: .circle)
+                .accessibilityLabel("Copy bill colors")
+
+                Button {
+                    session.isShowingBillDesigner = false
+                } label: {
+                    ButtonIcon(systemName: "xmark")
+                }
+                .liquidGlassButtonStyle(shape: .circle)
+                .accessibilityLabel("Close bill designer")
+            }
+            .padding(.horizontal, 16)
+
+            BillDesigner(backgroundColors: $colors)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    private func copyHexCodes() {
+        let hexColors = colors.map { $0.hexString }
+        UIPasteboard.general.string = hexColors.joined(separator: ", ")
+    }
+}
+
+private struct ButtonIcon: View {
+    let systemName: String
+
+    var body: some View {
+        if #available(iOS 26, *) {
+            Image(systemName: systemName)
+                .foregroundStyle(Color.textMain)
+                .frame(width: 32, height: 32)
+        } else {
+            Image(systemName: systemName)
+                .foregroundStyle(Color.textMain)
+                .frame(width: 44, height: 44)
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/Color Editor/ColorEditorControl.swift
+++ b/Flipcash/Core/Screens/Main/Color Editor/ColorEditorControl.swift
@@ -55,11 +55,7 @@ public struct ColorEditorControl: View {
     
     public var body: some View {
         VStack(spacing: 15) {
-            HStack(spacing: 8) {
-                removeButton
-                swatchRow
-                addButton
-            }
+            swatchRow
 
             panelContainer
         }
@@ -125,51 +121,6 @@ internal enum PanelMetrics {
 
 private extension ColorEditorControl {
 
-    var removeButton: some View {
-        Button {
-            if stops.count > 1 {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.9)) {
-                    stops.removeLast()
-                    if selectedIndex >= stops.count { 
-                        selectedIndex = max(0, stops.count - 1) 
-                    }
-                }
-            }
-        } label: {
-            ColorPickerButton(
-                systemName: "minus",
-                isEnabled: stops.count > 1
-            )
-        }
-        .buttonStyle(.plain)
-        .disabled(stops.count <= 1)
-    }
-    
-    var addButton: some View {
-        Button {
-            if stops.count < Self.maxStops {
-                let base = stops[selectedIndex]
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.9)) {
-                    stops.append(
-                        GradientStop(
-                            hue: base.hue,
-                            saturation: base.saturation,
-                            brightness: base.brightness
-                        )
-                    )
-                    selectedIndex = stops.count - 1
-                }
-            }
-        } label: {
-            ColorPickerButton(
-                systemName: "plus",
-                isEnabled: stops.count < Self.maxStops
-            )
-        }
-        .buttonStyle(.plain)
-        .disabled(stops.count >= Self.maxStops)
-    }
-    
     var swatchRow: some View {
         HStack(spacing: 8) {
             ForEach(Array(stops.enumerated()), id: \.element.id) { index, stop in
@@ -274,24 +225,6 @@ private extension ColorEditorControl {
 }
 
 // MARK: - Supporting Views
-
-private struct ColorPickerButton: View {
-    let systemName: String
-    let isEnabled: Bool
-    
-    var body: some View {
-        ZStack {
-            Color.clear
-                .frame(width: 44, height: 44)
-                .contentShape(Rectangle())
-            
-            Image(systemName: systemName)
-                .font(.system(size: 18, weight: .semibold))
-                .frame(width: 32, height: 32)
-                .foregroundStyle(.primary.opacity(isEnabled ? 1 : 0.35))
-        }
-    }
-}
 
 private struct ColorSwatch: View {
     let stop: GradientStop
@@ -405,13 +338,26 @@ private struct PresetTileView: View {
 // MARK: - Extensions
 
 extension ColorEditorControl {
-    /// Returns `maxStops` random colors sampled without replacement from
-    /// the solid presets.
-    public static func randomColors() -> [Color] {
-        GradientStop.solidPresets
-            .shuffled()
-            .prefix(maxStops)
-            .map(\.color)
+    /// Returns the three HSB-fixed colors used as the Bill Designer's
+    /// first-launch defaults: top (lightest) → bottom (darkest). The
+    /// caller-side order matches the gradient `BillView` paints after
+    /// reversing internally.
+    public static func deriveColors(fromHue hue: CGFloat) -> [Color] {
+        [
+            Color(hue: hue, saturation: 0.53, brightness: 1.00),
+            Color(hue: hue, saturation: 1.00, brightness: 0.71),
+            Color(hue: hue, saturation: 1.00, brightness: 0.23),
+        ]
+    }
+
+    /// Picks one random hue from `GradientStop.solidPresets`, skipping
+    /// the two degenerate (S:0) entries — White and Black — which would
+    /// collapse the derivation to a grayscale ramp.
+    public static func randomDerivedColors() -> [Color] {
+        let hue = GradientStop.solidPresets
+            .filter { $0.saturation > 0 }
+            .randomElement()?.hue ?? 0.6
+        return deriveColors(fromHue: hue)
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Color Editor/ColorEditorControl.swift
+++ b/Flipcash/Core/Screens/Main/Color Editor/ColorEditorControl.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import UIKit
+import FlipcashUI
 
 public struct ColorEditorControl: View {
     
@@ -149,8 +150,44 @@ private extension ColorEditorControl {
         }
         .animation(.spring(response: 0.45, dampingFraction: 0.9), value: stops.count)
         .animation(.spring(response: 0.45, dampingFraction: 0.9), value: selectedIndex)
+        .contextMenu {
+            // `hasStrings` is permissionless — long-press over an empty
+            // clipboard surfaces no menu, no OS prompt. The "Paste from app"
+            // alert only fires when the user actually taps Paste below.
+            // PasteButton would dodge the alert entirely but doesn't fit
+            // inside a context menu's item builder.
+            if UIPasteboard.general.hasStrings {
+                Button("Paste", systemImage: "doc.on.clipboard") {
+                    if let pasted = Self.parsePastedPalette(UIPasteboard.general.string) {
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            applyPastedColors(pasted)
+                        }
+                    }
+                }
+            }
+        }
     }
-    
+
+    /// Applies a pasted palette to `stops`. When the lengths match (the
+    /// common case after a round-trip from Copy), HSB values are mutated in
+    /// place so each `GradientStop.id` is preserved and the swatches
+    /// crossfade smoothly through their identity-stable views — mirroring
+    /// the presets path. When the lengths differ, falls back to wholesale
+    /// replacement, which triggers the existing collapse/expand transitions.
+    func applyPastedColors(_ colors: [Color]) {
+        if stops.count == colors.count {
+            for (index, color) in colors.enumerated() {
+                let hsb = GradientStop(from: color)
+                stops[index].hue = hsb.hue
+                stops[index].saturation = hsb.saturation
+                stops[index].brightness = hsb.brightness
+                stops[index].alpha = hsb.alpha
+            }
+        } else {
+            stops = colors.map(GradientStop.init(from:))
+        }
+    }
+
     var panelContainer: some View {
         GeometryReader { geo in
             let width = geo.size.width
@@ -358,6 +395,37 @@ extension ColorEditorControl {
             .filter { $0.saturation > 0 }
             .randomElement()?.hue ?? 0.6
         return deriveColors(fromHue: hue)
+    }
+}
+
+// MARK: - Clipboard parsing
+
+extension ColorEditorControl {
+
+    /// Parses the exact format produced by the Copy button:
+    /// `"#RRGGBB, #RRGGBB, #RRGGBB"`. Returns nil if the input doesn't
+    /// contain exactly 3 valid `#RRGGBB` tokens. Tolerant of outer
+    /// whitespace, case, and whitespace around commas; rejects shorthand
+    /// `#RGB`, alpha, missing `#`, or counts ≠ 3.
+    public static func parsePastedPalette(_ string: String?) -> [Color]? {
+        guard let string else { return nil }
+
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let components = trimmed
+            .split(separator: ",", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+        guard components.count == 3 else { return nil }
+
+        let colors = components.compactMap { component -> Color? in
+            guard component.hasPrefix("#") else { return nil }
+            return Color(hex: component)
+        }
+
+        guard colors.count == 3 else { return nil }
+        return colors
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationScreen.swift
@@ -46,7 +46,7 @@ final class CurrencyCreationState {
     var currencyDescription: String = "" {
         didSet { if currencyDescription != oldValue { descriptionAttestation = nil } }
     }
-    var backgroundColors: [Color] = ColorEditorControl.randomColors()
+    var backgroundColors: [Color] = ColorEditorControl.randomDerivedColors()
 
     // Attestations (cleared by the setters above when the corresponding field changes)
     var nameAttestation: ModerationAttestation?

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -26,6 +26,7 @@ struct ScanScreen: View {
 
     @State private var sendButtonState: ButtonState = .normal
     @State private var sendButtonTask: Task<Void, Never>?
+    @State private var billDesignerColors: [Color] = ColorEditorControl.randomDerivedColors()
 
     private var toast: String? {
         if let toast = session.toast {
@@ -117,10 +118,17 @@ struct ScanScreen: View {
                     .zIndex(1)
                     .transition(.opacity)
             }
+
+            if session.isShowingBillDesigner {
+                BillDesignerOverlay(colors: $billDesignerColors)
+                    .zIndex(2)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
         .background(Color.backgroundMain)
         .animation(.easeInOut(duration: 0.15), value: showControls)
         .animation(.easeInOut(duration: 0.3), value: preferences.cameraEnabled)
+        .animation(.spring(response: 0.4, dampingFraction: 0.85), value: session.isShowingBillDesigner)
         .ignoresSafeArea(.keyboard)
         .sheet(item: $session.valuation) { valuation in
             PartialSheet(background: .clear, canAccessBackground: true) {
@@ -251,6 +259,7 @@ struct ScanScreen: View {
             Spacer()
             bottomBar()
         }
+        .opacity(session.isShowingBillDesigner ? 0 : 1)
     }
     
     @ViewBuilder private func billActions() -> some View {

--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
@@ -6,33 +6,38 @@
 //
 
 import SwiftUI
+import FlipcashCore
 import FlipcashUI
 
 struct SettingsAdvancedFeaturesScreen: View {
 
     @Environment(AppRouter.self) private var router
+    @Environment(Session.self) private var session
 
     private let insets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
 
     var body: some View {
         Background(color: .backgroundMain) {
             ScrollView(showsIndicators: false) {
-                list()
+                VStack(alignment: .leading, spacing: 0) {
+                    SettingsRow(systemImage: "slider.horizontal.3", title: "Bill Designer", insets: insets) {
+                        Task {
+                            router.dismissSheet()
+                            try await Task.delay(milliseconds: 250)
+                            session.isShowingBillDesigner = true
+                        }
+                    }
+
+                    SettingsRow(systemImage: "doc.text", title: "Application Logs", insets: insets) {
+                        router.push(.settingsApplicationLogs)
+                    }
+                }
+                .font(.appDisplayXS)
+                .foregroundStyle(.textMain)
             }
             .padding(.horizontal, 20)
         }
         .navigationTitle("Advanced Features")
         .navigationBarTitleDisplayMode(.inline)
-    }
-
-    @ViewBuilder
-    private func list() -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            SettingsRow(systemImage: "doc.text", title: "Application Logs", insets: insets) {
-                router.push(.settingsApplicationLogs)
-            }
-        }
-        .font(.appDisplayXS)
-        .foregroundStyle(.textMain)
     }
 }

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -54,6 +54,10 @@ class Session {
     /// ``DialogWindow`` in a separate `UIWindow` above all sheets.
     var dialogItem: DialogItem?
 
+    /// Whether the standalone Bill Designer overlay is presented over
+    /// the scan screen. Toggled by the Settings → Advanced Features row.
+    var isShowingBillDesigner: Bool = false
+
     // MARK: - User State -
 
     /// Server-fetched user profile.

--- a/FlipcashTests/BillDesignerColorsTests.swift
+++ b/FlipcashTests/BillDesignerColorsTests.swift
@@ -1,0 +1,109 @@
+//
+//  BillDesignerColorsTests.swift
+//  FlipcashTests
+//
+//  Pin the bill designer's hue derivation: a single random hue must
+//  expand into three HSB-fixed colors that round-trip cleanly through
+//  the hex pipeline used by the launch payload.
+//
+
+import Testing
+import SwiftUI
+import UIKit
+import FlipcashUI
+@testable import Flipcash
+
+@Suite("Bill Designer color derivation")
+struct BillDesignerColorsTests {
+
+    private static let lightSaturation: CGFloat = 0.53
+    private static let lightBrightness: CGFloat = 1.00
+    private static let midSaturation:   CGFloat = 1.00
+    private static let midBrightness:   CGFloat = 0.71
+    private static let darkSaturation:  CGFloat = 1.00
+    private static let darkBrightness:  CGFloat = 0.23
+
+    @Test(
+        "deriveColors produces the spec's HSB triple for any hue",
+        arguments: [0.0, 0.08, 0.34, 0.5, 0.6, 0.75, 0.95] as [CGFloat]
+    )
+    func derivesExpectedHSB(hue: CGFloat) throws {
+        let result = ColorEditorControl.deriveColors(fromHue: hue)
+
+        try #require(result.count == 3)
+
+        let expected: [(s: CGFloat, b: CGFloat)] = [
+            (Self.lightSaturation, Self.lightBrightness),
+            (Self.midSaturation,   Self.midBrightness),
+            (Self.darkSaturation,  Self.darkBrightness),
+        ]
+
+        for (index, color) in result.enumerated() {
+            let components = hsb(of: color)
+            #expect(
+                abs(components.h - hue) < 0.005,
+                "color[\(index)] hue \(components.h) should match input \(hue)"
+            )
+            #expect(
+                abs(components.s - expected[index].s) < 0.005,
+                "color[\(index)] saturation \(components.s) should be \(expected[index].s)"
+            )
+            #expect(
+                abs(components.b - expected[index].b) < 0.005,
+                "color[\(index)] brightness \(components.b) should be \(expected[index].b)"
+            )
+        }
+    }
+
+    @Test("slot ordering paints lightest at top, darkest at bottom")
+    func slotOrdering() throws {
+        let result = ColorEditorControl.deriveColors(fromHue: 0.6)
+        try #require(result.count == 3)
+
+        let bs = result.map { hsb(of: $0).b }
+        #expect(bs[0] > bs[1], "slot 0 must be brighter than slot 1")
+        #expect(bs[1] > bs[2], "slot 1 must be brighter than slot 2")
+    }
+
+    @Test(
+        "hex round-trip is stable for derived colors",
+        arguments: [0.0, 0.08, 0.34, 0.5, 0.6, 0.75, 0.95] as [CGFloat]
+    )
+    func hexRoundTripStable(hue: CGFloat) throws {
+        let derived = ColorEditorControl.deriveColors(fromHue: hue)
+
+        for color in derived {
+            let firstHex = color.hexString
+            let parsed = try #require(Color(hex: firstHex))
+            let secondHex = parsed.hexString
+            #expect(
+                firstHex == secondHex,
+                "hex round-trip drifted: \(firstHex) → \(secondHex) for hue \(hue)"
+            )
+        }
+    }
+
+    @Test("randomDerivedColors never seeds from a degenerate (S:0) preset")
+    func randomSourceSkipsDegenerates() throws {
+        for _ in 0..<200 {
+            let colors = ColorEditorControl.randomDerivedColors()
+            try #require(colors.count == 3)
+            for color in colors {
+                let components = hsb(of: color)
+                #expect(
+                    components.s > 0.0,
+                    "saturation \(components.s) implies seed came from a White/Black preset"
+                )
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func hsb(of color: Color) -> (h: CGFloat, s: CGFloat, b: CGFloat) {
+        let uiColor = UIColor(color)
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uiColor.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        return (h, s, b)
+    }
+}

--- a/FlipcashTests/ColorEditorControlTests.swift
+++ b/FlipcashTests/ColorEditorControlTests.swift
@@ -9,6 +9,7 @@
 
 import Testing
 import SwiftUI
+import FlipcashUI
 @testable import Flipcash
 
 @Suite("ColorEditorControl")
@@ -57,5 +58,115 @@ struct ColorEditorControlTests {
         #expect(abs(stops[0].hue - 0.6) < 0.001)
         #expect(abs(stops[0].saturation - 0.7) < 0.001)
         #expect(abs(stops[0].brightness - 0.9) < 0.001)
+    }
+}
+
+@MainActor
+@Suite("ColorEditorControl.parsePastedPalette")
+struct ColorEditorControlPasteTests {
+
+    // MARK: - Valid inputs
+
+    @Test("Exact format produced by Copy yields three colors")
+    func exactFormat() throws {
+        let pasted = try #require(
+            ColorEditorControl.parsePastedPalette("#FF0000, #00FF00, #0000FF")
+        )
+        #expect(pasted.count == 3)
+        #expect(pasted[0].hexString == "#FF0000")
+        #expect(pasted[1].hexString == "#00FF00")
+        #expect(pasted[2].hexString == "#0000FF")
+    }
+
+    @Test("Lowercase hex digits are accepted")
+    func lowercase() throws {
+        let pasted = try #require(
+            ColorEditorControl.parsePastedPalette("#ff0000, #00ff00, #0000ff")
+        )
+        #expect(pasted.count == 3)
+    }
+
+    @Test("Trailing newline is tolerated")
+    func trailingNewline() throws {
+        let pasted = try #require(
+            ColorEditorControl.parsePastedPalette("#FF0000, #00FF00, #0000FF\n")
+        )
+        #expect(pasted.count == 3)
+    }
+
+    @Test("Missing whitespace around commas is tolerated")
+    func noSpaces() throws {
+        let pasted = try #require(
+            ColorEditorControl.parsePastedPalette("#FF0000,#00FF00,#0000FF")
+        )
+        #expect(pasted.count == 3)
+    }
+
+    @Test("Outer whitespace is tolerated")
+    func outerWhitespace() throws {
+        let pasted = try #require(
+            ColorEditorControl.parsePastedPalette("  #FF0000, #00FF00, #0000FF  ")
+        )
+        #expect(pasted.count == 3)
+    }
+
+    @Test("Round-trip from Copy format yields the same hex strings")
+    func roundTripFromCopy() throws {
+        let original: [Color] = [
+            Color(hue: 0.00, saturation: 0.9, brightness: 0.95),
+            Color(hue: 0.34, saturation: 0.8, brightness: 0.90),
+            Color(hue: 0.60, saturation: 0.75, brightness: 0.85),
+        ]
+        let copyOutput = original.map(\.hexString).joined(separator: ", ")
+        let parsed = try #require(ColorEditorControl.parsePastedPalette(copyOutput))
+        #expect(parsed.map(\.hexString) == original.map(\.hexString))
+    }
+
+    // MARK: - Invalid inputs
+
+    @Test("Nil input returns nil")
+    func nilInput() {
+        #expect(ColorEditorControl.parsePastedPalette(nil) == nil)
+    }
+
+    @Test("Empty string returns nil")
+    func emptyInput() {
+        #expect(ColorEditorControl.parsePastedPalette("") == nil)
+    }
+
+    @Test(
+        "Wrong number of hexes returns nil",
+        arguments: [
+            "#FF0000",
+            "#FF0000, #00FF00",
+            "#FF0000, #00FF00, #0000FF, #FFFFFF",
+        ]
+    )
+    func wrongCount(input: String) {
+        #expect(ColorEditorControl.parsePastedPalette(input) == nil)
+    }
+
+    @Test("Non-hex content returns nil")
+    func nonHexContent() {
+        #expect(ColorEditorControl.parsePastedPalette("red, green, blue") == nil)
+    }
+
+    @Test("Shorthand hex returns nil")
+    func shorthandHex() {
+        #expect(ColorEditorControl.parsePastedPalette("#FFF, #000, #00F") == nil)
+    }
+
+    @Test("Hex with alpha (8 chars) returns nil")
+    func hexWithAlpha() {
+        #expect(
+            ColorEditorControl.parsePastedPalette("#FF0000FF, #00FF00FF, #0000FFFF") == nil
+        )
+    }
+
+    @Test("Missing # prefix returns nil")
+    func missingHashPrefix() {
+        #expect(
+            ColorEditorControl.parsePastedPalette("FF0000, 00FF00, 0000FF") == nil
+        )
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
@@ -78,7 +78,10 @@ extension Color {
 
     /// Renders the Color as a `#RRGGBB` hex string. Resolves through `UIColor`
     /// so SwiftUI's dynamic colors flatten to their current trait collection's
-    /// concrete values.
+    /// concrete values. Rounds component products to keep
+    /// `Color(hex: c.hexString)?.hexString == c.hexString` — truncating leaks
+    /// a 1-bit drift on the round-trip because `n/255 * 255` is just under `n`
+    /// in floating point.
     public var hexString: String {
         let uiColor = UIColor(self)
         var red:   CGFloat = 0
@@ -87,7 +90,10 @@ extension Color {
         var alpha: CGFloat = 0
         uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
-        let rgb = Int(red * 255) << 16 | Int(green * 255) << 8 | Int(blue * 255)
+        let r = Int((red   * 255).rounded())
+        let g = Int((green * 255).rounded())
+        let b = Int((blue  * 255).rounded())
+        let rgb = r << 16 | g << 8 | b
         return String(format: "#%06X", rgb)
     }
 }


### PR DESCRIPTION
## Summary
Restores the Bill Designer screen in Advanced Features and adds clipboard paste support to the swatch row. Long-pressing the swatch row now shows a Paste menu when the clipboard contains a valid three-color palette in the same format the Copy button writes. Both the Bill Designer and the Currency Creation flow pick this up since they share the same color editor.

## Test plan
- [x] Bill Designer copies a palette and pastes it back to the same swatches
- [x] Currency Creation pastes a palette copied from the Bill Designer
- [x] Long-pressing with a non-palette clipboard shows Paste but applying it does nothing
- [x] Long-pressing with an empty clipboard shows no menu and no system prompts