### PR TITLE
feat: route No Balance dialog to Discover Currencies

### DIFF
--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -236,12 +236,15 @@ class GiveViewModel {
     
     private func showNoBalanceError() {
         session.dialogItem = .init(
-            style: .destructive,
+            style: .standard,
             title: "No Balance Yet",
-            subtitle: "Get another Flipcash user to give you some cash to get a balance",
+            subtitle: "Buy a currency to get started, or get another Flipcash user to give you some cash",
             dismissable: true
         ) {
-            .okay(kind: .destructive)
+            .standard("Discover Currencies") { [weak self] in
+                self?.sessionContainer.appRouter.present(.discover)
+            };
+            .cancel()
         }
     }
 

--- a/FlipcashTests/GiveViewModelTests.swift
+++ b/FlipcashTests/GiveViewModelTests.swift
@@ -110,23 +110,23 @@ struct GiveViewModelTests {
         _ = viewModel.attemptPresent()
 
         let dialog = try #require(viewModel.session.dialogItem)
-        let isStandard: Bool = switch dialog.style {
-        case .standard: true
-        case .success, .destructive: false
-        }
-        #expect(isStandard)
+        #expect(dialog.style == .standard)
     }
 
-    @Test("No-balance dialog exposes a Discover Currencies CTA above Cancel")
+    @Test("No-balance dialog exposes a primary Discover Currencies CTA above a subtle Cancel")
     func testAttemptPresent_NoBalances_ExposesDiscoverCTAAndCancel() throws {
         let viewModel = Self.createViewModel()
 
         _ = viewModel.attemptPresent()
 
         let actions = try #require(viewModel.session.dialogItem?.actions)
-        #expect(actions.count == 2)
-        #expect(actions.first?.title == "Discover Currencies")
-        #expect(actions.last?.title == "Cancel")
+        try #require(actions.count == 2)
+
+        #expect(actions[0].title == "Discover Currencies")
+        #expect(actions[0].kind == .standard)
+
+        #expect(actions[1].title == "Cancel")
+        #expect(actions[1].kind == .subtle)
     }
 
     @Test("Tapping Discover Currencies presents the Discover sheet")

--- a/FlipcashTests/GiveViewModelTests.swift
+++ b/FlipcashTests/GiveViewModelTests.swift
@@ -103,6 +103,47 @@ struct GiveViewModelTests {
         #expect(viewModel.selectedBalance == nil)
     }
 
+    @Test("No-balance dialog uses the standard (non-destructive) style")
+    func testAttemptPresent_NoBalances_UsesStandardStyle() throws {
+        let viewModel = Self.createViewModel()
+
+        _ = viewModel.attemptPresent()
+
+        let dialog = try #require(viewModel.session.dialogItem)
+        let isStandard: Bool = switch dialog.style {
+        case .standard: true
+        case .success, .destructive: false
+        }
+        #expect(isStandard)
+    }
+
+    @Test("No-balance dialog exposes a Discover Currencies CTA above Cancel")
+    func testAttemptPresent_NoBalances_ExposesDiscoverCTAAndCancel() throws {
+        let viewModel = Self.createViewModel()
+
+        _ = viewModel.attemptPresent()
+
+        let actions = try #require(viewModel.session.dialogItem?.actions)
+        #expect(actions.count == 2)
+        #expect(actions.first?.title == "Discover Currencies")
+        #expect(actions.last?.title == "Cancel")
+    }
+
+    @Test("Tapping Discover Currencies presents the Discover sheet")
+    func testAttemptPresent_NoBalances_DiscoverCTAPresentsDiscover() throws {
+        let sessionContainer = SessionContainer.mock
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: sessionContainer)
+
+        _ = viewModel.attemptPresent()
+
+        let action = try #require(
+            viewModel.session.dialogItem?.actions.first(where: { $0.title == "Discover Currencies" })
+        )
+        action.action()
+
+        #expect(sessionContainer.appRouter.presentedSheet == .discover)
+    }
+
     // MARK: - Currency Selection Sync Tests
 
     @Test("Selecting a currency syncs selectedBalance and ratesController")

--- a/FlipcashUI/Sources/FlipcashUI/Dialog/Dialog.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Dialog/Dialog.swift
@@ -90,7 +90,7 @@ public struct Dialog: View {
 }
 
 extension Dialog {
-    public enum Style {
+    public enum Style: Equatable {
         case standard
         case success
         case destructive

--- a/FlipcashUI/Sources/FlipcashUI/Dialog/DialogAction.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Dialog/DialogAction.swift
@@ -94,7 +94,7 @@ public struct DialogAction {
 // MARK: - Kind -
 
 extension DialogAction {
-    public enum Kind {
+    public enum Kind: Equatable {
         case standard
         case subtle
         case destructive

--- a/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
@@ -24,7 +24,7 @@ extension ShapeStyle where Self == Color {
     public static var textActionSecondaryDisabled: Color { Color(r: 24,  g: 24,  b: 24) }
 
     public static var bannerError: Color                 { Color(r: 188, g: 52,  b: 52) }
-    public static var bannerInfo: Color                  { Color(r: 26,  g: 49,  b: 37) }
+    public static var bannerInfo: Color                  { Color("backgroundSecondary") }
     public static var bannerSuccess: Color               { Color("backgroundSecondary") }
 
     public static var backgroundMain: Color              { Color("background") }

--- a/FlipcashUITests/Regression/GiveRegressionTests.swift
+++ b/FlipcashUITests/Regression/GiveRegressionTests.swift
@@ -38,7 +38,7 @@ final class GiveRegressionTests: BaseUITestCase {
             "Give amount entry must not present when the balance check fails — 'Next' button found alongside dialog"
         )
 
-        waitAndTap(app.buttons["OK"])
+        waitAndTap(app.buttons["Cancel"])
 
         assertMainScreenReached(timeout: 5, "Expected to return to the main screen after dismissing the No Balance dialog")
         XCTAssertFalse(


### PR DESCRIPTION
## Summary
- Switches the No Balance dialog from destructive to standard style
- Replaces the OK button with a primary Discover Currencies CTA that opens the Discover sheet, plus a subtle Cancel
- Adds tests for the style, CTA layout, and router transition

## Test plan
- [x] On Scan, tap Give with no giveable balance and confirm the dark non-destructive dialog appears
- [x] Tap Discover Currencies and confirm the Discover sheet opens
- [x] Tap Cancel and confirm the dialog dismisses without navigation