### PR TITLE
fix: iOS 26 toolbar items duplicate in CurrencyInfo loading state

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Views/Containers/Background.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Containers/Background.swift
@@ -9,23 +9,27 @@
 import SwiftUI
 
 public struct Background<Content>: View where Content: View {
-    public var background: AnyView
-    public var content: Content
-    
+    private let color: Color
+    private let content: Content
+
     // MARK: - Init -
-    
+
     public init(color: Color, @ViewBuilder content: () -> Content) {
-        self.background = AnyView(color)
+        self.color = color
         self.content = content()
     }
 
     // MARK: - Body -
 
+    // ZStack (not `.background`) — on iOS 26 the modifier form exposes
+    // content's TupleView at the top of the wrapper, causing parent
+    // `.toolbar { ToolbarItem }` items to duplicate per top-level sibling.
     public var body: some View {
-        content
-            .background {
-                background
-                    .ignoresSafeArea()
-            }
+        ZStack {
+            color
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
+            content
+        }
     }
 }


### PR DESCRIPTION
## Summary

On iOS 26, opening Currency Info for a token whose metadata isn't cached rendered the share button three times inside a single Liquid Glass pill in the toolbar. The shared Background utility composed its color via the `.background` modifier, which left its content's TupleView exposed at the top of the wrapper — iOS 26's toolbar pass then duplicated each ToolbarItem once per top-level sibling (Spacer/LoadingView/Spacer → three buttons). Switching Background's body to a ZStack encapsulates the children as a single subtree and the duplication doesn't fire.

While I was there, dropped the AnyView storage now that the property is always a Color, and tightened both stored properties to private.

## Test plan

- [x] Open Currency Info for a token you don't own from Discover and confirm the loading state shows one share button in the top right
- [x] Confirm the loaded state still shows one share button
- [x] Spot-check Wallet, Settings, Withdraw, and a couple of Onboarding screens for visual regressions