### PR TITLE
fix: guard withdraw submission against sub-fee pinned amounts

### DIFF
--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -375,16 +375,11 @@ class WithdrawViewModel {
 
         guard let (amountToWithdraw, verifiedState) = await prepareSubmission() else {
             withdrawButtonState = .normal
-            dialogItem = .error(title: "Rate Unavailable", subtitle: "Couldn't get a fresh rate. Please try again.")
+            showRateUnavailableError()
             return
         }
 
-        let fee: TokenAmount
-        if amountToWithdraw.mint == .usdf {
-            fee = session.userFlags?.withdrawalFeeAmount ?? .zero(mint: .usdf)
-        } else {
-            fee = exchangedFee?.onChainAmount ?? .zero(mint: .usdf)
-        }
+        let fee = resolvedFee?.onChain ?? .zero(mint: .usdf)
 
         guard fee.quarks < amountToWithdraw.onChainAmount.quarks else {
             withdrawButtonState = .normal
@@ -404,7 +399,7 @@ class WithdrawViewModel {
             case .usdfToUsdc:
                 guard let destinationOwner = enteredDestination else {
                     withdrawButtonState = .normal
-                    dialogItem = .error(title: "Something Went Wrong", subtitle: "Please try again later")
+                    showSomethingWentWrongError()
                     return
                 }
                 _ = try await client.withdrawAsUSDC(
@@ -425,7 +420,7 @@ class WithdrawViewModel {
 
         } catch Session.Error.verifiedStateStale {
             withdrawButtonState = .normal
-            dialogItem = .error(title: "Rate Unavailable", subtitle: "Couldn't get a fresh rate. Please try again.")
+            showRateUnavailableError()
         } catch {
             // .usdfToUsdc bypasses Session and reports/emits analytics here;
             // .sameMint flows through Session.withdraw, which owns both.
@@ -448,7 +443,7 @@ class WithdrawViewModel {
                 break
             }
             withdrawButtonState = .normal
-            dialogItem = .error(title: "Something Went Wrong", subtitle: "Please try again later")
+            showSomethingWentWrongError()
         }
     }
 
@@ -498,6 +493,20 @@ class WithdrawViewModel {
         dialogItem = .error(
             title: "Insufficient Balance",
             subtitle: "Please enter a lower amount and try again"
+        )
+    }
+
+    private func showRateUnavailableError() {
+        dialogItem = .error(
+            title: "Rate Unavailable",
+            subtitle: "Couldn't get a fresh rate. Please try again."
+        )
+    }
+
+    private func showSomethingWentWrongError() {
+        dialogItem = .error(
+            title: "Something Went Wrong",
+            subtitle: "Please try again later"
         )
     }
 

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -362,21 +362,13 @@ class WithdrawViewModel {
             subtitle: "Withdrawals are irreversible and cannot be undone once initiated"
         ) {
             .destructive("Yes, Withdraw") { [weak self] in
-                self?.completeWithdrawal()
+                Task { await self?.completeWithdrawal() }
             };
             .cancel()
         }
     }
 
-    private func completeWithdrawal() {
-        Task { await submitWithdrawal() }
-    }
-
-    /// Async body of the withdraw submission. Extracted from
-    /// `completeWithdrawal()` so the regression test can await the real
-    /// submission path instead of polling `dialogItem` after a fire-and-forget
-    /// Task. The UI entry point is still the private wrapper above.
-    func submitWithdrawal() async {
+    func completeWithdrawal() async {
         guard let kind, let destinationMetadata else { return }
 
         withdrawButtonState = .loading

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -394,6 +394,12 @@ class WithdrawViewModel {
             fee = exchangedFee?.onChainAmount ?? .zero(mint: .usdf)
         }
 
+        guard fee.quarks < amountToWithdraw.onChainAmount.quarks else {
+            withdrawButtonState = .normal
+            showWithdrawalTooSmallError()
+            return
+        }
+
         do {
             switch kind {
             case .sameMint:

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -369,81 +369,88 @@ class WithdrawViewModel {
     }
 
     private func completeWithdrawal() {
+        Task { await submitWithdrawal() }
+    }
+
+    /// Async body of the withdraw submission. Extracted from
+    /// `completeWithdrawal()` so the regression test can await the real
+    /// submission path instead of polling `dialogItem` after a fire-and-forget
+    /// Task. The UI entry point is still the private wrapper above.
+    func submitWithdrawal() async {
         guard let kind, let destinationMetadata else { return }
 
         withdrawButtonState = .loading
-        Task {
-            guard let (amountToWithdraw, verifiedState) = await prepareSubmission() else {
-                withdrawButtonState = .normal
-                dialogItem = .error(title: "Rate Unavailable", subtitle: "Couldn't get a fresh rate. Please try again.")
-                return
-            }
 
-            let fee: TokenAmount
-            if amountToWithdraw.mint == .usdf {
-                fee = session.userFlags?.withdrawalFeeAmount ?? .zero(mint: .usdf)
-            } else {
-                fee = exchangedFee?.onChainAmount ?? .zero(mint: .usdf)
-            }
+        guard let (amountToWithdraw, verifiedState) = await prepareSubmission() else {
+            withdrawButtonState = .normal
+            dialogItem = .error(title: "Rate Unavailable", subtitle: "Couldn't get a fresh rate. Please try again.")
+            return
+        }
 
-            do {
-                switch kind {
-                case .sameMint:
-                    try await session.withdraw(
-                        exchangedFiat: amountToWithdraw,
-                        verifiedState: verifiedState,
-                        fee: fee,
-                        to: destinationMetadata
-                    )
-                case .usdfToUsdc:
-                    guard let destinationOwner = enteredDestination else {
-                        withdrawButtonState = .normal
-                        dialogItem = .error(title: "Something Went Wrong", subtitle: "Please try again later")
-                        return
-                    }
-                    _ = try await client.withdrawAsUSDC(
-                        amount: amountToWithdraw,
-                        verifiedState: verifiedState,
-                        destinationOwner: destinationOwner,
-                        fee: fee,
-                        sourceCluster: session.owner
-                    )
-                    session.updatePostTransaction()
-                    Analytics.withdrawal(exchangedFiat: amountToWithdraw, successful: true, error: nil)
+        let fee: TokenAmount
+        if amountToWithdraw.mint == .usdf {
+            fee = session.userFlags?.withdrawalFeeAmount ?? .zero(mint: .usdf)
+        } else {
+            fee = exchangedFee?.onChainAmount ?? .zero(mint: .usdf)
+        }
+
+        do {
+            switch kind {
+            case .sameMint:
+                try await session.withdraw(
+                    exchangedFiat: amountToWithdraw,
+                    verifiedState: verifiedState,
+                    fee: fee,
+                    to: destinationMetadata
+                )
+            case .usdfToUsdc:
+                guard let destinationOwner = enteredDestination else {
+                    withdrawButtonState = .normal
+                    dialogItem = .error(title: "Something Went Wrong", subtitle: "Please try again later")
+                    return
                 }
-
-                try await Task.delay(milliseconds: 500)
-                withdrawButtonState = .success
-                try await Task.delay(milliseconds: 500)
-                showSuccessfulWithdrawalDialog()
-
-            } catch Session.Error.verifiedStateStale {
-                withdrawButtonState = .normal
-                dialogItem = .error(title: "Rate Unavailable", subtitle: "Couldn't get a fresh rate. Please try again.")
-            } catch {
-                // .usdfToUsdc bypasses Session and reports/emits analytics here;
-                // .sameMint flows through Session.withdraw, which owns both.
-                switch kind {
-                case .usdfToUsdc:
-                    ErrorReporting.captureError(
-                        error,
-                        reason: "Failed to withdraw",
-                        metadata: [
-                            "mint": amountToWithdraw.mint.base58,
-                            "amount": amountToWithdraw.nativeAmount.formatted(),
-                            "quarks": "\(amountToWithdraw.onChainAmount.quarks)",
-                            "fee": "\(fee.quarks)",
-                            "destination": destinationMetadata.destination.token.base58,
-                            "requiresInit": "\(destinationMetadata.requiresInitialization)",
-                        ]
-                    )
-                    Analytics.withdrawal(exchangedFiat: amountToWithdraw, successful: false, error: error)
-                case .sameMint:
-                    break
-                }
-                withdrawButtonState = .normal
-                dialogItem = .error(title: "Something Went Wrong", subtitle: "Please try again later")
+                _ = try await client.withdrawAsUSDC(
+                    amount: amountToWithdraw,
+                    verifiedState: verifiedState,
+                    destinationOwner: destinationOwner,
+                    fee: fee,
+                    sourceCluster: session.owner
+                )
+                session.updatePostTransaction()
+                Analytics.withdrawal(exchangedFiat: amountToWithdraw, successful: true, error: nil)
             }
+
+            try await Task.delay(milliseconds: 500)
+            withdrawButtonState = .success
+            try await Task.delay(milliseconds: 500)
+            showSuccessfulWithdrawalDialog()
+
+        } catch Session.Error.verifiedStateStale {
+            withdrawButtonState = .normal
+            dialogItem = .error(title: "Rate Unavailable", subtitle: "Couldn't get a fresh rate. Please try again.")
+        } catch {
+            // .usdfToUsdc bypasses Session and reports/emits analytics here;
+            // .sameMint flows through Session.withdraw, which owns both.
+            switch kind {
+            case .usdfToUsdc:
+                ErrorReporting.captureError(
+                    error,
+                    reason: "Failed to withdraw",
+                    metadata: [
+                        "mint": amountToWithdraw.mint.base58,
+                        "amount": amountToWithdraw.nativeAmount.formatted(),
+                        "quarks": "\(amountToWithdraw.onChainAmount.quarks)",
+                        "fee": "\(fee.quarks)",
+                        "destination": destinationMetadata.destination.token.base58,
+                        "requiresInit": "\(destinationMetadata.requiresInitialization)",
+                    ]
+                )
+                Analytics.withdrawal(exchangedFiat: amountToWithdraw, successful: false, error: error)
+            case .sameMint:
+                break
+            }
+            withdrawButtonState = .normal
+            dialogItem = .error(title: "Something Went Wrong", subtitle: "Please try again later")
         }
     }
 

--- a/FlipcashTests/Regressions/Regression_6a0e1a1.swift
+++ b/FlipcashTests/Regressions/Regression_6a0e1a1.swift
@@ -51,7 +51,9 @@ struct Regression_6a0e1a1 {
 
         await viewModel.completeWithdrawal()
 
-        #expect(viewModel.dialogItem?.title == "Withdrawal Amount Too Small")
+        let dialog = try #require(viewModel.dialogItem)
+        // Title from `WithdrawViewModel.showWithdrawalTooSmallError`.
+        #expect(dialog.title == "Withdrawal Amount Too Small")
         #expect(viewModel.withdrawButtonState == .normal)
     }
 }

--- a/FlipcashTests/Regressions/Regression_6a0e1a1.swift
+++ b/FlipcashTests/Regressions/Regression_6a0e1a1.swift
@@ -1,0 +1,57 @@
+//
+//  Regression_6a0e1a1.swift
+//  Flipcash
+//
+//  EXC_BREAKPOINT: ExchangedFiat.subtractingFee → TokenAmount.- traps when
+//                  the pinned recompute of the withdraw amount lands below
+//                  the fee. The amount-screen `isBelowMinimumWithdraw` gate
+//                  uses the live rate; `prepareSubmission` recomputes
+//                  against the pinned rate. Sufficient pinned-vs-live drift
+//                  (severe for 0-decimal currencies) produces sub-fee
+//                  quarks and trips the underflow precondition.
+//
+//  Fix:            Guard in WithdrawViewModel.submitWithdrawal after
+//                  prepareSubmission — surfaces the existing
+//                  "Withdrawal Amount Too Small" dialog instead of
+//                  reaching IntentWithdraw / TokenAmount subtraction.
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@Suite("Regression: 6a0e1a1 – withdraw traps when pinned amount falls below fee", .bug("6a0e1a1add5b5015cee68d6d"))
+struct Regression_6a0e1a1 {
+
+    @Test("USDF: pinned rate drift produces sub-fee quarks → too-small dialog, no trap")
+    @MainActor
+    func usdf_pinDriftBelowFee_surfacesTooSmallDialog() async throws {
+        // Fee: 500_000 USDF quarks ($0.50).
+        // Live rate: 1.0 EUR/USD. Pinned rate: 5.0 EUR/USD (worst-case drift
+        // to force the recompute below the fee). User enters 1 EUR — passes
+        // the live-rate minimum (€0.50 fee + €0.01 floor = €0.51; €1 > €0.51).
+        // Pinned recompute: 1 EUR / 5.0 = $0.20 = 200_000 USDF quarks < 500_000 fee.
+        let (container, usdf) = try WithdrawViewModelTestHelpers.makeUSDFFixture(
+            quarks: 100_000_000,
+            withdrawalFeeQuarks: 500_000
+        )
+        container.ratesController.configureTestRates(
+            balanceCurrency: .eur,
+            rates: [Rate(fx: 1.0, currency: .eur)]
+        )
+        await container.ratesController.verifiedProtoService.saveRates([
+            .freshRate(currencyCode: "EUR", rate: 5.0)
+        ])
+
+        let viewModel = WithdrawViewModel(container: .mock, sessionContainer: container)
+        viewModel.kind = .sameMint(usdf)
+        viewModel.enteredAmount = "1"
+        viewModel.destinationMetadata = WithdrawViewModelTestHelpers.createDestinationMetadata()
+
+        await viewModel.submitWithdrawal()
+
+        #expect(viewModel.dialogItem?.title == "Withdrawal Amount Too Small")
+        #expect(viewModel.withdrawButtonState == .normal)
+    }
+}

--- a/FlipcashTests/Regressions/Regression_6a0e1a1.swift
+++ b/FlipcashTests/Regressions/Regression_6a0e1a1.swift
@@ -10,7 +10,7 @@
 //                  (severe for 0-decimal currencies) produces sub-fee
 //                  quarks and trips the underflow precondition.
 //
-//  Fix:            Guard in WithdrawViewModel.submitWithdrawal after
+//  Fix:            Guard in WithdrawViewModel.completeWithdrawal after
 //                  prepareSubmission — surfaces the existing
 //                  "Withdrawal Amount Too Small" dialog instead of
 //                  reaching IntentWithdraw / TokenAmount subtraction.
@@ -49,7 +49,7 @@ struct Regression_6a0e1a1 {
         viewModel.enteredAmount = "1"
         viewModel.destinationMetadata = WithdrawViewModelTestHelpers.createDestinationMetadata()
 
-        await viewModel.submitWithdrawal()
+        await viewModel.completeWithdrawal()
 
         #expect(viewModel.dialogItem?.title == "Withdrawal Amount Too Small")
         #expect(viewModel.withdrawButtonState == .normal)


### PR DESCRIPTION
## Summary

Fixes a production crash where withdrawing a small amount could trap the app when the pinned exchange rate landed below the fee. The amount-entry gate uses the live rate; the submission recomputes against the pinned rate, so any drift could let a sub-fee amount through and underflow during the fee subtraction. Adds a guard at the submission seam that surfaces the existing "Withdrawal Amount Too Small" dialog, and tidies up duplicated dialog and fee-derivation logic in the same flow.

## Test plan

- [ ] Withdraw a USDF amount comfortably above the fee — completes as before.
- [ ] Enter a tiny amount, advance to confirm, and tap Yes — see the "Withdrawal Amount Too Small" dialog instead of a crash.
- [ ] USDF→USDC withdrawal still works end-to-end.
- [ ] On a non-USD locale (e.g. EUR), repeat the small-amount path to confirm the guard fires there too.