### PR TITLE
refactor: adopt toolbarTitleDisplayMode across screens

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/Wallet/EnterWalletAmountScreen.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Wallet/EnterWalletAmountScreen.swift
@@ -57,7 +57,7 @@ struct EnterWalletAmountScreen: View {
             .padding(20)
         }
         .navigationTitle("Amount to Buy")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 
     // MARK: - Actions -

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -111,7 +111,7 @@ struct DestinationView: View {
         case .accessKey:
             AccessKeyBackupScreen(mnemonic: sessionContainer.session.keyAccount.mnemonic)
                 .navigationTitle("Access Key")
-                .navigationBarTitleDisplayMode(.inline)
+                .toolbarTitleDisplayMode(.inline)
 
         case .depositCurrencyList:
             DepositCurrencyListScreen()

--- a/Flipcash/Core/Screens/Main/BalanceScreen.swift
+++ b/Flipcash/Core/Screens/Main/BalanceScreen.swift
@@ -91,7 +91,7 @@ struct BalanceScreen: View {
             .onChange(of: session.balances, initial: true) { _, _ in refreshSortedBalances() }
             .onChange(of: balanceRate) { _, _ in refreshSortedBalances() }
             .navigationTitle("Wallet")
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
             .appRouterDestinations(container: container, sessionContainer: sessionContainer)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Flipcash/Core/Screens/Main/Buy/BuyAmountScreen.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyAmountScreen.swift
@@ -82,7 +82,7 @@ struct BuyAmountScreen: View {
             .padding(20)
         }
         .navigationTitle(viewModel.screenTitle)
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .toolbar {
             if !isDismissBlocked {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Flipcash/Core/Screens/Main/Buy/PhantomFlowScreen.swift
+++ b/Flipcash/Core/Screens/Main/Buy/PhantomFlowScreen.swift
@@ -43,7 +43,7 @@ struct PhantomFlowScreen: View {
             .padding(20)
         }
         .navigationTitle(hasShownConfirm ? "Confirmation" : "Purchase")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .onDisappear {
             // Idempotent — cancelling a terminal operation is a no-op,
             // so we don't need to gate on state.

--- a/Flipcash/Core/Screens/Main/Buy/USDCDepositEducationScreen.swift
+++ b/Flipcash/Core/Screens/Main/Buy/USDCDepositEducationScreen.swift
@@ -49,7 +49,7 @@ struct USDCDepositEducationScreen: View {
             .padding(20)
         }
         .navigationTitle("Deposit")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationSummaryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationSummaryScreen.swift
@@ -58,7 +58,7 @@ struct CurrencyCreationSummaryScreen: View {
             }
             .padding(.horizontal, 20)
         }
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .navigationTitle("Create Your Currency")
     }
 }

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -260,7 +260,7 @@ struct CurrencyCreationWizardScreen: View {
         .sheet(item: $verificationViewModel.cancellingOnDismiss()) { vm in
             VerifyInfoScreen(viewModel: vm)
         }
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled()
         .toolbar {

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingScreen.swift
@@ -61,7 +61,7 @@ struct CurrencyLaunchProcessingScreen: View {
             }
         }
         .navigationTitle(viewModel.navigationTitle)
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled(true)
         .task {

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryScreen.swift
@@ -33,6 +33,6 @@ struct CurrencyDiscoveryScreen: View {
         }
         .background(Color.backgroundMain)
         .navigationTitle("Discover Currencies")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 }

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -114,7 +114,7 @@ struct CurrencyInfoScreen: View {
                 }
             }
         }
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 toolbarContent()

--- a/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
@@ -58,7 +58,7 @@ struct CurrencySelectionScreen: View {
                 .scrollContentBackground(.hidden)
             }
             .navigationTitle("Select Region")
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     CloseButton { dismiss() }

--- a/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellAmountScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellAmountScreen.swift
@@ -42,7 +42,7 @@ struct CurrencySellAmountScreen: View {
                 .padding(20)
             }
             .navigationTitle(viewModel.screenTitle)
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
             .navigationDestination(for: CurrencySellPath.self) { step in
                 switch step {
                 case .confirmation(let amount, let pinnedState):

--- a/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingScreen.swift
@@ -88,7 +88,7 @@ struct SwapProcessingScreen: View {
             }
         }
         .navigationTitle(viewModel.navigationTitle)
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled(true)
         .task {

--- a/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
+++ b/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
@@ -74,7 +74,7 @@ struct SelectCurrencyScreen: View {
                 .scrollContentBackground(.hidden)
             }
             .navigationTitle("Select Currency")
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     CloseButton(binding: $isPresented)

--- a/Flipcash/Core/Screens/Onboarding/AccessKeyHelpScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/AccessKeyHelpScreen.swift
@@ -43,7 +43,7 @@ struct AccessKeyHelpScreen: View {
             }
         }
         .navigationTitle("Can't Find Your Access Key?")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 }
 

--- a/Flipcash/Core/Screens/Onboarding/AccessKeyScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/AccessKeyScreen.swift
@@ -62,7 +62,7 @@ struct AccessKeyScreen: View {
             .foregroundStyle(.textMain)
             .padding(20)
             .navigationTitle("Your Access Key")
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
         }
         .dialog(item: $viewModel.dialogItem)
     }

--- a/Flipcash/Core/Screens/Onboarding/AccountSelectionScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/AccountSelectionScreen.swift
@@ -66,7 +66,7 @@ struct AccountSelectionScreen: View {
             }
         }
         .navigationTitle("Select Account")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .task {
             fetchAccounts()
             await fetchBalances()

--- a/Flipcash/Core/Screens/Onboarding/LoginScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/LoginScreen.swift
@@ -104,7 +104,7 @@ struct LoginScreen: View {
             }
         }
         .navigationTitle("Enter Access Key Words")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .onChange(of: inputText) {
             suggestAutoCompleteResults(for: inputText)
         }

--- a/Flipcash/Core/Screens/Onramp/ConfirmEmailScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/ConfirmEmailScreen.swift
@@ -105,7 +105,7 @@ struct ConfirmEmailScreen: View {
         }
         .dialog(item: $viewModel.dialogItem)
         .navigationTitle("Verify Email")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .onAppear {
             countdownEnd = Date.now.addingTimeInterval(60)
         }

--- a/Flipcash/Core/Screens/Onramp/ConfirmPhoneScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/ConfirmPhoneScreen.swift
@@ -97,7 +97,7 @@ struct ConfirmPhoneScreen: View {
         }
         .dialog(item: $viewModel.dialogItem)
         .navigationTitle("Verify Phone Number")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .onAppear {
             countdownEnd = Date.now.addingTimeInterval(60)
             isFocused = true

--- a/Flipcash/Core/Screens/Onramp/CountryCodeSelectionScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/CountryCodeSelectionScreen.swift
@@ -58,7 +58,7 @@ struct CountryCodeSelectionScreen: View {
                 }
             }
             .navigationTitle("Select Region")
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     CloseButton(binding: $isPresented)

--- a/Flipcash/Core/Screens/Onramp/EnterEmailScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/EnterEmailScreen.swift
@@ -61,7 +61,7 @@ struct EnterEmailScreen: View {
         }
         .dialog(item: $viewModel.dialogItem)
         .navigationTitle("Verify Email")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .onAppear {
             isFocused = true
         }

--- a/Flipcash/Core/Screens/Onramp/EnterPhoneScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/EnterPhoneScreen.swift
@@ -86,7 +86,7 @@ struct EnterPhoneScreen: View {
         }
         .dialog(item: $viewModel.dialogItem)
         .navigationTitle("Verify Phone Number")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .onAppear {
             isFocused = true
         }

--- a/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
@@ -54,7 +54,7 @@ struct VerifyInfoScreen: View {
                 .padding(.top, 20)
             }
             .navigationTitle("")
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     CloseButton {

--- a/Flipcash/Core/Screens/Settings/AccessKeyBackupScreen.swift
+++ b/Flipcash/Core/Screens/Settings/AccessKeyBackupScreen.swift
@@ -59,7 +59,7 @@ struct AccessKeyBackupScreen: View {
             .foregroundStyle(.textMain)
             .padding(20)
             .navigationTitle("Access Key")
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
         }
         .dialog(item: $dialogItem)
     }

--- a/Flipcash/Core/Screens/Settings/ApplicationLogsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/ApplicationLogsScreen.swift
@@ -56,6 +56,6 @@ struct ApplicationLogsScreen: View {
             }
         }
         .navigationTitle("Application Logs")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 }

--- a/Flipcash/Core/Screens/Settings/BetaFlagsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/BetaFlagsScreen.swift
@@ -70,7 +70,7 @@ struct BetaFlagsScreen: View {
             }
         }
         .navigationTitle("Beta Flags")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .alert(
             "Unlink Email?",
             isPresented: $isConfirmingUnlinkEmail

--- a/Flipcash/Core/Screens/Settings/DepositCurrencyListScreen.swift
+++ b/Flipcash/Core/Screens/Settings/DepositCurrencyListScreen.swift
@@ -51,7 +51,7 @@ struct DepositCurrencyListScreen: View {
             .scrollContentBackground(.hidden)
         }
         .navigationTitle("Select Currency")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .onChange(of: balances, initial: true) {
             handleAutoSelect()
         }

--- a/Flipcash/Core/Screens/Settings/DepositScreen.swift
+++ b/Flipcash/Core/Screens/Settings/DepositScreen.swift
@@ -47,7 +47,7 @@ struct DepositScreen: View {
             .padding(20)
         }
         .navigationTitle(name.map { "Deposit \($0)" } ?? "Deposit")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 
     private func copyAddress() {

--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
@@ -38,6 +38,6 @@ struct SettingsAdvancedFeaturesScreen: View {
             .padding(.horizontal, 20)
         }
         .navigationTitle("Advanced Features")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 }

--- a/Flipcash/Core/Screens/Settings/SettingsAppSettingsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAppSettingsScreen.swift
@@ -34,7 +34,7 @@ struct SettingsAppSettingsScreen: View {
             .padding(.horizontal, 20)
         }
         .navigationTitle("App Settings")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 
     private func cameraAutoStartDisabledBinding() -> Binding<Bool> {

--- a/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
@@ -29,7 +29,7 @@ struct SettingsMyAccountScreen: View {
             .padding(.horizontal, 20)
         }
         .navigationTitle("My Account")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .dialog(item: $dialogItem)
     }
 

--- a/Flipcash/Core/Screens/Settings/SettingsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsScreen.swift
@@ -93,7 +93,7 @@ struct SettingsScreen: View {
                     .padding(.horizontal, 20)
                 }
             }
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     CloseButton(action: router.dismissSheet)

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawAddressScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawAddressScreen.swift
@@ -75,7 +75,7 @@ struct WithdrawAddressScreen: View {
             .padding(20)
         }
         .navigationTitle("Withdraw")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .interactiveDismissDisabled()
     }
 }

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawAmountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawAmountScreen.swift
@@ -44,7 +44,7 @@ struct WithdrawAmountScreen: View {
             }
         }
         .navigationTitle(title)
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 
     // MARK: - Actions -

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawIntroScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawIntroScreen.swift
@@ -43,7 +43,7 @@ struct WithdrawIntroScreen: View {
             .padding(20)
         }
         .navigationTitle("Withdraw")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
     }
 }
 

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
@@ -55,7 +55,7 @@ struct WithdrawScreen: View {
             .scrollContentBackground(.hidden)
         }
         .navigationTitle("Select Currency")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .withdrawSubstepDestinations(viewModel: viewModel)
         .onAppear {
             viewModel.pushSubstep = { step in

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawSummaryScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawSummaryScreen.swift
@@ -70,7 +70,7 @@ struct WithdrawSummaryScreen: View {
             .padding(20)
         }
         .navigationTitle("Withdraw")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(.inline)
         .interactiveDismissDisabled()
     }
 }


### PR DESCRIPTION
## Summary

Modernizes 40 screens from the older navigation-bar-specific title modifier to the unified toolbar-title modifier introduced in iOS 17. The two are semantically equivalent for inline titles, but the newer modifier is Apple's preferred direction for the unified toolbar system.

## Test plan
- [x] Open every modernized screen and confirm the title still renders inline (small, centered) as before.
- [x] Verify no visible behavior differences in onboarding, settings, withdraw, buy, swap, currency creation, and discovery flows.