### PR TITLE
feat: home-screen quick actions for Give, Wallet, Discover

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -80,7 +80,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             object: nil
         )
 
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDeepLinkNotification(_:)),
+            name: .shortcutDeepLinkReceived,
+            object: nil
+        )
+
         return true
+    }
+
+    /// Routes scene events to ``SceneDelegate``. SwiftUI's `App` lifecycle
+    /// uses its own implicit scene delegate by default, swallowing
+    /// `windowScene(_:performActionFor:)`; without this method, the
+    /// `UISceneDelegateClassName` declared in `Info.plist` is not honored
+    /// and quick actions are dropped.
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let config = UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        config.delegateClass = SceneDelegate.self
+        return config
     }
 
     // MARK: - Lifecycle -

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -93,11 +93,20 @@ final class DeepLinkController {
             
         case .token(let mint):
             return actionForCurrencyInfo(mint: mint)
-            
+
+        case .give:
+            return actionForOpenSheet(.give)
+
+        case .wallet:
+            return actionForOpenSheet(.balance)
+
+        case .discover:
+            return actionForOpenSheet(.discover)
+
         case .unknown:
             break
         }
-        
+
         return nil
     }
     
@@ -131,6 +140,13 @@ final class DeepLinkController {
     private func actionForCurrencyInfo(mint: PublicKey) -> DeepLinkAction {
         DeepLinkAction(
             kind: .currencyInfo(mint),
+            sessionAuthenticator: sessionAuthenticator
+        )
+    }
+
+    private func actionForOpenSheet(_ sheet: AppRouter.SheetPresentation) -> DeepLinkAction {
+        DeepLinkAction(
+            kind: .openSheet(sheet),
             sessionAuthenticator: sessionAuthenticator
         )
     }
@@ -212,6 +228,24 @@ struct DeepLinkAction {
                 Analytics.deeplinkRouted(kind: kind)
                 container.appRouter.navigate(to: .currencyInfo(mint))
             }
+
+        case .openSheet(let sheet):
+            if case .loggedIn(let container) = sessionAuthenticator.state {
+                Analytics.deeplinkRouted(kind: kind)
+                // Mirror `ScanScreen.presentGive` so a no-balance user
+                // taking the quick-action route gets the same dialog the
+                // bottom bar shows, instead of an empty Give sheet.
+                if sheet == .give {
+                    let rate = container.ratesController.rateForBalanceCurrency()
+                    guard container.session.hasGiveableBalance(for: rate) else {
+                        container.session.dialogItem = .noGiveableBalance {
+                            container.appRouter.present(.discover)
+                        }
+                        return
+                    }
+                }
+                container.appRouter.present(sheet)
+            }
         }
     }
 }
@@ -224,6 +258,7 @@ extension DeepLinkAction {
         case receiveCashLink(MnemonicPhrase)
         case verifyEmail(VerificationDescription)
         case currencyInfo(PublicKey)
+        case openSheet(AppRouter.SheetPresentation)
     }
 }
 
@@ -234,6 +269,7 @@ extension DeepLinkAction.Kind {
         case .receiveCashLink:  "CashLink"
         case .verifyEmail:      "EmailVerification"
         case .currencyInfo:     "TokenInfo"
+        case .openSheet(let sheet): "Sheet:\(sheet)"
         }
     }
 }

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -232,19 +232,11 @@ struct DeepLinkAction {
         case .openSheet(let sheet):
             if case .loggedIn(let container) = sessionAuthenticator.state {
                 Analytics.deeplinkRouted(kind: kind)
-                // Mirror `ScanScreen.presentGive` so a no-balance user
-                // taking the quick-action route gets the same dialog the
-                // bottom bar shows, instead of an empty Give sheet.
                 if sheet == .give {
-                    let rate = container.ratesController.rateForBalanceCurrency()
-                    guard container.session.hasGiveableBalance(for: rate) else {
-                        container.session.dialogItem = .noGiveableBalance {
-                            container.appRouter.present(.discover)
-                        }
-                        return
-                    }
+                    container.presentGive()
+                } else {
+                    container.appRouter.present(sheet)
                 }
-                container.appRouter.present(sheet)
             }
         }
     }

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -233,10 +233,15 @@ struct DeepLinkAction {
             if case .loggedIn(let container) = sessionAuthenticator.state {
                 Analytics.deeplinkRouted(kind: kind)
                 if sheet == .give {
-                    container.presentGive()
-                } else {
-                    container.appRouter.present(sheet)
+                    let rate = container.ratesController.rateForBalanceCurrency()
+                    guard container.session.hasGiveableBalance(for: rate) else {
+                        container.session.dialogItem = .noGiveableBalance(
+                            onDiscover: { container.appRouter.present(.discover) }
+                        )
+                        return
+                    }
                 }
+                container.appRouter.present(sheet)
             }
         }
     }

--- a/Flipcash/Core/Controllers/Deep Links/Route.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Route.swift
@@ -85,6 +85,9 @@ nonisolated extension Route {
         case cash
         case verifyEmail
         case token(PublicKey)
+        case give
+        case wallet
+        case discover
         case unknown(String)
         
         static func parse(path: String) -> Path? {
@@ -111,6 +114,12 @@ nonisolated extension Route {
                     return nil
                 }
                 return .token(mint)
+            case "give":
+                return .give
+            case "wallet":
+                return .wallet
+            case "discover":
+                return .discover
             default:
                 return .unknown(url.lastPathComponent)
             }

--- a/Flipcash/Core/Controllers/NotificationController.swift
+++ b/Flipcash/Core/Controllers/NotificationController.swift
@@ -69,5 +69,6 @@ extension NSNotification.Name {
     static let pushNotificationWillPresent = Notification.Name("com.code.pushNotificationWillPresent")
     static let pushDeepLinkReceived         = Notification.Name("com.code.pushDeepLinkReceived")
     static let qrDeepLinkReceived          = Notification.Name("com.code.qrDeepLinkReceived")
+    static let shortcutDeepLinkReceived    = Notification.Name("com.code.shortcutDeepLinkReceived")
     static let messageNotificationReceived = Notification.Name("com.code.messageNotificationReceived")
 }

--- a/Flipcash/Core/SceneDelegate.swift
+++ b/Flipcash/Core/SceneDelegate.swift
@@ -1,0 +1,43 @@
+//
+//  SceneDelegate.swift
+//  Flipcash
+//
+
+import UIKit
+import FlipcashCore
+
+private let logger = Logger(label: "flipcash.scene-delegate")
+
+/// Bridges quick-action taps into the existing deep-link pipeline. SwiftUI's
+/// `App` lifecycle doesn't forward `UIApplicationShortcutItem` events to
+/// `AppDelegate`, so we receive them here, pull the embedded URL out of the
+/// shortcut's `userInfo`, and post the same notification the rest of the
+/// app's URL handlers already observe.
+final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        if let shortcut = connectionOptions.shortcutItem {
+            postDeepLink(for: shortcut)
+        }
+    }
+
+    func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+        completionHandler(postDeepLink(for: shortcutItem))
+    }
+
+    @discardableResult
+    private func postDeepLink(for shortcut: UIApplicationShortcutItem) -> Bool {
+        guard let urlString = shortcut.userInfo?["url"] as? String,
+              let url = URL(string: urlString) else {
+            logger.warning("Quick action missing url userInfo", metadata: ["type": "\(shortcut.type)"])
+            return false
+        }
+        NotificationCenter.default.post(
+            name: .shortcutDeepLinkReceived,
+            object: nil,
+            userInfo: ["url": url]
+        )
+        return true
+    }
+}

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -305,14 +305,7 @@ struct ScanScreen: View {
     // MARK: - Actions -
 
     private func presentGive() {
-        let rate = sessionContainer.ratesController.rateForBalanceCurrency()
-        guard session.hasGiveableBalance(for: rate) else {
-            session.dialogItem = .noGiveableBalance(
-                onDiscover: { router.present(.discover) }
-            )
-            return
-        }
-        router.present(.give)
+        sessionContainer.presentGive()
     }
 
     private func dismissBill() {

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -305,7 +305,14 @@ struct ScanScreen: View {
     // MARK: - Actions -
 
     private func presentGive() {
-        sessionContainer.presentGive()
+        let rate = sessionContainer.ratesController.rateForBalanceCurrency()
+        guard session.hasGiveableBalance(for: rate) else {
+            session.dialogItem = .noGiveableBalance(
+                onDiscover: { router.present(.discover) }
+            )
+            return
+        }
+        router.present(.give)
     }
 
     private func dismissBill() {

--- a/Flipcash/Core/Screens/Main/ScanViewModel.swift
+++ b/Flipcash/Core/Screens/Main/ScanViewModel.swift
@@ -116,7 +116,7 @@ class ScanViewModel {
         switch route.path {
         case .cash, .token:
             return true
-        case .login, .verifyEmail, .unknown:
+        case .login, .verifyEmail, .give, .wallet, .discover, .unknown:
             return false
         }
     }

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -452,6 +452,19 @@ struct SessionContainer {
             .environment(onrampDeeplinkInbox)
     }
 
+    /// Opens the Give sheet, or surfaces the no-balance dialog with a path
+    /// to Discover when the user has nothing giveable. Used by both the
+    /// bottom-bar tap and the `flipcash://give` deep link.
+    func presentGive() {
+        let rate = ratesController.rateForBalanceCurrency()
+        guard session.hasGiveableBalance(for: rate) else {
+            session.dialogItem = .noGiveableBalance(
+                onDiscover: { self.appRouter.present(.discover) }
+            )
+            return
+        }
+        appRouter.present(.give)
+    }
 }
 
 extension View {

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -451,20 +451,6 @@ struct SessionContainer {
             .environment(onrampCoordinator)
             .environment(onrampDeeplinkInbox)
     }
-
-    /// Opens the Give sheet, or surfaces the no-balance dialog with a path
-    /// to Discover when the user has nothing giveable. Used by both the
-    /// bottom-bar tap and the `flipcash://give` deep link.
-    func presentGive() {
-        let rate = ratesController.rateForBalanceCurrency()
-        guard session.hasGiveableBalance(for: rate) else {
-            session.dialogItem = .noGiveableBalance(
-                onDiscover: { self.appRouter.present(.discover) }
-            )
-            return
-        }
-        appRouter.present(.give)
-    }
 }
 
 extension View {

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -21,6 +21,65 @@
 	</array>
 	<key>SQLiteVersion</key>
 	<integer>11</integer>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>com.flipcash.shortcut.give</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Give</string>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>banknote</string>
+			<key>UIApplicationShortcutItemUserInfo</key>
+			<dict>
+				<key>url</key>
+				<string>flipcash://give</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>com.flipcash.shortcut.wallet</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Wallet</string>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>wallet.bifold</string>
+			<key>UIApplicationShortcutItemUserInfo</key>
+			<dict>
+				<key>url</key>
+				<string>flipcash://wallet</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>com.flipcash.shortcut.discover</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Discover</string>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>binoculars</string>
+			<key>UIApplicationShortcutItemUserInfo</key>
+			<dict>
+				<key>url</key>
+				<string>flipcash://discover</string>
+			</dict>
+		</dict>
+	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>


### PR DESCRIPTION
## Summary

- Long-press the app icon to jump into Give, Wallet, or Discover.
- Each shortcut emits a `flipcash://` URL handled by the existing deep link pipeline, so the same route handler covers QR codes, push notifications, and quick actions.
- A `SceneDelegate` bridges the iOS quick-action callback, which SwiftUI's `App` lifecycle does not forward to `AppDelegate`.

## Test plan

- [x] Long-press the icon → all three shortcuts appear.
- [x] Tap Give from a backgrounded app → Give sheet opens with a currency selected.
- [x] Tap Wallet → Wallet sheet opens.
- [x] Tap Discover → Discover sheet opens.
- [x] Tap Give with no giveable balance → "No Balance Yet" dialog, not an empty sheet.
- [x] Cold launch from a shortcut behaves the same as warm activation.