### PR TITLE
fix: surface specific Coinbase onramp error messages

### DIFF
--- a/Flipcash/Core/Controllers/Coinbase.swift
+++ b/Flipcash/Core/Controllers/Coinbase.swift
@@ -171,7 +171,9 @@ public nonisolated struct OnrampErrorResponse: Error, Decodable, Sendable {
                     return "Weekly Limit Exceeded"
                 case .transactionCount:
                     return "Maximum Purchases Reached"
-                case .cardRiskDeclined, .permissionDenied:
+                case .cardRiskDeclined:
+                    return "Couldn't Use This Card"
+                case .permissionDenied:
                     return "Something Went Wrong"
                 case .guestTransactionSendFailed, .invalidRequest:
                     return "Something Went Wrong"
@@ -202,7 +204,9 @@ public nonisolated struct OnrampErrorResponse: Error, Decodable, Sendable {
                     return "You can only add up to $1,000 per week"
                 case .transactionCount:
                     return "Each user is limited to 15 purchases total."
-                case .cardRiskDeclined, .permissionDenied:
+                case .cardRiskDeclined:
+                    return "Please try again with a different debit card."
+                case .permissionDenied:
                     return "Something went wrong. Please contact support"
                 case .guestRegionMismatch, .guestRegionForbidden, .networkNotTradable:
                     return "This feature isn't currently available in your region"
@@ -228,6 +232,14 @@ public nonisolated struct OnrampErrorResponse: Error, Decodable, Sendable {
         public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
             let rawValue = try container.decode(String.self)
+            self = ErrorType(coinbaseCode: rawValue)
+        }
+
+        /// Maps a raw Coinbase error code (`"ERROR_CODE_..."` or the bare
+        /// suffix Coinbase sometimes emits) onto a typed `ErrorType`. Used
+        /// by the HTTP-response decoder and by the Apple Pay WebView event
+        /// handler so both paths surface the same title/subtitle pair.
+        public init(coinbaseCode rawValue: String) {
             self = (
                 ErrorType(rawValue: rawValue.uppercased()) ??
                 ErrorType(rawValue: "ERROR_CODE_\(rawValue.uppercased())")

--- a/Flipcash/Core/Screens/Main/Buy/BuyAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyAmountViewModel.swift
@@ -166,6 +166,12 @@ final class BuyAmountViewModel: Identifiable {
                 if operation.didTimeOut {
                     self?.session.dialogItem = .applePaySheetTimeout
                 }
+            } catch let FundingOperationError.externalRejected(title, subtitle) {
+                logger.error("Coinbase funding rejected", metadata: [
+                    "mint": "\(self?.mint.base58 ?? "nil")",
+                    "title": "\(title)",
+                ])
+                self?.dialogItem = .externalRejection(title: title, subtitle: subtitle)
             } catch {
                 logger.error("Coinbase funding failed", metadata: [
                     "mint": "\(self?.mint.base58 ?? "nil")",
@@ -217,6 +223,12 @@ final class BuyAmountViewModel: Identifiable {
             } catch is CancellationError {
                 // User dismissed the flow locally (back swipe / sheet
                 // dismiss) — silent.
+            } catch let FundingOperationError.externalRejected(title, subtitle) {
+                logger.error("Phantom funding rejected", metadata: [
+                    "mint": "\(self?.mint.base58 ?? "nil")",
+                    "title": "\(title)",
+                ])
+                self?.dialogItem = .externalRejection(title: title, subtitle: subtitle)
             } catch {
                 logger.error("Phantom funding failed", metadata: [
                     "mint": "\(self?.mint.base58 ?? "nil")",
@@ -262,6 +274,13 @@ final class BuyAmountViewModel: Identifiable {
             routeToPicker(amount: amount, pin: pin)
         } catch Session.Error.verifiedStateStale {
             actionButtonState = .normal
+        } catch let FundingOperationError.externalRejected(title, subtitle) {
+            logger.error("Reserves-funded buy rejected", metadata: [
+                "mint": "\(mint.base58)",
+                "title": "\(title)",
+            ])
+            actionButtonState = .normal
+            dialogItem = .externalRejection(title: title, subtitle: subtitle)
         } catch {
             logger.error("Failed to buy currency from BuyAmountScreen", metadata: [
                 "mint": "\(mint.base58)",

--- a/Flipcash/Core/Screens/Main/Buy/BuyAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyAmountViewModel.swift
@@ -171,7 +171,7 @@ final class BuyAmountViewModel: Identifiable {
                     "mint": "\(self?.mint.base58 ?? "nil")",
                     "title": "\(title)",
                 ])
-                self?.dialogItem = .externalRejection(title: title, subtitle: subtitle)
+                self?.dialogItem = .error(title: title, subtitle: subtitle)
             } catch {
                 logger.error("Coinbase funding failed", metadata: [
                     "mint": "\(self?.mint.base58 ?? "nil")",
@@ -228,7 +228,7 @@ final class BuyAmountViewModel: Identifiable {
                     "mint": "\(self?.mint.base58 ?? "nil")",
                     "title": "\(title)",
                 ])
-                self?.dialogItem = .externalRejection(title: title, subtitle: subtitle)
+                self?.dialogItem = .error(title: title, subtitle: subtitle)
             } catch {
                 logger.error("Phantom funding failed", metadata: [
                     "mint": "\(self?.mint.base58 ?? "nil")",
@@ -280,7 +280,7 @@ final class BuyAmountViewModel: Identifiable {
                 "title": "\(title)",
             ])
             actionButtonState = .normal
-            dialogItem = .externalRejection(title: title, subtitle: subtitle)
+            dialogItem = .error(title: title, subtitle: subtitle)
         } catch {
             logger.error("Failed to buy currency from BuyAmountScreen", metadata: [
                 "mint": "\(mint.base58)",

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -436,7 +436,7 @@ struct CurrencyCreationWizardScreen: View {
             }
             if !isAvailable {
                 logger.info("Currency name unavailable", metadata: ["name_length": "\(name.count)"])
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "This Name is Taken",
                     subtitle: "Try a different currency name"
                 )
@@ -449,14 +449,14 @@ struct CurrencyCreationWizardScreen: View {
                 attestation = try await flipClient.moderateText(name, owner: session.ownerKeyPair)
             } catch ErrorModeration.denied(let category) {
                 logger.info("Currency name moderation denied", metadata: ["category": "\(category)"])
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "This Name is Not Allowed",
                     subtitle: "Try a different currency name"
                 )
                 return
             } catch ErrorModeration.unsupportedLanguage {
                 logger.info("Currency name moderation: unsupported language")
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Couldn't Check This Name",
                     subtitle: "Try a different name."
                 )
@@ -493,7 +493,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 logger.error("Failed to encode icon within 1 MB budget", metadata: ["error": "\(error)"])
                 ErrorReporting.captureError(error)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Couldn't Process Image",
                     subtitle: "Try a smaller or simpler image"
                 )
@@ -506,14 +506,14 @@ struct CurrencyCreationWizardScreen: View {
                 attestation = try await flipClient.moderateImage(imageData, owner: session.ownerKeyPair)
             } catch ErrorModeration.denied(let category) {
                 logger.info("Currency icon moderation denied", metadata: ["category": "\(category)"])
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "This Image is Not Allowed",
                     subtitle: "Try a different image"
                 )
                 return
             } catch ErrorModeration.unsupportedFormat {
                 logger.info("Currency icon format unsupported")
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "This Image Format Isn't Supported",
                     subtitle: "Use PNG, JPEG, or HEIC"
                 )
@@ -544,14 +544,14 @@ struct CurrencyCreationWizardScreen: View {
                 attestation = try await flipClient.moderateText(description, owner: session.ownerKeyPair)
             } catch ErrorModeration.denied(let category) {
                 logger.info("Currency description moderation denied", metadata: ["category": "\(category)"])
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "This Description is Not Allowed",
                     subtitle: "Try a different description"
                 )
                 return
             } catch ErrorModeration.unsupportedLanguage {
                 logger.info("Currency description moderation: unsupported language")
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Couldn't Check This Description",
                     subtitle: "Try a different description."
                 )
@@ -639,7 +639,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch ErrorLaunchCurrency.denied {
                 logger.error("Launch denied after preflight attestations passed")
                 ErrorReporting.captureError(ErrorLaunchCurrency.denied)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Couldn't Launch Currency",
                     subtitle: "Please try again. Contact support if this persists."
                 )
@@ -681,7 +681,7 @@ struct CurrencyCreationWizardScreen: View {
                 }
                 logger.error("Launch name-exists after preflight CheckAvailability passed")
                 ErrorReporting.captureError(ErrorLaunchCurrency.nameExists)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Name No Longer Available",
                     subtitle: "Please pick a different name."
                 )
@@ -689,7 +689,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch ErrorLaunchCurrency.invalidIcon {
                 logger.error("Launch rejected icon after preflight moderation passed")
                 ErrorReporting.captureError(ErrorLaunchCurrency.invalidIcon)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Image Is Invalid",
                     subtitle: "Please pick a different image."
                 )
@@ -705,7 +705,7 @@ struct CurrencyCreationWizardScreen: View {
                     "title": "\(title)",
                     "mint": "\(operation.launchedMint?.base58 ?? "nil")",
                 ])
-                errorDialog = makeDestructiveDialog(title: title, subtitle: subtitle)
+                errorDialog = DialogItem.error(title: title, subtitle: subtitle)
                 return
             } catch {
                 if Task.isCancelled { return }
@@ -732,14 +732,14 @@ struct CurrencyCreationWizardScreen: View {
 
     private func presentInsufficientFundsDialog(totalLaunchCost: ExchangedFiat) {
         logger.info("Insufficient balance to complete currency purchase")
-        errorDialog = makeDestructiveDialog(
+        errorDialog = DialogItem.error(
             title: "Not Enough Funds",
             subtitle: "You need \(totalLaunchCost.nativeAmount.formatted()) to create this currency."
         )
     }
 
     private func presentCouldNotCreateCurrencyDialog() {
-        errorDialog = makeDestructiveDialog(
+        errorDialog = DialogItem.error(
             title: "Couldn't Create Currency",
             subtitle: "Please try again."
         )
@@ -840,21 +840,21 @@ struct CurrencyCreationWizardScreen: View {
             } catch ErrorLaunchCurrency.denied {
                 logger.error("Phantom launch denied after preflight attestations passed")
                 ErrorReporting.captureError(ErrorLaunchCurrency.denied)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Couldn't Launch Currency",
                     subtitle: "Please try again. Contact support if this persists."
                 )
             } catch ErrorLaunchCurrency.nameExists {
                 logger.error("Phantom launch name-exists after preflight CheckAvailability passed")
                 ErrorReporting.captureError(ErrorLaunchCurrency.nameExists)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Name No Longer Available",
                     subtitle: "Please pick a different name."
                 )
             } catch ErrorLaunchCurrency.invalidIcon {
                 logger.error("Phantom launch rejected icon after preflight moderation passed")
                 ErrorReporting.captureError(ErrorLaunchCurrency.invalidIcon)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Image Is Invalid",
                     subtitle: "Please pick a different image."
                 )
@@ -864,7 +864,7 @@ struct CurrencyCreationWizardScreen: View {
                     "title": "\(title)",
                     "mint": "\(operation.launchedMint?.base58 ?? "nil")",
                 ])
-                errorDialog = makeDestructiveDialog(title: title, subtitle: subtitle)
+                errorDialog = DialogItem.error(title: title, subtitle: subtitle)
             } catch {
                 captureCreatedMint(operation.launchedMint, name: state.currencyName)
                 logger.error("Phantom-funded launch failed", metadata: [
@@ -872,7 +872,7 @@ struct CurrencyCreationWizardScreen: View {
                     "mint": "\(operation.launchedMint?.base58 ?? "nil")",
                 ])
                 ErrorReporting.captureError(error)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Couldn't Create Currency",
                     subtitle: "Please try again."
                 )
@@ -931,19 +931,19 @@ struct CurrencyCreationWizardScreen: View {
                 }
             } catch ErrorLaunchCurrency.denied {
                 ErrorReporting.captureError(ErrorLaunchCurrency.denied)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Couldn't Launch Currency",
                     subtitle: "Please try again. Contact support if this persists."
                 )
             } catch ErrorLaunchCurrency.nameExists {
                 ErrorReporting.captureError(ErrorLaunchCurrency.nameExists)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Name No Longer Available",
                     subtitle: "Please pick a different name."
                 )
             } catch ErrorLaunchCurrency.invalidIcon {
                 ErrorReporting.captureError(ErrorLaunchCurrency.invalidIcon)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Image Is Invalid",
                     subtitle: "Please pick a different image."
                 )
@@ -953,7 +953,7 @@ struct CurrencyCreationWizardScreen: View {
                     "title": "\(title)",
                     "mint": "\(operation.launchedMint?.base58 ?? "nil")",
                 ])
-                errorDialog = makeDestructiveDialog(title: title, subtitle: subtitle)
+                errorDialog = DialogItem.error(title: title, subtitle: subtitle)
             } catch {
                 captureCreatedMint(operation.launchedMint, name: state.currencyName)
                 logger.error("Coinbase-funded launch failed", metadata: [
@@ -961,7 +961,7 @@ struct CurrencyCreationWizardScreen: View {
                     "mint": "\(operation.launchedMint?.base58 ?? "nil")",
                 ])
                 ErrorReporting.captureError(error)
-                errorDialog = makeDestructiveDialog(
+                errorDialog = DialogItem.error(
                     title: "Couldn't Create Currency",
                     subtitle: "Please try again."
                 )
@@ -976,22 +976,12 @@ struct CurrencyCreationWizardScreen: View {
     // MARK: - Dialogs
 
     private func presentGenericErrorDialog() {
-        errorDialog = makeDestructiveDialog(
+        errorDialog = DialogItem.error(
             title: "Something Went Wrong",
             subtitle: "Please try again"
         )
     }
 
-    private func makeDestructiveDialog(title: String, subtitle: String) -> DialogItem {
-        .init(
-            style: .destructive,
-            title: title,
-            subtitle: subtitle,
-            dismissable: true
-        ) {
-            .okay(kind: .destructive)
-        }
-    }
 }
 
 // MARK: - NameStep

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -698,6 +698,15 @@ struct CurrencyCreationWizardScreen: View {
                 captureCreatedMint(operation.launchedMint, name: displayName)
                 presentInsufficientFundsDialog(totalLaunchCost: totalLaunchCost)
                 return
+            } catch let FundingOperationError.externalRejected(title, subtitle) {
+                if Task.isCancelled { return }
+                captureCreatedMint(operation.launchedMint, name: displayName)
+                logger.error("Reserves-funded launch rejected", metadata: [
+                    "title": "\(title)",
+                    "mint": "\(operation.launchedMint?.base58 ?? "nil")",
+                ])
+                errorDialog = makeDestructiveDialog(title: title, subtitle: subtitle)
+                return
             } catch {
                 if Task.isCancelled { return }
                 captureCreatedMint(operation.launchedMint, name: displayName)
@@ -849,6 +858,13 @@ struct CurrencyCreationWizardScreen: View {
                     title: "Image Is Invalid",
                     subtitle: "Please pick a different image."
                 )
+            } catch let FundingOperationError.externalRejected(title, subtitle) {
+                captureCreatedMint(operation.launchedMint, name: state.currencyName)
+                logger.error("Phantom-funded launch rejected", metadata: [
+                    "title": "\(title)",
+                    "mint": "\(operation.launchedMint?.base58 ?? "nil")",
+                ])
+                errorDialog = makeDestructiveDialog(title: title, subtitle: subtitle)
             } catch {
                 captureCreatedMint(operation.launchedMint, name: state.currencyName)
                 logger.error("Phantom-funded launch failed", metadata: [
@@ -931,6 +947,13 @@ struct CurrencyCreationWizardScreen: View {
                     title: "Image Is Invalid",
                     subtitle: "Please pick a different image."
                 )
+            } catch let FundingOperationError.externalRejected(title, subtitle) {
+                captureCreatedMint(operation.launchedMint, name: state.currencyName)
+                logger.error("Coinbase-funded launch rejected", metadata: [
+                    "title": "\(title)",
+                    "mint": "\(operation.launchedMint?.base58 ?? "nil")",
+                ])
+                errorDialog = makeDestructiveDialog(title: title, subtitle: subtitle)
             } catch {
                 captureCreatedMint(operation.launchedMint, name: state.currencyName)
                 logger.error("Coinbase-funded launch failed", metadata: [

--- a/Flipcash/Core/Screens/Main/Operations/CoinbaseFundingOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/CoinbaseFundingOperation.swift
@@ -141,7 +141,7 @@ final class CoinbaseFundingOperation: FundingOperation {
             }
             guard let attestations = payload.attestations else {
                 logger.error("Coinbase launch invoked without attestations")
-                throw FundingOperationError.serverRejected("Missing launch attestations")
+                throw FundingOperationError.unexpectedFailure(reason: "Missing launch attestations")
             }
             state = .working
             let mint = try await session.launchCurrency(
@@ -175,7 +175,7 @@ final class CoinbaseFundingOperation: FundingOperation {
             owner: session.owner.authorityPublicKey
         ) else {
             logger.error("Failed to derive USDF swap accounts for Coinbase order")
-            throw FundingOperationError.serverRejected("Couldn't derive destination account")
+            throw FundingOperationError.unexpectedFailure(reason: "Couldn't derive USDF swap accounts")
         }
 
         let userRef = session.ownerKeyPair.publicKey.base58
@@ -202,10 +202,18 @@ final class CoinbaseFundingOperation: FundingOperation {
             logger.error("Coinbase createOrder rejected", metadata: [
                 "error_type": "\(error.errorType)",
             ])
-            throw FundingOperationError.serverRejected(error.subtitle)
+            throw FundingOperationError.externalRejected(
+                title: error.title,
+                subtitle: error.subtitle
+            )
         } catch {
+            // Network/auth blip — `externalRejected` (no Bugsnag) so we don't
+            // alarm on routine Coinbase transport errors.
             logger.error("Coinbase createOrder failed", metadata: ["error": "\(error)"])
-            throw FundingOperationError.serverRejected("Couldn't create the Apple Pay order")
+            throw FundingOperationError.externalRejected(
+                title: "Something Went Wrong",
+                subtitle: "Please try again later"
+            )
         }
     }
 
@@ -228,7 +236,9 @@ final class CoinbaseFundingOperation: FundingOperation {
                 logger.error("Coinbase response missing purchaseAmount", metadata: [
                     "order_id": "\(order.id)",
                 ])
-                throw FundingOperationError.serverRejected("Coinbase response missing purchase amount")
+                throw FundingOperationError.unexpectedFailure(
+                    reason: "Coinbase response missing purchaseAmount"
+                )
             }
             let fundedAmount = ExchangedFiat.compute(
                 onChainAmount: TokenAmount(wholeTokens: recordedDecimal, mint: .usdf),
@@ -245,7 +255,7 @@ final class CoinbaseFundingOperation: FundingOperation {
         case .launch(let payload):
             guard let mint = launchedMint else {
                 logger.error("Coinbase launch reached recordSwap without a preflighted mint")
-                throw FundingOperationError.serverRejected("Missing launched mint")
+                throw FundingOperationError.unexpectedFailure(reason: "Missing launched mint")
             }
             // No Coinbase rounding rebuild here — `launchAmount` and
             // `launchFee` are built from server-supplied USDF quark
@@ -283,12 +293,22 @@ final class CoinbaseFundingOperation: FundingOperation {
                 throw CancellationError()
 
             case .commitError, .pollingError, .loadError:
-                let message = event.data?.errorMessage ?? "Apple Pay failed"
+                // Map the raw Coinbase code back through `OnrampErrorResponse.ErrorType`
+                // so WebView-surfaced errors render the same localized
+                // title/subtitle pair as HTTP-path errors. Unknown codes fall
+                // through to the generic ".unknown" message.
+                let errorType = OnrampErrorResponse.ErrorType(
+                    coinbaseCode: event.data?.errorCode ?? ""
+                )
                 logger.error("Apple Pay terminal error", metadata: [
                     "event": "\(event.name)",
                     "code": "\(event.data?.errorCode ?? "nil")",
+                    "type": "\(errorType)",
                 ])
-                throw FundingOperationError.serverRejected(message)
+                throw FundingOperationError.externalRejected(
+                    title: errorType.title,
+                    subtitle: errorType.subtitle
+                )
 
             case .pendingPaymentAuth:
                 idleTimer.arm { [weak self] in

--- a/Flipcash/Core/Screens/Main/Operations/FundingOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/FundingOperation.swift
@@ -75,7 +75,18 @@ nonisolated enum FundingOperationError: Error, Equatable, Sendable {
     case userCancelled
     case requirementUnsatisfied(FundingRequirement)
     case insufficientBalance
-    case serverRejected(String)
+    /// An external resource (Coinbase, Phantom, the chain) rejected the
+    /// operation in an expected, user-facing way (card declined, region
+    /// blocked, user rejected in wallet). Carries pre-built dialog strings
+    /// so call sites can render directly. Not reported to Bugsnag — these
+    /// happen by design.
+    case externalRejected(title: String, subtitle: String)
+    /// A defensive precondition fired or an external contract was violated
+    /// (missing field a caller should have guarded, malformed response from
+    /// Coinbase/Phantom). Renders the generic "Something Went Wrong" dialog
+    /// via the catch-all and falls through to Bugsnag — if this fires it's
+    /// a bug or an API contract change worth investigating.
+    case unexpectedFailure(reason: String)
     case chainSubmitFailed(String)
 }
 

--- a/Flipcash/Core/Screens/Main/Operations/PhantomFundingOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/PhantomFundingOperation.swift
@@ -141,12 +141,16 @@ final class PhantomFundingOperation: FundingOperation {
                 lastErrorMessage = "Connection cancelled in Phantom"
                 // loop: top of next iteration resets state to .education
             } catch WalletConnectionError.connectFailed(let code) {
-                throw FundingOperationError.serverRejected("Wallet connect failed (code: \(code))")
+                logger.error("Phantom connect failed", metadata: ["code": "\(code)"])
+                throw FundingOperationError.externalRejected(
+                    title: "Couldn't Connect",
+                    subtitle: "Please try again from your wallet"
+                )
             }
         }
 
         // Sign step — wallet-side cancel (deeplink code 4001) loops back to
-        // the confirm prompt; serverRejected and other terminal failures
+        // the confirm prompt; externalRejected and other terminal failures
         // propagate.
         while true {
             try Task.checkCancellation()
@@ -191,7 +195,7 @@ final class PhantomFundingOperation: FundingOperation {
             }
             guard let attestations = payload.attestations else {
                 logger.error("Phantom launch invoked without attestations")
-                throw FundingOperationError.serverRejected("Missing launch attestations")
+                throw FundingOperationError.unexpectedFailure(reason: "Missing launch attestations")
             }
             state = .working
             let mint = try await session.launchCurrency(
@@ -217,7 +221,7 @@ final class PhantomFundingOperation: FundingOperation {
     /// awaited signed-tx event arrives. Throws `FundingOperationError.userCancelled`
     /// on a wallet 4001 (so callers can surface a "Transaction Cancelled"
     /// dialog distinct from a silent Task-level cancellation) and
-    /// `.serverRejected` on any other wallet error.
+    /// `.externalRejected` on any other wallet error.
     private func awaitSignedTransaction() async throws -> String {
         for await event in walletConnection.deeplinkEvents {
             try Task.checkCancellation()
@@ -227,7 +231,11 @@ final class PhantomFundingOperation: FundingOperation {
             case .userCancelled:
                 throw FundingOperationError.userCancelled
             case .failed(let code):
-                throw FundingOperationError.serverRejected("Wallet returned error code \(code)")
+                logger.error("Phantom returned error", metadata: ["code": "\(code)"])
+                throw FundingOperationError.externalRejected(
+                    title: "Transaction Failed",
+                    subtitle: "Your wallet rejected the transaction. Please try again."
+                )
             }
         }
         // Stream ended without delivering an event — treat as cancellation.
@@ -243,8 +251,11 @@ final class PhantomFundingOperation: FundingOperation {
     ) async throws -> StartedSwap {
         let rawData = Data(Base58.toBytes(signedTx))
         guard let tx = SolanaTransaction(data: rawData) else {
+            // Phantom returned a payload we can't decode — wallet contract
+            // violation. Worth Bugsnagging so we can correlate against
+            // Phantom client versions.
             logger.error("Failed to decode signed transaction")
-            throw FundingOperationError.serverRejected("Couldn't decode the signed transaction")
+            throw FundingOperationError.unexpectedFailure(reason: "Couldn't decode signed transaction from Phantom")
         }
 
         let txBase64 = rawData.base64EncodedString()
@@ -270,7 +281,7 @@ final class PhantomFundingOperation: FundingOperation {
         case .launch(let payload):
             guard let mint = launchedMint else {
                 logger.error("Launch reached submit step without a preflighted mint")
-                throw FundingOperationError.serverRejected("Missing launched mint")
+                throw FundingOperationError.unexpectedFailure(reason: "Missing launched mint")
             }
             swapId = try await session.buyNewCurrencyWithExternalFunding(
                 amount: payload.launchAmount,
@@ -321,13 +332,19 @@ final class PhantomFundingOperation: FundingOperation {
             logger.error("Phantom signed transaction failed simulation", metadata: [
                 "logs": "\(logs.suffix(5).joined(separator: " | "))",
             ])
-            throw FundingOperationError.serverRejected("The network wouldn't accept this transaction")
+            throw FundingOperationError.externalRejected(
+                title: "Transaction Rejected",
+                subtitle: "The network wouldn't accept this transaction"
+            )
         } catch SolanaRPCError.responseError(let response) {
             logger.error("Phantom signed transaction rejected at preflight", metadata: [
                 "code": "\(response.code ?? -1)",
                 "message": "\(response.message ?? "nil")",
             ])
-            throw FundingOperationError.serverRejected(response.message ?? "Preflight rejected by the network")
+            throw FundingOperationError.externalRejected(
+                title: "Transaction Rejected",
+                subtitle: response.message ?? "Preflight rejected by the network"
+            )
         } catch {
             // Network blip — swallow and continue. The submit step has its
             // own error handling.

--- a/Flipcash/Core/Screens/Main/Operations/ReservesFundingOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/ReservesFundingOperation.swift
@@ -77,7 +77,7 @@ final class ReservesFundingOperation: FundingOperation {
         case .launch(let payload):
             guard let verifiedState = payload.verifiedState else {
                 logger.error("Reserves launch invoked without a verified state")
-                throw FundingOperationError.serverRejected("Missing verified state")
+                throw FundingOperationError.unexpectedFailure(reason: "Missing verified state")
             }
 
             let mint: PublicKey
@@ -88,7 +88,7 @@ final class ReservesFundingOperation: FundingOperation {
             } else {
                 guard let attestations = payload.attestations else {
                     logger.error("Reserves launch invoked without attestations")
-                    throw FundingOperationError.serverRejected("Missing launch attestations")
+                    throw FundingOperationError.unexpectedFailure(reason: "Missing launch attestations")
                 }
                 mint = try await session.launchCurrency(
                     name: payload.currencyName,

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -490,7 +490,7 @@ extension View {
 /// Thrown by the bearer-token provider when the Coinbase API key is missing
 /// from the build's Info.plist. Indicates a build-config bug, not user error;
 /// propagates as a transport failure through Coinbase and ultimately surfaces
-/// as `FundingOperationError.serverRejected` to the caller.
+/// as `FundingOperationError.externalRejected` to the caller.
 private struct MissingCoinbaseApiKey: Error {}
 
 // MARK: - UserDefaults -

--- a/Flipcash/UI/DialogItem+CashFlows.swift
+++ b/Flipcash/UI/DialogItem+CashFlows.swift
@@ -102,6 +102,22 @@ extension DialogItem {
         }
     }
 
+    /// Renders a destructive dialog from a
+    /// `FundingOperationError.externalRejected(title:subtitle:)` payload —
+    /// e.g. Coinbase's `ERROR_CODE_GUEST_REGION_MISMATCH` ("Your Region
+    /// Isn't Supported") or a Phantom wallet rejection. The funding
+    /// operation builds the strings; the call site just binds them.
+    static func externalRejection(title: String, subtitle: String) -> DialogItem {
+        .init(
+            style: .destructive,
+            title: title,
+            subtitle: subtitle,
+            dismissable: true
+        ) {
+            .okay(kind: .destructive)
+        }
+    }
+
     /// Coinbase Onramp rejects orders below `CoinbaseFundingOperation.minimumPurchaseUSD`
     /// with a generic error; surface the constraint up-front instead of letting
     /// the user round-trip to Apple Pay. `minimum` is the USD floor already

--- a/Flipcash/UI/DialogItem+CashFlows.swift
+++ b/Flipcash/UI/DialogItem+CashFlows.swift
@@ -102,12 +102,12 @@ extension DialogItem {
         }
     }
 
-    /// Renders a destructive dialog from a
-    /// `FundingOperationError.externalRejected(title:subtitle:)` payload —
-    /// e.g. Coinbase's `ERROR_CODE_GUEST_REGION_MISMATCH` ("Your Region
-    /// Isn't Supported") or a Phantom wallet rejection. The funding
-    /// operation builds the strings; the call site just binds them.
-    static func externalRejection(title: String, subtitle: String) -> DialogItem {
+    /// Generic destructive dialog with caller-supplied strings and an "OK"
+    /// destructive dismiss button. Use for any user-facing error where the
+    /// title/subtitle vary by context (e.g. validation failures, Coinbase
+    /// rejections, moderation denials). For the stock "Something Went Wrong"
+    /// fallback, prefer `.somethingWentWrong`.
+    static func error(title: String, subtitle: String) -> DialogItem {
         .init(
             style: .destructive,
             title: title,

--- a/FlipcashTests/CoinbaseFundingOperationTests.swift
+++ b/FlipcashTests/CoinbaseFundingOperationTests.swift
@@ -111,12 +111,12 @@ struct CoinbaseFundingOperationTests {
         #expect(env.session.launchCurrencyCalls.isEmpty, "launchCurrency must not run when preLaunchedMint is set")
     }
 
-    @Test("Launch missing attestations throws serverRejected before reaching the order step")
+    @Test("Launch missing attestations throws unexpectedFailure before reaching the order step")
     func launch_missingAttestations_throws() async {
         let env = Env()
         let payment = PaymentOperation.launch(.fixture(attestations: nil))
 
-        await #expect(throws: FundingOperationError.serverRejected("Missing launch attestations")) {
+        await #expect(throws: FundingOperationError.unexpectedFailure(reason: "Missing launch attestations")) {
             try await env.op.start(payment)
         }
         #expect(env.session.launchCurrencyCalls.isEmpty)
@@ -139,22 +139,26 @@ struct CoinbaseFundingOperationTests {
     // MARK: - Apple Pay terminal events
 
     @Test(
-        "Apple Pay terminal error events throw serverRejected carrying Coinbase's errorMessage",
+        "Apple Pay terminal error events map errorCode to OnrampErrorResponse.ErrorType and throw externalRejected",
         arguments: [
-            (ApplePayEvent.Event.pollingError, "Card declined"),
-            (ApplePayEvent.Event.commitError, "Auth failed"),
+            (ApplePayEvent.Event.pollingError, "ERROR_CODE_GUEST_REGION_MISMATCH"),
+            (ApplePayEvent.Event.commitError, "ERROR_CODE_GUEST_CARD_RISK_DECLINED"),
         ]
     )
-    func applePayTerminalError_throwsServerRejected(event: ApplePayEvent.Event, message: String) async throws {
+    func applePayTerminalError_throwsExternalRejected(event: ApplePayEvent.Event, code: String) async throws {
         let env = Env()
         env.session.buyWithCoinbaseOnrampHandler = { _, _, _ in .generate() }
 
         let payment = PaymentOperation.buy(.fixture())
         let task = Task { try await env.op.start(payment) }
         try await waitUntil(env.op) { $0.state == .awaitingExternal(.applePay) }
-        env.coinbaseService.receiveApplePayEvent(.fixture(event, errorMessage: message))
+        env.coinbaseService.receiveApplePayEvent(.fixture(event, errorCode: code))
 
-        await #expect(throws: FundingOperationError.serverRejected(message)) {
+        let expectedType = OnrampErrorResponse.ErrorType(coinbaseCode: code)
+        await #expect(throws: FundingOperationError.externalRejected(
+            title: expectedType.title,
+            subtitle: expectedType.subtitle
+        )) {
             try await task.value
         }
         #expect(env.op.state == .idle)
@@ -177,8 +181,8 @@ struct CoinbaseFundingOperationTests {
 
     // MARK: - createOrder failures
 
-    @Test("createOrder throwing a generic error surfaces as serverRejected")
-    func createOrder_genericError_throwsServerRejected() async {
+    @Test("createOrder throwing a generic error surfaces as externalRejected")
+    func createOrder_genericError_throwsExternalRejected() async {
         let env = Env()
         env.ordering.createOrderHandler = { _ in throw SentinelError.boom }
         let payment = PaymentOperation.buy(.fixture())
@@ -188,14 +192,17 @@ struct CoinbaseFundingOperationTests {
         }
     }
 
-    @Test("createOrder throwing OnrampErrorResponse propagates the subtitle into serverRejected")
-    func createOrder_onrampErrorResponse_propagatesSubtitle() async throws {
+    @Test("createOrder throwing OnrampErrorResponse propagates title and subtitle into externalRejected")
+    func createOrder_onrampErrorResponse_propagatesTitleAndSubtitle() async throws {
         let env = Env()
         let errorResponse = try OnrampErrorResponse.fixture(errorType: "ERROR_CODE_GUEST_INVALID_CARD")
         env.ordering.createOrderHandler = { _ in throw errorResponse }
         let payment = PaymentOperation.buy(.fixture())
 
-        await #expect(throws: FundingOperationError.serverRejected(errorResponse.subtitle)) {
+        await #expect(throws: FundingOperationError.externalRejected(
+            title: errorResponse.title,
+            subtitle: errorResponse.subtitle
+        )) {
             try await env.op.start(payment)
         }
     }

--- a/FlipcashTests/ReservesFundingOperationTests.swift
+++ b/FlipcashTests/ReservesFundingOperationTests.swift
@@ -85,7 +85,7 @@ struct ReservesFundingOperationTests {
         #expect(session.buyNewCurrencyCalls.first?.mint == mintedKey)
     }
 
-    @Test("Launch without attestations throws serverRejected")
+    @Test("Launch without attestations throws unexpectedFailure")
     func launch_missingAttestations_throws() async {
         let session = MockSession()
         let op = ReservesFundingOperation(session: session)
@@ -98,13 +98,15 @@ struct ReservesFundingOperationTests {
             verifiedState: .fresh()
         )
 
-        await #expect(throws: FundingOperationError.self) {
+        // Asserts the specific case — flipping to `.externalRejected` here
+        // would silently disable Bugsnag for this defensive precondition.
+        await #expect(throws: FundingOperationError.unexpectedFailure(reason: "Missing launch attestations")) {
             try await op.start(.launch(payload))
         }
         #expect(session.launchCurrencyCalls.isEmpty)
     }
 
-    @Test("Launch without verifiedState throws serverRejected")
+    @Test("Launch without verifiedState throws unexpectedFailure")
     func launch_missingVerifiedState_throws() async {
         let session = MockSession()
         let op = ReservesFundingOperation(session: session)
@@ -117,7 +119,7 @@ struct ReservesFundingOperationTests {
             verifiedState: nil
         )
 
-        await #expect(throws: FundingOperationError.self) {
+        await #expect(throws: FundingOperationError.unexpectedFailure(reason: "Missing verified state")) {
             try await op.start(.launch(payload))
         }
         #expect(session.launchCurrencyCalls.isEmpty)

--- a/FlipcashTests/TestSupport/ApplePayEvent+Fixtures.swift
+++ b/FlipcashTests/TestSupport/ApplePayEvent+Fixtures.swift
@@ -9,15 +9,20 @@ import Foundation
 extension ApplePayEvent {
 
     /// Builds a synthetic event the WebView would otherwise have decoded
-    /// from Coinbase's onramp postMessage payload. `errorMessage` populates
-    /// `EventData.errorMessage` so tests can assert it propagates into the
-    /// thrown `serverRejected(_:)`.
+    /// from Coinbase's onramp postMessage payload. `errorCode` and
+    /// `errorMessage` populate `EventData` so tests can assert how the
+    /// error path maps Coinbase's raw code onto `OnrampErrorResponse.ErrorType`
+    /// before throwing `externalRejected(title:subtitle:)`.
     static func fixture(
         _ event: ApplePayEvent.Event,
+        errorCode: String? = nil,
         errorMessage: String? = nil
     ) -> ApplePayEvent {
-        let data: ApplePayEvent.EventData? = errorMessage.map {
-            .init(errorCode: nil, errorMessage: $0)
+        let data: ApplePayEvent.EventData?
+        if errorCode == nil && errorMessage == nil {
+            data = nil
+        } else {
+            data = .init(errorCode: errorCode, errorMessage: errorMessage)
         }
         return ApplePayEvent(name: event.rawValue, data: data)
     }


### PR DESCRIPTION
## Summary
Coinbase rejections like region mismatch and card-risk-declined were collapsing to the generic "Something Went Wrong" dialog because catch sites dropped the message and the Apple Pay WebView error path bypassed our error-code enum entirely. The operation now pre-builds the dialog title and subtitle, the call sites surface them directly, and the card-risk-declined copy now suggests trying a different debit card. Also restored Bugsnag reporting for defensive precondition failures that had silently stopped after an earlier refactor.

## Test plan
- [x] Trigger a Coinbase region-mismatch error and confirm the dialog reads "Your Region Isn't Supported"
- [ ] Trigger a card-risk decline and confirm the dialog reads "Couldn't Use This Card"
- [ ] Trigger a card hard/soft decline and confirm the dialog still reads "Card Declined"
- [ ] Confirm Bugsnag still receives reports when an unexpected precondition fires (e.g. missing attestations)
- [x] Run the full test suite