### PR TITLE
refactor: consolidate Coinbase error copy into one switch

### DIFF
--- a/Flipcash/Core/Controllers/Coinbase.swift
+++ b/Flipcash/Core/Controllers/Coinbase.swift
@@ -144,82 +144,99 @@ public nonisolated struct OnrampErrorResponse: Error, Decodable, Sendable {
         case permissionDenied             = "ERROR_CODE_GUEST_PERMISSION_DENIED"
         case guestRegionMismatch          = "ERROR_CODE_GUEST_REGION_MISMATCH"
         case guestRegionForbidden         = "ERROR_CODE_GUEST_REGION_FORBIDDEN"
-        case assetNotTradable             = "ERROR_CODE_ASSET_NOT_TRADABLE"
-        
+
         case cardSoftDeclined             = "ERROR_CODE_GUEST_CARD_SOFT_DECLINED"
         case cardHardDeclined             = "ERROR_CODE_GUEST_CARD_HARD_DECLINED"
         case guestTransactionBuyFailed    = "ERROR_CODE_GUEST_TRANSACTION_BUY_FAILED"
         case guestTransactionSendFailed   = "ERROR_CODE_GUEST_TRANSACTION_SEND_FAILED"
-        
+
         case guestCardInsufficientBalance = "ERROR_CODE_GUEST_CARD_INSUFFICIENT_BALANCE"
         case guestCardPrepaidDeclined     = "ERROR_CODE_GUEST_CARD_PREPAID_DECLINED"
-        
+
         case transactionValidationFailed  = "ERROR_CODE_GUEST_TRANSACTION_AVS_VALIDATION_FAILED"
         case transactionFailed            = "ERROR_CODE_GUEST_TRANSACTION_TRANSACTION_FAILED"
-        
+
         case networkNotTradable           = "ERROR_CODE_NETWORK_NOT_TRADABLE"
+        case assetNotTradable             = "ERROR_CODE_ASSET_NOT_TRADABLE"
         case `internal`                   = "ERROR_CODE_INTERNAL"
         case invalidRequest               = "ERROR_CODE_INVALID_REQUEST"
-        
+
         case applePayNotSetup             = "ERROR_CODE_GUEST_APPLE_PAY_NOT_SETUP"
 
         case unknown                      = "UNKNOWN"
-        
-        public var title: String {
-                switch self {
-                case .invalidCard, .invalidCardNotDebit:
-                    return "Debit Cards Only"
-                case .transactionLimit:
-                    return "Weekly Limit Exceeded"
-                case .transactionCount:
-                    return "Maximum Purchases Reached"
-                case .guestRegionMismatch, .guestRegionForbidden, .networkNotTradable:
-                    return "Your Region Isn't Supported"
-                case .cardSoftDeclined, .cardHardDeclined, .guestTransactionBuyFailed, .cardRiskDeclined, .assetNotTradable:
-                    return "Card Declined"
-                case .guestCardInsufficientBalance:
-                    return "Insufficient Funds"
-                case .guestCardPrepaidDeclined:
-                    return "Card Not Supported"
-                case .transactionValidationFailed:
-                    return "Billing Address Invalid"
-                case .applePayNotSetup:
-                    return "Apple Pay Not Set Up"
-                case .unknown, .permissionDenied, .transactionFailed, .internal, .guestTransactionSendFailed, .invalidRequest:
-                    return "Something Went Wrong"
-                }
+
+        public var title: String { copy.title }
+        public var subtitle: String { copy.subtitle }
+
+        private var copy: (title: String, subtitle: String) {
+            switch self {
+            case .invalidCard, .invalidCardNotDebit:
+                return (
+                    "Debit Cards Only",
+                    "This transaction was declined. Please make sure you are using a debit card and the billing address is correct"
+                )
+            case .transactionLimit:
+                return (
+                    "Weekly Limit Exceeded",
+                    "You can only add up to $1,000 per week"
+                )
+            case .transactionCount:
+                return (
+                    "Maximum Purchases Reached",
+                    "Each user is limited to 15 purchases total. Please try another purchase method"
+                )
+            case .guestRegionMismatch, .guestRegionForbidden, .networkNotTradable, .assetNotTradable:
+                return (
+                    "Your Region Isn't Supported",
+                    "This feature isn't currently available in your region"
+                )
+            case .cardSoftDeclined, .cardHardDeclined, .guestTransactionBuyFailed:
+                return (
+                    "Card Declined",
+                    "This transaction was declined by your bank. Please contact your bank or try again with a different card"
+                )
+            case .cardRiskDeclined:
+                return (
+                    "Card Declined",
+                    "Please try again with a different debit card."
+                )
+            case .guestCardInsufficientBalance:
+                return (
+                    "Insufficient Funds",
+                    "Please make sure you have enough funds in the account linked to your debit card and try again"
+                )
+            case .guestCardPrepaidDeclined:
+                return (
+                    "Card Not Supported",
+                    "Prepaid debit cards are not supported. Please try again with another debit card"
+                )
+            case .transactionValidationFailed:
+                return (
+                    "Billing Address Invalid",
+                    "Please check that your billing address is correct and try again"
+                )
+            case .applePayNotSetup:
+                return (
+                    "Apple Pay Not Set Up",
+                    "It looks like you don't have a debit card linked to Apple Pay. Please link a card and try again"
+                )
+            case .transactionFailed, .internal:
+                return (
+                    "Something Went Wrong",
+                    "The Coinbase team has been notified and is investigating the issue. Your funds will arrive once resolved. We appreciate your patience"
+                )
+            case .guestTransactionSendFailed, .invalidRequest:
+                return (
+                    "Something Went Wrong",
+                    "We are working with the Coinbase team to resolve the issue. Your card will be refunded in the meantime. Please try again later"
+                )
+            case .unknown, .permissionDenied:
+                return (
+                    "Something Went Wrong",
+                    "Please contact support@flipcash.com"
+                )
             }
-            
-        public var subtitle: String {
-                switch self {
-                case .invalidCard, .invalidCardNotDebit:
-                    return "This transaction was declined. Please make sure you are using a debit card and the billing address is correct"
-                case .transactionLimit:
-                    return "You can only add up to $1,000 per week"
-                case .transactionCount:
-                    return "Each user is limited to 15 purchases total. Please try another purchase method"
-                case .cardRiskDeclined:
-                    return "Please try again with a different debit card."
-                case .guestRegionMismatch, .guestRegionForbidden, .networkNotTradable, .assetNotTradable:
-                    return "This feature isn't currently available in your region"
-                case .cardSoftDeclined, .cardHardDeclined, .guestTransactionBuyFailed:
-                    return "This transaction was declined by your bank. Please contact your bank or try again with a different card"
-                case .guestTransactionSendFailed, .invalidRequest:
-                    return "We are working with the Coinbase team to resolve the issue. Your card will be refunded in the meantime. Please try again later"
-                case .guestCardInsufficientBalance:
-                    return "Please make sure you have enough funds in the account linked to your debit card and try again"
-                case .guestCardPrepaidDeclined:
-                    return "Prepaid debit cards are not supported. Please try again with another debit card"
-                case .transactionValidationFailed:
-                    return "Please check that your billing address is correct and try again"
-                case .transactionFailed, .internal:
-                    return "The Coinbase team has been notified and is investigating the issue. Your funds will arrive once resolved. We appreciate your patience"
-                case .applePayNotSetup:
-                    return "It looks like you don't have a debit card linked to Apple Pay. Please link a card and try again"
-                case .unknown, .permissionDenied:
-                    return "Please contact support@flipcash.com"
-                }
-            }
+        }
         
         public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()

--- a/Flipcash/Core/Controllers/Coinbase.swift
+++ b/Flipcash/Core/Controllers/Coinbase.swift
@@ -137,12 +137,14 @@ public nonisolated struct OnrampErrorResponse: Error, Decodable, Sendable {
     
     public enum ErrorType: String, Decodable, Sendable {
         case invalidCard                  = "ERROR_CODE_GUEST_INVALID_CARD"
+        case invalidCardNotDebit          = "ERROR_CODE_GUEST_CARD_NOT_DEBIT"
         case transactionLimit             = "ERROR_CODE_GUEST_TRANSACTION_LIMIT"
         case transactionCount             = "ERROR_CODE_GUEST_TRANSACTION_COUNT"
         case cardRiskDeclined             = "ERROR_CODE_GUEST_CARD_RISK_DECLINED"
         case permissionDenied             = "ERROR_CODE_GUEST_PERMISSION_DENIED"
         case guestRegionMismatch          = "ERROR_CODE_GUEST_REGION_MISMATCH"
         case guestRegionForbidden         = "ERROR_CODE_GUEST_REGION_FORBIDDEN"
+        case assetNotTradable             = "ERROR_CODE_ASSET_NOT_TRADABLE"
         
         case cardSoftDeclined             = "ERROR_CODE_GUEST_CARD_SOFT_DECLINED"
         case cardHardDeclined             = "ERROR_CODE_GUEST_CARD_HARD_DECLINED"
@@ -165,23 +167,15 @@ public nonisolated struct OnrampErrorResponse: Error, Decodable, Sendable {
         
         public var title: String {
                 switch self {
-                case .invalidCard:
+                case .invalidCard, .invalidCardNotDebit:
                     return "Debit Cards Only"
                 case .transactionLimit:
                     return "Weekly Limit Exceeded"
                 case .transactionCount:
                     return "Maximum Purchases Reached"
-                case .cardRiskDeclined:
-                    return "Couldn't Use This Card"
-                case .permissionDenied:
-                    return "Something Went Wrong"
-                case .guestTransactionSendFailed, .invalidRequest:
-                    return "Something Went Wrong"
-                case .transactionFailed, .internal:
-                    return "Something Went Wrong"
                 case .guestRegionMismatch, .guestRegionForbidden, .networkNotTradable:
                     return "Your Region Isn't Supported"
-                case .cardSoftDeclined, .cardHardDeclined, .guestTransactionBuyFailed:
+                case .cardSoftDeclined, .cardHardDeclined, .guestTransactionBuyFailed, .cardRiskDeclined, .assetNotTradable:
                     return "Card Declined"
                 case .guestCardInsufficientBalance:
                     return "Insufficient Funds"
@@ -191,27 +185,25 @@ public nonisolated struct OnrampErrorResponse: Error, Decodable, Sendable {
                     return "Billing Address Invalid"
                 case .applePayNotSetup:
                     return "Apple Pay Not Set Up"
-                case .unknown:
+                case .unknown, .permissionDenied, .transactionFailed, .internal, .guestTransactionSendFailed, .invalidRequest:
                     return "Something Went Wrong"
                 }
             }
             
         public var subtitle: String {
                 switch self {
-                case .invalidCard:
+                case .invalidCard, .invalidCardNotDebit:
                     return "This transaction was declined. Please make sure you are using a debit card and the billing address is correct"
                 case .transactionLimit:
                     return "You can only add up to $1,000 per week"
                 case .transactionCount:
-                    return "Each user is limited to 15 purchases total."
+                    return "Each user is limited to 15 purchases total. Please try another purchase method"
                 case .cardRiskDeclined:
                     return "Please try again with a different debit card."
-                case .permissionDenied:
-                    return "Something went wrong. Please contact support"
-                case .guestRegionMismatch, .guestRegionForbidden, .networkNotTradable:
+                case .guestRegionMismatch, .guestRegionForbidden, .networkNotTradable, .assetNotTradable:
                     return "This feature isn't currently available in your region"
                 case .cardSoftDeclined, .cardHardDeclined, .guestTransactionBuyFailed:
-                    return "This transaction was declined by your bank. Please try again with a different card"
+                    return "This transaction was declined by your bank. Please contact your bank or try again with a different card"
                 case .guestTransactionSendFailed, .invalidRequest:
                     return "We are working with the Coinbase team to resolve the issue. Your card will be refunded in the meantime. Please try again later"
                 case .guestCardInsufficientBalance:
@@ -224,8 +216,8 @@ public nonisolated struct OnrampErrorResponse: Error, Decodable, Sendable {
                     return "The Coinbase team has been notified and is investigating the issue. Your funds will arrive once resolved. We appreciate your patience"
                 case .applePayNotSetup:
                     return "It looks like you don't have a debit card linked to Apple Pay. Please link a card and try again"
-                case .unknown:
-                    return "Please try again later"
+                case .unknown, .permissionDenied:
+                    return "Please contact support@flipcash.com"
                 }
             }
         

--- a/FlipcashTests/OnrampErrorTypeTests.swift
+++ b/FlipcashTests/OnrampErrorTypeTests.swift
@@ -1,0 +1,91 @@
+//
+//  OnrampErrorTypeTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+@testable import Flipcash
+
+@Suite("OnrampErrorResponse.ErrorType")
+struct OnrampErrorTypeTests {
+
+    typealias ErrorType = OnrampErrorResponse.ErrorType
+
+    // MARK: - init(coinbaseCode:)
+
+    @Test(
+        "init(coinbaseCode:) maps the raw Coinbase code to the matching case",
+        arguments: [
+            ("ERROR_CODE_GUEST_INVALID_CARD",    ErrorType.invalidCard),
+            ("ERROR_CODE_GUEST_CARD_NOT_DEBIT",  .invalidCardNotDebit),
+            ("ERROR_CODE_ASSET_NOT_TRADABLE",    .assetNotTradable),
+            ("GUEST_INVALID_CARD",               .invalidCard),
+            ("ASSET_NOT_TRADABLE",               .assetNotTradable),
+            ("error_code_guest_invalid_card",    .invalidCard),
+            ("ERROR_CODE_NONEXISTENT",           .unknown),
+            ("",                                 .unknown),
+        ]
+    )
+    func decodesCoinbaseCode(_ code: String, _ expected: ErrorType) {
+        #expect(ErrorType(coinbaseCode: code) == expected)
+    }
+
+    // MARK: - Copy equivalence
+
+    @Test(
+        "Equivalent ErrorType cases share both title and subtitle",
+        arguments: [
+            (ErrorType.invalidCardNotDebit, ErrorType.invalidCard),
+            (.assetNotTradable,             .networkNotTradable),
+            (.cardHardDeclined,             .cardSoftDeclined),
+            (.guestTransactionBuyFailed,    .cardSoftDeclined),
+            (.internal,                     .transactionFailed),
+            (.invalidRequest,               .guestTransactionSendFailed),
+            (.permissionDenied,             .unknown),
+        ]
+    )
+    func casesShareCopy(_ subject: ErrorType, _ reference: ErrorType) {
+        #expect(subject.title == reference.title)
+        #expect(subject.subtitle == reference.subtitle)
+    }
+
+    // MARK: - Copy anchors
+
+    @Test("invalidCard surfaces as Debit Cards Only")
+    func invalidCardAnchor() {
+        #expect(ErrorType.invalidCard.title == "Debit Cards Only")
+    }
+
+    @Test("assetNotTradable surfaces as a regional availability issue, not a card decline")
+    func assetNotTradableAnchor() {
+        #expect(ErrorType.assetNotTradable.title == "Your Region Isn't Supported")
+    }
+
+    @Test("Bank-declined cases direct the user to contact their bank")
+    func bankDeclineSubtitleAnchor() {
+        #expect(ErrorType.cardSoftDeclined.subtitle.contains("contact your bank"))
+    }
+
+    @Test("cardRiskDeclined shares the Card Declined title but keeps its own remediation")
+    func cardRiskDeclinedTitleSharedSubtitleDistinct() {
+        #expect(ErrorType.cardRiskDeclined.title == ErrorType.cardSoftDeclined.title)
+        #expect(ErrorType.cardRiskDeclined.title == "Card Declined")
+        #expect(ErrorType.cardRiskDeclined.subtitle != ErrorType.cardSoftDeclined.subtitle)
+    }
+
+    @Test("Server-side failures direct the user to wait for Coinbase to investigate")
+    func serverFailureSubtitleAnchor() {
+        #expect(ErrorType.transactionFailed.subtitle.contains("Coinbase team has been notified"))
+    }
+
+    @Test("Send-path failures explain the refund and ask the user to retry later")
+    func sendFailureSubtitleAnchor() {
+        #expect(ErrorType.guestTransactionSendFailed.subtitle.contains("working with the Coinbase team"))
+    }
+
+    @Test("unknown and permissionDenied direct the user to support email")
+    func supportEmailSubtitleAnchor() {
+        #expect(ErrorType.unknown.subtitle.contains("support@flipcash.com"))
+    }
+}


### PR DESCRIPTION
## Summary

Folds the two parallel title and subtitle switches on `OnrampErrorResponse.ErrorType` into a single tuple-returning property so every case must declare both halves together — the previous setup had already started to drift. Also fixes `assetNotTradable`, which showed "Card Declined" as the title with a region-unavailable subtitle; it now reads as a region availability issue, matching its sibling `networkNotTradable`. Adds unit tests covering the raw-code decoder and the shared-copy invariants between cases.

## Test plan

- [x] Trigger a buy that fails with the asset-not-tradable error and confirm the dialog now reads "Your Region Isn't Supported"
- [x] Confirm declined-card, invalid-card, and weekly-limit dialogs still show the same copy as before
- [x] Run the OnrampErrorTypeTests suite