### PR TITLE
fix: scanner still opens at 0.5× on multi-lens iPhones

### DIFF
--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -256,11 +256,6 @@ struct ScanScreen: View {
     @ViewBuilder private func interfaceView() -> some View {
         VStack {
             ScanTopBar { router.present(.settings) }
-            // FIXME(camera-zoom): temporary diagnostic so users can report the
-            // exact zoom level they see while we verify the half-zoom fix on
-            // multi-lens iPhones. Remove once we have a clean report.
-            ZoomDiagnosticPill(cameraSession: viewModel.cameraSession)
-                .padding(.top, 8)
             Spacer()
             ScanBottomBar(
                 toast: toast,
@@ -333,38 +328,6 @@ struct ScanScreen: View {
 extension String: @retroactive Identifiable {
     public var id: String {
         self
-    }
-}
-
-// MARK: - ZoomDiagnosticPill -
-
-/// Temporary on-screen readout of the current camera zoom, formatted in the
-/// same units the iOS Camera app shows (`0.5×`, `1×`, `1.2×`, …). Lets
-/// TestFlight users on multi-lens iPhones report exactly what zoom they see
-/// while we verify the half-zoom fix.
-private struct ZoomDiagnosticPill: View {
-
-    let cameraSession: CameraSession<CodeExtractor>
-
-    var body: some View {
-        TimelineView(.periodic(from: .now, by: 0.1)) { _ in
-            Text(formatted(cameraSession.displayZoomFactor))
-                .font(.system(size: 14, weight: .semibold).monospacedDigit())
-                .foregroundStyle(.white)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(Color.black.opacity(0.55), in: Capsule())
-        }
-        .accessibilityHidden(true)
-        .allowsHitTesting(false)
-    }
-
-    private func formatted(_ value: CGFloat) -> String {
-        let rounded = (value * 10).rounded() / 10
-        if rounded == floor(rounded) {
-            return "\(Int(rounded))×"
-        }
-        return String(format: "%.1f×", rounded)
     }
 }
 

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -256,6 +256,11 @@ struct ScanScreen: View {
     @ViewBuilder private func interfaceView() -> some View {
         VStack {
             ScanTopBar { router.present(.settings) }
+            // FIXME(camera-zoom): temporary diagnostic so users can report the
+            // exact zoom level they see while we verify the half-zoom fix on
+            // multi-lens iPhones. Remove once we have a clean report.
+            ZoomDiagnosticPill(cameraSession: viewModel.cameraSession)
+                .padding(.top, 8)
             Spacer()
             ScanBottomBar(
                 toast: toast,
@@ -328,6 +333,38 @@ struct ScanScreen: View {
 extension String: @retroactive Identifiable {
     public var id: String {
         self
+    }
+}
+
+// MARK: - ZoomDiagnosticPill -
+
+/// Temporary on-screen readout of the current camera zoom, formatted in the
+/// same units the iOS Camera app shows (`0.5×`, `1×`, `1.2×`, …). Lets
+/// TestFlight users on multi-lens iPhones report exactly what zoom they see
+/// while we verify the half-zoom fix.
+private struct ZoomDiagnosticPill: View {
+
+    let cameraSession: CameraSession<CodeExtractor>
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 0.1)) { _ in
+            Text(formatted(cameraSession.displayZoomFactor))
+                .font(.system(size: 14, weight: .semibold).monospacedDigit())
+                .foregroundStyle(.white)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color.black.opacity(0.55), in: Capsule())
+        }
+        .accessibilityHidden(true)
+        .allowsHitTesting(false)
+    }
+
+    private func formatted(_ value: CGFloat) -> String {
+        let rounded = (value * 10).rounded() / 10
+        if rounded == floor(rounded) {
+            return "\(Int(rounded))×"
+        }
+        return String(format: "%.1f×", rounded)
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
@@ -32,7 +32,7 @@ public protocol AnyCameraSession {
 
 @MainActor
 public class CameraSession<T>: ObservableObject, AnyCameraSession where T: CameraSessionExtractor {
-    
+
     public private(set) var extraction = PassthroughSubject<T.Output?, Never>()
     /// Publishes raw string values detected from QR codes via `AVCaptureMetadataOutput`.
     /// Only fires when a new, distinct QR code is detected (duplicate consecutive frames are filtered).
@@ -40,6 +40,20 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession where T: Camer
 
     public let extractor: T
     public let session: AVCaptureSession
+
+    /// Zoom factor in the same units the iOS Camera app shows (`0.5`, `1`, `2`, …).
+    /// On a virtual device that leads with an ultrawide constituent, `videoZoomFactor`
+    /// is in the ultrawide's units (`1.0` = ultrawide = "0.5×"); this property divides
+    /// it by the wide-angle threshold so the value matches what the user sees.
+    public var displayZoomFactor: CGFloat {
+        guard let device = activeBackDevice else { return 1.0 }
+        let denominator = device.wideStartZoomFactor
+        return denominator > 0 ? device.videoZoomFactor / denominator : device.videoZoomFactor
+    }
+
+    private var activeBackDevice: AVCaptureDevice? {
+        (session.inputs.first as? AVCaptureDeviceInput)?.device
+    }
 
     private var isConfigured: Bool = false
     private let videoDelegate: VideoDelegate
@@ -82,10 +96,9 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession where T: Camer
             session.sessionPreset = .hd1920x1080
         }
         
-        // Inputs
-
-        // Virtual devices first — AVFoundation handles ultrawide/wide/telephoto
-        // switching automatically as the user pinches across zoom thresholds.
+        // Resolve a virtual capture device first so AVFoundation handles
+        // ultrawide/wide/telephoto switching automatically as the user pinches
+        // across zoom thresholds.
         let preferred: [AVCaptureDevice.DeviceType] = [
             .builtInTripleCamera,
             .builtInDualWideCamera,
@@ -102,43 +115,11 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession where T: Camer
             throw Error.deviceUnavailable
         }
 
-        // Tune the camera for close‑range, high‑speed code scanning
-        try device.lockForConfiguration()
-
-        // Focus configuration
-        if device.isAutoFocusRangeRestrictionSupported {
-            device.autoFocusRangeRestriction = .near
-        }
-        if device.isFocusModeSupported(.continuousAutoFocus) {
-            device.focusMode = .continuousAutoFocus
-        }
-        if device.isFocusPointOfInterestSupported {
-            device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
-        }
-
-        // Exposure configuration
-        if device.isExposureModeSupported(.continuousAutoExposure) {
-            device.exposureMode = .continuousAutoExposure
-        }
-        if device.isExposurePointOfInterestSupported {
-            device.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
-        }
-
-        // White‑balance configuration
-        if device.isWhiteBalanceModeSupported(.continuousAutoWhiteBalance) {
-            device.whiteBalanceMode = .continuousAutoWhiteBalance
-        }
-
-        // Low‑light boost
-        if device.isLowLightBoostSupported {
-            device.automaticallyEnablesLowLightBoostWhenAvailable = true
-        }
-
-        // Default to the wide-angle lens on multi-lens devices that lead with
-        // an ultrawide. Without this, iPhone Pro / Plus models open at 0.5×.
-        device.videoZoomFactor = device.wideStartZoomFactor
-
-        device.unlockForConfiguration()
+        // Add input + outputs BEFORE tuning the device. `session.addInput`
+        // and the deferred `commitConfiguration` set the device's
+        // `activeFormat` to match the session preset, which resets
+        // format-dependent properties like `videoZoomFactor`. Tuning
+        // afterwards lets the values we write be the last ones standing.
 
         guard let input = try? AVCaptureDeviceInput(device: device) else {
             throw Error.inputCreationFailed
@@ -149,19 +130,15 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession where T: Camer
         }
 
         session.addInput(input)
-        
-        // Outputs
-        
+
         let output = AVCaptureVideoDataOutput()
         output.setSampleBufferDelegate(videoDelegate, queue: videoDelegate.queue)
-        
+
         guard session.canAddOutput(output) else {
             throw Error.outputAddFailed
         }
-        
-        session.addOutput(output)
 
-        // QR Code Output
+        session.addOutput(output)
 
         let metadataOutput = AVCaptureMetadataOutput()
         metadataOutput.setMetadataObjectsDelegate(metadataDelegate, queue: metadataDelegate.queue)
@@ -174,6 +151,41 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession where T: Camer
                 metadataOutput.metadataObjectTypes = [.qr]
             }
         }
+
+        // Tune the camera for close-range, high-speed code scanning.
+        try device.lockForConfiguration()
+
+        if device.isAutoFocusRangeRestrictionSupported {
+            device.autoFocusRangeRestriction = .near
+        }
+        if device.isFocusModeSupported(.continuousAutoFocus) {
+            device.focusMode = .continuousAutoFocus
+        }
+        if device.isFocusPointOfInterestSupported {
+            device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
+        }
+
+        if device.isExposureModeSupported(.continuousAutoExposure) {
+            device.exposureMode = .continuousAutoExposure
+        }
+        if device.isExposurePointOfInterestSupported {
+            device.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
+        }
+
+        if device.isWhiteBalanceModeSupported(.continuousAutoWhiteBalance) {
+            device.whiteBalanceMode = .continuousAutoWhiteBalance
+        }
+
+        if device.isLowLightBoostSupported {
+            device.automaticallyEnablesLowLightBoostWhenAvailable = true
+        }
+
+        // Open at the wide-angle lens on multi-lens devices that lead with an
+        // ultrawide so the scanner starts at "1×" instead of the ultrawide
+        // constituent's "0.5×".
+        device.videoZoomFactor = device.wideStartZoomFactor
+
+        device.unlockForConfiguration()
 
         isConfigured = true
     }

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
@@ -41,20 +41,6 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession where T: Camer
     public let extractor: T
     public let session: AVCaptureSession
 
-    /// Zoom factor in the same units the iOS Camera app shows (`0.5`, `1`, `2`, …).
-    /// On a virtual device that leads with an ultrawide constituent, `videoZoomFactor`
-    /// is in the ultrawide's units (`1.0` = ultrawide = "0.5×"); this property divides
-    /// it by the wide-angle threshold so the value matches what the user sees.
-    public var displayZoomFactor: CGFloat {
-        guard let device = activeBackDevice else { return 1.0 }
-        let denominator = device.wideStartZoomFactor
-        return denominator > 0 ? device.videoZoomFactor / denominator : device.videoZoomFactor
-    }
-
-    private var activeBackDevice: AVCaptureDevice? {
-        (session.inputs.first as? AVCaptureDeviceInput)?.device
-    }
-
     private var isConfigured: Bool = false
     private let videoDelegate: VideoDelegate
     private let metadataDelegate: MetadataDelegate


### PR DESCRIPTION
## Summary
- The earlier attempt at this fix was clobbered by AVFoundation: setting the initial zoom before adding the input doesn't stick, because adding an input makes the session pick an active format for the chosen preset and that reset wipes the zoom value.
- Tuning now runs after the input and outputs are wired up, so the zoom write is the last thing the session sees and survives commit.
- Verified via a TestFlight build with a temporary on-screen zoom pill that multi-lens iPhones now open the scanner at 1×; the pill has been removed in the second commit on this branch.

## Test plan
- [x] Open scanner on a multi-lens iPhone (Pro / Plus / Dual Wide) — opens at 1×, not 0.5×
- [x] Pinch out — switches to telephoto smoothly without going blurry
- [x] Release pinch — snaps back to 1×
- [x] Open scanner on a single-lens iPhone — opens at 1× as before