### PR TITLE
fix: prevent crash when withdraw fee exceeds entered amount

### DIFF
--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -420,6 +420,9 @@ class WithdrawViewModel {
             } catch Session.Error.verifiedStateStale {
                 withdrawButtonState = .normal
                 dialogItem = .error(title: "Rate Unavailable", subtitle: "Couldn't get a fresh rate. Please try again.")
+            } catch IntentWithdrawError.feeExceedsAmount {
+                withdrawButtonState = .normal
+                showBalanceBelowFeeError()
             } catch {
                 // .usdfToUsdc bypasses Session and reports/emits analytics here;
                 // .sameMint flows through Session.withdraw, which owns both.
@@ -502,6 +505,19 @@ class WithdrawViewModel {
             subtitle: "Your withdrawal amount is too small to cover the fee. Please try a different amount"
         ) {
             .okay(kind: .standard)
+        }
+    }
+
+    /// Shown when the submission-time amount is below the fee — typically when
+    /// balance < fee, so no entered amount can succeed. Unwinds the flow on OK.
+    private func showBalanceBelowFeeError() {
+        dialogItem = .error(
+            title: "Withdrawal Amount Too Small",
+            subtitle: "Your balance is below the withdrawal fee."
+        ) {
+            .okay(kind: .standard) { [weak self] in
+                self?.onComplete()
+            }
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentWithdraw.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentWithdraw.swift
@@ -10,6 +10,12 @@ import Foundation
 import FlipcashAPI
 import SwiftProtobuf
 
+public enum IntentWithdrawError: Swift.Error {
+    /// The on-chain fee exceeds the entered amount; the post-fee remainder is
+    /// not representable in `TokenAmount`.
+    case feeExceedsAmount
+}
+
 final class IntentWithdraw: IntentType {
 
     let id: PublicKey
@@ -34,6 +40,9 @@ final class IntentWithdraw: IntentType {
         var group = ActionGroup()
 
         if fee.quarks > 0 {
+            guard fee.quarks <= exchangedFiat.onChainAmount.quarks else {
+                throw IntentWithdrawError.feeExceedsAmount
+            }
             let amountToWithdraw = exchangedFiat.subtractingFee(fee)
             group.append(
                 ActionTransfer(

--- a/FlipcashCore/Tests/FlipcashCoreTests/IntentWithdrawTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/IntentWithdrawTests.swift
@@ -38,10 +38,6 @@ struct IntentWithdrawTests {
         #expect(transfer.amount.quarks == 0)
     }
 
-    // Note: a fee larger than the amount is now a precondition-fail in
-    // TokenAmount subtraction, not a throwable error — callers are expected to
-    // validate sufficient-funds before constructing a withdraw intent.
-
     @Test("With non-zero fee and no initialization required, still emits ActionTransfer (entered − fee) + ActionFeeTransfer")
     func actionGroup_withNonZeroFee_noRequiresInit_includesFeeTransfer() throws {
         let intent = try makeIntent(

--- a/FlipcashTests/Regressions/Regression_6a0e1a1add5b5015cee68d6d.swift
+++ b/FlipcashTests/Regressions/Regression_6a0e1a1add5b5015cee68d6d.swift
@@ -1,0 +1,52 @@
+//
+//  Regression_6a0e1a1add5b5015cee68d6d.swift
+//  FlipcashTests
+//
+//  EXC_BREAKPOINT: TokenAmount subtraction underflow inside
+//  ExchangedFiat.subtractingFee, called from IntentWithdraw.init when the
+//  on-chain fee exceeds the entered amount. Surfaces when balance < fee:
+//  ExchangedFiat.compute(fromEntered:) silently caps the on-chain quarks to
+//  balance, hasSufficientFunds passes because capped == balance, and
+//  IntentWithdraw.init invokes subtractingFee unconditionally.
+//
+//  Fix: IntentWithdraw.init guards fee <= onChainAmount.quarks and throws
+//  IntentWithdrawError.feeExceedsAmount when the precondition would fire.
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("Regression: 6a0e1a1 – IntentWithdraw underflow when fee exceeds amount", .bug("6a0e1a1add5b5015cee68d6d"))
+struct Regression_6a0e1a1 {
+
+    @Test("IntentWithdraw throws feeExceedsAmount when fee.quarks > onChainAmount.quarks instead of trapping")
+    func intentWithdraw_throwsWhenFeeExceedsAmount() throws {
+        // Reproduces the production scenario: $0.30 USDF balance, $0.50 fee.
+        // The viewmodel's cap-to-balance path produces an on-chain amount
+        // below the fee; before the fix, this trapped `TokenAmount.-`.
+        let exchangedFiat = ExchangedFiat(
+            nativeAmount: .usd(Decimal(0.30)),
+            rate: .oneToOne
+        )
+        let fee = TokenAmount(quarks: 500_000, mint: .usdf)
+        let destinationMetadata = DestinationMetadata(
+            kind: .token,
+            destination: PublicKey.generate()!,
+            mint: .usdf,
+            isValid: true,
+            requiresInitialization: true,
+            fee: fee
+        )
+
+        #expect(throws: IntentWithdrawError.feeExceedsAmount) {
+            _ = try IntentWithdraw(
+                sourceCluster: .mock,
+                fee: fee,
+                destinationMetadata: destinationMetadata,
+                exchangedFiat: exchangedFiat,
+                verifiedState: .fresh(bonded: false)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The withdraw flow crashed with EXC_BREAKPOINT when the on-chain fee exceeded the entered amount — typically when a user's balance sits below the withdrawal fee. The intent now throws a recoverable error before the underflow, and the viewmodel catches it to show a "Withdrawal Amount Too Small" dialog that unwinds the flow on OK so the user isn't stuck on the Confirmation screen retrying.

## Test plan

- [ ] Open Withdraw with a USDF balance below the fee, enter an amount, tap Withdraw — confirm the dialog shows and OK returns to Settings root.
- [ ] Withdraw normally with sufficient balance to confirm the happy path still works.
- [ ] Run the Bugsnag regression test for incident 6a0e1a1.