### PR TITLE
fix: silence server-result errors in Bugsnag

### DIFF
--- a/Flipcash/Utilities/ErrorReporting.swift
+++ b/Flipcash/Utilities/ErrorReporting.swift
@@ -107,6 +107,10 @@ enum ErrorReporting {
     }
     
     private static func capture(_ error: Swift.Error, reason: String? = nil, id: String? = nil, file: String = #file, function: String = #function, line: Int = #line, buildUserInfo: (inout [String: Any]) -> Void) {
+        if let serverError = error as? ServerError, !serverError.isReportable {
+            return
+        }
+
         let swiftError = error as NSError
 
         var userInfo: [String: Any] = [:]

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/AccountService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/AccountService.swift
@@ -147,6 +147,42 @@ public enum ErrorFetchUnauthenticatedUserFlags: Int, Error {
     case unknown = -1
 }
 
+extension ErrorRegisterAccount: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .invalidSignature, .denied: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorLoginAccount: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .invalidTimestamp, .denied: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorFetchUserFlags: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorFetchUnauthenticatedUserFlags: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Account_V1_AccountClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ActivityService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ActivityService.swift
@@ -104,6 +104,24 @@ public enum ErrorFetchTransactionHistoryItemsByID: Int, Error {
     case unknown = -1
 }
 
+extension ErrorFetchTransactionHistory: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorFetchTransactionHistoryItemsByID: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .notFound: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Activity_V1_ActivityFeedClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EmailService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EmailService.swift
@@ -124,6 +124,33 @@ public enum ErrorUnlinkEmail: Int, Error {
     case unknown = -1
 }
 
+extension ErrorSendEmailCode: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .rateLimited, .invalidEmailAddress: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorCheckEmailCode: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .rateLimited, .invalidCode, .noVerification: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorUnlinkEmail: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Email_V1_EmailVerificationClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/IAPService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/IAPService.swift
@@ -55,6 +55,15 @@ public enum ErrorCompletePurchase: Int, Error {
     case unknown = -1
 }
 
+extension ErrorCompletePurchase: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .invalidReceipt, .invalidMetadata: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Iap_V1_IapClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ModerationService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ModerationService.swift
@@ -107,6 +107,15 @@ public enum ErrorModeration: Error, Sendable {
     case network(Error)
 }
 
+extension ErrorModeration: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .denied, .unsupportedFormat, .unsupportedLanguage: false
+        case .unknown, .network: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Moderation_V1_ModerationClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PhoneService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PhoneService.swift
@@ -128,6 +128,33 @@ public enum ErrorUnlinkPhone: Int, Error {
     case unknown = -1
 }
 
+extension ErrorSendVerificationCode: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .rateLimited, .invalidPhoneNumber, .unsupportedPhoneType: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorCheckVerificationCode: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .rateLimited, .invalidCode, .noVerification: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorUnlinkPhone: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Phone_V1_PhoneVerificationClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
@@ -57,6 +57,15 @@ public enum ErrorFetchProfile: Int, Error {
     case unknown = -1
 }
 
+extension ErrorFetchProfile: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .notFound: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Profile_V1_ProfileClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PushService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PushService.swift
@@ -81,6 +81,24 @@ public enum ErrorDeleteToken: Int, Error, Sendable {
     case unknown = -1
 }
 
+extension ErrorAddToken: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .invalidPushToken: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorDeleteToken: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Push_V1_PushClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/SettingsService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/SettingsService.swift
@@ -53,6 +53,15 @@ public enum ErrorUpdateSettings: Int, Error {
     case unknown = -1
 }
 
+extension ErrorUpdateSettings: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .invalidLocale, .invalidRegion: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Settings_V1_SettingsClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ThirdPartyService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ThirdPartyService.swift
@@ -60,6 +60,15 @@ public enum ErrorFetchJWT: Int, Error {
     case unknown = -1
 }
 
+extension ErrorFetchJWT: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .unsupportedProvider, .invalidApiKey, .phoneVerificationRequired, .emailVerificationRequired: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Flipcash_Thirdparty_V1_ThirdPartyClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
@@ -124,6 +124,15 @@ public enum ErrorFetchBalance: Int, Error, Equatable, Sendable {
     case parseFailed      = -3
 }
 
+extension ErrorFetchBalance: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .notFound, .accountNotInList: false
+        case .unknown, .parseFailed: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Ocp_Account_V1_AccountClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/CurrencyService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/CurrencyService.swift
@@ -223,6 +223,24 @@ public enum ErrorLaunchCurrency: Error, Sendable {
     case network(Error)
 }
 
+extension ErrorRateHistory: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .notFound: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorLaunchCurrency: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .denied, .nameExists, .invalidIcon: false
+        case .unknown, .network: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Ocp_Currency_V1_CurrencyClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
@@ -632,3 +632,22 @@ public enum ErrorGetSwap: Int, Error {
     case unknown = -1
     case failedToParse = -2
 }
+
+extension ErrorSwap: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .denied, .invalidSwap: false
+        case .signatureError, .failed, .unknown, .grpcStatus, .grpcError: true
+        case .fundingIntent(let inner): inner.isReportable
+        }
+    }
+}
+
+extension ErrorGetSwap: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .notFound, .denied: false
+        case .unknown, .failedToParse: true
+        }
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -978,6 +978,42 @@ public enum ErrorFetchLimits: Int, Error {
     case unknown = -1
 }
 
+extension ErrorSubmitIntent: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .denied, .invalidIntent, .staleState: false
+        case .signatureError, .unknown, .deviceTokenUnavailable, .grpcStatus, .grpcError: true
+        }
+    }
+}
+
+extension ErrorVoidGiftCard: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .claimed, .notFound: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorFetchIntentMetadata: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .notFound, .denied: false
+        case .unknown, .failedToParse: true
+        }
+    }
+}
+
+extension ErrorFetchLimits: ServerError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok: false
+        case .unknown: true
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Ocp_Transaction_V1_TransactionClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Models/ServerError.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/ServerError.swift
@@ -1,0 +1,21 @@
+//
+//  ServerError.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+/// Marker for errors carrying a server-returned result code (denied, not-found,
+/// invalid-input, etc.). Filtered out of error reporting by default — they
+/// represent user-driven outcomes, not iOS bugs.
+///
+/// Override `isReportable` per enum to surface specific cases that *should*
+/// reach the reporter — typically `.unknown` (raw value the client doesn't
+/// recognize → proto/client drift) and wrapped non-business causes.
+public protocol ServerError: Error {
+    var isReportable: Bool { get }
+}
+
+public extension ServerError {
+    var isReportable: Bool { false }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/ServerErrorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ServerErrorTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("ServerError reportability")
+struct ServerErrorTests {
+
+    @Test("ErrorLoginAccount reportability", arguments: [
+        (ErrorLoginAccount.denied, false),
+        (ErrorLoginAccount.invalidTimestamp, false),
+        (ErrorLoginAccount.unknown, true),
+    ])
+    func loginAccount_isReportable(error: ErrorLoginAccount, expected: Bool) {
+        #expect(error.isReportable == expected)
+    }
+
+    @Test("ErrorRegisterAccount reportability", arguments: [
+        (ErrorRegisterAccount.denied, false),
+        (ErrorRegisterAccount.invalidSignature, false),
+        (ErrorRegisterAccount.unknown, true),
+    ])
+    func registerAccount_isReportable(error: ErrorRegisterAccount, expected: Bool) {
+        #expect(error.isReportable == expected)
+    }
+
+    @Test("ErrorSubmitIntent reportability", arguments: [
+        (ErrorSubmitIntent.denied([], messages: []), false),
+        (ErrorSubmitIntent.invalidIntent([]), false),
+        (ErrorSubmitIntent.staleState([], kinds: []), false),
+        (ErrorSubmitIntent.signatureError, true),
+        (ErrorSubmitIntent.unknown, true),
+        (ErrorSubmitIntent.deviceTokenUnavailable, true),
+    ])
+    func submitIntent_isReportable(error: ErrorSubmitIntent, expected: Bool) {
+        #expect(error.isReportable == expected)
+    }
+
+    @Test("ErrorSwap.fundingIntent delegates to wrapped ErrorSubmitIntent", arguments: [
+        (ErrorSubmitIntent.denied([], messages: []), false),
+        (ErrorSubmitIntent.signatureError, true),
+    ])
+    func errorSwap_fundingIntentDelegates(inner: ErrorSubmitIntent, expected: Bool) {
+        #expect(ErrorSwap.fundingIntent(inner).isReportable == expected)
+    }
+
+    @Test("Default protocol implementation returns false")
+    func defaultIsReportable_returnsFalse() {
+        struct Sample: ServerError {}
+        #expect(Sample().isReportable == false)
+    }
+}


### PR DESCRIPTION
## Summary

Expected business outcomes from the server (denied, not-found, validation errors) were being reported to Bugsnag and drowning out genuine iOS bugs. This adds a deterministic filter that mirrors the Android client: every gRPC result enum conforms to a new ServerError protocol with a per-case "is this worth reporting" rule, defaulting to silent. Only proto/client drift (unrecognized raw values) and wrapped non-business causes still surface.

## Test plan

- [x] Login with a known mnemonic still completes end to end.
- [x] Account selection re-login still completes end to end.
- [x] Targeted unit tests for the new filter pass.
- [x] No new Bugsnag entries appear for the routine login-denied path after deploy.