### PR TITLE
fix: stop Account Selection hang from main-thread key derivation

### DIFF
--- a/Flipcash/Core/Screens/Onboarding/AccountSelectionScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/AccountSelectionScreen.swift
@@ -42,7 +42,14 @@ struct AccountSelectionScreen: View {
             VStack(spacing: 0) {
                 List {
                     ForEach(accounts) { account in
-                        row(for: account)
+                        AccountRow(
+                            account: account,
+                            isSelected: isSelected(for: account.details),
+                            onTap: { action(account.details) },
+                            onDelete: { confirmDelete(account: account.details) },
+                            onCopyAccessKey: { copyAccessKey(description: account.details) },
+                            onCopyVaultAddress: { copyVaultAddress(description: account.details) }
+                        )
                     }
                     .listRowInsets(EdgeInsets())
                     .listRowSeparatorTint(Color.rowSeparator)
@@ -60,83 +67,11 @@ struct AccountSelectionScreen: View {
         }
         .navigationTitle("Select Account")
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
+        .task {
             fetchAccounts()
-            fetchBalances()
+            await fetchBalances()
         }
         .dialog(item: $dialogItem)
-    }
-
-    @ViewBuilder private func row(for account: HistoricalAccount) -> some View {
-        Button {
-            action(account.details)
-        } label: {
-            HStack(alignment: .center, spacing: 15) {
-                CheckView(active: isSelected(for: account.details))
-
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(alignment: .bottom, spacing: 10) {
-                        Text(account.mnemonic.name)
-
-                        if account.isNotFound {
-                            Badge(decoration: .circle(.textError), text: "Not Found")
-                        }
-
-                        Spacer()
-
-                        if let balance = account.totalBalance {
-                            AmountText(
-                                flagStyle: balance.nativeAmount.currency.flagStyle,
-                                flagSize: .small,
-                                content: balance.nativeAmount.formatted(),
-                                canScale: false
-                            )
-                            .font(.appTextMedium)
-                        }
-                    }
-                    .font(.appTextMedium)
-                    .foregroundStyle(.textMain)
-                    .padding(.bottom, 5)
-
-                    Group {
-                        Text("Created \(DateFormatter.relative.string(from: account.details.creationDate))")
-                        Text(account.details.account.ownerPublicKey.base58)
-                            .truncationMode(.middle)
-                    }
-                    .font(.appTextHeading)
-                    .foregroundStyle(.textSecondary)
-                    .multilineTextAlignment(.leading)
-                }
-                .frame(maxWidth: .infinity)
-                .lineLimit(1)
-            }
-        }
-        .disabled(isSelected(for: account.details))
-        .listRowBackground(Color.backgroundMain)
-        .padding(20)
-        .swipeActions(allowsFullSwipe: false) {
-            if !isSelected(for: account.details) {
-                Button {
-                    confirmDelete(account: account.details)
-                } label: {
-                    Image.asset(.delete)
-                }
-                .tint(.bannerError)
-            }
-        }
-        .contextMenu {
-            Button {
-                copyAccessKey(description: account.details)
-            } label: {
-                Label("Copy Access Key", systemImage: SystemSymbol.doc.rawValue)
-            }
-
-            Button {
-                copyVaultAddress(description: account.details)
-            } label: {
-                Label("Copy Vault Address", systemImage: SystemSymbol.doc.rawValue)
-            }
-        }
     }
 
     private func isSelected(for description: AccountDescription) -> Bool {
@@ -198,56 +133,49 @@ struct AccountSelectionScreen: View {
 
     private func fetchAccounts() {
         accounts = accountManager.fetchHistorical()
-            .map {
-                HistoricalAccount(details: $0)
-            }
-            .filter {
-                // Don't show deleted accounts
-                $0.details.deletionDate == nil
-            }
+            .filter { $0.deletionDate == nil }
+            .map { HistoricalAccount(details: $0) }
     }
 
-    private func fetchBalances() {
+    private func fetchBalances() async {
         let rate = balanceRate
 
-        Task {
-            await withThrowingTaskGroup(of: Void.self) { group in
-                accounts.forEach { historicalAccount in
-                    group.addTask {
-                        let owner = historicalAccount.details.account.owner
-                        do {
-                            let accountInfos = try await client.fetchPrimaryAccounts(owner: owner)
-                            let mints = Set(accountInfos.map { $0.mint })
-                            let mintMetadata = try await client.fetchMints(mints: Array(mints))
+        await withThrowingTaskGroup(of: Void.self) { group in
+            accounts.forEach { historicalAccount in
+                group.addTask {
+                    let owner = historicalAccount.details.account.owner
+                    do {
+                        let accountInfos = try await client.fetchPrimaryAccounts(owner: owner)
+                        let mints = Set(accountInfos.map { $0.mint })
+                        let mintMetadata = try await client.fetchMints(mints: Array(mints))
 
-                            let totalBalance = accountInfos
-                                .map { info in
-                                    ExchangedFiat.compute(
-                                        onChainAmount: TokenAmount(quarks: info.quarks, mint: info.mint),
-                                        rate: rate,
-                                        supplyQuarks: mintMetadata[info.mint]?.launchpadMetadata?.supplyFromBonding
-                                    )
-                                }
-                                .total(rate: rate)
-
-                            await update(owner: owner.publicKey) {
-                                $0.setBalance(totalBalance)
+                        let totalBalance = accountInfos
+                            .map { info in
+                                ExchangedFiat.compute(
+                                    onChainAmount: TokenAmount(quarks: info.quarks, mint: info.mint),
+                                    rate: rate,
+                                    supplyQuarks: mintMetadata[info.mint]?.launchpadMetadata?.supplyFromBonding
+                                )
                             }
+                            .total(rate: rate)
 
-                        } catch ErrorFetchBalance.notFound {
-                            await update(owner: owner.publicKey) {
-                                $0.setNotFound()
-                            }
-                        } catch {
-                            // Silently ignore conversion errors
+                        await update(owner: owner.publicKey) {
+                            $0.setBalance(totalBalance)
                         }
+
+                    } catch ErrorFetchBalance.notFound {
+                        await update(owner: owner.publicKey) {
+                            $0.setNotFound()
+                        }
+                    } catch {
+                        // Silently ignore conversion errors
                     }
                 }
             }
         }
     }
 
-    private func update(owner: PublicKey, handler: @MainActor (inout HistoricalAccount) -> Void) {
+    private func update(owner: PublicKey, handler: (inout HistoricalAccount) -> Void) {
         let index = accounts.firstIndex { $0.details.account.ownerPublicKey == owner }
 
         guard let index = index else {
@@ -258,9 +186,85 @@ struct AccountSelectionScreen: View {
     }
 }
 
+// MARK: - AccountRow -
+
+private struct AccountRow: View {
+
+    let account: HistoricalAccount
+    let isSelected: Bool
+    let onTap: () -> Void
+    let onDelete: () -> Void
+    let onCopyAccessKey: () -> Void
+    let onCopyVaultAddress: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(alignment: .center, spacing: 15) {
+                CheckView(active: isSelected)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(alignment: .bottom, spacing: 10) {
+                        Text(account.mnemonic.name)
+
+                        if account.isNotFound {
+                            Badge(decoration: .circle(.textError), text: "Not Found")
+                        }
+
+                        Spacer()
+
+                        if let balance = account.totalBalance {
+                            AmountText(
+                                flagStyle: balance.nativeAmount.currency.flagStyle,
+                                flagSize: .small,
+                                content: balance.nativeAmount.formatted(),
+                                canScale: false
+                            )
+                            .font(.appTextMedium)
+                        }
+                    }
+                    .font(.appTextMedium)
+                    .foregroundStyle(.textMain)
+                    .padding(.bottom, 5)
+
+                    Group {
+                        Text("Created \(DateFormatter.relative.string(from: account.details.creationDate))")
+                        Text(account.details.account.ownerPublicKey.base58)
+                            .truncationMode(.middle)
+                    }
+                    .font(.appTextHeading)
+                    .foregroundStyle(.textSecondary)
+                    .multilineTextAlignment(.leading)
+                }
+                .frame(maxWidth: .infinity)
+                .lineLimit(1)
+            }
+        }
+        .disabled(isSelected)
+        .listRowBackground(Color.backgroundMain)
+        .padding(20)
+        .swipeActions(allowsFullSwipe: false) {
+            if !isSelected {
+                Button(action: onDelete) {
+                    Image.asset(.delete)
+                }
+                .tint(.bannerError)
+            }
+        }
+        .contextMenu {
+            Button(action: onCopyAccessKey) {
+                Label("Copy Access Key", systemImage: SystemSymbol.doc.rawValue)
+            }
+
+            Button(action: onCopyVaultAddress) {
+                Label("Copy Vault Address", systemImage: SystemSymbol.doc.rawValue)
+            }
+        }
+    }
+}
+
 // MARK: - HistoricalAccount -
 
-class HistoricalAccount: Identifiable {
+struct HistoricalAccount: Identifiable {
 
     nonisolated
     var id: String {
@@ -270,7 +274,6 @@ class HistoricalAccount: Identifiable {
     nonisolated
     let details: AccountDescription
 
-    let cluster: AccountCluster
     let mnemonic: MnemonicPhrase
 
     private(set) var totalBalance: ExchangedFiat?
@@ -279,18 +282,13 @@ class HistoricalAccount: Identifiable {
     init(details: AccountDescription) {
         self.details  = details
         self.mnemonic = details.account.mnemonic
-        self.cluster  = AccountCluster(
-            authority: .derive(using: .primary(), mnemonic: details.account.mnemonic),
-            mint: .usdf,
-            timeAuthority: .usdcAuthority
-        )
     }
 
-    func setBalance(_ exchangedFiat: ExchangedFiat) {
+    mutating func setBalance(_ exchangedFiat: ExchangedFiat) {
         totalBalance = exchangedFiat
     }
 
-    func setNotFound() {
+    mutating func setNotFound() {
         isNotFound = true
     }
 }

--- a/Flipcash/Core/Screens/Onboarding/AccountSelectionScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/AccountSelectionScreen.swift
@@ -175,7 +175,7 @@ struct AccountSelectionScreen: View {
         }
     }
 
-    private func update(owner: PublicKey, handler: (inout HistoricalAccount) -> Void) {
+    private func update(owner: PublicKey, handler: @MainActor (inout HistoricalAccount) -> Void) {
         let index = accounts.firstIndex { $0.details.account.ownerPublicKey == owner }
 
         guard let index = index else {

--- a/FlipcashTests/Regressions/Regression_6a008a1.swift
+++ b/FlipcashTests/Regressions/Regression_6a008a1.swift
@@ -1,0 +1,45 @@
+//
+//  Regression_6a008a1.swift
+//  Flipcash
+//
+//  App Hang: AccountSelectionScreen blocks main thread because
+//            HistoricalAccount.init eagerly builds an AccountCluster
+//            whose authority is `.derive(using:mnemonic:)` — i.e.
+//            BIP-39 PBKDF2-HMAC-SHA512 / 2048 rounds per instance.
+//            Constructing N historical accounts at screen-open time
+//            multiplies the cost and stalls the main run loop.
+//
+//  Fix:      Defer key derivation out of HistoricalAccount.init so
+//            construction is microseconds and the heavy work runs
+//            only when the user selects an account.
+//
+
+import Foundation
+import Testing
+@testable import Flipcash
+@testable import FlipcashCore
+
+@Suite("Regression: 6a008a1 – AccountSelectionScreen hang from BIP-39 PBKDF2 in HistoricalAccount.init", .bug("6a008a1e8c3285d1a52ac2c2"))
+struct Regression_6a008a1 {
+
+    @Test("HistoricalAccount construction is fast (no eager BIP-39 PBKDF2 derivation)")
+    @MainActor
+    func historicalAccount_init_doesNotDeriveKeys() {
+        let descriptions = Array(AccountDescription.mockMany().prefix(10))
+        var results: [HistoricalAccount] = []
+
+        let clock = ContinuousClock()
+        let elapsed = clock.measure {
+            results = descriptions.map { HistoricalAccount(details: $0) }
+        }
+
+        // Observe the result so the optimizer can't elide construction.
+        #expect(results.count == 10)
+        // PBKDF2-HMAC-SHA512 / 2048 rounds per init measures ~1 ms each on
+        // an iPhone simulator with hardware SHA accel — 10 inits land near
+        // ~10 ms. Without derivation in init the same loop is microseconds.
+        // 5 ms boundary keeps a 2× margin over the regression and ample
+        // headroom for CI jitter.
+        #expect(elapsed < .milliseconds(5), "elapsed=\(elapsed)")
+    }
+}


### PR DESCRIPTION
## Summary

Account Selection could hang on returning users when the device was thermally throttled, because key derivation ran on the main thread for every stored account at screen open. The screen now lists accounts instantly and only derives a key when the user picks one. While the file was open the row was extracted into its own view, the data load moved to structured concurrency so it cancels on dismiss, and a regression test pins the new behaviour.

## Test plan

- [x] Full test plan green on iPhone 16 and iPhone 17 simulators
- [x] New regression test fails on the old code and passes on the new
- [x] Manual: open Account Selection with several stored accounts and confirm it appears instantly