### PR TITLE
feat: explain Apple Pay timeout to the user

### DIFF
--- a/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampCoordinator.swift
@@ -317,6 +317,16 @@ final class OnrampCoordinator {
         applePayIdleTimer.disarm()
     }
 
+    private func handleApplePayIdleTimeout() {
+        logger.info("Apple Pay sheet idle timeout, dismissing")
+        clearPendingState()
+
+        Task { @concurrent in
+            try? await Task.sleep(for: AppRouter.dismissAnimationDuration)
+            await MainActor.run { dialogItem = .applePaySheetTimeout }
+        }
+    }
+
     // MARK: - Verification navigation -
 
     /// Entry point invoked by `VerifyInfoScreen`'s Next button.
@@ -841,8 +851,7 @@ final class OnrampCoordinator {
         case .pendingPaymentAuth:
             logger.info("Apple Pay pending payment auth")
             applePayIdleTimer.arm { [weak self] in
-                logger.info("Apple Pay sheet idle timeout, dismissing")
-                self?.cancel()
+                self?.handleApplePayIdleTimeout()
             }
         case .paymentAuthorized:
             // Face ID / Touch ID confirmed — the sheet is no longer idle. If

--- a/Flipcash/UI/DialogItem+CashFlows.swift
+++ b/Flipcash/UI/DialogItem+CashFlows.swift
@@ -79,4 +79,15 @@ extension DialogItem {
             .cancel()
         }
     }
+
+    static var applePaySheetTimeout: DialogItem {
+        .init(
+            style: .standard,
+            title: "Purchase Timed Out",
+            subtitle: "Purchases must be authorized within 60 seconds",
+            dismissable: true
+        ) {
+            .okay(kind: .standard)
+        }
+    }
 }

--- a/FlipcashTests/DialogItemFactoriesTests.swift
+++ b/FlipcashTests/DialogItemFactoriesTests.swift
@@ -50,4 +50,28 @@ struct DialogItemFactoriesTests {
 
         #expect(fired)
     }
+
+    // MARK: - applePaySheetTimeout
+
+    @Test("applePaySheetTimeout dialog uses the standard (informational) style")
+    func applePaySheetTimeout_usesStandardStyle() {
+        let dialog = DialogItem.applePaySheetTimeout
+        #expect(dialog.style == .standard)
+    }
+
+    @Test("applePaySheetTimeout dialog title and subtitle match the wording shown when the Apple Pay sheet times out")
+    func applePaySheetTimeout_copy() {
+        let dialog = DialogItem.applePaySheetTimeout
+        #expect(dialog.title == "Purchase Timed Out")
+        #expect(dialog.subtitle == "Purchases must be authorized within 60 seconds")
+    }
+
+    @Test("applePaySheetTimeout exposes a single OK action")
+    func applePaySheetTimeout_actionLayout() throws {
+        let dialog = DialogItem.applePaySheetTimeout
+
+        try #require(dialog.actions.count == 1)
+        #expect(dialog.actions[0].title == "OK")
+        #expect(dialog.actions[0].kind == .standard)
+    }
 }


### PR DESCRIPTION
## Summary

When the Apple Pay sheet sits idle for 60 seconds we already dismiss it, but the user got no explanation — the sheet just disappeared. Match the Android client by surfacing an informational dialog right after the dismiss animation: **"Purchase Timed Out — Purchases must be authorized within 60 seconds."**

## Test plan

- [x] Start a buy on an existing currency, leave the Apple Pay sheet untouched for 60 seconds — sheet auto-dismisses and the timeout dialog appears
- [x] Same flow on a currency launch — dialog appears the same way
- [x] Authorize the buy with Face ID / Touch ID before 60 seconds — no dialog appears, normal completion runs through
- [x] Manually swipe the Apple Pay sheet down before 60 seconds — no dialog appears
- [x] Tap OK on the timeout dialog — dialog dismisses cleanly with no lingering Apple Pay sheet