### PR TITLE
refactor: mint-driven Give screen, drop attemptPresent gate

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -64,15 +64,13 @@ struct DestinationView: View {
             TransactionHistoryScreen(mint: mint)
 
         case .give(let mint):
-            // Builds a fresh `GiveViewModel` and primes its presentation
-            // lifecycle (`isPresented = true`) so `refreshSelectedBalance`
-            // and the entered-amount reset run before first render. The
-            // wrapper survives recomposition via `@State`, so the viewModel
-            // lasts the destination's lifetime.
-            GiveDestinationView(
-                mint: mint,
+            // `.id(mint)` for the same reason as `.currencyInfo` above —
+            // a deeplink replacing `.give(A)` with `.give(B)` must build a
+            // fresh `GiveViewModel`, not reuse the one wired to `A`.
+            GiveScreen(
                 container: container,
-                sessionContainer: sessionContainer
+                sessionContainer: sessionContainer,
+                mint: mint
             )
             .id(mint)
 
@@ -157,35 +155,5 @@ extension View {
                 sessionContainer: sessionContainer
             )
         }
-    }
-}
-
-/// Owns the `GiveViewModel` for the `.give(mint)` destination. Constructing
-/// the viewModel inline in `DestinationView`'s switch would lose `@State`
-/// semantics — every body evaluation would create a fresh instance — so the
-/// dedicated wrapper preserves the same instance across recomposition.
-///
-/// On creation, the viewModel's `isPresented = true` setter fires its didSet
-/// (which calls `refreshSelectedBalance` and resets the entered amount). That
-/// matches the previous behaviour where `CurrencyInfoScreen.onGive` set
-/// `giveViewModel.isPresented = true` immediately before the navigation push.
-private struct GiveDestinationView: View {
-    @State private var viewModel: GiveViewModel
-
-    init(mint: PublicKey, container: Container, sessionContainer: SessionContainer) {
-        sessionContainer.ratesController.selectToken(mint)
-        let viewModel = GiveViewModel(container: container, sessionContainer: sessionContainer)
-        // Runs the same gate + state priming the ScanScreen Give button uses,
-        // so `selectedBalance` is resolved and `enteredAmount` is cleared
-        // before first render. If the user has no giveable balance, the
-        // viewmodel raises a "No Balance Yet" dialog through
-        // `session.dialogItem`; the destination still mounts but stays empty
-        // behind the dialog until dismissed.
-        _ = viewModel.attemptPresent()
-        _viewModel = State(initialValue: viewModel)
-    }
-
-    var body: some View {
-        GiveScreen(viewModel: viewModel)
     }
 }

--- a/Flipcash/Core/Screens/Main/GiveScreen.swift
+++ b/Flipcash/Core/Screens/Main/GiveScreen.swift
@@ -9,29 +9,18 @@ import SwiftUI
 import FlipcashUI
 import FlipcashCore
 
-/// Amount entry screen for giving cash to another user.
-///
-/// This view does not own a `NavigationStack` — the caller is responsible
-/// for providing one. When presented as a **sheet** (e.g. from `ScanScreen`),
-/// wrap it in a `NavigationStack` and add a close button. When **pushed**
-/// (e.g. from `CurrencyInfoScreen`), use it directly inside the existing
-/// navigation stack.
-///
-/// On completion (`viewModel.isPresented` becomes `false`), this view calls
-/// `dismissParentContainer()` so that any ancestor sheet is dismissed in a
-/// single animation before the bill appears.
+/// Amount entry screen for giving cash to another user. Caller provides the
+/// surrounding `NavigationStack` (sheet wraps it, push uses the active one).
 struct GiveScreen: View {
 
     @Environment(Session.self) private var session
     @Environment(RatesController.self) private var ratesController
     @Environment(AppRouter.self) private var router
 
-    @Bindable private var viewModel: GiveViewModel
+    @State private var viewModel: GiveViewModel
 
     @State private var isShowingCurrencySelection: Bool = false
     @State private var isShowingTokenSelection: Bool = false
-
-    @Environment(\.dismissParentContainer) private var dismissParentContainer
 
     private var maxLimit: ExchangedFiat {
         let rate = ratesController.rateForBalanceCurrency()
@@ -54,8 +43,12 @@ struct GiveScreen: View {
 
     // MARK: - Init -
 
-    init(viewModel: GiveViewModel) {
-        self.viewModel = viewModel
+    init(container: Container, sessionContainer: SessionContainer, mint: PublicKey?) {
+        _viewModel = State(initialValue: GiveViewModel(
+            container: container,
+            sessionContainer: sessionContainer,
+            mint: mint
+        ))
     }
 
     // MARK: - Body -
@@ -106,11 +99,6 @@ struct GiveScreen: View {
                 },
                 fixedRate: nil,
             )
-        }
-        .onChange(of: viewModel.isPresented) { _, isPresented in
-            if !isPresented {
-                dismissParentContainer()
-            }
         }
     }
 

--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -13,7 +13,7 @@ import Logging
 private let logger = Logger(label: "flipcash.send-cash")
 
 @Observable
-class GiveViewModel {
+final class GiveViewModel {
 
     var enteredAmount: String = ""
     var actionState: ButtonState = .normal
@@ -30,22 +30,22 @@ class GiveViewModel {
     @ObservationIgnored let ratesController: RatesController
 
     private(set) var selectedBalance: ExchangedBalance?
-    
+
     private var enteredFiat: ExchangedFiat? {
         guard !enteredAmount.isEmpty else {
             return nil
         }
-        
+
         guard let amount = NumberFormatter.decimal(from: enteredAmount), amount > 0 else {
             return nil
         }
-        
+
         guard let selectedBalance else {
             return nil
         }
-        
+
         let mint = selectedBalance.stored.mint
-        
+
         // Only applies for bonded tokens
         if mint != .usdf {
             guard let supplyQuarks = selectedBalance.stored.supplyFromBonding else {
@@ -86,51 +86,55 @@ class GiveViewModel {
             )
         }
     }
-    
-    var isPresented = false
-
-    /// Validates that the user has a giveable balance and primes the view model
-    /// for entry. Returns `true` if the give sheet should be presented; on
-    /// `false`, `session.dialogItem` carries the explanation. Callers must gate
-    /// `router.present(.give)` on this return — otherwise the sheet renders
-    /// behind the dialog with a $0 amount entry.
-    func attemptPresent() -> Bool {
-        let rate = ratesController.rateForBalanceCurrency()
-        let hasGiveableBalance = session.balances(for: rate).contains { $0.stored.mint != .usdf }
-
-        guard hasGiveableBalance else {
-            showNoBalanceError()
-            return false
-        }
-
-        refreshSelectedBalance()
-        enteredAmount = ""
-        isPresented = true
-        return true
-    }
 
     // MARK: - Init -
 
-    init(container: Container, sessionContainer: SessionContainer) {
-        self.isPresented      = false
+    /// The `selectToken` sync is the only visible side-effect; the `if mismatch`
+    /// guard makes it idempotent across repeated inits.
+    init(container: Container, sessionContainer: SessionContainer, mint: PublicKey?) {
+        let session          = sessionContainer.session
+        let ratesController  = sessionContainer.ratesController
+        let resolved         = Self.resolveInitialBalance(
+            mint: mint,
+            session: session,
+            ratesController: ratesController
+        )
+
         self.container        = container
         self.sessionContainer = sessionContainer
-        self.session          = sessionContainer.session
-        self.ratesController  = sessionContainer.ratesController
+        self.session          = session
+        self.ratesController  = ratesController
+        self.selectedBalance  = resolved
+
+        if let resolved, ratesController.selectedTokenMint != resolved.stored.mint {
+            ratesController.selectToken(resolved.stored.mint)
+        }
     }
 
-    private func refreshSelectedBalance() {
+    /// Caller's `mint` wins; otherwise prefer the stored selection, then the
+    /// highest-value giveable balance. The two-tier fallback exists because
+    /// `RatesController.selectedTokenMint` is a *global* selector and may
+    /// point to `.usdf` or to a sub-threshold balance that no longer appears
+    /// in `Session.balances(for:)`.
+    private static func resolveInitialBalance(
+        mint: PublicKey?,
+        session: Session,
+        ratesController: RatesController
+    ) -> ExchangedBalance? {
         let rate = ratesController.rateForBalanceCurrency()
-        let availableBalances = session.balances(for: rate)
-            .filter { $0.stored.mint != .usdf }
 
-        if let selectedTokenMint = ratesController.selectedTokenMint,
-           let match = availableBalances.first(where: { $0.stored.mint == selectedTokenMint }) {
-            selectedBalance = match
-        } else if let first = availableBalances.first {
-            selectedBalance = first
-            ratesController.selectToken(first.stored.mint)
+        if let mint, let stored = session.balance(for: mint) {
+            return ExchangedBalance(stored: stored, exchangedFiat: stored.computeExchangedValue(with: rate))
         }
+
+        let giveable = session.balances(for: rate).filter { $0.stored.mint != .usdf }
+
+        if let stored = ratesController.selectedTokenMint,
+           let match = giveable.first(where: { $0.stored.mint == stored }) {
+            return match
+        }
+
+        return giveable.first
     }
 
     // MARK: - Action -
@@ -160,8 +164,6 @@ class GiveViewModel {
                     showLimitsError()
                     return
                 }
-
-                isPresented = false
 
                 try await Task.delay(milliseconds: 50)
 
@@ -216,37 +218,23 @@ class GiveViewModel {
 
         return (amount, pin)
     }
-    
+
     func selectCurrencyAction(exchangedBalance: ExchangedBalance) {
         selectedBalance = exchangedBalance
         ratesController.selectToken(exchangedBalance.stored.mint)
         enteredAmount = ""
     }
-    
+
     // MARK: - Navigation -
-    
+
     private func presentDeposit() {
         depositMint = selectedBalance?.stored.mint
         if let depositMint {
             Analytics.tokenInfoOpened(from: .openedFromGive, mint: depositMint)
         }
     }
-    
+
     // MARK: - Errors -
-    
-    private func showNoBalanceError() {
-        session.dialogItem = .init(
-            style: .standard,
-            title: "No Balance Yet",
-            subtitle: "Buy a currency to get started, or get another Flipcash user to give you some cash",
-            dismissable: true
-        ) {
-            .standard("Discover Currencies") { [weak self] in
-                self?.sessionContainer.appRouter.present(.discover)
-            };
-            .cancel()
-        }
-    }
 
     private func showInsufficientBalanceError() {
         session.dialogItem = .init(

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -20,8 +20,6 @@ struct ScanScreen: View {
 
     @State private var viewModel: ScanViewModel
 
-    @State private var giveViewModel: GiveViewModel
-
     @State private var cameraAuthorizer = CameraAuthorizer()
 
     @State private var sendButtonState: ButtonState = .normal
@@ -66,11 +64,6 @@ struct ScanScreen: View {
         self.session          = sessionContainer.session
         
         self.viewModel = ScanViewModel(
-            container: container,
-            sessionContainer: sessionContainer
-        )
-
-        self.giveViewModel = GiveViewModel(
             container: container,
             sessionContainer: sessionContainer
         )
@@ -157,8 +150,7 @@ struct ScanScreen: View {
             RoutedSheet(
                 sheet: sheet,
                 container: container,
-                sessionContainer: sessionContainer,
-                giveViewModel: giveViewModel
+                sessionContainer: sessionContainer
             )
         }
         // Dismiss all presented sheets when a bill is about to appear.
@@ -169,7 +161,6 @@ struct ScanScreen: View {
         .onChange(of: session.presentationState.isPresenting) { _, isPresenting in
             guard isPresenting else { return }
             router.dismissSheet()
-            giveViewModel.isPresented = false
         }
         // Reset button state on bill dismissal — `sendButtonState` outlives individual bills.
         .onChange(of: session.billState.bill) { _, newBill in
@@ -259,11 +250,7 @@ struct ScanScreen: View {
             Spacer()
             ScanBottomBar(
                 toast: toast,
-                onGive: {
-                    if giveViewModel.attemptPresent() {
-                        router.present(.give)
-                    }
-                },
+                onGive: presentGive,
                 onWallet: { router.present(.balance) },
                 onDiscover: { router.present(.discover) }
             )
@@ -316,7 +303,18 @@ struct ScanScreen: View {
     }
 
     // MARK: - Actions -
-    
+
+    private func presentGive() {
+        let rate = sessionContainer.ratesController.rateForBalanceCurrency()
+        guard session.hasGiveableBalance(for: rate) else {
+            session.dialogItem = .noGiveableBalance(
+                onDiscover: { router.present(.discover) }
+            )
+            return
+        }
+        router.present(.give)
+    }
+
     private func dismissBill() {
         session.dismissCashBill(style: .slide)
 //        if let action = session.billState.secondaryAction {
@@ -340,7 +338,6 @@ private struct RoutedSheet: View {
     let sheet: AppRouter.SheetPresentation
     let container: Container
     let sessionContainer: SessionContainer
-    let giveViewModel: GiveViewModel
 
     @Environment(AppRouter.self) private var router
 
@@ -358,19 +355,18 @@ private struct RoutedSheet: View {
                 sessionContainer: sessionContainer
             )
         case .give:
-            // Stack bound to the router so deposit-mint pushes from inside
-            // GiveScreen (`.currencyInfoForDeposit`) actually render.
             NavigationStack(path: $router[.give]) {
-                GiveScreen(viewModel: giveViewModel)
-                    .appRouterDestinations(container: container, sessionContainer: sessionContainer)
-                    .toolbar {
-                        ToolbarItem(placement: .topBarTrailing) {
-                            CloseButton {
-                                giveViewModel.isPresented = false
-                                router.dismissSheet()
-                            }
-                        }
+                GiveScreen(
+                    container: container,
+                    sessionContainer: sessionContainer,
+                    mint: nil
+                )
+                .appRouterDestinations(container: container, sessionContainer: sessionContainer)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        CloseButton(action: router.dismissSheet)
                     }
+                }
             }
         case .discover:
             NavigationStack(path: $router[.discover]) {
@@ -388,4 +384,3 @@ private struct RoutedSheet: View {
         }
     }
 }
-

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -168,6 +168,15 @@ class Session {
         // SwiftUI body re-eval from amount-entry computed props.
         updateableBalances.value.first { $0.mint == mint }
     }
+
+    /// True when the user has at least one non-USDF balance with a displayable
+    /// fiat value. Skips the sort + allocate that `balances(for:)` does, so
+    /// callers gating a presentation pay only the early-exit predicate cost.
+    func hasGiveableBalance(for rate: Rate) -> Bool {
+        updateableBalances.value.contains { stored in
+            stored.mint != .usdf && stored.computeExchangedValue(with: rate).hasDisplayableValue()
+        }
+    }
     
     @ObservationIgnored private let container: Container
     @ObservationIgnored private let client: Client

--- a/Flipcash/UI/DialogItem+CashFlows.swift
+++ b/Flipcash/UI/DialogItem+CashFlows.swift
@@ -67,4 +67,16 @@ extension DialogItem {
             .subtle("Don't Collect", action: onCancel)
         }
     }
+
+    static func noGiveableBalance(onDiscover: @escaping () -> Void) -> DialogItem {
+        .init(
+            style: .standard,
+            title: "No Balance Yet",
+            subtitle: "Buy a currency to get started, or get another Flipcash user to give you some cash",
+            dismissable: true
+        ) {
+            .standard("Discover Currencies", action: onDiscover);
+            .cancel()
+        }
+    }
 }

--- a/FlipcashTests/DialogItemFactoriesTests.swift
+++ b/FlipcashTests/DialogItemFactoriesTests.swift
@@ -1,0 +1,53 @@
+//
+//  DialogItemFactoriesTests.swift
+//  FlipcashTests
+//
+//  Created by Raul Riera on 2026-05-12.
+//
+
+import Foundation
+import Testing
+import FlipcashUI
+@testable import Flipcash
+
+@MainActor
+@Suite("DialogItem factories")
+struct DialogItemFactoriesTests {
+
+    // MARK: - noGiveableBalance
+
+    @Test("noGiveableBalance dialog uses the standard (non-destructive) style")
+    func noGiveableBalance_usesStandardStyle() {
+        let dialog = DialogItem.noGiveableBalance(onDiscover: {})
+        #expect(dialog.style == .standard)
+    }
+
+    @Test("noGiveableBalance dialog title and subtitle match the wording shown to users with no giveable balance")
+    func noGiveableBalance_copy() {
+        let dialog = DialogItem.noGiveableBalance(onDiscover: {})
+        #expect(dialog.title == "No Balance Yet")
+        #expect(dialog.subtitle == "Buy a currency to get started, or get another Flipcash user to give you some cash")
+    }
+
+    @Test("noGiveableBalance exposes a primary Discover CTA above a subtle Cancel")
+    func noGiveableBalance_actionLayout() throws {
+        let dialog = DialogItem.noGiveableBalance(onDiscover: {})
+
+        try #require(dialog.actions.count == 2)
+        #expect(dialog.actions[0].title == "Discover Currencies")
+        #expect(dialog.actions[0].kind == .standard)
+        #expect(dialog.actions[1].title == "Cancel")
+        #expect(dialog.actions[1].kind == .subtle)
+    }
+
+    @Test("Tapping Discover fires the supplied onDiscover closure")
+    func noGiveableBalance_discoverActionFires() throws {
+        var fired = false
+        let dialog = DialogItem.noGiveableBalance(onDiscover: { fired = true })
+
+        let discoverAction = try #require(dialog.actions.first { $0.title == "Discover Currencies" })
+        discoverAction.action()
+
+        #expect(fired)
+    }
+}

--- a/FlipcashTests/GiveViewModelTests.swift
+++ b/FlipcashTests/GiveViewModelTests.swift
@@ -18,14 +18,15 @@ struct GiveViewModelTests {
 
     // MARK: - Test Helpers
 
-    /// Helper to create a test view model
+    /// Helper to create a test view model with no mint (auto-select path).
     static func createViewModel() -> GiveViewModel {
         let container = Container.mock
         let sessionContainer = SessionContainer.mock
 
         let viewModel = GiveViewModel(
             container: container,
-            sessionContainer: sessionContainer
+            sessionContainer: sessionContainer,
+            mint: nil
         )
 
         return viewModel
@@ -78,7 +79,7 @@ struct GiveViewModelTests {
 
     @Test
     func testInitialization() {
-        // Given/When: Creating a new view model
+        // Given/When: Creating a new view model with no balances and no mint
         let viewModel = Self.createViewModel()
 
         // Then: Initial state should be correct
@@ -87,61 +88,6 @@ struct GiveViewModelTests {
         #expect(viewModel.session.dialogItem == nil)
         #expect(viewModel.selectedBalance == nil)
         #expect(viewModel.canGive == false)
-    }
-
-    // MARK: - Presentation Tests
-
-    @Test("attemptPresent with no giveable balances returns false and shows error")
-    func testAttemptPresent_NoBalances_RejectsAndShowsError() {
-        let viewModel = Self.createViewModel()
-
-        let presented = viewModel.attemptPresent()
-
-        #expect(presented == false)
-        #expect(viewModel.isPresented == false)
-        #expect(viewModel.session.dialogItem != nil)
-        #expect(viewModel.selectedBalance == nil)
-    }
-
-    @Test("No-balance dialog uses the standard (non-destructive) style")
-    func testAttemptPresent_NoBalances_UsesStandardStyle() throws {
-        let viewModel = Self.createViewModel()
-
-        _ = viewModel.attemptPresent()
-
-        let dialog = try #require(viewModel.session.dialogItem)
-        #expect(dialog.style == .standard)
-    }
-
-    @Test("No-balance dialog exposes a primary Discover Currencies CTA above a subtle Cancel")
-    func testAttemptPresent_NoBalances_ExposesDiscoverCTAAndCancel() throws {
-        let viewModel = Self.createViewModel()
-
-        _ = viewModel.attemptPresent()
-
-        let actions = try #require(viewModel.session.dialogItem?.actions)
-        try #require(actions.count == 2)
-
-        #expect(actions[0].title == "Discover Currencies")
-        #expect(actions[0].kind == .standard)
-
-        #expect(actions[1].title == "Cancel")
-        #expect(actions[1].kind == .subtle)
-    }
-
-    @Test("Tapping Discover Currencies presents the Discover sheet")
-    func testAttemptPresent_NoBalances_DiscoverCTAPresentsDiscover() throws {
-        let sessionContainer = SessionContainer.mock
-        let viewModel = GiveViewModel(container: .mock, sessionContainer: sessionContainer)
-
-        _ = viewModel.attemptPresent()
-
-        let action = try #require(
-            viewModel.session.dialogItem?.actions.first(where: { $0.title == "Discover Currencies" })
-        )
-        action.action()
-
-        #expect(sessionContainer.appRouter.presentedSheet == .discover)
     }
 
     // MARK: - Currency Selection Sync Tests
@@ -443,28 +389,26 @@ struct GiveViewModelTests {
         #expect(canGive == true, "Should allow exchange amount well under max supply value")
     }
 
-    // MARK: - refreshSelectedBalance (presentation) Tests
+    // MARK: - Init resolution Tests
 
-    @Test("Presenting with a selected token resolves to that mint")
-    func testPresentation_WithSelectedToken_ResolvesRequestedMint() throws {
+    @Test("Init with no mint and a stored selection resolves to the stored mint")
+    func testInit_NoMint_HonorsStoredSelection() throws {
         let container = try SessionContainer.makeTest(holdings: [
             .init(
                 mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: 10_000 * 10_000_000_000),
                 quarks: 1_000_000_000_000
             ),
         ])
-        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
-
         container.ratesController.selectToken(.jeffy)
 
-        #expect(viewModel.attemptPresent() == true)
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container, mint: nil)
 
         #expect(viewModel.selectedBalance?.stored.mint == .jeffy)
         #expect(container.ratesController.selectedTokenMint == .jeffy)
     }
 
-    @Test("Presenting with no prior selection picks highest-value non-USDF and persists it")
-    func testPresentation_FirstTime_PicksHighestAndPersists() throws {
+    @Test("Init with no mint and no prior selection picks the highest-value giveable balance and persists it")
+    func testInit_NoMint_PicksHighestAndPersists() throws {
         // Same supply for both mints (so per-token curve price is equal), but
         // Jeffy has 100× the holding in quarks → 100× the USDF-equivalent,
         // putting Jeffy first in the `usdf`-desc sort.
@@ -478,33 +422,57 @@ struct GiveViewModelTests {
                 quarks: 100_000_000_000
             ),
         ])
-        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
-
         container.ratesController.selectedTokenMint = nil
 
-        #expect(viewModel.attemptPresent() == true)
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container, mint: nil)
 
         #expect(viewModel.selectedBalance?.stored.mint == .jeffy)
         #expect(container.ratesController.selectedTokenMint == .jeffy)
     }
 
-    @Test("Presenting with a remembered selection resolves to that mint, not the highest")
-    func testPresentation_Subsequent_UsesRememberedSelection() throws {
+    @Test("Init with no mint and a stale sub-threshold selection falls back to the highest displayable balance")
+    func testInit_NoMint_SubThresholdRememberedMint_FallsBackToHighest() throws {
+        let staleHolding = SessionContainer.Holding(
+            mint: .makeLaunchpad(
+                address: .jeffy,
+                supplyFromBonding: 10_000_000 * 10_000_000_000
+            ),
+            quarks: 100
+        )
+        let displayableHolding = SessionContainer.Holding(
+            mint: .makeLaunchpad(
+                address: .usdcAuthority,
+                supplyFromBonding: 10_000 * 10_000_000_000
+            ),
+            quarks: 1_000_000_000_000
+        )
         let container = try SessionContainer.makeTest(holdings: [
-            .init(
-                mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: 50_000 * 10_000_000_000),
-                quarks: 100_000_000_000
-            ),
-            .init(
-                mint: .makeLaunchpad(address: .usdcAuthority, supplyFromBonding: 5_000 * 10_000_000_000),
-                quarks: 10_000_000_000_000
-            ),
+            staleHolding,
+            displayableHolding,
         ])
-        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
-
         container.ratesController.selectToken(.jeffy)
 
-        #expect(viewModel.attemptPresent() == true)
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container, mint: nil)
+
+        #expect(viewModel.selectedBalance?.stored.mint == .usdcAuthority)
+        #expect(container.ratesController.selectedTokenMint == .usdcAuthority)
+    }
+
+    @Test("Init with a mint resolves to that mint even if a different one is stored")
+    func testInit_WithMint_OverridesStoredSelection() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(
+                mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: 10_000 * 10_000_000_000),
+                quarks: 1_000_000_000_000
+            ),
+            .init(
+                mint: .makeLaunchpad(address: .usdcAuthority, supplyFromBonding: 10_000 * 10_000_000_000),
+                quarks: 1_000_000_000_000
+            ),
+        ])
+        container.ratesController.selectToken(.usdcAuthority)
+
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container, mint: .jeffy)
 
         #expect(viewModel.selectedBalance?.stored.mint == .jeffy)
         #expect(container.ratesController.selectedTokenMint == .jeffy)
@@ -512,7 +480,7 @@ struct GiveViewModelTests {
 
     // MARK: - Over-balance (insufficient funds)
 
-    @Test("Over-balance bonded entry fires 'Short' dialog with a real shortfall, stays on screen")
+    @Test("Over-balance bonded entry fires 'Short' dialog with a real shortfall")
     func giveAction_overBalanceBonded_firesShortDialogWithRealShortfall() throws {
         let container = try SessionContainer.makeTest(holdings: [
             .init(
@@ -523,9 +491,8 @@ struct GiveViewModelTests {
                 quarks: 10 * 10_000_000_000
             ),
         ])
-        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
         container.ratesController.selectToken(.jeffy)
-        #expect(viewModel.attemptPresent() == true)
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container, mint: nil)
 
         let balance = try #require(viewModel.selectedBalance)
         // 100× the displayed balance — unambiguously over and may exceed curve TVL.
@@ -549,38 +516,5 @@ struct GiveViewModelTests {
         // like "$10.00 Short", whose "0.00 Short" substring would otherwise
         // match.
         #expect(!title.contains("$0.00"))
-
-        // Flow did not proceed to the bill.
-        #expect(viewModel.isPresented == true)
-    }
-
-    @Test("Presenting with a stale sub-threshold selection falls back to the highest displayable balance")
-    func testPresentation_SubThresholdRememberedMint_FallsBackToHighest() throws {
-        let staleHolding = SessionContainer.Holding(
-            mint: .makeLaunchpad(
-                address: .jeffy,
-                supplyFromBonding: 10_000_000 * 10_000_000_000
-            ),
-            quarks: 100
-        )
-        let displayableHolding = SessionContainer.Holding(
-            mint: .makeLaunchpad(
-                address: .usdcAuthority,
-                supplyFromBonding: 10_000 * 10_000_000_000
-            ),
-            quarks: 1_000_000_000_000
-        )
-        let container = try SessionContainer.makeTest(holdings: [
-            staleHolding,
-            displayableHolding,
-        ])
-        let viewModel = GiveViewModel(container: .mock, sessionContainer: container)
-
-        container.ratesController.selectToken(.jeffy)
-
-        #expect(viewModel.attemptPresent() == true)
-
-        #expect(viewModel.selectedBalance?.stored.mint == .usdcAuthority)
-        #expect(container.ratesController.selectedTokenMint == .usdcAuthority)
     }
 }

--- a/FlipcashTests/Regressions/Regression_native_amount_mismatch.swift
+++ b/FlipcashTests/Regressions/Regression_native_amount_mismatch.swift
@@ -224,7 +224,8 @@ struct Regression_native_amount_mismatch {
 
         let vm = GiveViewModel(
             container: .mock,
-            sessionContainer: sessionContainer
+            sessionContainer: sessionContainer,
+            mint: nil
         )
         vm.selectCurrencyAction(
             exchangedBalance: WithdrawViewModelTestHelpers.createBondedBalance(
@@ -259,7 +260,8 @@ struct Regression_native_amount_mismatch {
 
         let vm = GiveViewModel(
             container: .mock,
-            sessionContainer: sessionContainer
+            sessionContainer: sessionContainer,
+            mint: nil
         )
         vm.selectCurrencyAction(
             exchangedBalance: WithdrawViewModelTestHelpers.createBondedBalance(


### PR DESCRIPTION
## Summary

The Give viewmodel's `attemptPresent()` mixed validation, state priming, and a presentation flag — callers had to call it, gate the router on its return, and trust the viewmodel to surface a dialog on failure. Replaces that with a `mint: PublicKey?` init parameter: caller's mint wins, otherwise the stored selection, otherwise the highest-value giveable balance. The "No Balance Yet" dialog moves to the caller that opens Give without a mint, and the two wrapper views that existed only to hold the viewmodel as `@State` are gone.

## Test plan

- [x] Tap Give from the scan screen with no giveable balance — dialog appears, sheet does not.
- [x] Tap Give with a giveable balance — sheet opens with the last-used or highest-value currency pre-selected.
- [x] Tap Discover from the dialog — Discover sheet opens.
- [x] From a currency-info screen, tap Give — screen opens pre-selected to that currency regardless of what was last used.
- [x] Complete a give — bill appears, sheet or push dismisses cleanly.
- [x] Re-open Give — entered amount cleared, last currency remembered.