### PR TITLE
chore: add --device flag to build.sh for paired iPhone builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,7 +380,7 @@ Use the project scripts — they encode the correct scheme and destination:
 
 **Never run `swift test` in a package directory** (`FlipcashCore`, `FlipcashUI`, etc.). Packages are iOS-only; `swift test` targets the macOS host and fails with code-signing errors. Always go through `./Scripts/test.sh` (which routes through the `Flipcash` scheme on the iOS Simulator).
 
-**Don't assume only simulators are available for builds.** When checking what's connected, use `xcrun devicectl list devices` — it reports paired iPhones as `available (paired)` even over network pairing. `xcrun xctrace list devices` is unreliable for this: it often labels a perfectly usable paired iPhone as `Offline`. `./Scripts/build.sh --device` resolves the UDID via devicectl and feeds it to `xcodebuild -destination "platform=iOS,id=<udid>"`. If the user asks to build on their device, take them at their word and try the device path before claiming none is connected. Tests still run on simulator only.
+For paired-device builds, see [Xcode MCP Server](#xcode-mcp-server) below.
 
 ### Test Naming
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,16 +369,19 @@ struct SessionTests {
 
 ### Running the App & Tests
 
-Use the project scripts — they encode the correct scheme, simulator, and destination:
+Use the project scripts — they encode the correct scheme and destination. Both default to a simulator but accept `--device` to run against a paired physical iPhone:
 
-- **Build the app:** `./Scripts/build.sh`
+- **Build the app:** `./Scripts/build.sh` (generic iOS) or `./Scripts/build.sh --device` (paired device)
 - **Targeted tests (for your changes):** `./Scripts/test.sh <Target>/<Suite>[/<TestName>] [...]`
   - One suite: `./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests`
   - Multiple suites: `./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests FlipcashCoreTests/FiatTests`
   - One test: `./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests/myTestCase`
+  - On a paired device: `./Scripts/test.sh --device FlipcashTests/SomeUITests` (optionally `--device "<name substring>"` to disambiguate)
 - **Full `AllTargets` suite is the user's job** — don't run it. If you think it's required before declaring work done, ask the user to run it.
 
-**Never run `swift test` in a package directory** (`FlipcashCore`, `FlipcashUI`, etc.). Packages are iOS-only; `swift test` targets the macOS host and fails with code-signing errors. Always go through `./Scripts/test.sh` (which routes through the `Flipcash` scheme on the iOS Simulator).
+**Never run `swift test` in a package directory** (`FlipcashCore`, `FlipcashUI`, etc.). Packages are iOS-only; `swift test` targets the macOS host and fails with code-signing errors. Always go through `./Scripts/test.sh` (which routes through the `Flipcash` scheme).
+
+**Don't assume only simulators are available.** When checking what's connected, use `xcrun devicectl list devices` — it reports paired iPhones as `available (paired)` even over network pairing. `xcrun xctrace list devices` is unreliable for this: it often labels a perfectly usable paired iPhone as `Offline`. The `--device` flag on `build.sh` / `test.sh` resolves the UDID via devicectl and feeds it to `xcodebuild -destination "platform=iOS,id=<udid>"`. If the user asks to run on their device, take them at their word and try the device path before claiming none is connected.
 
 ### Test Naming
 
@@ -557,3 +560,11 @@ BondingCurve.maxSupply   // 21,000,000 tokens
 **Prefer Xcode MCP tools over `xcodebuild` shell commands** when the Xcode MCP server is available. It provides direct integration with the open Xcode workspace for building, testing, reading/writing project files, rendering SwiftUI previews, and searching Apple documentation.
 
 **Fall back to `./Scripts/build.sh` and `./Scripts/test.sh`** when the MCP server is not connected. See [Running the App & Tests](#running-the-app--tests) for usage. For edge cases the scripts don't cover (e.g., a one-off destination, `xcodebuild clean`), drop down to raw `xcodebuild`.
+
+**Physical-device runs require the script fallback even when MCP is connected.** XcodeBuildMCP only enables simulator workflow tools by default — `build_run_sim`, `test_sim`, etc. Device tools (`build_run_dev`, `test_device`, …) are gated behind a separate workflow flag the user has not enabled. So when the user asks to run on their device, the correct pattern is:
+
+1. Acknowledge that device tools aren't enabled in XcodeBuildMCP — fall back to `xcodebuild` + `devicectl`.
+2. Run `xcrun devicectl list devices` to confirm a paired iPhone is available. **Do not use `xcrun xctrace list devices`** — it mislabels paired iPhones as `Offline` and will lead you to falsely claim no device is connected.
+3. Invoke `./Scripts/build.sh --device` or `./Scripts/test.sh --device [name] <suite>`, which resolves the UDID via devicectl and feeds `platform=iOS,id=<udid>` to xcodebuild.
+
+If the user says "run on my device," take them at their word and follow this flow — don't push back claiming only simulators are available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,19 +369,18 @@ struct SessionTests {
 
 ### Running the App & Tests
 
-Use the project scripts — they encode the correct scheme and destination. Both default to a simulator but accept `--device` to run against a paired physical iPhone:
+Use the project scripts — they encode the correct scheme and destination:
 
-- **Build the app:** `./Scripts/build.sh` (generic iOS) or `./Scripts/build.sh --device` (paired device)
-- **Targeted tests (for your changes):** `./Scripts/test.sh <Target>/<Suite>[/<TestName>] [...]`
+- **Build the app:** `./Scripts/build.sh` (generic iOS) or `./Scripts/build.sh --device` (paired physical iPhone)
+- **Targeted tests (for your changes):** `./Scripts/test.sh <Target>/<Suite>[/<TestName>] [...]` — always runs on the iPhone 17 simulator
   - One suite: `./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests`
   - Multiple suites: `./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests FlipcashCoreTests/FiatTests`
   - One test: `./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests/myTestCase`
-  - On a paired device: `./Scripts/test.sh --device FlipcashTests/SomeUITests` (optionally `--device "<name substring>"` to disambiguate)
 - **Full `AllTargets` suite is the user's job** — don't run it. If you think it's required before declaring work done, ask the user to run it.
 
-**Never run `swift test` in a package directory** (`FlipcashCore`, `FlipcashUI`, etc.). Packages are iOS-only; `swift test` targets the macOS host and fails with code-signing errors. Always go through `./Scripts/test.sh` (which routes through the `Flipcash` scheme).
+**Never run `swift test` in a package directory** (`FlipcashCore`, `FlipcashUI`, etc.). Packages are iOS-only; `swift test` targets the macOS host and fails with code-signing errors. Always go through `./Scripts/test.sh` (which routes through the `Flipcash` scheme on the iOS Simulator).
 
-**Don't assume only simulators are available.** When checking what's connected, use `xcrun devicectl list devices` — it reports paired iPhones as `available (paired)` even over network pairing. `xcrun xctrace list devices` is unreliable for this: it often labels a perfectly usable paired iPhone as `Offline`. The `--device` flag on `build.sh` / `test.sh` resolves the UDID via devicectl and feeds it to `xcodebuild -destination "platform=iOS,id=<udid>"`. If the user asks to run on their device, take them at their word and try the device path before claiming none is connected.
+**Don't assume only simulators are available for builds.** When checking what's connected, use `xcrun devicectl list devices` — it reports paired iPhones as `available (paired)` even over network pairing. `xcrun xctrace list devices` is unreliable for this: it often labels a perfectly usable paired iPhone as `Offline`. `./Scripts/build.sh --device` resolves the UDID via devicectl and feeds it to `xcodebuild -destination "platform=iOS,id=<udid>"`. If the user asks to build on their device, take them at their word and try the device path before claiming none is connected. Tests still run on simulator only.
 
 ### Test Naming
 
@@ -561,10 +560,10 @@ BondingCurve.maxSupply   // 21,000,000 tokens
 
 **Fall back to `./Scripts/build.sh` and `./Scripts/test.sh`** when the MCP server is not connected. See [Running the App & Tests](#running-the-app--tests) for usage. For edge cases the scripts don't cover (e.g., a one-off destination, `xcodebuild clean`), drop down to raw `xcodebuild`.
 
-**Physical-device runs require the script fallback even when MCP is connected.** XcodeBuildMCP only enables simulator workflow tools by default — `build_run_sim`, `test_sim`, etc. Device tools (`build_run_dev`, `test_device`, …) are gated behind a separate workflow flag the user has not enabled. So when the user asks to run on their device, the correct pattern is:
+**Physical-device builds require the script fallback even when MCP is connected.** XcodeBuildMCP only enables simulator workflow tools by default — `build_run_sim`, `test_sim`, etc. Device tools (`build_run_dev`, …) are gated behind a separate workflow flag the user has not enabled. So when the user asks to build on their device, the correct pattern is:
 
 1. Acknowledge that device tools aren't enabled in XcodeBuildMCP — fall back to `xcodebuild` + `devicectl`.
 2. Run `xcrun devicectl list devices` to confirm a paired iPhone is available. **Do not use `xcrun xctrace list devices`** — it mislabels paired iPhones as `Offline` and will lead you to falsely claim no device is connected.
-3. Invoke `./Scripts/build.sh --device` or `./Scripts/test.sh --device [name] <suite>`, which resolves the UDID via devicectl and feeds `platform=iOS,id=<udid>` to xcodebuild.
+3. Invoke `./Scripts/build.sh --device` (optionally `--device "<name substring>"`), which resolves the UDID via devicectl and feeds `platform=iOS,id=<udid>` to xcodebuild.
 
-If the user says "run on my device," take them at their word and follow this flow — don't push back claiming only simulators are available.
+If the user says "build on my device," take them at their word and follow this flow — don't push back claiming only simulators are available. Tests remain simulator-only.

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -4,14 +4,68 @@
 # Use this to verify the app compiles without running tests.
 #
 # Usage:
-#   ./Scripts/build.sh [extra xcodebuild args...]
+#   ./Scripts/build.sh [extra xcodebuild args...]            # generic iOS build (default)
+#   ./Scripts/build.sh --device [name] [extra args...]       # paired physical device
 #
-# Override the destination with DESTINATION env var (default: generic/platform=iOS).
+# --device with no argument picks the first paired iOS device. Pass a name
+# substring to disambiguate (e.g. --device "Raul's iPhone").
+#
+# Override the destination directly with DESTINATION env var.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
+
+# Resolve a paired iOS device UDID via devicectl.
+#
+# Use devicectl, NOT `xcrun xctrace list devices` — xctrace often labels
+# paired iPhones as "Offline" even when they are connected and available
+# to xcodebuild via the network-paired CoreDevice transport.
+resolve_device_udid() {
+    local match="${1:-}"
+    local tmp
+    tmp=$(mktemp)
+    if ! xcrun devicectl list devices --json-output "$tmp" >/dev/null 2>&1; then
+        rm -f "$tmp"
+        return 1
+    fi
+    python3 - "$match" "$tmp" <<'PY'
+import json, sys
+match = sys.argv[1].lower()
+data = json.load(open(sys.argv[2]))
+for dev in data["result"]["devices"]:
+    hw = dev.get("hardwareProperties", {})
+    if hw.get("platform") != "iOS":
+        continue
+    name = dev.get("deviceProperties", {}).get("name", "")
+    if match and match not in name.lower():
+        continue
+    udid = hw.get("udid", "")
+    if udid:
+        print(udid)
+        break
+PY
+    rm -f "$tmp"
+}
+
+DESTINATION="${DESTINATION:-}"
+
+if [[ "${1:-}" == "--device" ]]; then
+    shift
+    MATCH=""
+    if [[ $# -gt 0 && "$1" != -* ]]; then
+        MATCH="$1"
+        shift
+    fi
+    UDID="$(resolve_device_udid "$MATCH")"
+    if [[ -z "$UDID" ]]; then
+        echo "error: no paired iOS device found${MATCH:+ matching \"$MATCH\"}." >&2
+        echo "       List with: xcrun devicectl list devices" >&2
+        exit 1
+    fi
+    DESTINATION="platform=iOS,id=$UDID"
+fi
 
 DESTINATION="${DESTINATION:-generic/platform=iOS}"
 

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -1,30 +1,86 @@
 #!/usr/bin/env bash
 #
-# Run targeted iOS Simulator tests via the Flipcash scheme.
+# Run targeted iOS tests via the Flipcash scheme.
 #
 # Usage:
-#   ./Scripts/test.sh <Target>/<Suite>[/<TestName>] [<Target>/<Suite>[/<TestName>]...]
+#   ./Scripts/test.sh [--device [name]] <Target>/<Suite>[/<TestName>] [...]
+#
+# Default destination is the iPhone 17 simulator. Pass --device (optionally
+# followed by a name substring) to run against a paired physical device.
 #
 # Examples:
 #   ./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests
 #   ./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests FlipcashCoreTests/FiatTests
 #   ./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests/myTestCase
+#   ./Scripts/test.sh --device FlipcashTests/SomeUITests
+#   ./Scripts/test.sh --device "Raul's iPhone" FlipcashTests/SomeUITests
 #
 # This script intentionally does NOT support -testPlan AllTargets —
 # the full suite is run from Xcode or CI, not from here.
 
 set -e
 
+# Resolve a paired iOS device UDID via devicectl.
+#
+# Use devicectl, NOT `xcrun xctrace list devices` — xctrace often labels
+# paired iPhones as "Offline" even when they are connected and available
+# to xcodebuild via the network-paired CoreDevice transport.
+resolve_device_udid() {
+    local match="${1:-}"
+    local tmp
+    tmp=$(mktemp)
+    if ! xcrun devicectl list devices --json-output "$tmp" >/dev/null 2>&1; then
+        rm -f "$tmp"
+        return 1
+    fi
+    python3 - "$match" "$tmp" <<'PY'
+import json, sys
+match = sys.argv[1].lower()
+data = json.load(open(sys.argv[2]))
+for dev in data["result"]["devices"]:
+    hw = dev.get("hardwareProperties", {})
+    if hw.get("platform") != "iOS":
+        continue
+    name = dev.get("deviceProperties", {}).get("name", "")
+    if match and match not in name.lower():
+        continue
+    udid = hw.get("udid", "")
+    if udid:
+        print(udid)
+        break
+PY
+    rm -f "$tmp"
+}
+
+DESTINATION="platform=iOS Simulator,name=iPhone 17"
+
+if [[ "${1:-}" == "--device" ]]; then
+    shift
+    MATCH=""
+    if [[ $# -gt 0 && "$1" != -* && "$1" != */* ]]; then
+        MATCH="$1"
+        shift
+    fi
+    UDID="$(resolve_device_udid "$MATCH")"
+    if [[ -z "$UDID" ]]; then
+        echo "error: no paired iOS device found${MATCH:+ matching \"$MATCH\"}." >&2
+        echo "       List with: xcrun devicectl list devices" >&2
+        exit 1
+    fi
+    DESTINATION="platform=iOS,id=$UDID"
+fi
+
 if [ "$#" -eq 0 ]; then
     cat >&2 <<EOF
 error: at least one test identifier is required.
 
-Usage: $0 <Target>/<Suite>[/<TestName>] [<Target>/<Suite>[/<TestName>]...]
+Usage: $0 [--device [name]] <Target>/<Suite>[/<TestName>] [<Target>/<Suite>[/<TestName>]...]
 
 Examples:
   $0 FlipcashCoreTests/ExchangedFiatTests
   $0 FlipcashCoreTests/ExchangedFiatTests FlipcashCoreTests/FiatTests
   $0 FlipcashCoreTests/ExchangedFiatTests/myTestCase
+  $0 --device FlipcashTests/SomeUITests
 EOF
     exit 2
 fi
@@ -37,8 +93,8 @@ for target in "$@"; do
     args+=(-only-testing:"$target")
 done
 
-echo "+ xcodebuild test -scheme Flipcash -destination 'platform=iOS Simulator,name=iPhone 17' ${args[*]}"
+echo "+ xcodebuild test -scheme Flipcash -destination '$DESTINATION' ${args[*]}"
 exec xcodebuild test \
     -scheme Flipcash \
-    -destination "platform=iOS Simulator,name=iPhone 17" \
+    -destination "$DESTINATION" \
     "${args[@]}"

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -1,86 +1,30 @@
 #!/usr/bin/env bash
 #
-# Run targeted iOS tests via the Flipcash scheme.
+# Run targeted iOS Simulator tests via the Flipcash scheme.
 #
 # Usage:
-#   ./Scripts/test.sh [--device [name]] <Target>/<Suite>[/<TestName>] [...]
-#
-# Default destination is the iPhone 17 simulator. Pass --device (optionally
-# followed by a name substring) to run against a paired physical device.
+#   ./Scripts/test.sh <Target>/<Suite>[/<TestName>] [<Target>/<Suite>[/<TestName>]...]
 #
 # Examples:
 #   ./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests
 #   ./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests FlipcashCoreTests/FiatTests
 #   ./Scripts/test.sh FlipcashCoreTests/ExchangedFiatTests/myTestCase
-#   ./Scripts/test.sh --device FlipcashTests/SomeUITests
-#   ./Scripts/test.sh --device "Raul's iPhone" FlipcashTests/SomeUITests
 #
 # This script intentionally does NOT support -testPlan AllTargets —
 # the full suite is run from Xcode or CI, not from here.
 
 set -e
 
-# Resolve a paired iOS device UDID via devicectl.
-#
-# Use devicectl, NOT `xcrun xctrace list devices` — xctrace often labels
-# paired iPhones as "Offline" even when they are connected and available
-# to xcodebuild via the network-paired CoreDevice transport.
-resolve_device_udid() {
-    local match="${1:-}"
-    local tmp
-    tmp=$(mktemp)
-    if ! xcrun devicectl list devices --json-output "$tmp" >/dev/null 2>&1; then
-        rm -f "$tmp"
-        return 1
-    fi
-    python3 - "$match" "$tmp" <<'PY'
-import json, sys
-match = sys.argv[1].lower()
-data = json.load(open(sys.argv[2]))
-for dev in data["result"]["devices"]:
-    hw = dev.get("hardwareProperties", {})
-    if hw.get("platform") != "iOS":
-        continue
-    name = dev.get("deviceProperties", {}).get("name", "")
-    if match and match not in name.lower():
-        continue
-    udid = hw.get("udid", "")
-    if udid:
-        print(udid)
-        break
-PY
-    rm -f "$tmp"
-}
-
-DESTINATION="platform=iOS Simulator,name=iPhone 17"
-
-if [[ "${1:-}" == "--device" ]]; then
-    shift
-    MATCH=""
-    if [[ $# -gt 0 && "$1" != -* && "$1" != */* ]]; then
-        MATCH="$1"
-        shift
-    fi
-    UDID="$(resolve_device_udid "$MATCH")"
-    if [[ -z "$UDID" ]]; then
-        echo "error: no paired iOS device found${MATCH:+ matching \"$MATCH\"}." >&2
-        echo "       List with: xcrun devicectl list devices" >&2
-        exit 1
-    fi
-    DESTINATION="platform=iOS,id=$UDID"
-fi
-
 if [ "$#" -eq 0 ]; then
     cat >&2 <<EOF
 error: at least one test identifier is required.
 
-Usage: $0 [--device [name]] <Target>/<Suite>[/<TestName>] [<Target>/<Suite>[/<TestName>]...]
+Usage: $0 <Target>/<Suite>[/<TestName>] [<Target>/<Suite>[/<TestName>]...]
 
 Examples:
   $0 FlipcashCoreTests/ExchangedFiatTests
   $0 FlipcashCoreTests/ExchangedFiatTests FlipcashCoreTests/FiatTests
   $0 FlipcashCoreTests/ExchangedFiatTests/myTestCase
-  $0 --device FlipcashTests/SomeUITests
 EOF
     exit 2
 fi
@@ -93,8 +37,8 @@ for target in "$@"; do
     args+=(-only-testing:"$target")
 done
 
-echo "+ xcodebuild test -scheme Flipcash -destination '$DESTINATION' ${args[*]}"
+echo "+ xcodebuild test -scheme Flipcash -destination 'platform=iOS Simulator,name=iPhone 17' ${args[*]}"
 exec xcodebuild test \
     -scheme Flipcash \
-    -destination "$DESTINATION" \
+    -destination "platform=iOS Simulator,name=iPhone 17" \
     "${args[@]}"


### PR DESCRIPTION
## Summary

- `./Scripts/build.sh --device` now targets the first paired iPhone, with an optional name substring to disambiguate.
- The script resolves the device UDID via `devicectl` rather than `xctrace`, because `xctrace` mislabels paired iPhones as offline.
- CLAUDE.md now documents the device build flow and explains that XcodeBuildMCP does not enable device tools by default, so device builds must fall back to xcodebuild + devicectl. Tests remain simulator-only.

## Test plan

- Default `./Scripts/build.sh` builds the app without regression.
- `./Scripts/build.sh --device` builds against the paired iPhone with correct code signing.
- Default `./Scripts/test.sh` still runs a unit suite on the iPhone 17 simulator.
- `./Scripts/build.sh --device "<name not present>"` exits with a clear error pointing at devicectl.