### PR TITLE
fix: cross-section swipe glitch in region picker

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
@@ -30,20 +30,24 @@ struct CurrencySelectionScreen: View {
                         if viewModel.isSearching {
                             Section(header: ListHeader("Results")) {
                                 ForEach(viewModel.searchingCurrencies) { description in
-                                    CurrencyRow(description: description, viewModel: viewModel, allowDelete: false, dismiss: dismiss)
+                                    CurrencyRow(description: description, viewModel: viewModel, allowDelete: false)
                                 }
                             }
                         } else {
                             if !viewModel.availableRecentCurrencies.isEmpty {
                                 Section(header: ListHeader("Recent Regions")) {
                                     ForEach(viewModel.availableRecentCurrencies) { description in
-                                        CurrencyRow(description: description, viewModel: viewModel, allowDelete: true, dismiss: dismiss)
+                                        CurrencyRow(
+                                            description: description,
+                                            viewModel: viewModel,
+                                            allowDelete: !viewModel.isCurrencyActive(description.currency)
+                                        )
                                     }
                                 }
                             }
                             Section(header: ListHeader("Other Regions")) {
                                 ForEach(viewModel.availableCurrencies) { description in
-                                    CurrencyRow(description: description, viewModel: viewModel, allowDelete: false, dismiss: dismiss)
+                                    CurrencyRow(description: description, viewModel: viewModel, allowDelete: false)
                                 }
                             }
                         }
@@ -74,7 +78,28 @@ private struct CurrencyRow: View {
     let description: CurrencyDescription
     let viewModel: CurrencySelectionViewModel
     let allowDelete: Bool
-    let dismiss: DismissAction
+
+    var body: some View {
+        if allowDelete {
+            CurrencyRowContent(description: description, viewModel: viewModel)
+                .swipeActions {
+                    Button {
+                        withAnimation { viewModel.removeRecent(description.currency) }
+                    } label: {
+                        Image.asset(.delete)
+                    }
+                    .tint(.bannerError)
+                }
+        } else {
+            CurrencyRowContent(description: description, viewModel: viewModel)
+        }
+    }
+}
+
+private struct CurrencyRowContent: View {
+    @Environment(\.dismiss) private var dismiss
+    let description: CurrencyDescription
+    let viewModel: CurrencySelectionViewModel
 
     var body: some View {
         Button {
@@ -100,15 +125,5 @@ private struct CurrencyRow: View {
         .disabled(viewModel.isSelectionDisabled(for: description.currency))
         .listRowBackground(Color.backgroundMain)
         .buttonStyle(.plain)
-        .swipeActions {
-            if allowDelete {
-                Button {
-                    withAnimation { viewModel.removeRecent(description.currency) }
-                } label: {
-                    Image.asset(.delete)
-                }
-                .tint(.bannerError)
-            }
-        }
     }
 }

--- a/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionViewModel.swift
@@ -14,19 +14,16 @@ class CurrencySelectionViewModel {
 
     var availableCurrencies: [CurrencyDescription] = []
     var availableRecentCurrencies: [CurrencyDescription] = []
+    var searchingCurrencies: [CurrencyDescription] = []
 
-    var searchText = ""
-    var isFocused = false
+    var searchText = "" {
+        didSet {
+            updateSearchingCurrencies()
+        }
+    }
 
     var isSearching: Bool {
         !searchText.isEmpty
-    }
-
-    var searchingCurrencies: [CurrencyDescription] {
-        let term = searchText.lowercased()
-        return currencies.filter {
-            $0.currency.rawValue.lowercased().contains(term) || $0.localizedName.lowercased().contains(term)
-        }
     }
 
     @ObservationIgnored private let ratesController: RatesController
@@ -79,11 +76,17 @@ class CurrencySelectionViewModel {
         }
     }
 
+    private func updateSearchingCurrencies() {
+        let term = searchText.lowercased()
+        searchingCurrencies = term.isEmpty ? [] : currencies.filter {
+            $0.currency.rawValue.lowercased().contains(term) || $0.localizedName.lowercased().contains(term)
+        }
+    }
+
     // MARK: - Selection -
 
     func select(currency: CurrencyCode) {
         ratesController.balanceCurrency = currency
-        isFocused = false
 
         Task {
             try await Task.delay(milliseconds: 200)


### PR DESCRIPTION
## Summary

Removing a recent region was animating the row in from the top of Other Regions instead of fading out cleanly. The picker had grown a uniformly-attached swipe modifier, which combined with same-typed rows in both sections caused SwiftUI to treat the move as cross-section reuse. Branching the row body so swipeable and non-swipeable rows are distinct types restores the diff isolation, and the swipe is now blocked on the active region.

## Test plan

- Open the region picker with multiple recents and swipe-delete a non-active recent — row fades out cleanly.
- Swipe on the currently selected recent — no swipe gesture appears.
- Type to search, clear, and re-search — results section behaves normally.
- Tap a currency in either section — picker dismisses and balance currency updates.