### PR TITLE
refactor: server-driven Coinbase onramp with Apple Pay idle timeout

### DIFF
--- a/Flipcash/Core/Controllers/Coinbase.swift
+++ b/Flipcash/Core/Controllers/Coinbase.swift
@@ -27,62 +27,6 @@ public actor Coinbase {
     }
     
     // MARK: - API -
-    
-    /// Fetches the current state of an existing onramp order. Used to retrieve
-    /// the on-chain `txHash` after the user has completed Apple Pay — Coinbase
-    /// only populates `txHash` once `status == ONRAMP_ORDER_STATUS_COMPLETED`.
-    public func fetchOrder(orderId: String) async throws -> OnrampOrderStatusResponse {
-        let url = config.baseURL.appendingPathComponent("onramp/orders/\(orderId)")
-
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "GET"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        // CDP JWTs are URI-bound — token must be minted for this exact path.
-        let token = try await config.bearerTokenProvider("GET", "platform/v2/onramp/orders/\(orderId)")
-        urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-
-        let (data, response): (Data, URLResponse)
-        do {
-            (data, response) = try await config.urlSession.data(for: urlRequest)
-        } catch {
-            logger.error("fetchOrder transport error", metadata: [
-                "order_id": "\(orderId)",
-                "error": "\(error)"
-            ])
-            throw Error.transport(error)
-        }
-
-        guard let http = response as? HTTPURLResponse else {
-            throw Error.invalidResponse
-        }
-
-        guard (200..<300).contains(http.statusCode) else {
-            if var errorResponse = try? decoder.decode(OnrampErrorResponse.self, from: data) {
-                errorResponse.errorCode = http.statusCode
-                logger.error("fetchOrder rejected", metadata: [
-                    "order_id": "\(orderId)",
-                    "error_type": "\(errorResponse.errorType)",
-                    "status": "\(http.statusCode)"
-                ])
-                throw errorResponse
-            } else {
-                let body = String(data: data, encoding: .utf8) ?? "nil"
-                logger.error("fetchOrder http error", metadata: [
-                    "order_id": "\(orderId)",
-                    "status": "\(http.statusCode)",
-                    "body": "\(body)"
-                ])
-                throw Error.badStatus(code: http.statusCode, body: data)
-            }
-        }
-
-        do {
-            return try decoder.decode(OnrampOrderStatusResponse.self, from: data)
-        } catch {
-            throw Error.decoding(error)
-        }
-    }
 
     public func createOrder(request: OnrampOrderRequest, idempotencyKey: UUID? = nil) async throws -> OnrampOrderResponse {
 
@@ -350,12 +294,6 @@ public nonisolated struct OnrampOrderResponse: Decodable, Identifiable, Sendable
     }
     public let order: Order
     public let paymentLink: PaymentLink
-}
-
-/// Response shape for `GET /v2/onramp/orders/{orderId}`. Unlike the create-order
-/// response, this only contains the `order` envelope — no `paymentLink`.
-public nonisolated struct OnrampOrderStatusResponse: Decodable, Sendable {
-    public let order: OnrampOrderResponse.Order
 }
 
 // MARK: - Error -

--- a/Flipcash/Core/Controllers/Onramp/ApplePayIdleTimer.swift
+++ b/Flipcash/Core/Controllers/Onramp/ApplePayIdleTimer.swift
@@ -1,0 +1,40 @@
+//
+//  ApplePayIdleTimer.swift
+//  Flipcash
+//
+
+import Foundation
+
+/// One-shot timer that fires on `MainActor` if not disarmed before `timeout`
+/// elapses. Used by `OnrampCoordinator` to dismiss the native Apple Pay sheet
+/// when the user leaves it idle on screen. Mirrors the Android client's
+/// `PAYMENT_SHEET_TIMEOUT_MS` (60s).
+@MainActor
+final class ApplePayIdleTimer {
+
+    private let timeout: Duration
+
+    private var task: Task<Void, Never>?
+
+    init(timeout: Duration) {
+        self.timeout = timeout
+    }
+
+    /// Arms (or re-arms) the timer. If a previous `arm` was pending, it is
+    /// cancelled in favor of this one. `onExpiry` runs on `MainActor`.
+    func arm(onExpiry: @escaping @MainActor () -> Void) {
+        let timeout = self.timeout
+        task?.cancel()
+        task = Task { @MainActor in
+            try? await Task.sleep(for: timeout)
+            // `try?` above swallows the CancellationError from `disarm`; re-check before firing.
+            guard !Task.isCancelled else { return }
+            onExpiry()
+        }
+    }
+
+    func disarm() {
+        task?.cancel()
+        task = nil
+    }
+}

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -16,7 +16,15 @@ final class OnrampCoordinator {
     // MARK: - State -
 
     /// Apple Pay order — drives the invisible WebView overlay hosted at root.
-    private(set) var coinbaseOrder: OnrampOrderResponse?
+    private(set) var coinbaseOrder: OnrampOrderResponse? {
+        didSet {
+            // Catch-all disarm for any path that nils the order (cancel(), error handlers).
+            // `commitSuccess` / `pollingStart` disarm explicitly because they leave the order set.
+            if coinbaseOrder == nil {
+                applePayIdleTimer.disarm()
+            }
+        }
+    }
 
     /// Non-nil once the post-onramp swap succeeds. Drives the calling
     /// screen's processing-screen cover.
@@ -101,13 +109,12 @@ final class OnrampCoordinator {
 
     var dialogItem: DialogItem?
 
-    /// True once Coinbase has accepted the order and remains true through the
-    /// full committed flow: Apple Pay commit, on-chain settlement, the poll
-    /// loop, the downstream `buyWithExternalFunding` swap, and while the
-    /// processing screen is presented. Drives the sheet-level dismiss lock —
-    /// the USDF destination is a staging ATA that only `buyWithExternalFunding`
-    /// can drain, so dismissing mid-flight would strand funds with no recovery
-    /// path through normal UI.
+    /// True from the moment a Coinbase order is created and a server-side
+    /// swap stream is initiated through Apple Pay completion. Drives the
+    /// EnterAmountView's dismiss lock — the user can't back out while we
+    /// have an in-flight stateful swap on the server that's waiting for
+    /// Coinbase to clear; the processing screen takes over after Apple Pay
+    /// commits.
     var isProcessingPayment: Bool {
         coinbaseOrder != nil || pendingOperation != nil
     }
@@ -128,18 +135,25 @@ final class OnrampCoordinator {
     /// (no `coinbaseOrder` change) to its callers.
     private var pendingOperation: OnrampOperation?
     @ObservationIgnored private var pendingAmount: ExchangedFiat?
-    @ObservationIgnored private var fundingTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingSwapId: SwapId?
+
+    @ObservationIgnored private let applePayIdleTimer: ApplePayIdleTimer
 
     @ObservationIgnored private let phoneFormatter = PhoneFormatter()
 
     // MARK: - Init -
 
-    init(session: Session, flipClient: FlipClient) {
+    init(
+        session: Session,
+        flipClient: FlipClient,
+        applePayIdleTimeout: Duration = .seconds(60)
+    ) {
         self.session = session
         self.flipClient = flipClient
         self.owner = session.ownerKeyPair
         self.region = phoneFormatter.currentRegion
         self.coinbaseApiKey = try? InfoPlist.value(for: "coinbase").value(for: "apiKey").string()
+        self.applePayIdleTimer = ApplePayIdleTimer(timeout: applePayIdleTimeout)
 
         // Weak capture breaks the retain cycle between the coordinator and
         // the Coinbase client (which stores this closure for the lifetime of
@@ -299,10 +313,13 @@ final class OnrampCoordinator {
     }
 
     func cancel() {
-        fundingTask?.cancel()
-        fundingTask = nil
+        clearPendingState()
+    }
+
+    private func clearPendingState() {
         pendingOperation = nil
         pendingAmount = nil
+        pendingSwapId = nil
         coinbaseOrder = nil
     }
 
@@ -686,10 +703,32 @@ final class OnrampCoordinator {
                 agreementAcceptedAt: .now
             ))
 
-            coinbaseOrder = response
             logger.info("Coinbase order created", metadata: [
                 "order_id": "\(response.id)"
             ])
+
+            // Server must be watching the Coinbase order before Apple Pay
+            // commits — otherwise the user pays into a swap the backend
+            // hasn't registered.
+            do {
+                pendingSwapId = try await initiateCoinbaseOnrampSwap(
+                    for: operation,
+                    amount: amount,
+                    orderId: response.id
+                )
+            } catch {
+                logger.error("Failed to initiate Coinbase-onramp swap", metadata: [
+                    "error": "\(error)",
+                    "order_id": "\(response.id)",
+                    "destination_kind": "\(operation.logKind)"
+                ])
+                pendingOperation = nil
+                pendingAmount = nil
+                showBuyFailedDialog()
+                return
+            }
+
+            coinbaseOrder = response
         }
 
         catch let error as OnrampErrorResponse {
@@ -722,6 +761,52 @@ final class OnrampCoordinator {
         }
     }
 
+    // MARK: - Coinbase onramp swap helpers -
+
+    private func initiateCoinbaseOnrampSwap(
+        for operation: OnrampOperation,
+        amount: ExchangedFiat,
+        orderId: String
+    ) async throws -> SwapId {
+        switch operation {
+        case .buy(let mint, _):
+            return try await session.buyWithCoinbaseOnramp(
+                amount: amount,
+                of: mint,
+                orderId: orderId
+            )
+        case .launch(let mint, _, let launchAmount, let launchFee):
+            return try await session.buyNewCurrencyWithCoinbaseOnramp(
+                amount: launchAmount,
+                feeAmount: launchFee,
+                mint: mint,
+                orderId: orderId
+            )
+        }
+    }
+
+    private func makeOnrampCompletion(
+        for operation: OnrampOperation,
+        swapId: SwapId,
+        amount: ExchangedFiat
+    ) -> OnrampCompletion {
+        switch operation {
+        case .buy:
+            return .buyProcessing(
+                swapId: swapId,
+                currencyName: operation.displayName,
+                amount: amount
+            )
+        case .launch(let mint, _, let launchAmount, _):
+            return .launchProcessing(
+                swapId: swapId,
+                launchedMint: mint,
+                currencyName: operation.displayName,
+                amount: launchAmount
+            )
+        }
+    }
+
     func receiveApplePayEvent(_ event: ApplePayEvent) {
         func errorMetadata() -> Logger.Metadata {
             [
@@ -731,9 +816,7 @@ final class OnrampCoordinator {
         }
 
         func handleEventError(_ kind: ApplePayEvent.Event) {
-            coinbaseOrder = nil
-            pendingOperation = nil
-            pendingAmount = nil
+            clearPendingState()
 
             // Prefer the Coinbase-provided reason if we have one — users hitting
             // a region mismatch or card decline shouldn't see "Something went wrong".
@@ -766,19 +849,24 @@ final class OnrampCoordinator {
             logger.info("Apple Pay button pressed")
         case .pendingPaymentAuth:
             logger.info("Apple Pay pending payment auth")
+            applePayIdleTimer.arm { [weak self] in
+                logger.info("Apple Pay sheet idle timeout, dismissing")
+                self?.cancel()
+            }
+        case .paymentAuthorized:
+            logger.info("Apple Pay payment authorized")
 
         case .commitSuccess:
             logger.info("Apple Pay commit succeeded")
+            applePayIdleTimer.disarm()
         case .commitError:
             logger.error("Apple Pay commit failed", metadata: errorMetadata())
             handleEventError(.commitError)
         case .pollingStart:
             logger.info("Apple Pay polling started")
+            applePayIdleTimer.disarm()
         case .pollingSuccess:
-            fundingTask?.cancel()
-            fundingTask = Task { [weak self] in
-                await self?.handleCoinbaseFundingSuccess()
-            }
+            handleCoinbaseOnrampSuccess()
         case .pollingError:
             logger.error("Apple Pay polling failed", metadata: errorMetadata())
             Analytics.onrampCompleted(
@@ -789,191 +877,42 @@ final class OnrampCoordinator {
             handleEventError(.pollingError)
         case .cancelled:
             logger.info("Apple Pay cancelled")
-            coinbaseOrder = nil
-            pendingOperation = nil
-            pendingAmount = nil
+            clearPendingState()
         case .none:
             logger.warning("Apple Pay received unknown event", metadata: ["raw_event": "\(event.name)"])
         }
     }
 
-    // MARK: - Poll + settle -
+    // MARK: - Coinbase onramp completion -
 
-    /// Polls `GET /v2/onramp/orders/{id}` until the order reaches a terminal state
-    /// (COMPLETED or FAILED) or the timeout expires. Returns the final order on
-    /// success. Throws on timeout, FAILED status, or repeated network errors.
-    private func pollCoinbaseOrderUntilComplete(orderId: String) async throws -> OnrampOrderResponse.Order {
-        let start = Date()
-        let deadline = start.addingTimeInterval(60) // sandbox completes in 250ms; 60s is generous for production
-        var pollCount = 0
-        var lastError: Error?
+    private func handleCoinbaseOnrampSuccess() {
+        defer { clearPendingState() }
 
-        while Date() < deadline {
-            try Task.checkCancellation()
-            pollCount += 1
-            do {
-                let response = try await coinbase.fetchOrder(orderId: orderId)
-                let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
-                let status = response.order.status.uppercased()
-
-                logger.info("Coinbase order poll", metadata: [
-                    "poll": "\(pollCount)",
-                    "elapsed_ms": "\(elapsedMs)",
-                    "status": "\(response.order.status)",
-                    "tx_hash": "\(response.order.txHash ?? "nil")"
-                ])
-
-                if status.contains("COMPLETED") {
-                    return response.order
-                }
-                if status.contains("FAILED") {
-                    throw OnrampError.coinbaseOrderFailed(status: response.order.status)
-                }
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch let error as OnrampError {
-                throw error
-            } catch {
-                lastError = error
-                logger.warning("Coinbase order poll error, retrying", metadata: [
-                    "poll": "\(pollCount)",
-                    "error": "\(error)"
-                ])
-            }
-
-            // Backoff: start at 500ms, +200ms every 5 polls
-            let delayMs = 500 + (200 * (pollCount / 5))
-            try await Task.delay(milliseconds: delayMs)
-        }
-
-        throw lastError ?? OnrampError.coinbaseOrderPollTimeout
-    }
-
-    /// Builds an ExchangedFiat for the buyWithExternalFunding call. The Coinbase
-    /// `purchaseAmount` is a string-encoded decimal in USDF units (e.g. "5" for $5).
-    /// Returns nil if the order didn't actually purchase USDF (defense against future
-    /// Coinbase API changes — we always request USDF, so a mismatch indicates a server
-    /// behavior change worth failing closed on).
-    private func makeUsdfSwapAmount(from order: OnrampOrderResponse.Order) -> ExchangedFiat? {
-        guard let purchaseCurrency = order.purchaseCurrency,
-              purchaseCurrency.uppercased() == "USDF" else {
-            return nil
-        }
-
-        guard let purchaseAmountString = order.purchaseAmount,
-              let decimal = NumberFormatter.decimal(from: purchaseAmountString) else {
-            return nil
-        }
-
-        return ExchangedFiat(
-            nativeAmount: FiatAmount(value: decimal, currency: .usd),
-            rate: .oneToOne
-        )
-    }
-
-    private func handleCoinbaseFundingSuccess() async {
-        // Always release the transient onramp state when this method exits,
-        // regardless of success / error / sandbox short-circuit. Without this
-        // the user is stranded with `isProcessingPayment == true` and no way
-        // to retry.
-        defer {
-            pendingOperation = nil
-            pendingAmount = nil
-            coinbaseOrder = nil
-            fundingTask = nil
-        }
-
-        guard let operation = pendingOperation else {
-            logger.error("pollingSuccess fired with no pending operation")
+        guard let operation = pendingOperation,
+              let amount = pendingAmount,
+              let swapId = pendingSwapId else {
+            logger.error("Onramp success fired with missing pending state", metadata: [
+                "has_operation": "\(pendingOperation != nil)",
+                "has_amount": "\(pendingAmount != nil)",
+                "has_swapId": "\(pendingSwapId != nil)"
+            ])
+            showBuyFailedDialog()
             return
         }
 
-        logger.info("Coinbase funding succeeded", metadata: [
+        logger.info("Coinbase onramp funding succeeded", metadata: [
+            "swap_id": "\(swapId.publicKey.base58)",
             "destination_kind": "\(operation.logKind)",
             "destination_name": "\(operation.displayName)"
         ])
 
-        guard let orderId = coinbaseOrder?.order.orderId else {
-            logger.error("pollingSuccess fired with no active Coinbase order")
-            showBuyFailedDialog()
-            return
-        }
+        completion = makeOnrampCompletion(for: operation, swapId: swapId, amount: amount)
 
-        // Poll Coinbase for the completed order. This runs in sandbox too — it
-        // validates the full Coinbase integration (JWT scoping, GET endpoint,
-        // status transitions, txHash field parsing) end-to-end on every run.
-        let order: OnrampOrderResponse.Order
-        do {
-            order = try await pollCoinbaseOrderUntilComplete(orderId: orderId)
-        } catch is CancellationError {
-            logger.info("Coinbase order poll cancelled")
-            return
-        } catch {
-            logger.error("Coinbase order poll failed", metadata: ["error": "\(error)"])
-            ErrorReporting.captureError(error)
-            showBuyFailedDialog()
-            return
-        }
-
-        guard let txHash = order.txHash, !txHash.isEmpty else {
-            logger.error("Coinbase order completed with no txHash", metadata: [
-                "order_id": "\(orderId)",
-                "status": "\(order.status)"
-            ])
-            showBuyFailedDialog()
-            return
-        }
-
-        guard let signature = try? Signature(base58: txHash) else {
-            logger.error("Failed to decode txHash as Solana signature", metadata: [
-                "tx_hash": "\(txHash)",
-                "tx_hash_length": "\(txHash.count)"
-            ])
-            showBuyFailedDialog()
-            return
-        }
-
-        guard let amount = makeUsdfSwapAmount(from: order) else {
-            logger.error("Failed to construct swap amount from order", metadata: [
-                "order_id": "\(orderId)"
-            ])
-            showBuyFailedDialog()
-            return
-        }
-
-        let onCompletedClosure: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
-        switch operation {
-        case .buy(_, _, let cb):    onCompletedClosure = cb
-        case .launch(_, let cb):    onCompletedClosure = cb
-        }
-
-        do {
-            switch try await onCompletedClosure(signature, amount) {
-            case .buyExisting(let swapId):
-                self.completion = .buyProcessing(
-                    swapId: swapId,
-                    currencyName: operation.displayName,
-                    amount: amount
-                )
-            case .launch(let swapId, let mint):
-                self.completion = .launchProcessing(
-                    swapId: swapId,
-                    launchedMint: mint,
-                    currencyName: operation.displayName,
-                    amount: amount
-                )
-            }
-
-            Analytics.onrampCompleted(
-                amount: amount.usdfValue,
-                successful: true,
-                error: nil
-            )
-        } catch {
-            logger.error("Buy failed", metadata: ["error": "\(error)"])
-            ErrorReporting.captureError(error)
-            showBuyFailedDialog()
-        }
+        Analytics.onrampCompleted(
+            amount: amount.usdfValue,
+            successful: true,
+            error: nil
+        )
     }
 }
 

--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -16,15 +16,7 @@ final class OnrampCoordinator {
     // MARK: - State -
 
     /// Apple Pay order — drives the invisible WebView overlay hosted at root.
-    private(set) var coinbaseOrder: OnrampOrderResponse? {
-        didSet {
-            // Catch-all disarm for any path that nils the order (cancel(), error handlers).
-            // `commitSuccess` / `pollingStart` disarm explicitly because they leave the order set.
-            if coinbaseOrder == nil {
-                applePayIdleTimer.disarm()
-            }
-        }
-    }
+    private(set) var coinbaseOrder: OnrampOrderResponse?
 
     /// Non-nil once the post-onramp swap succeeds. Drives the calling
     /// screen's processing-screen cover.
@@ -111,7 +103,8 @@ final class OnrampCoordinator {
 
     /// True from the moment a Coinbase order is created and a server-side
     /// swap stream is initiated through Apple Pay completion. Drives the
-    /// EnterAmountView's dismiss lock — the user can't back out while we
+    /// calling flow's dismiss lock (buy: `EnterAmountView`, launch:
+    /// `CurrencyCreationWizardScreen`) so the user can't back out while we
     /// have an in-flight stateful swap on the server that's waiting for
     /// Coinbase to clear; the processing screen takes over after Apple Pay
     /// commits.
@@ -321,6 +314,7 @@ final class OnrampCoordinator {
         pendingAmount = nil
         pendingSwapId = nil
         coinbaseOrder = nil
+        applePayIdleTimer.disarm()
     }
 
     // MARK: - Verification navigation -
@@ -615,7 +609,7 @@ final class OnrampCoordinator {
     }
 
     private func showBuyFailedDialog() {
-        coinbaseOrder = nil
+        clearPendingState()
         presentDestructiveDialog(
             title: "Couldn't Buy Token",
             subtitle: "Your USDF is in your wallet. Try again from the currency screen."
@@ -722,8 +716,7 @@ final class OnrampCoordinator {
                     "order_id": "\(response.id)",
                     "destination_kind": "\(operation.logKind)"
                 ])
-                pendingOperation = nil
-                pendingAmount = nil
+                clearPendingState()
                 showBuyFailedDialog()
                 return
             }
@@ -737,8 +730,7 @@ final class OnrampCoordinator {
                 "error_title": "\(error.title)"
             ])
             ErrorReporting.captureError(error)
-            pendingOperation = nil
-            pendingAmount = nil
+            clearPendingState()
 
             if error.errorType == .guestRegionForbidden {
                 presentDestructiveDialog(title: error.title, subtitle: error.subtitle) { [weak self] in
@@ -756,8 +748,7 @@ final class OnrampCoordinator {
                 "error": "\(error)"
             ])
             ErrorReporting.captureError(error)
-            pendingOperation = nil
-            pendingAmount = nil
+            clearPendingState()
         }
     }
 
@@ -854,7 +845,11 @@ final class OnrampCoordinator {
                 self?.cancel()
             }
         case .paymentAuthorized:
+            // Face ID / Touch ID confirmed — the sheet is no longer idle. If
+            // commit is slow (network), letting the timer keep running would
+            // cancel a committed order mid-flight.
             logger.info("Apple Pay payment authorized")
+            applePayIdleTimer.disarm()
 
         case .commitSuccess:
             logger.info("Apple Pay commit succeeded")
@@ -894,7 +889,7 @@ final class OnrampCoordinator {
             logger.error("Onramp success fired with missing pending state", metadata: [
                 "has_operation": "\(pendingOperation != nil)",
                 "has_amount": "\(pendingAmount != nil)",
-                "has_swapId": "\(pendingSwapId != nil)"
+                "has_swap_id": "\(pendingSwapId != nil)"
             ])
             showBuyFailedDialog()
             return

--- a/Flipcash/Core/Controllers/Onramp/OnrampOperation.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampOperation.swift
@@ -9,18 +9,19 @@ import FlipcashCore
 enum OnrampOperation {
     case buy(
         mint: PublicKey,
-        displayName: String,
-        onCompleted: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
+        displayName: String
     )
     case launch(
+        mint: PublicKey,
         displayName: String,
-        onCompleted: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
+        launchAmount: ExchangedFiat,
+        launchFee: ExchangedFiat
     )
 
     var displayName: String {
         switch self {
-        case .buy(_, let displayName, _): displayName
-        case .launch(let displayName, _): displayName
+        case .buy(_, let displayName):              displayName
+        case .launch(_, let displayName, _, _):     displayName
         }
     }
 

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -239,15 +239,28 @@ struct CurrencyCreationWizardScreen: View {
             // sheet has fully dismissed so the two sheets don't collide.
             guard pendingCoinbaseLaunch else { return }
             pendingCoinbaseLaunch = false
-            onrampCoordinator.start(
-                .launch(
-                    displayName: state.currencyName,
-                    onCompleted: { signature, _ in
-                        try await launchAfterExternalFunding(signature: signature, source: .coinbase)
-                    }
-                ),
-                amount: totalLaunchCost
-            )
+
+            // Launch the currency upfront so the stateful swap stream can be
+            // opened with the new mint before Apple Pay is presented.
+            let displayName = state.currencyName
+            let launchAmount = self.launchAmount
+            let launchFee = self.launchFee
+            let totalLaunchCost = self.totalLaunchCost
+            Task {
+                guard let mint = await launchCurrencyWithPreflightRouting() else {
+                    isValidating = false
+                    return
+                }
+                onrampCoordinator.start(
+                    .launch(
+                        mint: mint,
+                        displayName: displayName,
+                        launchAmount: launchAmount,
+                        launchFee: launchFee
+                    ),
+                    amount: totalLaunchCost
+                )
+            }
         }) {
             FundingSelectionSheet(
                 reserveBalance: reserveBalance,

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -246,7 +246,8 @@ struct CurrencyCreationWizardScreen: View {
             let launchAmount = self.launchAmount
             let launchFee = self.launchFee
             let totalLaunchCost = self.totalLaunchCost
-            Task {
+            validationTask?.cancel()
+            validationTask = Task {
                 guard let mint = await launchCurrencyWithPreflightRouting() else {
                     isValidating = false
                     return

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -255,14 +255,6 @@ struct CurrencyInfoScreen: View {
                 displayName: target.displayName,
                 session: sessionContainer.session,
                 onrampCoordinator: onrampCoordinator,
-                onUsdfReady: { signature, amount in
-                    let swapId = try await sessionContainer.session.buyWithExternalFunding(
-                        amount: amount,
-                        of: target.mint,
-                        transactionSignature: signature
-                    )
-                    return .buyExisting(swapId: swapId)
-                },
                 onDismiss: { onrampDestination = nil }
             )
         }

--- a/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampAmountScreen.swift
@@ -23,7 +23,6 @@ struct OnrampAmountScreen: View {
         displayName: String,
         session: Session,
         onrampCoordinator: OnrampCoordinator,
-        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult,
         onDismiss: @escaping () -> Void
     ) -> OnrampAmountScreen {
         OnrampAmountScreen(
@@ -31,8 +30,7 @@ struct OnrampAmountScreen: View {
                 mint: mint,
                 displayName: displayName,
                 session: session,
-                onrampCoordinator: onrampCoordinator,
-                onUsdfReady: onUsdfReady
+                onrampCoordinator: onrampCoordinator
             ),
             onDismiss: onDismiss
         )

--- a/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampViewModel.swift
@@ -49,7 +49,6 @@ class OnrampViewModel {
     @ObservationIgnored private let session: Session
     @ObservationIgnored private let mint: PublicKey
     @ObservationIgnored private let onrampCoordinator: OnrampCoordinator
-    @ObservationIgnored private let onUsdfReady: @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
 
     // MARK: - Init -
 
@@ -57,15 +56,13 @@ class OnrampViewModel {
         mint: PublicKey,
         displayName: String,
         session: Session,
-        onrampCoordinator: OnrampCoordinator,
-        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
+        onrampCoordinator: OnrampCoordinator
     ) -> OnrampViewModel {
         OnrampViewModel(
             displayName: displayName,
             mint: mint,
             session: session,
-            onrampCoordinator: onrampCoordinator,
-            onUsdfReady: onUsdfReady
+            onrampCoordinator: onrampCoordinator
         )
     }
 
@@ -73,14 +70,12 @@ class OnrampViewModel {
         displayName: String,
         mint: PublicKey,
         session: Session,
-        onrampCoordinator: OnrampCoordinator,
-        onUsdfReady: @escaping @MainActor @Sendable (Signature, ExchangedFiat) async throws -> SignedSwapResult
+        onrampCoordinator: OnrampCoordinator
     ) {
         self.displayName = displayName
         self.mint = mint
         self.session = session
         self.onrampCoordinator = onrampCoordinator
-        self.onUsdfReady = onUsdfReady
     }
 
     // MARK: - Actions -
@@ -110,7 +105,7 @@ class OnrampViewModel {
         }
 
         onrampCoordinator.start(
-            .buy(mint: mint, displayName: displayName, onCompleted: onUsdfReady),
+            .buy(mint: mint, displayName: displayName),
             amount: exchangedFiat
         )
     }
@@ -171,8 +166,6 @@ extension Profile {
 // MARK: - OnrampError -
 
 enum OnrampError: Error {
-    case coinbaseOrderFailed(status: String)
-    case coinbaseOrderPollTimeout
     case missingCoinbaseApiKey
 }
 

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -629,6 +629,24 @@ class Session {
     }
 
     @discardableResult
+    func buyWithCoinbaseOnramp(
+        amount: ExchangedFiat,
+        of mint: PublicKey,
+        orderId: String
+    ) async throws -> SwapId {
+        let token = try await fetchMintMetadata(mint: mint)
+        let swapId = SwapId.generate()
+
+        return try await client.buyWithCoinbaseOnramp(
+            swapId: swapId,
+            amount: amount,
+            of: token.metadata,
+            owner: owner,
+            orderId: orderId
+        )
+    }
+
+    @discardableResult
     func launchCurrency(
         name: String,
         description: String,
@@ -720,6 +738,39 @@ class Session {
         )
 
         logger.info("New currency buy (external) completed", metadata: [
+            "swapId": "\(metadata.swapId.publicKey.base58)",
+            "state": "\(metadata.state)"
+        ])
+
+        updatePostTransaction()
+        return metadata.swapId
+    }
+
+    @discardableResult
+    func buyNewCurrencyWithCoinbaseOnramp(
+        amount: ExchangedFiat,
+        feeAmount: ExchangedFiat,
+        mint: PublicKey,
+        orderId: String
+    ) async throws -> SwapId {
+        logger.info("Buying new currency (Coinbase onramp funding)", metadata: [
+            "amount": "\(amount.nativeAmount.formatted())",
+            "feeAmount": "\(feeAmount.nativeAmount.formatted())",
+            "mint": "\(mint.base58)",
+            "orderId": "\(orderId)"
+        ])
+
+        let swapId = SwapId.generate()
+        let metadata = try await client.buyNewCurrencyWithCoinbaseOnramp(
+            swapId: swapId,
+            amount: amount,
+            feeAmount: feeAmount,
+            mint: mint,
+            owner: ownerKeyPair,
+            orderId: orderId
+        )
+
+        logger.info("New currency buy (Coinbase onramp) completed", metadata: [
             "swapId": "\(metadata.swapId.publicKey.base58)",
             "state": "\(metadata.state)"
         ])

--- a/Flipcash/UI/ApplePayWebView.swift
+++ b/Flipcash/UI/ApplePayWebView.swift
@@ -146,6 +146,7 @@ public struct ApplePayEvent: Codable, Sendable {
 
         case applePayButtonPressed = "onramp_api.apple_pay_button_pressed"
         case pendingPaymentAuth    = "onramp_api.pending_payment_auth"
+        case paymentAuthorized     = "onramp_api.payment_authorized"
 
         case commitSuccess         = "onramp_api.commit_success"
         case commitError           = "onramp_api.commit_error"

--- a/FlipcashAPI/Sources/FlipcashAPI/Payments/Generated/transaction_v1_transaction_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Payments/Generated/transaction_v1_transaction_service.pb.swift
@@ -25,6 +25,7 @@ public enum Ocp_Transaction_V1_FundingSource: SwiftProtobuf.Enum, Swift.CaseIter
   case unknown // = 0
   case submitIntent // = 1
   case externalWallet // = 2
+  case coinbaseOnramp // = 3
   case UNRECOGNIZED(Int)
 
   public init() {
@@ -36,6 +37,7 @@ public enum Ocp_Transaction_V1_FundingSource: SwiftProtobuf.Enum, Swift.CaseIter
     case 0: self = .unknown
     case 1: self = .submitIntent
     case 2: self = .externalWallet
+    case 3: self = .coinbaseOnramp
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
@@ -45,6 +47,7 @@ public enum Ocp_Transaction_V1_FundingSource: SwiftProtobuf.Enum, Swift.CaseIter
     case .unknown: return 0
     case .submitIntent: return 1
     case .externalWallet: return 2
+    case .coinbaseOnramp: return 3
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -54,6 +57,7 @@ public enum Ocp_Transaction_V1_FundingSource: SwiftProtobuf.Enum, Swift.CaseIter
     .unknown,
     .submitIntent,
     .externalWallet,
+    .coinbaseOnramp,
   ]
 
 }
@@ -926,6 +930,7 @@ public struct Ocp_Transaction_V1_StatefulSwapRequest: Sendable {
       ///
       /// For FUNDING_SOURCE_SUBMIT_INTENT, this value is the base58 encoded intent ID.
       /// For FUNDING_SOURCE_EXTERNAL_WALLET, this value is the base58 encoded transaction signature.
+      /// For FUNDING_SOURCE_COINBASE_ONRAMP, this value is the order ID
       public var fundingID: String = String()
 
       /// The fee amount to pay for this swap
@@ -3131,7 +3136,7 @@ public struct Ocp_Transaction_V1_SwapMetadata: Sendable {
 fileprivate let _protobuf_package = "ocp.transaction.v1"
 
 extension Ocp_Transaction_V1_FundingSource: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0FUNDING_SOURCE_UNKNOWN\0\u{1}FUNDING_SOURCE_SUBMIT_INTENT\0\u{1}FUNDING_SOURCE_EXTERNAL_WALLET\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0FUNDING_SOURCE_UNKNOWN\0\u{1}FUNDING_SOURCE_SUBMIT_INTENT\0\u{1}FUNDING_SOURCE_EXTERNAL_WALLET\0\u{1}FUNDING_SOURCE_COINBASE_ONRAMP\0")
 }
 
 extension Ocp_Transaction_V1_SubmitIntentRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/FlipcashAPI/Sources/FlipcashAPI/Payments/proto/transaction/v1/transaction_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Payments/proto/transaction/v1/transaction_service.proto
@@ -337,13 +337,14 @@ message StatefulSwapRequest {
 
             // Where "amount" of "from_mint" will be sent from to the VM swap PDA
             FundingSource funding_source = 5 [(validate.rules).enum = {
-                in: [1, 2] // FUNDING_SOURCE_SUBMIT_INTENT, FUNDING_SOURCE_EXTERNAL_WALLET
+                in: [1, 2, 3] // FUNDING_SOURCE_SUBMIT_INTENT, FUNDING_SOURCE_EXTERNAL_WALLET, FUNDING_SOURCE_COINBASE_ONRAMP
             }];
 
             // The ID of the "transaction" to lookup funding state.
             //
             // For FUNDING_SOURCE_SUBMIT_INTENT, this value is the base58 encoded intent ID.
             // For FUNDING_SOURCE_EXTERNAL_WALLET, this value is the base58 encoded transaction signature.
+            // For FUNDING_SOURCE_COINBASE_ONRAMP, this value is the order ID
             string funding_id = 6 [(validate.rules).string = {
                 min_len: 32,
                 max_len: 88,
@@ -1216,4 +1217,5 @@ enum FundingSource {
     FUNDING_SOURCE_UNKNOWN         = 0;
     FUNDING_SOURCE_SUBMIT_INTENT   = 1;
     FUNDING_SOURCE_EXTERNAL_WALLET = 2;
+    FUNDING_SOURCE_COINBASE_ONRAMP = 3;
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Transaction.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Transaction.swift
@@ -156,6 +156,33 @@ extension Client {
         }
     }
 
+    /// Buy an existing currency funded by a Coinbase Onramp order.
+    /// Server watches the order; submits the swap when Coinbase clears.
+    @discardableResult
+    public func buyWithCoinbaseOnramp(
+        swapId: SwapId,
+        amount: ExchangedFiat,
+        of token: MintMetadata,
+        owner: AccountCluster,
+        orderId: String
+    ) async throws -> SwapId {
+        try await ensureAccountExists(
+            owner: owner.authority.keyPair,
+            ownerAuthority: owner.authority,
+            token: token
+        )
+
+        return try await withCheckedThrowingContinuation { c in
+            transactionService.buyWithCoinbaseOnramp(
+                swapId: swapId,
+                amount: amount,
+                of: token,
+                owner: owner.authority.keyPair,
+                orderId: orderId
+            ) { c.resume(with: $0) }
+        }
+    }
+
     @discardableResult
     public func sell(amount: ExchangedFiat, verifiedState: VerifiedState, in token: MintMetadata, owner: AccountCluster) async throws -> SwapId {
         try await withCheckedThrowingContinuation { c in
@@ -233,6 +260,37 @@ extension Client {
                 amount: amount.onChainAmount,
                 feeAmount: feeAmount.onChainAmount,
                 fundingSource: .externalWallet(transactionSignature: transactionSignature),
+                owner: owner,
+                isNewCurrencyLaunch: true
+            ) { c.resume(with: $0) }
+        }
+    }
+
+    /// Same launch-first-buy atomic flow as ``buyNewCurrency`` but funded by a
+    /// Coinbase Onramp order. Server watches the order and executes the swap
+    /// once Coinbase clears, using the `TransferForSwapWithFee` server-side
+    /// path. The caller must have already created the currency on-chain via
+    /// `launch(...)` and pass the resulting mint.
+    ///
+    /// No `ensureAccountExists` precheck: the mint was just created, and the
+    /// destination ATA lives at the VM swap PDA, not on the user's owner.
+    /// Matches ``buyNewCurrencyWithExternalFunding``.
+    @discardableResult
+    public func buyNewCurrencyWithCoinbaseOnramp(
+        swapId: SwapId,
+        amount: ExchangedFiat,
+        feeAmount: ExchangedFiat,
+        mint: PublicKey,
+        owner: KeyPair,
+        orderId: String
+    ) async throws -> SwapMetadata {
+        return try await withCheckedThrowingContinuation { c in
+            transactionService.swapService.swap(
+                swapId: swapId,
+                direction: .buy(mint: .launchStub(address: mint)),
+                amount: amount.onChainAmount,
+                feeAmount: feeAmount.onChainAmount,
+                fundingSource: .coinbaseOnramp(orderId: orderId),
                 owner: owner,
                 isNewCurrencyLaunch: true
             ) { c.resume(with: $0) }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -344,6 +344,50 @@ class TransactionService: CodeService<Ocp_Transaction_V1_TransactionNIOClient> {
         }
     }
 
+    /// A buy of an existing currency funded by a Coinbase Onramp order.
+    /// Server watches the order, holds the client-signed transaction, and
+    /// submits it on-chain once Coinbase reports the funding as complete.
+    /// Wire-identical to `buyWithExternalFunding` except the funding source
+    /// is the order ID instead of an on-chain transaction signature.
+    func buyWithCoinbaseOnramp(
+        swapId: SwapId,
+        amount: ExchangedFiat,
+        of token: MintMetadata,
+        owner: KeyPair,
+        orderId: String,
+        completion: @Sendable @escaping (Result<SwapId, ErrorSwap>) -> Void
+    ) {
+        logger.info("Starting Coinbase-onramp-funded buy", metadata: [
+            "amount": "\(amount.nativeAmount.formatted())",
+            "symbol": "\(token.symbol)",
+            "swapId": "\(swapId.publicKey.base58)",
+            "orderId": "\(orderId)"
+        ])
+
+        swapService.swap(
+            swapId: swapId,
+            direction: .buy(mint: token),
+            amount: amount.onChainAmount,
+            fundingSource: .coinbaseOnramp(orderId: orderId),
+            owner: owner
+        ) { result in
+            switch result {
+            case .success:
+                logger.info("Buy swap initiated with Coinbase onramp funding", metadata: [
+                    "swapId": "\(swapId.publicKey.base58)",
+                    "orderId": "\(orderId)"
+                ])
+                completion(.success(swapId))
+            case .failure(let error):
+                logger.error("Failed to start Coinbase-onramp-funded buy swap", metadata: [
+                    "error": "\(error)",
+                    "orderId": "\(orderId)"
+                ])
+                completion(.failure(error))
+            }
+        }
+    }
+
     /// A buy of a freshly-launched currency, funded by the caller's USDF VM
     /// (Phase 1 + Phase 2 via IntentFundSwap). Mirrors `buy(...)` but takes a
     /// raw `mint: PublicKey` because the currency is too new to have

--- a/FlipcashCore/Sources/FlipcashCore/Models/SwapModels.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/SwapModels.swift
@@ -86,20 +86,23 @@ public enum FundingSource: Sendable, Equatable {
     case unknown
     case submitIntent(id: PublicKey)
     case externalWallet(transactionSignature: Signature)
+    case coinbaseOnramp(orderId: String)
 
     public var protoSource: Ocp_Transaction_V1_FundingSource {
         switch self {
-        case .unknown: return .unknown
-        case .submitIntent: return .submitIntent
+        case .unknown:        return .unknown
+        case .submitIntent:   return .submitIntent
         case .externalWallet: return .externalWallet
+        case .coinbaseOnramp: return .coinbaseOnramp
         }
     }
 
     public var fundingID: String {
         switch self {
-        case .unknown: return ""
-        case .submitIntent(let id): return id.base58
+        case .unknown:                       return ""
+        case .submitIntent(let id):          return id.base58
         case .externalWallet(let signature): return signature.base58
+        case .coinbaseOnramp(let orderId):   return orderId
         }
     }
 }
@@ -121,7 +124,14 @@ extension FundingSource {
             } else {
                 self = .unknown
             }
-        default:
+        case .coinbaseOnramp:
+            // Order IDs are opaque strings; server enforces length 32–88.
+            if let fundingID, !fundingID.isEmpty {
+                self = .coinbaseOnramp(orderId: fundingID)
+            } else {
+                self = .unknown
+            }
+        case .unknown, .UNRECOGNIZED:
             self = .unknown
         }
     }

--- a/FlipcashTests/ApplePayIdleTimerTests.swift
+++ b/FlipcashTests/ApplePayIdleTimerTests.swift
@@ -1,0 +1,63 @@
+//
+//  ApplePayIdleTimerTests.swift
+//  FlipcashTests
+//
+
+import Testing
+@testable import Flipcash
+
+@MainActor
+@Suite("ApplePayIdleTimer")
+struct ApplePayIdleTimerTests {
+
+    @Test("arm fires the callback after the timeout elapses")
+    func armedTimer_firesAfterTimeout() async {
+        let timer = ApplePayIdleTimer(timeout: .milliseconds(50))
+        var fired = false
+        timer.arm { fired = true }
+
+        try? await Task.sleep(for: .milliseconds(10))
+        #expect(!fired, "timer fired before the timeout elapsed")
+
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(fired)
+    }
+
+    @Test("disarm prevents the callback from firing")
+    func disarmedTimer_doesNotFire() async {
+        let timer = ApplePayIdleTimer(timeout: .milliseconds(50))
+        var fired = false
+        timer.arm { fired = true }
+        timer.disarm()
+
+        try? await Task.sleep(for: .milliseconds(200))
+
+        #expect(!fired)
+    }
+
+    @Test("re-arming cancels the previous pending callback")
+    func reArm_cancelsPreviousCallback() async {
+        let timer = ApplePayIdleTimer(timeout: .milliseconds(50))
+        var firstFired = false
+        var secondFired = false
+        timer.arm { firstFired = true }
+        timer.arm { secondFired = true }
+
+        try? await Task.sleep(for: .milliseconds(200))
+
+        #expect(!firstFired)
+        #expect(secondFired)
+    }
+
+    @Test("disarm is idempotent — calling it twice is harmless")
+    func disarm_calledTwice_doesNotCrash() async {
+        let timer = ApplePayIdleTimer(timeout: .milliseconds(50))
+        timer.arm { }
+        timer.disarm()
+        timer.disarm()
+
+        try? await Task.sleep(for: .milliseconds(100))
+        // Reaching here without trap or hang is the assertion. A no-op disarm
+        // must not error or schedule anything.
+    }
+}

--- a/FlipcashTests/ApplePayIdleTimerTests.swift
+++ b/FlipcashTests/ApplePayIdleTimerTests.swift
@@ -49,15 +49,16 @@ struct ApplePayIdleTimerTests {
         #expect(secondFired)
     }
 
-    @Test("disarm is idempotent — calling it twice is harmless")
-    func disarm_calledTwice_doesNotCrash() async {
+    @Test("disarm is idempotent and the timer remains armable after")
+    func disarm_calledTwice_remainsArmable() async {
         let timer = ApplePayIdleTimer(timeout: .milliseconds(50))
         timer.arm { }
         timer.disarm()
         timer.disarm()
 
-        try? await Task.sleep(for: .milliseconds(100))
-        // Reaching here without trap or hang is the assertion. A no-op disarm
-        // must not error or schedule anything.
+        var fired = false
+        timer.arm { fired = true }
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(fired)
     }
 }

--- a/FlipcashTests/OnrampCoordinatorTests.swift
+++ b/FlipcashTests/OnrampCoordinatorTests.swift
@@ -24,8 +24,10 @@ struct OnrampCoordinatorTests {
         let onrampCoordinator = OnrampCoordinator(session: .verifiedMock, flipClient: .mock)
         onrampCoordinator.start(
             .launch(
+                mint: .jeffy,
                 displayName: "Test",
-                onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
+                launchAmount: .mockOne,
+                launchFee: .mockOne
             ),
             amount: .mockOne
         )
@@ -37,8 +39,10 @@ struct OnrampCoordinatorTests {
         let onrampCoordinator = OnrampCoordinator(session: .unverifiedMock, flipClient: .mock)
         onrampCoordinator.start(
             .launch(
+                mint: .jeffy,
                 displayName: "Test",
-                onCompleted: { _, _ in .launch(swapId: .generate(), mint: .jeffy) }
+                launchAmount: .mockOne,
+                launchFee: .mockOne
             ),
             amount: .mockOne
         )


### PR DESCRIPTION
## Summary

- Move Coinbase onramp off the client polling loop and onto the server-driven OnrampSwap stream, so the backend watches the order and submits the on-chain swap once Coinbase clears.
- Add a 60-second idle timeout that auto-dismisses the Apple Pay sheet if the user walks away mid-flow, mirroring the Android client.
- Tighten coordinator state lifecycle so every teardown path clears the same fields and disarms the timer, and so an authorized payment can't be cancelled by a slow commit.

## Test plan

- [x] Buy an existing currency with Coinbase from the funding sheet and confirm the bill arrives.
- [x] Launch a new currency with Coinbase funding and confirm the processing screen takes over after Apple Pay.
- [x] Open Apple Pay, leave the sheet idle for 60 seconds, and confirm it auto-dismisses without leaving the flow stuck.
- [x] Cancel Apple Pay manually and confirm the wizard becomes interactive again.
- [x] Trigger a Coinbase decline error and confirm the dialog surfaces the server-provided reason.