### PR TITLE
fix: crash when dialog modifier renders without AppRouter

### DIFF
--- a/Flipcash/UI/View+Dialog.swift
+++ b/Flipcash/UI/View+Dialog.swift
@@ -16,7 +16,7 @@ extension View {
 private struct DialogItemModifier: ViewModifier {
 
     let item: Binding<DialogItem?>
-    @Environment(AppRouter.self) private var router
+    @Environment(AppRouter.self) private var router: AppRouter?
 
     func body(content: Content) -> some View {
         content
@@ -36,7 +36,7 @@ private struct DialogItemModifier: ViewModifier {
                         Analytics.errorModalDisplayed(
                             title: title,
                             message: subtitle,
-                            screen: router.presentedSheet?.description ?? "scan",
+                            screen: router?.presentedSheet?.description ?? "scan",
                             callSite: nil
                         )
                     }


### PR DESCRIPTION
## Summary

The dialog modifier reads `AppRouter` from the environment to tag analytics with the currently-presented sheet, but `AppRouter` only exists while the user is logged in (it lives on `SessionContainer`). Any logged-out screen that uses `.dialog(item:)` — for example the account selection screen on the Log In flow — fatal-errors on resolution. Making the environment lookup optional ends the crash; the analytics screen field falls back to its existing default when no router is present.

## Test plan

- [x] Log in, log out, tap Log In, reach the account picker without crashing
- [x] Trigger an error dialog while logged in and confirm the analytics event still records the sheet name