### PR TITLE
fix: release build crash in CameraSession and Updateable deinits

### DIFF
--- a/Flipcash/Core/Controllers/Database/Updateable.swift
+++ b/Flipcash/Core/Controllers/Database/Updateable.swift
@@ -14,13 +14,19 @@ import SwiftUI
 /// manual refresh calls. The ``value`` property is tracked by `@Observable`,
 /// so SwiftUI views reading it will update automatically.
 @Observable
-class Updateable<T> {
+final class Updateable<T> {
 
     private(set) var value: T
 
     @ObservationIgnored private let valueBlock: () -> T
     @ObservationIgnored private let didSet: (() -> Void)?
-    @ObservationIgnored private var observer: Any?
+    // SAFETY: observer is assigned once in init and read once in deinit;
+    // no concurrent mutation. `nonisolated(unsafe)` lets the nonisolated
+    // deinit read it without a Sendable wrapper.
+    // FOLLOW-UP: Drop `(unsafe)` once Foundation marks
+    // `NotificationCenter.addObserver`'s `(any NSObjectProtocol)` return as
+    // `Sendable`.
+    @ObservationIgnored nonisolated(unsafe) private var observer: Any?
 
     init(_ valueBlock: @escaping () -> T, didSet: (() -> Void)? = nil) {
         self.valueBlock = valueBlock
@@ -39,7 +45,10 @@ class Updateable<T> {
         }
     }
 
-    isolated deinit {
+    // nonisolated to dodge a Swift 6.3 EarlyPerfInliner crash on @MainActor
+    // generic class deinits. `NotificationCenter.removeObserver` is thread-safe,
+    // so this is functionally equivalent to an isolated deinit here.
+    nonisolated deinit {
         if let observer {
             NotificationCenter.default.removeObserver(observer)
         }

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
@@ -61,7 +61,7 @@ public protocol AnyCameraSession {
 // `DispatchQueue.main.async` is sound.
 // FOLLOW-UP: Drop `@unchecked` once Combine annotates `PassthroughSubject`
 // as `Sendable` and AVFoundation marks `AVCaptureSession` `Sendable`.
-public class CameraSession<T>: ObservableObject, AnyCameraSession, @unchecked Sendable where T: CameraSessionExtractor {
+public final class CameraSession<T>: AnyCameraSession, @unchecked Sendable where T: CameraSessionExtractor {
 
     // The publishers, extractor, and session are reachable from the off-main
     // delegate queue via `receiveSampleBuffer`, so they need to be nonisolated.
@@ -97,6 +97,10 @@ public class CameraSession<T>: ObservableObject, AnyCameraSession, @unchecked Se
             }
         }
     }
+
+    // Empty nonisolated deinit dodges a Swift 6.3 EarlyPerfInliner crash on
+    // @MainActor generic class deinits.
+    nonisolated deinit {}
     
     // MARK: - Configure -
     

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraSessionExtractor.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraSessionExtractor.swift
@@ -9,7 +9,7 @@
 import Foundation
 import AVKit
 
-public nonisolated protocol CameraSessionExtractor {
+public nonisolated protocol CameraSessionExtractor: AnyObject {
 
     associatedtype Output
 


### PR DESCRIPTION
## Summary

Release archive builds were crashing the Swift compiler in an optimizer pass that infinite-recurses on layout constraints while synthesizing deinits for generic classes. Two classes were hit after the recent default-isolation flips put them on the main actor by default. The crash only happens at full optimization, so Debug builds and tests stayed green and we only noticed when archiving.

The fix marks the affected classes final, makes their deinits nonisolated, and strips a couple of incidental complications (a vestigial ObservableObject conformance, an unconstrained protocol). Behavior is unchanged.

## Test plan

- [x] Release archive builds without crashing the compiler.
- [x] QR and Kik code scanning still work on a real device.
- [x] Balance, limits, and currency info views still refresh from database changes.