### PR TITLE
fix: drop unused processing background mode

### DIFF
--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -85,7 +85,6 @@
 	<array>
 		<string>fetch</string>
 		<string>remote-notification</string>
-		<string>processing</string>
 	</array>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>


### PR DESCRIPTION
PR #294 removed the `BGTaskSchedulerPermittedIdentifiers` key as dead config but left the corresponding `processing` value inside `UIBackgroundModes`. App Store Connect rejects the binary at upload validation with code 90771 — the identifiers key is required whenever `processing` is declared.

No code in `Flipcash/`, `FlipcashCore/`, or `FlipcashUI/` uses `BGTaskScheduler`, `BGProcessingTaskRequest`, or the `com.flipcash.background.task` identifier, so dropping the `processing` mode is the right cleanup rather than restoring the identifier.

## Test plan
- [x] Archive validates against App Store Connect without code 90771