### PR TITLE
fix: dismiss nested sheets in a single coordinated animation

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -330,25 +330,14 @@ final class AppRouter {
         ])
     }
 
-    /// Global navigation reset: dismisses every presented sheet and clears
-    /// every stack's `NavigationPath`. The user lands on the Scanner — the
-    /// unconditional root rendered behind all sheets.
+    /// Dismisses every presented sheet and clears every inactive stack's
+    /// path, landing the user on the Scanner. Used by the
+    /// auto-return-on-background trigger to discard in-flight navigation.
     ///
-    /// Distinct from ``popToRoot(on:)``, which is a per-stack pop. Used by
-    /// the auto-return-on-background trigger when the user has been away long
-    /// enough that any in-flight navigation should be discarded.
-    ///
-    /// Dismissal is delegated to UIKit's modal cascade: calling
-    /// `dismiss(animated:)` on the root presenter tears down the entire
-    /// nested-sheet chain in a single coordinated animation. Setting
-    /// `presentedSheets = []` directly would force SwiftUI to issue two
-    /// independent `dismiss(animated:)` calls (one per `.sheet(item:)`
-    /// binding), which UIKit serialises into an outer-then-inner cascade.
-    ///
-    /// The dismissing root sheet's `NavigationPath` is retained through the
-    /// animation and cleared on next present via ``dismissedStacks``;
-    /// inactive stacks have no on-screen UI so their paths are cleared
-    /// synchronously.
+    /// Driven through UIKit's `dismiss(animated:)` on the root presenter so
+    /// the full nested-sheet chain tears down in one coordinated animation.
+    /// The dismissing root's path is retained through the animation and
+    /// cleared on next present via ``dismissedStacks``.
     func dismissAll() {
         let rootStack = presentedSheets.first?.stack
 

--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -334,30 +334,46 @@ final class AppRouter {
     /// every stack's `NavigationPath`. The user lands on the Scanner — the
     /// unconditional root rendered behind all sheets.
     ///
-    /// Distinct from ``popToRoot(on:)``, which is a per-stack pop. This
-    /// method is the all-sheets + all-stacks variant, used by the
-    /// auto-return-on-background trigger when the user has been away long
+    /// Distinct from ``popToRoot(on:)``, which is a per-stack pop. Used by
+    /// the auto-return-on-background trigger when the user has been away long
     /// enough that any in-flight navigation should be discarded.
     ///
-    /// The dismissing root sheet's slide-down animation runs with its current
-    /// contents — the same behaviour as ``dismissSheet()``. Inactive stacks
-    /// have no on-screen UI so their paths are cleared synchronously.
+    /// Dismissal is delegated to UIKit's modal cascade: calling
+    /// `dismiss(animated:)` on the root presenter tears down the entire
+    /// nested-sheet chain in a single coordinated animation. Setting
+    /// `presentedSheets = []` directly would force SwiftUI to issue two
+    /// independent `dismiss(animated:)` calls (one per `.sheet(item:)`
+    /// binding), which UIKit serialises into an outer-then-inner cascade.
+    ///
+    /// The dismissing root sheet's `NavigationPath` is retained through the
+    /// animation and cleared on next present via ``dismissedStacks``;
+    /// inactive stacks have no on-screen UI so their paths are cleared
+    /// synchronously.
     func dismissAll() {
-        let dismissing = presentedSheets
-        let dismissingRoot = presentedSheets.first
-        presentedSheets = []
-        for sheet in dismissing {
+        let rootStack = presentedSheets.first?.stack
+
+        for sheet in presentedSheets {
             dismissedStacks.insert(sheet.stack)
         }
-        // Clear every stack's path except the dismissing root's — that stack
-        // keeps its path through the slide-off animation, cleared on next
-        // present of that root via the dismissedStacks mechanism.
-        for stack in Stack.allCases where stack != dismissingRoot?.stack {
+        for stack in Stack.allCases where stack != rootStack {
             paths[stack] = NavigationPath()
         }
-        logger.info("Dismiss all", metadata: [
-            "dismissedSheets": "\(dismissing.map(String.init(describing:)))",
-        ])
+
+        let presenter = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }?
+            .keyWindow?
+            .rootViewController
+
+        if let presenter, presenter.presentedViewController != nil {
+            presenter.dismiss(animated: true) { [weak self] in
+                self?.presentedSheets = []
+            }
+        } else {
+            presentedSheets = []
+        }
+
+        logger.info("Dismiss all")
     }
 
     // MARK: - Logging helpers


### PR DESCRIPTION
## Summary
Backgrounding and restoring the app past the auto-return window used to slide the nested sheet off first, then the root, in a visible two-step cascade. The router now delegates the dismissal to UIKit's native modal teardown so the entire chain animates off together in one coordinated slide-down.

## Test plan
- [x] Open a balance, push into a currency, then open a buy sheet on top.
- [x] Background the app, wait past the auto-return window, then bring it forward.
- [x] Confirm the buy sheet and balance dismiss together in a single animation rather than one after the other.