### PR TITLE
fix: skip telemetry init outside Release production launches

### DIFF
--- a/Code.xcodeproj/project.pbxproj
+++ b/Code.xcodeproj/project.pbxproj
@@ -9,12 +9,12 @@
 /* Begin PBXBuildFile section */
 		4CB225762F77260D0075874E /* FirebaseInstallations in Frameworks */ = {isa = PBXBuildFile; productRef = 4CB225752F77260D0075874E /* FirebaseInstallations */; };
 		4CB225782F7726500075874E /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 4CB225772F7726500075874E /* FirebaseMessaging */; };
+		508AF9C6D67C4CD29DE10A16 /* TweetNacl in Frameworks */ = {isa = PBXBuildFile; productRef = 2B166ABF94584FEF9C368C81 /* TweetNacl */; };
 		88FB56E02EE0AB2F0014EC5F /* CLAUDE.md in Resources */ = {isa = PBXBuildFile; fileRef = 88FB56DF2EE0AB2F0014EC5F /* CLAUDE.md */; };
 		88FB56E52EE0AB810014EC5F /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 88FB56E32EE0AB810014EC5F /* README.md */; };
 		88FB56E62EE0AB810014EC5F /* 2025-11-27-swap-rpc-analysis.md in Resources */ = {isa = PBXBuildFile; fileRef = 88FB56E12EE0AB810014EC5F /* 2025-11-27-swap-rpc-analysis.md */; };
 		88FB56E82EE0C3150014EC5F /* 2025-12-03-swap-models-startswap.md in Resources */ = {isa = PBXBuildFile; fileRef = 88FB56E72EE0C3150014EC5F /* 2025-12-03-swap-models-startswap.md */; };
 		9A017D692EAC1DE200216925 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 9A017D682EAC1DE200216925 /* Kingfisher */; };
-		508AF9C6D67C4CD29DE10A16 /* TweetNacl in Frameworks */ = {isa = PBXBuildFile; productRef = 2B166ABF94584FEF9C368C81 /* TweetNacl */; };
 		9A444EE72E8C414D002B1E39 /* BigDecimal in Frameworks */ = {isa = PBXBuildFile; productRef = 9A444EE62E8C414D002B1E39 /* BigDecimal */; };
 		9A780F972EDF817D009BC4D9 /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 9A780F962EDF817D009BC4D9 /* CodeScanner */; };
 		9ABDD1952D9D7B61006B6CDA /* FlipcashCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9ABDD1942D9D7B61006B6CDA /* FlipcashCore */; };
@@ -1175,6 +1175,14 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		10A6C0E8F8974C1887219D41 /* XCRemoteSwiftPackageReference "tweetnacl-swiftwrap" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/bitmark-inc/tweetnacl-swiftwrap";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.2;
+			};
+		};
 		9A1654D526790419000A135E /* XCRemoteSwiftPackageReference "grpc-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/grpc/grpc-swift.git";
@@ -1189,14 +1197,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 10.24.0;
-			};
-		};
-		10A6C0E8F8974C1887219D41 /* XCRemoteSwiftPackageReference "tweetnacl-swiftwrap" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/bitmark-inc/tweetnacl-swiftwrap";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.2;
 			};
 		};
 		9A444EE52E8C414D002B1E39 /* XCRemoteSwiftPackageReference "BigDecimal" */ = {
@@ -1242,6 +1242,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2B166ABF94584FEF9C368C81 /* TweetNacl */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 10A6C0E8F8974C1887219D41 /* XCRemoteSwiftPackageReference "tweetnacl-swiftwrap" */;
+			productName = TweetNacl;
+		};
 		4CB225752F77260D0075874E /* FirebaseInstallations */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9A1A827528660A6F00A4979F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
@@ -1256,11 +1261,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9A8D9A3D2D78C2E200E755B9 /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
-		};
-		2B166ABF94584FEF9C368C81 /* TweetNacl */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 10A6C0E8F8974C1887219D41 /* XCRemoteSwiftPackageReference "tweetnacl-swiftwrap" */;
-			productName = TweetNacl;
 		};
 		9A444EE62E8C414D002B1E39 /* BigDecimal */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -44,9 +44,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        let isUITesting = CommandLine.arguments.contains("--ui-testing")
+        // Telemetry runs only in Release production launches; DEBUG and any
+        // test process stay silent to avoid polluting production dashboards.
+        #if DEBUG
+        let shouldEnableTelemetry = false
+        #else
+        let shouldEnableTelemetry = !Container.isRunningUITests && !Container.isRunningUnitTests
+        #endif
 
-        if !isUITesting {
+        if shouldEnableTelemetry {
             Analytics.initialize()
             ErrorReporting.initialize()
         }
@@ -54,7 +60,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         FontBook.registerApplicationFonts()
         setupAppearance()
 
-        if isUITesting {
+        if Container.isRunningUITests {
             UIView.setAnimationsEnabled(false)
         }
 

--- a/Flipcash/Core/Container.swift
+++ b/Flipcash/Core/Container.swift
@@ -62,6 +62,12 @@ class Container {
     static var isRunningUnitTests: Bool {
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
+
+    /// UI tests launch the app with `--ui-testing` so the host process can
+    /// suppress animations, telemetry, and other production-only side effects.
+    static var isRunningUITests: Bool {
+        CommandLine.arguments.contains("--ui-testing")
+    }
 }
 
 extension View {

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -90,7 +90,7 @@ final class SessionAuthenticator {
         // During UI testing the deeplink handles login. Skip auto-login
         // to avoid racing with resetForUITesting() and the deeplink's
         // switchAccount(to:) call.
-        guard !CommandLine.arguments.contains("--ui-testing") else {
+        guard !Container.isRunningUITests else {
             accountManager.nukeForUITesting()
             state = .loggedOut
             return


### PR DESCRIPTION
## Summary

Telemetry now only initializes in Release production launches. Debug builds and any test process skip both crash reporting and analytics, which addresses two real problems: developer activity polluting the production dashboards, and unit-test processes aborting under Thread Sanitizer because of a race inside the crash-reporting SDK's memory-polling timer.

Three inline checks for the UI-testing CLI flag have been consolidated into a single helper, mirroring the existing helper used by Firebase initialization. Includes a one-time re-sort of three Swift Package rows in the project file that Xcode keeps trying to re-apply on every open.

## Test plan

- [x] Debug build launches without sending events to the production dashboards.
- [x] Release build still sends events as before.
- [x] The full test plan on iPhone 16 / iOS 18.6 no longer crashes in the dozens from the Bugsnag race.
- [x] UI tests still suppress animations.
- [x] Re-opening the Xcode project does not re-dirty the project file.