### PR TITLE
feat: add triage skill for daily Bugsnag review

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: triage
+description: Daily Bugsnag triage ritual — surface the top open production issue, investigate with evidence, propose a fix direction, route through experts, write a lean review brief.
+argument-hint: "[--skip <count> | --id <bugsnag_id_or_url>]"
+model: opus
+effort: max
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Skill
+  - Bash(./.claude/skills/triage/scripts/bugsnag-top.sh:*)
+  - Bash(curl:*)
+  - Bash(jq:*)
+  - Bash(git log:*)
+  - Bash(git show:*)
+  - Bash(find:*)
+---
+
+# Triage
+
+<!-- `ultrathink` escalates the harness to max thinking budget. The harness scans for it as a standalone token, so it must remain on its own line and not be wrapped in code fences or prose. -->
+ultrathink
+
+You are running the daily Bugsnag triage ritual. The deliverable is **one lean review brief** at `.claude/plans/<YYYY-MM-DD>-bugsnag-<short_id>.md`. The brief is the user's review artifact — see `references/brief-template.md` for the structure and word cap.
+
+## Hard rules
+
+1. **Max effort, no shortcuts.** Read full stack traces. Read each source file the trace touches in full, not snippets. Trace through callers when the crash site is ambiguous. Never skip an expert review when the trigger applies.
+2. **No claim without a citation.** Every assertion in the brief (stack lines, "this is the root cause", "this code path runs first") must be followed by a `file.swift:NN` reference or a quoted log/breadcrumb excerpt. If unable to cite, mark as "hypothesis, unverified" and propose how to verify.
+3. **Root cause must be reachable from evidence.** The Root cause section is a short chain: `evidence → inference → evidence → inference → cause`. No leaps. If the chain breaks, the section is renamed "Leading hypothesis" and the Proposed direction becomes "Verification steps".
+4. **No mid-flow questions.** The brief is the review checkpoint. Don't ask the user anything until it's written.
+5. **Skip experts whose triggers don't apply.** Running an irrelevant expert wastes tokens.
+
+## Steps
+
+### 1. Fetch the issue
+
+Run the data fetch script with whatever arguments the user passed (`--skip <N>` or `--id <bugsnag_id_or_url>`):
+
+```bash
+./.claude/skills/triage/scripts/bugsnag-top.sh $ARGUMENTS
+```
+
+The script emits one JSON object on success. On any non-zero exit, the script already wrote a clear stderr message — relay that to the user verbatim and stop. Do not proceed.
+
+When `--id` is used, the script bypasses the default filters (status=open, release_stage=production, last 7d) so the user can target any issue — including closed, fixed, ignored, or stale ones — directly.
+
+Parse the JSON. You'll use:
+
+- `id`, `short_id`, `error_class`, `message`
+- `events`, `users`, `first_seen`, `last_seen`, `release_stages`
+- `introduced_in_release`, `grouping_hint`
+- `html_url` (browser link to put in the brief header)
+- `latest_event_id`, `latest_event_url` (for fetching the full event report next)
+
+### 2. Existing-plan check
+
+Glob `.claude/plans/*-bugsnag-<short_id>.md`.
+
+If a file matches, exit immediately with a one-liner pointing at it. Format:
+
+> Top issue `<short_id>` already triaged → `<matching path>`. Use `/triage --skip <N+1>` for the next-ranked issue.
+
+…where `N` is the `--skip` value used (defaulting to 0). Do not write a second brief.
+
+### 3. Invoke systematic-debugging
+
+Use the `Skill` tool to invoke `superpowers:systematic-debugging`. That skill owns the evidence-before-conclusion discipline for the rest of this run.
+
+### 4. Fetch the full latest event
+
+The event endpoint returns a full report:
+
+```bash
+curl -sH "Authorization: token $BUGSNAG_TOKEN" -H "X-Version: 2" "<latest_event_url>"
+```
+
+Confirm the response has `is_full_report: true`. If `false`, the event is truncated and you cannot reason about its stack — note this in the brief and propose better instrumentation.
+
+#### 4a. Version sanity check (skip stale versions)
+
+**Skip this step entirely if `$ARGUMENTS` contains `--id`.** The user explicitly chose this issue; honor the override.
+
+Otherwise, don't waste cycles investigating a bug that's only firing on old app builds. Read the current marketing version from the project:
+
+```bash
+grep -m1 'MARKETING_VERSION = ' Code.xcodeproj/project.pbxproj | sed 's/.*= //; s/;//' | xargs
+```
+
+The first match is good enough — across configurations the app uses one marketing version, and any one of them is a valid baseline for the staleness comparison.
+
+Compare it (semver) to the event's `app.version`. Skip the issue — print a one-liner and stop, do not write a brief — when either condition holds:
+
+- **`app.version` is missing or empty** → the event is corrupted or odd. Skip:
+  > Top issue's latest event has no `app.version` (corrupted or odd event). Skipping. Use `/triage --skip <N+1>`.
+- **`app.version` is older than the local marketing version** → likely fixed in a newer build. Skip:
+  > Top issue last seen in `<event.app.version>` but you're on `<MARKETING_VERSION>`. Likely fixed in a newer build. Use `/triage --skip <N+1>` for the next-ranked current-version issue.
+
+Where `<N>` is the current `--skip` value (defaulting to 0).
+
+Read `references/event-shape.md` for the full structure of the event response and which sections are first-class evidence sources. The four that drive citations:
+
+- `exceptions[0].stacktrace` (frames with `in_project`)
+- `metaData.nserror` (Swift error domain/code/userInfo, often with `location: file.swift:NN`)
+- `metaData.app_logs.recent_logs` (chronological log stream — usually the strongest signal)
+- `breadcrumbs[]` (timestamped UI/state events)
+
+Plus secondary context in `metaData.app`, `metaData.device`, `feature_flags`, `user`, `session`, `request`.
+
+Save the response to a tempfile (`mktemp`) and run subsequent jq queries against the file. Never re-curl the same event — it's the hottest part of the run.
+
+### 5. Locate source files for app frames
+
+For each `in_project: true` stack frame **and** each file mentioned in `metaData.nserror.userInfo.location` (Swift errors thrown via `ErrorReporting.captureError` typically include the call-site file:line in nserror, which is more useful than the top stack frame — the top frame is usually `ErrorReporting.capture` itself):
+
+- The `file` path is a CI build path like `Volumes/workspace/repository/Flipcash/Utilities/ErrorReporting.swift`. Strip the `Volumes/workspace/repository/` prefix to get the local repo path.
+- `Read` the file in full (no `limit`/`offset` unless the file genuinely exceeds the read window — if it does, read the relevant section anchored on `line_number`).
+- If a frame is in generated/SDK code (`<compiler-generated>`, `Generated/`, package sources), walk one frame up to find the calling app code.
+- If the file no longer exists at that path, run `git log --follow --all -- '*<basename>'` to find rename/move history.
+
+#### 5a. Possible-fix check (commit verification)
+
+Once the touched files are known, look for commits that may already address this issue:
+
+```bash
+git log --since="<last_seen>" --oneline -- <file1> <file2> ...
+```
+
+If any commits are found, capture each as `<short_sha> — <subject>` and which file(s) it touched. These go into the brief as a `## ⚠️ Possible fix already in main` section right after the header (before Root cause). If no commits are found, the section is omitted entirely.
+
+This is **not** a skip — keep investigating. The flag tells the reviewer to check whether the listed commits actually address the root cause before further action.
+
+### 6. Build the evidence chain
+
+Mine all four sources for citations:
+
+1. **`metaData.app_logs.recent_logs`** — scan for ERROR/WARNING lines, repeated patterns, and the last few lines before the throw. Quote them in Evidence with their timestamps. This is usually the strongest signal for "what was the user actually doing?"
+2. **`metaData.nserror.userInfo`** — extract `location`, plus any domain-specific keys (`mint`, `amount`, `intentId`, etc.). These are the exact runtime values at crash time.
+3. **Stack trace** — the throw point and the call chain. Cite app frames as `file.swift:NN`.
+4. **`breadcrumbs[]`** — UI/state events around the crash. Quote with `[<timestamp>] <type> — <name>` and any relevant `metaData`.
+
+Then check git context for the touched files:
+
+```bash
+git log --since="<first_seen>" -- <file>
+```
+
+For each Root cause claim, gather a citation from at least one of the four sources above. If you cannot cite, downgrade the language to "hypothesis, unverified".
+
+### 7. Draft the brief
+
+Write the file at `.claude/plans/<YYYY-MM-DD>-bugsnag-<short_id>.md` (today's date in ISO format). Read `references/brief-template.md` for the exact structure and the word cap.
+
+### 8. Run /simplify
+
+Use the `Skill` tool to invoke the project's `simplify` skill on the draft brief. Apply the feedback in place. Note the key insight in the Expert input section.
+
+### 9. Route to domain experts (parallel where independent)
+
+Inspect the **Proposed direction** you wrote. For each trigger that applies, dispatch the matching expert via `Skill` (run independent experts in parallel by issuing multiple Skill calls in one assistant turn — see `superpowers:dispatching-parallel-agents`):
+
+| Expert | Trigger |
+|--------|---------|
+| `swiftui-expert:swiftui-expert-skill` | Proposed direction touches files under `Flipcash/Core/Screens/`, `FlipcashUI/Sources/`, or any `.swift` containing `View`, `@State`, `@Observable`, `@Environment`. Also: hangs / hitches / matched-geometry errors in the stack. |
+| `swift-concurrency:swift-concurrency` | Stack trace contains `Task`, `Sendable`, `actor`, `@MainActor`, `await`, `_dispatch_assert_queue`, or `EXC_BAD_ACCESS` on a known concurrent path. Also: proposed direction changes isolation, adds/removes `@MainActor`, or wraps in `Task { }`. |
+| `swift-testing-expert:swift-testing-expert` | Proposed direction adds files under `FlipcashTests/`, `FlipcashCoreTests/`, or modifies any `@Suite` / `@Test`. |
+| `xcuitest-resilience` | Proposed direction adds files under `FlipcashUITests/` or modifies `XCUIApplication` / `XCUIElement` usage. |
+
+After each expert returns, fold their concrete actionable feedback into the brief: tighten the Proposed direction if needed, append a one-bullet summary under Expert input. Skipped experts are omitted entirely from the brief — no empty headings.
+
+Update the `Experts consulted:` line in the brief header.
+
+### 10. Print the chat summary
+
+A 4–6 line summary, no code blocks:
+
+- Error class and short id
+- Last 7d events / users
+- Root cause one-liner
+- Experts consulted
+- Path to brief file
+
+That's the end of the run.
+
+## Failure modes
+
+The script handles all API-side failures (missing token, 401, network down, no qualifying issues, --skip overrun) and exits with a clear stderr message. Relay it and stop.
+
+For investigation-side failures:
+
+- **Latest event has zero `in_project: true` frames AND empty `metaData.app_logs` / `metaData.nserror`** — only then write the "insufficient symbolicated app frames" brief and skip experts. If app frames are absent but `metaData.nserror.userInfo.location` or `metaData.app_logs.recent_logs` has content, those are valid evidence sources — proceed normally and cite from them.
+- **Source file moved/renamed** — use `git log --follow --all -- '*<basename>'`. Note the rename with the commit SHA in Evidence.
+- **Plan file write fails** — print the error verbatim. Don't dump the brief content to chat as a fallback.
+- **Expert skill invocation fails** — note in Expert input as `**/<expert>**: skipped — <error>`. Don't fail the whole run.

--- a/.claude/skills/triage/references/brief-template.md
+++ b/.claude/skills/triage/references/brief-template.md
@@ -1,0 +1,62 @@
+# Triage brief template
+
+The exact markdown structure to write to `.claude/plans/<YYYY-MM-DD>-bugsnag-<short_id>.md`.
+
+Hard cap: ~200–300 words total. If a section runs longer, tighten it. Skim-readable in under a minute.
+
+```markdown
+# Bugsnag triage: <error_class>
+
+**id:** `<short_id>…` · **URL:** <html_url>
+**Triaged:** <YYYY-MM-DD> · **Status:** open · production
+**Last 7d:** <events> events · <users> users · last seen <last_seen date>
+**App version:** <event.app.version> (local: <MARKETING_VERSION>)
+**Introduced in:** <introduced_in_release or "unknown">
+**Experts consulted:** <comma-separated list, set after the expert routing step>
+
+## ⚠️ Possible fix already in main
+
+(Only present if `git log --since=<last_seen>` on the touched files returned commits. Omit the entire section otherwise.)
+
+- `<short_sha>` — <commit subject> (touches `<file1>`, `<file2>`)
+
+## Root cause
+
+<2–4 sentences. Every claim cites file.swift:NN or quoted log.>
+
+## Evidence
+
+- `<file>:<line>` — <one-line quote>
+- log `[<timestamp>] <level> <subsystem>` — <one-line quote from metaData.app_logs.recent_logs>
+- nserror.userInfo — `<key>=<value>` (domain-specific runtime values, e.g. `quarks`, `mint`, `intentId`)
+- breadcrumb `[<timestamp>] <type>` — <one-line quote>
+- `git log` since first_seen — <one-line summary>
+
+(omit any line that has no relevant content — Evidence shows what's there, not a fixed schema)
+
+## Proposed direction
+
+<one paragraph. The shape of the fix, not the steps.>
+
+## Risk
+
+<one or two sentences. What it touches, who feels the change.>
+
+## Expert input
+
+- **/simplify**: <one bullet, key insight or "no changes needed">
+- (other experts only if triggered)
+
+## Next step
+
+If actioned: run `superpowers:writing-plans` against this file to expand into an implementation plan.
+```
+
+## Notes on each section
+
+- **Header block** — everything above the first `##`. The reader should know whether to engage from this alone.
+- **Possible fix already in main** — optional. Only included when commits exist on the touched files since `last_seen`. Tells the reader to verify whether those commits address the issue before taking further action — but the brief is still produced normally.
+- **Root cause** — if the chain breaks, rename to "Leading hypothesis" and the Proposed direction becomes "Verification steps".
+- **Evidence** — schema is illustrative; include only the rows you have. A row with no quote is rot.
+- **Proposed direction** — the *shape* of the fix, not numbered steps. Numbered steps belong in the implementation plan that comes later.
+- **Expert input** — only triggered experts get a bullet. No empty headings.

--- a/.claude/skills/triage/references/event-shape.md
+++ b/.claude/skills/triage/references/event-shape.md
@@ -1,0 +1,67 @@
+# Bugsnag event report shape
+
+A reference for what's in the full event response from `GET /projects/<project_id>/events/<event_id>` and how to use each section during investigation.
+
+The full report (`is_full_report: true`) is required. The truncated event embedded in the issues list response is missing most of the useful fields — always fetch the standalone event endpoint.
+
+## Top-level keys
+
+| Key | Notes |
+|-----|-------|
+| `id` | Event id |
+| `error_id` | Parent error/issue id |
+| `is_full_report` | Must be `true`; if not, the event is truncated and you cannot reason from it |
+| `received_at` | When Bugsnag received the report |
+| `severity` | `error` / `warning` / `info` |
+| `unhandled` | `true` for crashes, `false` for handled errors |
+| `exceptions[]` | Stack trace data (see below) |
+| `breadcrumbs[]` | Timestamped UI/state events |
+| `metaData` | Custom metadata buckets — `nserror`, `app_logs`, `app`, `device` |
+| `app`, `device`, `user`, `session`, `request`, `feature_flags` | Runtime context |
+| `threads[]` | Other threads at crash time (rarely needed) |
+| `correlation` | Spans / trace correlation if instrumented |
+| `missing_dsym` | Boolean — if true, the event isn't symbolicated |
+
+## Four first-class evidence sources
+
+These four are where citations come from. Order is roughly by signal strength.
+
+### `metaData.app_logs.recent_logs`
+
+Chronological log stream leading up to the crash. Each line carries timestamp, level, subsystem, message, and the structured `metadata` from `logger.x(...)` calls.
+
+**Why it matters:** the user's session in narrative form. Reveals patterns that stack traces hide — repeated retries, state transitions, race-window timing. For our test issue (`invalidIntent insufficient balance`), this section showed seven retries of the same withdrawal in 40 seconds, which is invisible from the stack trace.
+
+**How to cite:** `log [<timestamp>] <level> <subsystem> — <verbatim line>`.
+
+### `metaData.nserror`
+
+The Swift error context. Has `domain`, `code`, `reason`, and `userInfo`.
+
+`userInfo` typically includes:
+
+- `location` — file:line where the error was thrown (e.g., `WithdrawViewModel.swift:completeWithdrawal():371`). This is more useful than the top stack frame because the top frame is usually `ErrorReporting.capture` itself.
+- Domain-specific structured fields the developer attached: `mint`, `amount`, `quarks`, `destination`, `intentId`, etc.
+
+**How to cite:** `nserror.userInfo — <key>=<value>` for runtime values, or treat `location` as a normal `file.swift:NN` citation.
+
+### `exceptions[0].stacktrace`
+
+Frames with `method`, `file`, `line_number`, `in_project`. Iterate `in_project: true` frames for app code; walk one frame up if a frame is in generated/SDK code.
+
+**Path mapping:** the `file` field is a CI build path like `Volumes/workspace/repository/Flipcash/Utilities/ErrorReporting.swift`. Strip `Volumes/workspace/repository/` to get the local repo path.
+
+**How to cite:** `<file>:<line>` (after stripping the prefix).
+
+### `breadcrumbs[]`
+
+Timestamped UI/state events — Bugsnag-managed (orientation changes, scenePhase) plus app-emitted. Recent events lead up to the throw.
+
+**How to cite:** `breadcrumb [<timestamp>] <type> — <name>` plus any relevant `metaData` fields.
+
+## Secondary context
+
+- `metaData.app` / `app` — bundle id, version, build, release stage. Use for "is this version-specific?"
+- `metaData.device` / `device` — model, OS, free disk, RAM. Use for "is this device-specific?"
+- `feature_flags` — flags active at crash time. Use for "is this a flagged-rollout issue?"
+- `user`, `session` — disambiguate "one user retrying" vs "many users hitting".

--- a/.claude/skills/triage/scripts/bugsnag-top.sh
+++ b/.claude/skills/triage/scripts/bugsnag-top.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# bugsnag-top.sh — fetch the top open production issue from Bugsnag (last 7 days).
+# Emits one JSON object to stdout on success.
+#
+# Exit codes:
+#   0  success — issue found, JSON on stdout
+#   2  missing/invalid argument or BUGSNAG_TOKEN unset
+#   3  token rejected by Bugsnag (401)
+#   4  Bugsnag API unreachable after one retry
+#   5  no qualifying issues (or --skip exceeds available results)
+
+set -euo pipefail
+
+PROJECT_ID="6824c89e398a98001fdaa7ec"
+ORG_SLUG="1000710770-ontario-inc"
+PROJECT_SLUG="flipcash-ios"
+BROWSER_BASE="https://app.bugsnag.com/$ORG_SLUG/$PROJECT_SLUG/errors"
+API_BASE="https://api.bugsnag.com/projects/$PROJECT_ID"
+
+# Resolve repo root: script lives at .claude/skills/triage/scripts/bugsnag-top.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Source .env if BUGSNAG_TOKEN is not already set
+if [ -z "${BUGSNAG_TOKEN:-}" ] && [ -f "$REPO_ROOT/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$REPO_ROOT/.env"
+  set +a
+fi
+
+if [ -z "${BUGSNAG_TOKEN:-}" ]; then
+  echo "BUGSNAG_TOKEN not set. Add to .env or ~/.zshenv." >&2
+  exit 2
+fi
+
+# Parse --skip <N> | --id <bugsnag_error_id_or_url>
+SKIP=0
+FORCED_ID=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip)
+      SKIP="${2:-}"
+      if ! [[ "$SKIP" =~ ^[0-9]+$ ]]; then
+        echo "--skip requires a non-negative integer" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --id)
+      FORCED_ID="${2:-}"
+      if [ -z "$FORCED_ID" ]; then
+        echo "--id requires a Bugsnag error id (24-char hex) or a Bugsnag error URL" >&2
+        exit 2
+      fi
+      # If the user pasted a URL, extract the trailing id
+      FORCED_ID="${FORCED_ID##*/}"
+      if ! [[ "$FORCED_ID" =~ ^[0-9a-f]{24}$ ]]; then
+        echo "--id value '$FORCED_ID' is not a 24-char hex Bugsnag error id" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -n "$FORCED_ID" ] && [ "$SKIP" -ne 0 ]; then
+  echo "--id and --skip are mutually exclusive. --skip walks the ranked list; --id targets one issue directly." >&2
+  exit 2
+fi
+
+if [ -n "$FORCED_ID" ]; then
+  # Targeted lookup — bypass the filtered query so the user can triage anything
+  # (closed, fixed, ignored, non-prod, older than 7d) by id.
+  URL="$API_BASE/errors/$FORCED_ID"
+else
+  # Bugsnag requires URL-encoded bracket characters in filter params
+  QUERY="sort=events&direction=desc&per_page=1&offset=$SKIP"
+  QUERY="$QUERY&filters%5Berror.status%5D%5B%5D%5Btype%5D=eq"
+  QUERY="$QUERY&filters%5Berror.status%5D%5B%5D%5Bvalue%5D=open"
+  QUERY="$QUERY&filters%5Brelease_stage%5D%5B%5D%5Btype%5D=eq"
+  QUERY="$QUERY&filters%5Brelease_stage%5D%5B%5D%5Bvalue%5D=production"
+  QUERY="$QUERY&filters%5Bevent.since%5D%5B%5D%5Btype%5D=eq"
+  QUERY="$QUERY&filters%5Bevent.since%5D%5B%5D%5Bvalue%5D=7d"
+
+  URL="$API_BASE/errors?$QUERY"
+fi
+
+# Calls $1 (a function name that prints `<body>\n<http_code>`), retries once on
+# transient failures, and sets globals HTTP_CODE / BODY for the caller. Caller
+# is responsible for HTTP_CODE-specific handling (401, 404, etc).
+fetch_with_retry() {
+  local fn="$1"
+  local raw
+  raw=$($fn || echo $'\n0')
+  HTTP_CODE=$(printf '%s' "$raw" | tail -n1)
+  BODY=$(printf '%s' "$raw" | sed '$d')
+  if [ -z "$HTTP_CODE" ] || ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]] || [ "$HTTP_CODE" -ge 500 ]; then
+    sleep 2
+    raw=$($fn || echo $'\n0')
+    HTTP_CODE=$(printf '%s' "$raw" | tail -n1)
+    BODY=$(printf '%s' "$raw" | sed '$d')
+  fi
+}
+
+# Print a generic "API unreachable" message plus a truncated body for debugging
+# unexpected status codes (403, 422, gateway errors, etc.).
+report_unreachable_and_exit() {
+  local label="$1"
+  echo "$label" >&2
+  if [ -n "$BODY" ]; then
+    echo "Response body (truncated to 500 chars):" >&2
+    echo "$BODY" | head -c 500 >&2
+    echo >&2
+  fi
+  exit 4
+}
+
+fetch_errors() {
+  curl -sS \
+    -H "Authorization: token $BUGSNAG_TOKEN" \
+    -H "X-Version: 2" \
+    -w "\n%{http_code}" \
+    "$URL"
+}
+
+fetch_with_retry fetch_errors
+
+if [ "$HTTP_CODE" = "401" ]; then
+  echo "Bugsnag rejected the token (401). Check it hasn't expired or been revoked." >&2
+  exit 3
+fi
+
+if [ "$HTTP_CODE" = "404" ] && [ -n "$FORCED_ID" ]; then
+  echo "Bugsnag has no error with id $FORCED_ID. Double-check the id (24-char hex) or the URL." >&2
+  exit 5
+fi
+
+if [ "$HTTP_CODE" != "200" ]; then
+  report_unreachable_and_exit "Bugsnag API unreachable: HTTP $HTTP_CODE. Try again later."
+fi
+
+# The list endpoint returns an array; the by-id endpoint returns a single object.
+# Wrap the single-object case so downstream jq stays uniform.
+if [ -n "$FORCED_ID" ]; then
+  BODY="[$BODY]"
+fi
+
+# Guard: response should be a JSON array (after the wrap above). Fail loudly if
+# Bugsnag's response shape ever changes (e.g., {"errors": [...]}).
+if ! echo "$BODY" | jq -e 'type == "array"' >/dev/null; then
+  report_unreachable_and_exit "Unexpected Bugsnag response shape (not a JSON array). API may have changed."
+fi
+COUNT=$(echo "$BODY" | jq 'length')
+if [ "$COUNT" -eq 0 ]; then
+  if [ "$SKIP" -gt 0 ]; then
+    echo "Only $SKIP open production issues this week, --skip $SKIP skipped past all of them." >&2
+  else
+    echo "No open production issues with events in the last 7 days. Nothing to triage today." >&2
+  fi
+  exit 5
+fi
+
+# Save the errors response — the helper overwrites $BODY on each fetch and we
+# still need this for the final JSON emit below.
+ERRORS_BODY="$BODY"
+ERROR_ID=$(echo "$ERRORS_BODY" | jq -r '.[0].id')
+
+# Resolve the latest event id for the surfaced issue so the SKILL can fetch the
+# full report. Without retry here a transient 5xx would hand the SKILL an empty
+# event id and a /events/ URL ending in a bare slash.
+fetch_latest_event() {
+  curl -sS \
+    -H "Authorization: token $BUGSNAG_TOKEN" \
+    -H "X-Version: 2" \
+    -w "\n%{http_code}" \
+    "$API_BASE/errors/$ERROR_ID/events?per_page=1"
+}
+
+fetch_with_retry fetch_latest_event
+
+if [ "$HTTP_CODE" != "200" ]; then
+  report_unreachable_and_exit "Bugsnag events fetch failed for error $ERROR_ID: HTTP $HTTP_CODE."
+fi
+
+LATEST_EVENT_ID=$(echo "$BODY" | jq -r '.[0].id // empty')
+
+if [ -z "$LATEST_EVENT_ID" ]; then
+  echo "Bugsnag returned no events for error $ERROR_ID — cannot proceed without a latest event to investigate." >&2
+  exit 4
+fi
+
+# Emit the consolidated JSON (operating on the saved errors response)
+echo "$ERRORS_BODY" | jq \
+  --arg browser_base "$BROWSER_BASE" \
+  --arg latest_event_id "$LATEST_EVENT_ID" \
+  --arg api_base "$API_BASE" \
+  '.[0] | {
+    id,
+    short_id: (.id[0:7]),
+    error_class,
+    message,
+    events,
+    users,
+    first_seen: .first_seen_unfiltered,
+    last_seen,
+    release_stages,
+    introduced_in_release: (.introduced_in_releases[0].build_label // null),
+    grouping_hint: (.grouping_fields.custom // null),
+    html_url: ($browser_base + "/" + .id),
+    latest_event_id: $latest_event_id,
+    latest_event_url: ($api_base + "/events/" + $latest_event_id)
+  }'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ## Private assets
 Configurations/secrets.local.xcconfig
 ci_scripts/ci_post_xcodebuild.sh
+.env
+.env.local
 
 ## System files
 .DS_Store


### PR DESCRIPTION
## Summary

Adds a triage skill that pulls the top open production Bugsnag issue, mines the event for evidence (logs, nserror data, stack, breadcrumbs), and writes a short review brief that I can read over coffee. The skill skips issues only firing on older app versions automatically and routes investigations through Swift, SwiftUI, concurrency, and test experts based on what the proposed fix touches. Includes a flag to triage a specific issue by URL or id, and gitignores the dotenv file so the personal access token stays out of source control.

## Test plan

- [x] Run the skill in a fresh chat and confirm a review brief is written
- [x] Re-run and confirm it exits with the existing-plan one-liner
- [x] Skip past the top result and confirm the next-ranked issue is triaged
- [x] Pass a Bugsnag URL and confirm that exact issue is targeted
- [x] Confirm an older-version issue triggers the version-skip message
- [x] Confirm an unset token produces a clear error