### PR TITLE
chore: ui polish across settings, bill designer, and discovery promo

### DIFF
--- a/Flipcash/Core/Screens/Main/Bill Designer/BillDesignerOverlay.swift
+++ b/Flipcash/Core/Screens/Main/Bill Designer/BillDesignerOverlay.swift
@@ -52,10 +52,12 @@ private struct ButtonIcon: View {
         if #available(iOS 26, *) {
             Image(systemName: systemName)
                 .foregroundStyle(Color.textMain)
+                .font(.appTextLarge)
                 .frame(width: 32, height: 32)
         } else {
             Image(systemName: systemName)
                 .foregroundStyle(Color.textMain)
+                .font(.appTextLarge)
                 .frame(width: 44, height: 44)
         }
     }

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyCreationPromoCard.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyCreationPromoCard.swift
@@ -7,10 +7,10 @@ import SwiftUI
 import FlipcashUI
 
 struct CurrencyCreationPromoCard: View {
-    let onCreate: () -> Void
+    let action: () -> Void
 
     var body: some View {
-        Button(action: onCreate) {
+        Button(action: action) {
             VStack(alignment: .leading, spacing: 6) {
                 HStack(spacing: 8) {
                     Text("Create Your Own Currency")
@@ -26,11 +26,11 @@ struct CurrencyCreationPromoCard: View {
             }
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(alignment: .trailing) {
+            .background(alignment: .bottomTrailing) {
                 Image(.CurrencyDiscovery.bills)
                     .resizable()
                     .scaledToFit()
-                    .frame(width: 120, height: 120)
+                    .frame(width: 120)
             }
             .background(Color.backgroundRow)
             .compositingGroup()

--- a/Flipcash/Core/Screens/Settings/SettingsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsScreen.swift
@@ -35,8 +35,8 @@ struct SettingsScreen: View {
         NavigationStack(path: $router[.settings]) {
             Background(color: .backgroundMain) {
                 ScrollView(showsIndicators: false) {
-                    VStack(spacing: 20) {
-                        HStack(spacing: 10) {
+                    VStack(spacing: 6) {
+                        HStack(spacing: 12) {
                             Button("Deposit") {
                                 router.push(.depositCurrencyList)
                             }


### PR DESCRIPTION
## Summary
- Tighten spacing on the Settings screen header buttons.
- Bump the bill designer overlay icon size so the glyphs match the button footprint.
- Reposition the bills illustration on the currency creation promo card so it anchors to the bottom-trailing corner.

## Test plan
- [x] Open Settings and confirm the top action row spacing looks right.
- [x] Open the bill designer overlay and confirm the toolbar icons are correctly sized on iOS 26 and earlier.
- [x] Open Discovery and confirm the create-currency promo card image sits flush with the bottom-right corner.