### PR TITLE
fix: stop crash when log writer hits disk-full

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Logging/Handlers/RotatingFileLogHandler.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Logging/Handlers/RotatingFileLogHandler.swift
@@ -14,6 +14,7 @@ public actor FileWriterActor {
     private var currentFileIndex: Int = 0
     private var currentFileHandle: FileHandle?
     private var currentFileSize: Int = 0
+    private var fatalFailure: Bool = false
 
     public init(directory: URL, maxFileSize: Int = 500_000, maxFileCount: Int = 3) {
         self.directory = directory
@@ -22,7 +23,7 @@ public actor FileWriterActor {
     }
 
     public func write(_ line: String) {
-        guard let data = line.data(using: .utf8) else { return }
+        guard !fatalFailure, let data = line.data(using: .utf8) else { return }
 
         if currentFileHandle == nil {
             openCurrentFile()
@@ -32,8 +33,12 @@ public actor FileWriterActor {
             rotate()
         }
 
-        currentFileHandle?.write(data)
-        currentFileSize += data.count
+        do {
+            try currentFileHandle?.write(contentsOf: data)
+            currentFileSize += data.count
+        } catch {
+            fatalFailure = true
+        }
     }
 
     public func logFileURLs() -> [URL] {
@@ -66,20 +71,29 @@ public actor FileWriterActor {
             fm.createFile(atPath: url.path, contents: nil)
         }
 
-        currentFileHandle = try? FileHandle(forWritingTo: url)
-        currentFileHandle?.seekToEndOfFile()
-        currentFileSize = Int(currentFileHandle?.offsetInFile ?? 0)
+        guard let handle = try? FileHandle(forWritingTo: url) else {
+            fatalFailure = true
+            return
+        }
+        currentFileHandle = handle
+        currentFileSize = Int((try? handle.seekToEnd()) ?? 0)
     }
 
     private func rotate() {
-        currentFileHandle?.closeFile()
+        try? currentFileHandle?.close()
         currentFileHandle = nil
         currentFileIndex = (currentFileIndex + 1) % maxFileCount
         currentFileSize = 0
 
-        // Truncate the file we're about to write to
+        // Truncate the file we're about to write to. If we can't, we'd
+        // append to stale rotated content — bail instead.
         let url = fileURL(index: currentFileIndex)
-        try? "".write(to: url, atomically: true, encoding: .utf8)
+        do {
+            try "".write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            fatalFailure = true
+            return
+        }
 
         openCurrentFile()
     }

--- a/FlipcashCore/Sources/FlipcashCore/Logging/LogStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Logging/LogStore.swift
@@ -90,7 +90,7 @@ public final class LogStore: Sendable {
 
             var chunk = try inputHandle.read(upToCount: Self.exportChunkSize) ?? Data()
             while !chunk.isEmpty {
-                outputHandle.write(chunk)
+                try outputHandle.write(contentsOf: chunk)
                 chunk = try inputHandle.read(upToCount: Self.exportChunkSize) ?? Data()
             }
         }


### PR DESCRIPTION
## Summary

Replace the legacy `FileHandle` ObjC-bridged methods in the rotating log writer and the log exporter with modern Swift-throwing variants. The legacy methods raise `NSFileHandleOperationException` on I/O failure, which Swift cannot catch — so any logger call would terminate the app whenever the device ran out of disk space while logs flushed.

The actor now also sets a `fatalFailure` flag when an open, write, or rotation truncation fails. Subsequent writes short-circuit, so a sustained disk-full state stops looping retries instead of appending onto stale post-rotation content.

## Test plan

- [x] Existing `RotatingFileLogHandlerTests` and `LogStoreTests` pass
- [x] App builds clean with no new warnings
- [x] Verified on device — launch, navigation, and Settings → Application Logs export all produce well-formed log entries