### PR TITLE
fix: route Wallet quick action to /balance, reserve /wallet for Phantom

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -97,7 +97,7 @@ final class DeepLinkController {
         case .give:
             return actionForOpenSheet(.give)
 
-        case .wallet:
+        case .balance:
             return actionForOpenSheet(.balance)
 
         case .discover:

--- a/Flipcash/Core/Controllers/Deep Links/Route.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Route.swift
@@ -86,7 +86,7 @@ nonisolated extension Route {
         case verifyEmail
         case token(PublicKey)
         case give
-        case wallet
+        case balance
         case discover
         case unknown(String)
         
@@ -116,13 +116,13 @@ nonisolated extension Route {
                 return .token(mint)
             case "give":
                 return .give
+            case "balance":
+                return .balance
             case "wallet":
-                // Plain `/wallet` is the home-screen quick-action target.
-                // `/wallet/walletConnected` and `/wallet/transactionSigned`
-                // (with optional `errorCode`) are Phantom deep-link returns
-                // consumed by `WalletConnection.didReceiveURL` — fall
-                // through to `.unknown` so the deep-link router skips them.
-                return components.count == 1 ? .wallet : .unknown(url.lastPathComponent)
+                // Reserved for Phantom callbacks (consumed by
+                // `WalletConnection.didReceiveURL`). Home-screen
+                // "Wallet" quick action uses `/balance` instead.
+                return .unknown(url.lastPathComponent)
             case "discover":
                 return .discover
             default:

--- a/Flipcash/Core/Screens/Main/ScanViewModel.swift
+++ b/Flipcash/Core/Screens/Main/ScanViewModel.swift
@@ -116,7 +116,7 @@ class ScanViewModel {
         switch route.path {
         case .cash, .token:
             return true
-        case .login, .verifyEmail, .give, .wallet, .discover, .unknown:
+        case .login, .verifyEmail, .give, .balance, .discover, .unknown:
             return false
         }
     }

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -46,7 +46,7 @@
 			<key>UIApplicationShortcutItemUserInfo</key>
 			<dict>
 				<key>url</key>
-				<string>flipcash://wallet</string>
+				<string>flipcash://balance</string>
 			</dict>
 		</dict>
 		<dict>

--- a/FlipcashTests/RouteTests.swift
+++ b/FlipcashTests/RouteTests.swift
@@ -120,42 +120,70 @@ struct RouteTests {
         #expect(Route(url: noMintUniversalLink) == nil)
     }
 
-    // MARK: - Wallet Callback URLs -
+    // MARK: - Sheet Routes -
+    //
+    // The three home-screen quick actions defined in Info.plist (Give,
+    // Wallet, Discover) all open sheets via these routes. Universal links
+    // and `flipcash://` deep links must both parse to the same case.
 
-    @Test("Wallet callback universal links parse as unknown routes")
-    func walletCallbackUniversalLinks() {
-        // Wallet callback URLs (from Phantom) parse as .unknown routes.
-        // DeepLinkController returns nil action for .unknown.
-
-        let walletConnected = URL(string: "https://app.flipcash.com/wallet/walletConnected?nonce=abc&data=xyz")!
-        let transactionSigned = URL(string: "https://app.flipcash.com/wallet/transactionSigned?nonce=abc&data=xyz")!
-        let walletError = URL(string: "https://app.flipcash.com/wallet/walletConnected?errorCode=4001")!
-
-        if case .unknown = Route(url: walletConnected)?.path {} else {
-            Issue.record("walletConnected should parse as .unknown")
-        }
-        if case .unknown = Route(url: transactionSigned)?.path {} else {
-            Issue.record("transactionSigned should parse as .unknown")
-        }
-        if case .unknown = Route(url: walletError)?.path {} else {
-            Issue.record("walletError should parse as .unknown")
+    @Test(
+        "Give route parses from both URL formats",
+        arguments: ["flipcash://give", "https://app.flipcash.com/give"]
+    )
+    func giveRoute(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        if case .give = path {} else {
+            Issue.record("\(urlString) should parse as .give")
         }
     }
 
-    @Test("Wallet callback deep links parse as unknown routes")
-    func walletCallbackDeepLinks() {
-        let walletConnected = URL(string: "flipcash://wallet/walletConnected?nonce=abc&data=xyz")!
-        let transactionSigned = URL(string: "flipcash://wallet/transactionSigned?nonce=abc&data=xyz")!
-        let walletError = URL(string: "flipcash://wallet/walletConnected?errorCode=4001")!
+    @Test(
+        "Balance route parses from both URL formats",
+        arguments: ["flipcash://balance", "https://app.flipcash.com/balance"]
+    )
+    func balanceRoute(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        if case .balance = path {} else {
+            Issue.record("\(urlString) should parse as .balance")
+        }
+    }
 
-        if case .unknown = Route(url: walletConnected)?.path {} else {
-            Issue.record("walletConnected deep link should parse as .unknown")
+    @Test(
+        "Discover route parses from both URL formats",
+        arguments: ["flipcash://discover", "https://app.flipcash.com/discover"]
+    )
+    func discoverRoute(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        if case .discover = path {} else {
+            Issue.record("\(urlString) should parse as .discover")
         }
-        if case .unknown = Route(url: transactionSigned)?.path {} else {
-            Issue.record("transactionSigned deep link should parse as .unknown")
+    }
+
+    // MARK: - Wallet Callback URLs -
+
+    @Test(
+        "Plain /wallet is reserved for Phantom and parses as unknown",
+        arguments: ["flipcash://wallet", "https://app.flipcash.com/wallet"]
+    )
+    func walletNamespaceReserved(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        if case .unknown = path {} else {
+            Issue.record("\(urlString) should parse as .unknown")
         }
-        if case .unknown = Route(url: walletError)?.path {} else {
-            Issue.record("walletError deep link should parse as .unknown")
+    }
+
+    @Test("Phantom callback URLs parse as unknown", arguments: [
+        "https://app.flipcash.com/wallet/walletConnected?nonce=abc&data=xyz",
+        "https://app.flipcash.com/wallet/transactionSigned?nonce=abc&data=xyz",
+        "https://app.flipcash.com/wallet/walletConnected?errorCode=4001",
+        "flipcash://wallet/walletConnected?nonce=abc&data=xyz",
+        "flipcash://wallet/transactionSigned?nonce=abc&data=xyz",
+        "flipcash://wallet/walletConnected?errorCode=4001",
+    ])
+    func walletCallback(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        if case .unknown = path {} else {
+            Issue.record("\(urlString) should parse as .unknown")
         }
     }
 


### PR DESCRIPTION
## Summary

The Wallet home-screen quick action and Phantom wallet deeplinks both routed through `/wallet`, an ambiguous namespace where plain `/wallet` was the quick-action target and `/wallet/walletConnected`/`/wallet/transactionSigned` were Phantom callbacks. The quick action now opens `/balance` (visible label stays "Wallet") and the `/wallet` namespace is documented and reserved for Phantom. Added parameterized parse tests for all three home-screen quick actions plus the Phantom callback paths — the original code shipped without tests for the quick-action URLs.

## Test plan
- [x] Long-press the home screen icon and tap Wallet — opens the Balance sheet
- [x] Long-press the home screen icon and tap Give and Discover — still open their respective sheets
- [x] Connect a Phantom wallet — connection and transaction signing callbacks still complete