### PR TITLE
fix: no-op telemetry calls when SDKs were never initialized

### DIFF
--- a/Flipcash/Utilities/Analytics.swift
+++ b/Flipcash/Utilities/Analytics.swift
@@ -23,18 +23,23 @@ extension AnalyticsEvent where Self: RawRepresentable<String> {
 }
 
 enum Analytics {
-    
+
+    private static var isEnabled = false
+
     static func initialize() {
         let apiKey = try? InfoPlist.value(for: "mixpanel").value(for: "apiKey").string()
         if let apiKey {
             logger.info("Initializing Mixpanel")
             Mixpanel.initialize(token: apiKey, trackAutomaticEvents: true)
+            isEnabled = true
         } else {
             logger.error("Failed to initialize Mixpanel. No API key found in Info.plist")
         }
     }
-    
+
     static func track(event: some AnalyticsEvent, properties: [Property: AnalyticsValue]? = nil, error: Error? = nil) {
+        guard isEnabled else { return }
+
         var container: [String: AnalyticsValue] = [:]
 
         properties?.forEach { key, value in
@@ -46,11 +51,7 @@ enum Analytics {
             container["Error"] = "\(swiftError.domain).\(error):\(swiftError.code)"
         }
 
-        track(event.eventName, properties: container)
-    }
-        
-    private static func track(_ name: String, properties: [String: AnalyticsValue]? = nil) {
-        mixpanel.track(event: name, properties: properties)
+        mixpanel.track(event: event.eventName, properties: container)
     }
 }
 
@@ -58,6 +59,7 @@ enum Analytics {
 
 extension Analytics {
     static func setIdentity(_ userID: UserID) {
+        guard isEnabled else { return }
         // Ensure that this runs after `initialize` has been called
         // on all the tracking platforms
         DispatchQueue.main.async {

--- a/Flipcash/Utilities/ErrorReporting.swift
+++ b/Flipcash/Utilities/ErrorReporting.swift
@@ -10,14 +10,18 @@ import Bugsnag
 import FlipcashCore
 
 enum ErrorReporting {
-    
+
+    private static var isEnabled = false
+
     static func initialize() {
         let config = BugsnagConfiguration.loadConfig()
         config.maxStringValueLength = 50_000
         Bugsnag.start(with: config)
+        isEnabled = true
     }
-    
+
     static func breadcrumb(_ breadcrumb: Breadcrumb) {
+        guard isEnabled else { return }
         Bugsnag.leaveBreadcrumb(
             breadcrumb.rawValue,
             metadata: nil,
@@ -40,6 +44,7 @@ enum ErrorReporting {
     }
     
     static func breadcrumb(name: String, metadata: [String: Any] = [:], exchangedFiat: ExchangedFiat? = nil, fiat: FiatAmount? = nil, type: BreadcrumbType) {
+        guard isEnabled else { return }
         var container: [String: Any] = [:]
         
         metadata.forEach { key, value in
@@ -107,6 +112,8 @@ enum ErrorReporting {
     }
     
     private static func capture(_ error: Swift.Error, reason: String? = nil, id: String? = nil, file: String = #file, function: String = #function, line: Int = #line, buildUserInfo: (inout [String: Any]) -> Void) {
+        guard isEnabled else { return }
+
         if let serverError = error as? ServerError, !serverError.isReportable {
             return
         }


### PR DESCRIPTION
## Summary

Follow-up to #269. Gating telemetry init to Release builds meant Mixpanel and Bugsnag were never started in DEBUG, but every call site still fired — and Mixpanel asserts on access when unstarted, crashing the app on device as soon as the first analytics call ran after login. Both facades now track whether they were initialized and silently no-op every public entry point when not.

## Test plan

- Launch a DEBUG build on a physical device, complete login, and confirm no Mixpanel assertion or Bugsnag error.
- Confirm Release builds still report events and errors as before.