### PR TITLE
chore: silence dead-code warning on telemetry init

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -48,16 +48,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Telemetry runs only in Release production launches; DEBUG and any
         // test process stay silent to avoid polluting production dashboards.
-        #if DEBUG
-        let shouldEnableTelemetry = false
-        #else
-        let shouldEnableTelemetry = !Container.isRunningTests
-        #endif
-
-        if shouldEnableTelemetry {
+        #if !DEBUG
+        if !Container.isRunningTests {
             Analytics.initialize()
             ErrorReporting.initialize()
         }
+        #endif
 
         FontBook.registerApplicationFonts()
         setupAppearance()


### PR DESCRIPTION
## Summary
The DEBUG branch made `shouldEnableTelemetry` a compile-time constant `false`, which caused the compiler to warn that the telemetry-init block would never execute. Replaced the runtime flag with a `#if !DEBUG` gate around the whole block — same behavior in every configuration, no more warning.

## Test plan
- [ ] Build in DEBUG and confirm the dead-code warning is gone
- [ ] Build in Release and confirm Analytics + ErrorReporting still initialize on launch
- [ ] Confirm test runs (which set `Container.isRunningTests`) still skip telemetry init