### PR TITLE
fix: stop silent antispam denials from stale-historical auto-login

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -51,7 +51,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #if DEBUG
         let shouldEnableTelemetry = false
         #else
-        let shouldEnableTelemetry = !Container.isRunningUITests && !Container.isRunningUnitTests
+        let shouldEnableTelemetry = !Container.isRunningTests
         #endif
 
         if shouldEnableTelemetry {

--- a/Flipcash/Core/Container.swift
+++ b/Flipcash/Core/Container.swift
@@ -68,6 +68,13 @@ class Container {
     static var isRunningUITests: Bool {
         CommandLine.arguments.contains("--ui-testing")
     }
+
+    /// True when the host process is either a hosted unit-test run or a UI
+    /// test run. Used to suppress production-only side effects (telemetry,
+    /// auto-login from a stale keychain) at startup.
+    static var isRunningTests: Bool {
+        isRunningUITests || isRunningUnitTests
+    }
 }
 
 extension View {

--- a/Flipcash/Core/Screens/Onboarding/AccountSelectionScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/AccountSelectionScreen.swift
@@ -132,8 +132,7 @@ struct AccountSelectionScreen: View {
     }
 
     private func fetchAccounts() {
-        accounts = accountManager.fetchHistorical()
-            .filter { $0.deletionDate == nil }
+        accounts = accountManager.fetchActiveHistorical()
             .map { HistoricalAccount(details: $0) }
     }
 

--- a/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
@@ -35,9 +35,9 @@ class OnboardingViewModel {
     // MARK: - Action -
 
     func loginAction() {
-        let hasAccounts = sessionAuthenticator.accountManager
-            .fetchHistorical()
-            .contains { $0.deletionDate == nil }
+        let hasAccounts = !sessionAuthenticator.accountManager
+            .fetchActiveHistorical()
+            .isEmpty
 
         if hasAccounts {
             navigateToAccountSelection()

--- a/Flipcash/Core/Session/AccountManager.swift
+++ b/Flipcash/Core/Session/AccountManager.swift
@@ -21,15 +21,6 @@ class AccountManager {
         Keychain.historicalAccounts?.count ?? 0
     }
     
-    private var currentKeyAccount: KeyAccount? {
-        get {
-            Keychain.keyAccount
-        }
-        set {
-            Keychain.keyAccount = newValue
-        }
-    }
-    
     private var currentUserAccount: UserAccount? {
         get {
             Keychain.userAccount
@@ -38,16 +29,16 @@ class AccountManager {
             Keychain.userAccount = newValue
         }
     }
-    
+
     // MARK: - Init -
-    
+
     init() {}
-    
+
     func fetchHistorical(sortBy criteria: SortCritieria = .creationDate) -> [AccountDescription] {
         guard let map = Keychain.historicalAccounts else {
             return []
         }
-        
+
         return Array(map.values).sorted { lhs, rhs in
             switch criteria {
             case .creationDate:
@@ -57,18 +48,25 @@ class AccountManager {
             }
         }
     }
-    
+
+    /// Historical accounts that haven't been soft-deleted via
+    /// ``setDeleted(ownerPublicKey:deleted:)``. The canonical accessor for
+    /// "accounts the user can still log into" — used by onboarding's account
+    /// selection list and the auto-login fallback in ``SessionAuthenticator``.
+    func fetchActiveHistorical(sortBy criteria: SortCritieria = .creationDate) -> [AccountDescription] {
+        fetchHistorical(sortBy: criteria).filter { $0.deletionDate == nil }
+    }
+
     func fetchCurrentUserAccount() -> UserAccount? {
         currentUserAccount
     }
-    
+
     func set(keyAccount: KeyAccount, userID: UserID) {
-        currentKeyAccount = keyAccount
         currentUserAccount = UserAccount(
             userID: userID,
             keyAccount: keyAccount
         )
-        
+
         upsert(keyAccount: keyAccount)
     }
     
@@ -116,7 +114,6 @@ class AccountManager {
     }
     
     func resetForLogout() {
-        currentKeyAccount = nil
         currentUserAccount = nil
     }
     
@@ -152,9 +149,6 @@ class AccountManager {
 // MARK: - Keychain -
 
 private extension Keychain {
-    @SecureCodable(.keyAccount)
-    static var keyAccount: KeyAccount?
-
     @SecureCodable(.currentUserAccount)
     static var userAccount: UserAccount?
 

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -87,10 +87,11 @@ final class SessionAuthenticator {
         // (forced upgrade, forced logout on timelock unlock).
         startPolling()
 
-        // During UI testing the deeplink handles login. Skip auto-login
-        // to avoid racing with resetForUITesting() and the deeplink's
-        // switchAccount(to:) call.
-        guard !Container.isRunningUITests else {
+        // Both UI tests and hosted unit tests boot the full AppDelegate
+        // chain. In either case, skip auto-login and reset the keychain so
+        // leftover state from a previous run can't quietly fire
+        // `login + createAccounts` and trip the OCP antispam guard.
+        guard !Container.isRunningTests else {
             accountManager.nukeForUITesting()
             state = .loggedOut
             return
@@ -130,15 +131,22 @@ final class SessionAuthenticator {
             accountManager.upsert(keyAccount: userAccount.keyAccount)
             
         } else {
-            if let recentAccount = accountManager.fetchHistorical(sortBy: .lastSeen).first {
+            // Auto-attempt historical login only when wasLoggedIn is true.
+            // Otherwise the silent login + createAccounts chain fires against
+            // whichever historical entry sits in the keychain and trips the
+            // OCP antispam guard.
+            let wasLoggedIn = UserDefaults.wasLoggedIn == true
+            let recentAccount = wasLoggedIn
+                ? accountManager.fetchActiveHistorical(sortBy: .lastSeen).first
+                : nil
+
+            if let recentAccount {
                 didFindRecentAccount(recentAccount.account)
             } else {
                 state = .loggedOut
-                
-                // Only attempt to recover if there was an
-                // account that was previous already logged in
-                if UserDefaults.wasLoggedIn == true {
-                    
+
+                if wasLoggedIn {
+
                     // Try a total of 6 times, first attempt +
                     // 5 more retries after that
                     if count <= 5 {

--- a/Flipcash/Keychain/Secure.swift
+++ b/Flipcash/Keychain/Secure.swift
@@ -9,12 +9,10 @@ import Foundation
 import FlipcashCore
 
 enum SecureKey: String {
-    case keyAccount         = "com.flipcash.account.key"
     case historicalAccounts = "com.flipcash.account.list"
     case currentUserAccount = "com.flipcash.account.userAccount"
-    case onboardingMnemonic = "com.flipcash.account.onboardingMnemonic"
     case betaFlagsEnabled   = "com.flipcash.betaFlags.enabled"
-    
+
     case connectedWalletSession = "com.flipcash.wallet.connectedSession"
 }
 

--- a/FlipcashUITests/Support/BaseUITestCase.swift
+++ b/FlipcashUITests/Support/BaseUITestCase.swift
@@ -28,14 +28,20 @@ class BaseUITestCase: XCTestCase {
             app.resetAuthorizationStatus(for: permission)
         }
 
+        // Always launch with `app.launch()` first so the configured
+        // `launchArguments` (including `--ui-testing`) are applied and
+        // `SessionAuthenticator.nukeForUITesting()` fires. `app.open(URL)`
+        // alone uses URL-scheme dispatch and does NOT pass launchArguments,
+        // which would leave the keychain in whatever state the previous run
+        // left behind and let the auto-login path fire `createAccounts`.
+        app.launch()
+
         if requiresAuthentication {
             let accessKey = Bundle(for: Self.self).infoDictionary?["UITestAccessKey"] as? String ?? ""
             try XCTSkipIf(accessKey.isEmpty, "FLIPCASH_UI_TEST_ACCESS_KEY not set in secrets.local.xcconfig — skipping authenticated UI test")
 
             let loginURL = URL(string: "flipcash://login#e=\(accessKey.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) ?? accessKey)")!
             app.open(loginURL)
-        } else {
-            app.launch()
         }
     }
 


### PR DESCRIPTION
## Summary

Auto-login is now gated on whether the user actually expected to still be logged in, and soft-deleted accounts are filtered out of the auto-login pick.

Also extended the existing test-mode keychain reset to cover hosted unit tests, and fixed a UI-test launch path where the keychain wasn't being reset for any test that opened a deeplink.

## Test plan

- [x] Log in, kill the app, reopen — still logged in
- [x] Log in, log out from Settings, reopen — IntroScreen, no surprise account creation
- [x] After logging out, tap Log In — the prior account still appears in the selection list and logs in cleanly
- [x] Delete an account from Settings, reopen — does not auto-login back into the deleted account
- [x] Watch engineering-alerts for the next day — antispam denial rate goes to zero