### PR TITLE
refactor: invert withdraw flow to USDC-first with picker escape hatch

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -134,16 +134,22 @@ struct DestinationView: View {
             }
 
         case .withdraw:
-            WithdrawScreen(
+            PreselectedWithdrawRoot(
+                mint: .usdf,
                 container: container,
-                sessionContainer: sessionContainer
+                sessionContainer: sessionContainer,
+                popStack: .settings,
+                onWithdrawOtherCurrencies: {
+                    sessionContainer.appRouter.pushAny(WithdrawNavigationPath.picker)
+                }
             )
 
         case .withdrawCurrency(let mint):
             PreselectedWithdrawRoot(
                 mint: mint,
                 container: container,
-                sessionContainer: sessionContainer
+                sessionContainer: sessionContainer,
+                popStack: .balance
             )
 
         case .usdcDepositEducation:

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -138,7 +138,7 @@ struct DestinationView: View {
                 mint: .usdf,
                 container: container,
                 sessionContainer: sessionContainer,
-                popStack: .settings,
+                onComplete: { sessionContainer.appRouter.popToRoot(on: .settings) },
                 onWithdrawOtherCurrencies: {
                     sessionContainer.appRouter.pushAny(WithdrawNavigationPath.picker)
                 }
@@ -149,7 +149,7 @@ struct DestinationView: View {
                 mint: mint,
                 container: container,
                 sessionContainer: sessionContainer,
-                popStack: .balance
+                onComplete: { sessionContainer.appRouter.popToRoot(on: .balance) }
             )
 
         case .usdcDepositEducation:

--- a/Flipcash/Core/Screens/Settings/Withdraw/PreselectedWithdrawRoot.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/PreselectedWithdrawRoot.swift
@@ -9,33 +9,49 @@ import SwiftUI
 import FlipcashUI
 import FlipcashCore
 
-/// Withdraw flow entry point that skips the "Select Currency" picker.
-/// Configures `WithdrawViewModel` with the mint before `@State` boxes it,
-/// so the intro screen renders with `kind` already populated.
+/// Withdraw flow entry point that lands the user on `WithdrawIntroScreen`
+/// with `mint` already selected on the view model. Used by both the Settings
+/// "Withdraw" button (USDF default, with a "Withdraw Other Flipcash
+/// Currencies" escape hatch) and the Wallet → USDF Currency Info entry
+/// (USDF only, no escape hatch).
 struct PreselectedWithdrawRoot: View {
 
     @Environment(AppRouter.self) private var router
     @State private var viewModel: WithdrawViewModel
 
-    init(mint: PublicKey, container: Container, sessionContainer: SessionContainer) {
+    private let popStack: AppRouter.Stack
+    private let onWithdrawOtherCurrencies: (() -> Void)?
+
+    init(
+        mint: PublicKey,
+        container: Container,
+        sessionContainer: SessionContainer,
+        popStack: AppRouter.Stack,
+        onWithdrawOtherCurrencies: (() -> Void)? = nil
+    ) {
         let vm = WithdrawViewModel(container: container, sessionContainer: sessionContainer)
         if let stored = sessionContainer.session.balance(for: mint) {
             let rate = sessionContainer.ratesController.rateForBalanceCurrency()
-            vm.selectCurrency(stored.exchanged(with: rate))
+            vm.setKind(for: stored.exchanged(with: rate))
         }
         self._viewModel = State(wrappedValue: vm)
+        self.popStack = popStack
+        self.onWithdrawOtherCurrencies = onWithdrawOtherCurrencies
     }
 
     var body: some View {
-        WithdrawIntroScreen()
-            .withdrawSubstepDestinations(viewModel: viewModel)
-            .onAppear {
-                viewModel.pushSubstep = { step in
-                    router.pushAny(step)
-                }
-                viewModel.onComplete = {
-                    router.popToRoot(on: .balance)
-                }
+        WithdrawIntroScreen(
+            onNext: viewModel.continueFromIntro,
+            onWithdrawOtherCurrencies: onWithdrawOtherCurrencies
+        )
+        .withdrawSubstepDestinations(viewModel: viewModel)
+        .onAppear {
+            viewModel.pushSubstep = { step in
+                router.pushAny(step)
             }
+            viewModel.onComplete = {
+                router.popToRoot(on: popStack)
+            }
+        }
     }
 }

--- a/Flipcash/Core/Screens/Settings/Withdraw/PreselectedWithdrawRoot.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/PreselectedWithdrawRoot.swift
@@ -19,14 +19,14 @@ struct PreselectedWithdrawRoot: View {
     @Environment(AppRouter.self) private var router
     @State private var viewModel: WithdrawViewModel
 
-    private let popStack: AppRouter.Stack
+    private let onComplete: () -> Void
     private let onWithdrawOtherCurrencies: (() -> Void)?
 
     init(
         mint: PublicKey,
         container: Container,
         sessionContainer: SessionContainer,
-        popStack: AppRouter.Stack,
+        onComplete: @escaping () -> Void,
         onWithdrawOtherCurrencies: (() -> Void)? = nil
     ) {
         let vm = WithdrawViewModel(container: container, sessionContainer: sessionContainer)
@@ -35,7 +35,7 @@ struct PreselectedWithdrawRoot: View {
             vm.setKind(for: stored.exchanged(with: rate))
         }
         self._viewModel = State(wrappedValue: vm)
-        self.popStack = popStack
+        self.onComplete = onComplete
         self.onWithdrawOtherCurrencies = onWithdrawOtherCurrencies
     }
 
@@ -49,9 +49,7 @@ struct PreselectedWithdrawRoot: View {
             viewModel.pushSubstep = { step in
                 router.pushAny(step)
             }
-            viewModel.onComplete = {
-                router.popToRoot(on: popStack)
-            }
+            viewModel.onComplete = onComplete
         }
     }
 }

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawIntroScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawIntroScreen.swift
@@ -9,7 +9,13 @@ import FlipcashUI
 
 struct WithdrawIntroScreen: View {
 
-    @Environment(AppRouter.self) private var router
+    let onNext: () -> Void
+    let onWithdrawOtherCurrencies: (() -> Void)?
+
+    init(onNext: @escaping () -> Void, onWithdrawOtherCurrencies: (() -> Void)? = nil) {
+        self.onNext = onNext
+        self.onWithdrawOtherCurrencies = onWithdrawOtherCurrencies
+    }
 
     var body: some View {
         Background(color: .backgroundMain) {
@@ -35,10 +41,15 @@ struct WithdrawIntroScreen: View {
 
                 Spacer()
 
-                Button("Next") {
-                    router.pushAny(WithdrawNavigationPath.enterAmount)
+                VStack(spacing: 8) {
+                    Button("Next", action: onNext)
+                        .buttonStyle(.filled)
+
+                    if let onWithdrawOtherCurrencies {
+                        Button("Withdraw Other Flipcash Currencies", action: onWithdrawOtherCurrencies)
+                            .buttonStyle(.subtle)
+                    }
                 }
-                .buttonStyle(.filled)
             }
             .padding(20)
         }

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
@@ -9,43 +9,29 @@ import SwiftUI
 import FlipcashUI
 import FlipcashCore
 
+/// Currency picker reached via the "Withdraw Other Flipcash Currencies" button
+/// on `WithdrawIntroScreen`. Lists every balance except USDF — USDF lives on
+/// the intro screen as the default destination, so it's removed from the
+/// picker to avoid two paths to the same flow.
 struct WithdrawScreen: View {
 
-    @Environment(AppRouter.self) private var router
     @Environment(Session.self) private var session
     @Environment(RatesController.self) private var ratesController
 
-    @State private var viewModel: WithdrawViewModel
-
-    private let container: Container
-    private let sessionContainer: SessionContainer
+    let onSelect: (ExchangedBalance) -> Void
 
     private var balances: [ExchangedBalance] {
         session.balances(for: ratesController.rateForBalanceCurrency())
+            .filter { $0.stored.mint != .usdf }
     }
-
-    // MARK: - Init -
-
-    init(container: Container, sessionContainer: SessionContainer) {
-        self.container        = container
-        self.sessionContainer = sessionContainer
-        self._viewModel       = State(wrappedValue: WithdrawViewModel(
-            container: container,
-            sessionContainer: sessionContainer
-        ))
-    }
-
-    // MARK: - Body -
 
     var body: some View {
         Background(color: .backgroundMain) {
             List {
                 Section {
                     ForEach(balances) { balance in
-                        CurrencyBalanceRow(
-                            exchangedBalance: balance
-                        ) {
-                            viewModel.selectCurrency(balance)
+                        CurrencyBalanceRow(exchangedBalance: balance) {
+                            onSelect(balance)
                         }
                     }
                 }
@@ -56,27 +42,15 @@ struct WithdrawScreen: View {
         }
         .navigationTitle("Select Currency")
         .toolbarTitleDisplayMode(.inline)
-        .withdrawSubstepDestinations(viewModel: viewModel)
-        .onAppear {
-            viewModel.pushSubstep = { step in
-                router.pushAny(step)
-            }
-            viewModel.onComplete = {
-                // Successful withdrawal: unwind the entire flow back to
-                // Settings root. Using `dismiss()` here would tear down the
-                // whole Settings sheet and land the user back at Scan.
-                router.popToRoot(on: .settings)
-            }
-        }
     }
 }
 
 extension View {
 
-    /// Registers the four `WithdrawNavigationPath` substeps on the enclosing
-    /// `NavigationStack`. Shared between `WithdrawScreen` (Settings entry —
-    /// picker first) and `PreselectedWithdrawRoot` (Wallet entry — picker
-    /// skipped), so both code paths render identical substep screens.
+    /// Registers the `WithdrawNavigationPath` substeps on the enclosing
+    /// `NavigationStack`. Applied at the root of every withdraw flow
+    /// (`PreselectedWithdrawRoot`), so every substep — picker, amount,
+    /// address, confirmation — resolves against the same view model.
     func withdrawSubstepDestinations(viewModel: WithdrawViewModel) -> some View {
         navigationDestination(for: WithdrawNavigationPath.self) { path in
             WithdrawSubstepDestination(path: path, viewModel: viewModel)
@@ -91,8 +65,8 @@ private struct WithdrawSubstepDestination: View {
 
     var body: some View {
         switch path {
-        case .intro:
-            WithdrawIntroScreen()
+        case .picker:
+            WithdrawScreen(onSelect: viewModel.selectCurrency)
                 .dialog(item: $viewModel.dialogItem)
         case .enterAmount:
             WithdrawAmountScreen(

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -12,7 +12,7 @@ import FlipcashUI
 @Observable
 class WithdrawViewModel {
     /// Pushes a sub-step onto the parent NavigationStack. Wired by
-    /// `WithdrawScreen` to call `router.pushAny(_:on: .settings)`.
+    /// `PreselectedWithdrawRoot.onAppear` to call `router.pushAny(_:)`.
     @ObservationIgnored var pushSubstep: (WithdrawNavigationPath) -> Void = { _ in }
 
     var withdrawButtonState: ButtonState = .normal
@@ -223,7 +223,6 @@ class WithdrawViewModel {
     /// Set by `WithdrawScreen` from `@Environment(\.dismiss)` once the view
     /// is on screen. Invoked by the success dialog to unwind the entire flow.
     @ObservationIgnored var onComplete: () -> Void = {}
-    @ObservationIgnored private let container: Container
     @ObservationIgnored private let client: Client
     @ObservationIgnored private let session: Session
     @ObservationIgnored private let ratesController: RatesController
@@ -231,7 +230,6 @@ class WithdrawViewModel {
     // MARK: - Init -
 
     init(container: Container, sessionContainer: SessionContainer) {
-        self.container       = container
         self.client          = container.client
         self.session         = sessionContainer.session
         self.ratesController = sessionContainer.ratesController
@@ -314,20 +312,34 @@ class WithdrawViewModel {
     // MARK: - Actions -
 
     func selectCurrency(_ balance: ExchangedBalance) {
-        let kindForBalance: WithdrawKind = balance.stored.mint == .usdf
+        setKind(for: balance)
+        pushEnterAmountScreen()
+    }
+
+    /// Intro screen's "Next" action. Re-syncs `kind` to USDF in case the user
+    /// drifted into the "Withdraw Other Flipcash Currencies" picker, picked a
+    /// non-USDF balance, then backed out to the intro — the intro screen
+    /// represents the USDF→USDC path, so a USDF-only kind is the contract here.
+    func continueFromIntro() {
+        if kind?.sourceMint != .usdf, let stored = session.balance(for: .usdf) {
+            let rate = ratesController.rateForBalanceCurrency()
+            setKind(for: stored.exchanged(with: rate))
+        }
+        pushEnterAmountScreen()
+    }
+
+    /// Sets `kind` from `balance` and clears per-flow inputs. Does NOT navigate;
+    /// `selectCurrency` is the action that advances the flow. Called from
+    /// `PreselectedWithdrawRoot.init` to pre-select the entry mint before
+    /// navigation closures are wired.
+    func setKind(for balance: ExchangedBalance) {
+        kind = balance.stored.mint == .usdf
             ? .usdfToUsdc(balance)
             : .sameMint(balance)
-        self.kind = kindForBalance
         enteredAmount = ""
         enteredAddress = ""
         destinationMetadata = nil
         withdrawButtonState = .normal
-
-        if kindForBalance.showsIntroScreen {
-            pushIntroScreen()
-        } else {
-            pushEnterAmountScreen()
-        }
     }
 
     func amountEnteredAction() {
@@ -460,10 +472,6 @@ class WithdrawViewModel {
 
     // MARK: - Navigation -
 
-    private func pushIntroScreen() {
-        pushSubstep(.intro)
-    }
-
     func pushEnterAmountScreen() {
         pushSubstep(.enterAmount)
     }
@@ -507,7 +515,7 @@ class WithdrawViewModel {
 }
 
 enum WithdrawNavigationPath {
-    case intro
+    case picker
     case enterAmount
     case enterAddress
     case confirmation
@@ -553,14 +561,6 @@ enum WithdrawKind: Equatable {
         switch self {
         case .sameMint:    return true
         case .usdfToUsdc:  return false
-        }
-    }
-
-    /// Whether the picker pushes the intro screen before amount entry.
-    var showsIntroScreen: Bool {
-        switch self {
-        case .sameMint:    return false
-        case .usdfToUsdc:  return true
         }
     }
 }

--- a/FlipcashTests/WithdrawViewModelTests.swift
+++ b/FlipcashTests/WithdrawViewModelTests.swift
@@ -388,8 +388,8 @@ struct WithdrawViewModelTests {
         #expect(viewModel.displayFee?.value == Decimal(string: "0.70"))
     }
 
-    @Test("selectCurrency pushes .intro substep for USDF balance")
-    func selectCurrency_usdfBalance_pushesIntroSubstep() {
+    @Test("selectCurrency pushes .enterAmount substep for USDF balance")
+    func selectCurrency_usdfBalance_pushesEnterAmountSubstep() {
         var pushed: [WithdrawNavigationPath] = []
         let viewModel = WithdrawViewModelTestHelpers.createViewModel()
         viewModel.pushSubstep = { pushed.append($0) }
@@ -397,7 +397,7 @@ struct WithdrawViewModelTests {
         let balance = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf)
         viewModel.selectCurrency(balance)
 
-        #expect(pushed == [.intro])
+        #expect(pushed == [.enterAmount])
     }
 
     @Test("selectCurrency pushes .enterAmount substep for non-USDF balance")
@@ -523,14 +523,6 @@ struct WithdrawKindTests {
         let usdf = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf)
         #expect(WithdrawKind.sameMint(bonded).acceptsTokenAccount == true)
         #expect(WithdrawKind.usdfToUsdc(usdf).acceptsTokenAccount == false)
-    }
-
-    @Test("showsIntroScreen: false for sameMint, true for usdfToUsdc")
-    func showsIntroScreen() {
-        let bonded = WithdrawViewModelTestHelpers.createBondedBalance()
-        let usdf = WithdrawViewModelTestHelpers.createExchangedBalance(mint: .usdf)
-        #expect(WithdrawKind.sameMint(bonded).showsIntroScreen == false)
-        #expect(WithdrawKind.usdfToUsdc(usdf).showsIntroScreen == true)
     }
 
 }

--- a/FlipcashUITests/Smoke/WithdrawSmokeTests.swift
+++ b/FlipcashUITests/Smoke/WithdrawSmokeTests.swift
@@ -1,0 +1,61 @@
+//
+//  WithdrawSmokeTests.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+final class WithdrawSmokeTests: BaseUITestCase {
+
+    override var requiresAuthentication: Bool { true }
+
+    /// Settings → Withdraw lands on the USDC education screen with USDF
+    /// pre-selected as the source, and exposes a subtle "Withdraw Other
+    /// Flipcash Currencies" escape hatch.
+    func testWithdraw_landsOnUSDCEducationScreenWithBothButtons() {
+        assertMainScreenReached()
+
+        openWithdrawFromSettings()
+
+        XCTAssertTrue(
+            app.staticTexts["Withdraw as USDC"].waitForExistence(timeout: 10),
+            "Expected the USDC education screen as the withdraw entry point"
+        )
+        XCTAssertTrue(app.buttons["Next"].exists, "Expected the primary Next button")
+        XCTAssertTrue(
+            app.buttons["Withdraw Other Flipcash Currencies"].exists,
+            "Expected the subtle 'Withdraw Other Flipcash Currencies' escape hatch below Next"
+        )
+    }
+
+    /// Tapping the escape hatch pushes the currency picker, and USDF is
+    /// absent from the list — USDF is reached exclusively via the intro
+    /// screen's Next button, so listing it in the picker would create two
+    /// paths to the same flow.
+    func testWithdraw_otherCurrenciesPickerHidesUSDF() {
+        assertMainScreenReached()
+
+        openWithdrawFromSettings()
+
+        waitAndTap(app.buttons["Withdraw Other Flipcash Currencies"])
+
+        XCTAssertTrue(
+            app.staticTexts["Select Currency"].waitForExistence(timeout: 10),
+            "Expected the 'Select Currency' picker after tapping the escape hatch"
+        )
+
+        // Picker rows have accessibility labels of the form "<name>, $<amount>".
+        // USDF is the only mint the picker is required to hide; any other
+        // mint listed here is account-dependent and not asserted on.
+        let usdfRow = app.buttons.matching(NSPredicate(format: "label BEGINSWITH 'USDF,'"))
+        XCTAssertEqual(usdfRow.count, 0, "USDF must not appear in the 'other currencies' picker")
+    }
+
+    // MARK: - Helpers
+
+    private func openWithdrawFromSettings() {
+        let settings = SettingsUIScreen(app: app)
+        settings.open(from: self)
+        waitAndTap(settings.withdrawButton)
+    }
+}


### PR DESCRIPTION
## Summary
Settings → Withdraw now lands on the USDC education screen with USDF pre-selected. A subtle "Withdraw Other Flipcash Currencies" button below Next pushes the currency picker, with USDF filtered out since it's already the default. The Wallet → USDF Currency Info entry is unchanged.

## Test plan
- [x] Settings → Withdraw lands on the USDC education screen with both buttons visible.
- [x] Tapping Next continues to USDF amount entry as before.
- [x] Tapping "Withdraw Other Flipcash Currencies" pushes the currency picker.
- [x] USDF is not present in the picker.
- [x] Picking a non-USDF balance goes to its amount entry.
- [x] Backing from amount → picker → intro, then tapping Next, lands on USDF amount entry (not the previously picked currency).
- [x] Wallet → USDF Currency Info → Withdraw still works with no escape hatch button.