### PR TITLE
fix: poller backpressure and onboarding cleanup

### DIFF
--- a/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
@@ -22,7 +22,6 @@ class OnboardingViewModel {
     private(set) var inflightMnemonic: MnemonicPhrase = .generate(.words12)
 
     @ObservationIgnored private let container: Container
-    @ObservationIgnored private let flipClient: FlipClient
     @ObservationIgnored private let sessionAuthenticator: SessionAuthenticator
     @ObservationIgnored private var initializedAccount: InitializedAccount?
 
@@ -30,7 +29,6 @@ class OnboardingViewModel {
 
     init(container: Container) {
         self.container            = container
-        self.flipClient           = container.flipClient
         self.sessionAuthenticator = container.sessionAuthenticator
     }
 
@@ -145,8 +143,6 @@ class OnboardingViewModel {
         ) {
             .okay(kind: .destructive)
         }
-
-        ErrorReporting.captureError(error)
     }
 
     func recoverExistingAccount(accountDescription: AccountDescription) {
@@ -222,8 +218,6 @@ class OnboardingViewModel {
         let owner = mnemonic.solanaKeyPair()
 
         Analytics.createAccount(owner: owner.publicKey)
-
-        try await flipClient.register(owner: owner)
 
         let account = try await sessionAuthenticator.initialize(
             using: mnemonic,

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -427,20 +427,13 @@ class Session {
     }
     
     // MARK: - Poller -
-    
+
     private func registerPoller() {
         poller = Poller(seconds: 10, fireImmediately: true) { [weak self] in
-            Task {
-                try await self?.poll()
-            }
+            // Limits failure must not block balance fetch
+            try? await self?.fetchLimitsIfNeeded()
+            try? await self?.fetchBalance()
         }
-    }
-    
-    private var didAttemptBuy = false
-    private func poll() async throws {
-        // Limits failure must not block balance fetch
-        try? await fetchLimitsIfNeeded()
-        try await fetchBalance()
     }
     
     // MARK: - Limits -

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -305,9 +305,16 @@ final class SessionAuthenticator {
         
         do {
             let userID: UserID
-            
-            // Create VM accounts first, this is a no-op
-            // if the accounts have been previously created
+
+            // Register/login first: the OCP antispam guard for createAccounts
+            // requires the owner to already exist as a Flipcash user.
+            if isRegistration {
+                userID = try await flipClient.register(owner: keyAccount.owner)
+            } else {
+                userID = try await flipClient.login(owner: keyAccount.owner)
+            }
+
+            // No-op when accounts already exist.
             try await client.createAccounts(
                 owner: cluster.authority.keyPair,
                 mint: .usdf, // USDF is the foundation mint
@@ -315,13 +322,7 @@ final class SessionAuthenticator {
                 kind: .primary,
                 derivationIndex: 0
             )
-            
-            if isRegistration {
-                userID = try await flipClient.register(owner: keyAccount.owner)
-            } else {
-                userID = try await flipClient.login(owner: keyAccount.owner)
-            }
-            
+
             accountManager.set(
                 keyAccount: keyAccount,
                 userID: userID

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -170,10 +170,8 @@ final class SessionAuthenticator {
     /// logged in).
     private func startPolling() {
         poller = Poller(seconds: 30, fireImmediately: true) { [weak self] in
-            Task {
-                await self?.fetchUnauthenticatedUserFlags()
-                await self?.checkForUnusableAccount()
-            }
+            await self?.fetchUnauthenticatedUserFlags()
+            await self?.checkForUnusableAccount()
         }
     }
 


### PR DESCRIPTION
## Summary

Two changes that came out of the registration-time error burst we saw in the logs. The session-state pollers were spawning detached child tasks per tick instead of awaiting the work, so each tick fired regardless of whether the previous one had finished — a flaky channel could stack dozens of in-flight calls that all failed when the transport eventually died. Tightened that so the existing serialization actually applies. Also straightened out a redundant register call in the onboarding flow and the call ordering inside the session authenticator that was masking the redundancy.

## Test plan

- [x] Register a brand new account and confirm onboarding completes
- [x] Recover an existing account and confirm login still works
- [x] Switch between accounts and confirm the active session changes
- [x] Cold launch and confirm the home screen balance refreshes
- [x] Background the app for several minutes, resume, and confirm the balance still updates