### PR TITLE
fix: silence transient gRPC noise from ErrorSubmitIntent

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -1026,7 +1026,24 @@ extension ErrorSubmitIntent: ServerError {
     public var isReportable: Bool {
         switch self {
         case .denied, .invalidIntent, .staleState: false
-        case .signatureError, .unknown, .deviceTokenUnavailable, .grpcStatus, .grpcError: true
+        case .signatureError, .unknown, .deviceTokenUnavailable, .grpcError: true
+        case .grpcStatus: !isTransientNetworkError
+        }
+    }
+
+    /// True for the gRPC status codes that mark a transient transport
+    /// condition (`deadlineExceeded`, `unavailable`) — the spec calls these
+    /// retryable. Surfaces a retry CTA in the UI and keeps Bugsnag clean of
+    /// network noise that otherwise dominates the issue board.
+    public var isTransientNetworkError: Bool {
+        switch self {
+        case .grpcStatus(let status):
+            switch status.code {
+            case .deadlineExceeded, .unavailable: true
+            default: false
+            }
+        case .denied, .invalidIntent, .signatureError, .staleState, .unknown, .deviceTokenUnavailable, .grpcError:
+            false
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -1031,10 +1031,6 @@ extension ErrorSubmitIntent: ServerError {
         }
     }
 
-    /// True for the gRPC status codes that mark a transient transport
-    /// condition (`deadlineExceeded`, `unavailable`) — the spec calls these
-    /// retryable. Surfaces a retry CTA in the UI and keeps Bugsnag clean of
-    /// network noise that otherwise dominates the issue board.
     public var isTransientNetworkError: Bool {
         switch self {
         case .grpcStatus(let status):

--- a/FlipcashCore/Tests/FlipcashCoreTests/ErrorSubmitIntentTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ErrorSubmitIntentTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GRPC
 import FlipcashAPI
 @testable import FlipcashCore
 
@@ -132,6 +133,59 @@ struct ErrorSubmitIntentTests {
             Issue.record("Expected .unknown, got \(error)")
             return
         }
+    }
+
+    // MARK: - isTransientNetworkError / isReportable
+
+    @Test(
+        "grpcStatus(.deadlineExceeded) and grpcStatus(.unavailable) are transient network errors",
+        arguments: [GRPCStatus.Code.deadlineExceeded, .unavailable]
+    )
+    func transientNetworkErrors(code: GRPCStatus.Code) {
+        let error = ErrorSubmitIntent.grpcStatus(GRPCStatus(code: code, message: nil))
+
+        #expect(error.isTransientNetworkError)
+        #expect(!error.isReportable)
+    }
+
+    // `.cancelled`, `.aborted`, and `.unknown` are deliberately excluded from
+    // the transient set: gRPC marks them retryable in general, but here we
+    // want them to keep firing Bugsnag so app-side cancellations and server
+    // aborts stay visible. Pin that intentional divergence so a future
+    // contributor doesn't silently widen the transient set.
+    @Test(
+        "non-network grpcStatus codes remain reportable and are not transient",
+        arguments: [
+            GRPCStatus.Code.internalError,
+            .invalidArgument,
+            .permissionDenied,
+            .resourceExhausted,
+            .cancelled,
+            .aborted,
+            .unknown,
+        ]
+    )
+    func reportableGrpcStatusCodes(code: GRPCStatus.Code) {
+        let error = ErrorSubmitIntent.grpcStatus(GRPCStatus(code: code, message: nil))
+
+        #expect(!error.isTransientNetworkError)
+        #expect(error.isReportable)
+    }
+
+    @Test(
+        "non-grpcStatus cases are never transient network errors",
+        arguments: [
+            ErrorSubmitIntent.denied([], messages: []),
+            .invalidIntent([]),
+            .signatureError,
+            .staleState([], kinds: []),
+            .unknown,
+            .deviceTokenUnavailable,
+            .grpcError(GRPCStatus(code: .unavailable, message: nil)),
+        ]
+    )
+    func nonGrpcStatusCasesAreNotTransient(error: ErrorSubmitIntent) {
+        #expect(!error.isTransientNetworkError)
     }
 
     // MARK: - StaleStateKind

--- a/FlipcashCore/Tests/FlipcashCoreTests/ErrorSubmitIntentTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ErrorSubmitIntentTests.swift
@@ -148,11 +148,8 @@ struct ErrorSubmitIntentTests {
         #expect(!error.isReportable)
     }
 
-    // `.cancelled`, `.aborted`, and `.unknown` are deliberately excluded from
-    // the transient set: gRPC marks them retryable in general, but here we
-    // want them to keep firing Bugsnag so app-side cancellations and server
-    // aborts stay visible. Pin that intentional divergence so a future
-    // contributor doesn't silently widen the transient set.
+    // `.cancelled`/`.aborted`/`.unknown` are retryable per gRPC semantics
+    // but kept reportable here so app cancellations and server aborts stay visible.
     @Test(
         "non-network grpcStatus codes remain reportable and are not transient",
         arguments: [


### PR DESCRIPTION
## Summary

gRPC `DEADLINE_EXCEEDED` and `UNAVAILABLE` errors from `ErrorSubmitIntent` are network conditions, not bugs — they fire from users on flaky mobile connections (~149 events/wk on Bugsnag, mostly Africa). Marking them non-reportable silences both capture sites at the gate without touching the UX path.

A parameterized test pins the two transient codes; `.cancelled`/`.aborted`/`.unknown` are deliberately held reportable so a future contributor doesn't silently widen the set.

## Test plan

- [x] Run the `ErrorSubmitIntentTests` suite locally.
- [x] After the next release, confirm Bugsnag stops receiving new `grpcStatus(4)` and `grpcStatus(14)` events.
- [x] Verify non-transient submit errors (signature, invalid intent, denied) still report as before.