### PR TITLE
fix: stop duplicate cash-link submissions on rapid taps

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Views/Buttons/CapsuleButton.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Buttons/CapsuleButton.swift
@@ -100,6 +100,7 @@ public struct CapsuleButton: View {
             .padding(.horizontal, contentHorizontalPadding)
         }
         .liquidGlassButtonStyle(shape: title == nil ? .circle : .capsule)
+        .disabled(!state.isNormal)
     }
 
     private var contentHeight: CGFloat {


### PR DESCRIPTION
## Summary

A fast double-tap on "Send as a Link" was creating two cash-link intents on the same rendezvous, and the server rejected the second one as stale state. The shared capsule button kept firing its action while showing the loading or success state, so the second tap got through. Disabling the button outside the idle state brings it in line with the older filled-style button and absorbs the second tap.

## Test plan

- [x] Open the give flow, generate a bill, and double-tap the share button as fast as possible — only one cash link is created and no stale-state error is reported.