### PR TITLE
refactor: rename Give tab to Cash and reorder bottom bar

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -282,7 +282,7 @@ private struct LoadedContent: View {
                     .buttonStyle(.filled)
 
                     if balance.hasDisplayableValue {
-                        CodeButton(style: .filledSecondary, title: "Give") {
+                        CodeButton(style: .filledSecondary, title: "Cash") {
                             onGive()
                         }
 

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -282,7 +282,7 @@ private struct LoadedContent: View {
                     .buttonStyle(.filled)
 
                     if balance.hasDisplayableValue {
-                        CodeButton(style: .filledSecondary, title: "Cash") {
+                        CodeButton(style: .filledSecondary, title: "Give") {
                             onGive()
                         }
 

--- a/Flipcash/Core/Screens/Main/ScanBottomBar.swift
+++ b/Flipcash/Core/Screens/Main/ScanBottomBar.swift
@@ -15,7 +15,19 @@ struct ScanBottomBar: View {
     var body: some View {
         HStack(alignment: .bottom) {
             LargeButton(
-                title: "Give",
+                title: "Discover",
+                image: Image(.Icons.coins),
+                spacing: 12,
+                maxWidth: 80,
+                maxHeight: 80,
+                fullWidth: true,
+                aligment: .bottom,
+                action: onDiscover
+            )
+            .accessibilityIdentifier("scan-discover-button")
+
+            LargeButton(
+                title: "Cash",
                 image: .asset(.cash),
                 spacing: 12,
                 maxWidth: 80,
@@ -24,7 +36,7 @@ struct ScanBottomBar: View {
                 aligment: .bottom,
                 action: onGive
             )
-            .accessibilityIdentifier("scan-give-button")
+            .accessibilityIdentifier("scan-cash-button")
 
             ToastContainer(toast: toast) {
                 LargeButton(
@@ -39,18 +51,6 @@ struct ScanBottomBar: View {
                 )
                 .accessibilityIdentifier("scan-wallet-button")
             }
-
-            LargeButton(
-                title: "Discover",
-                image: Image(.Icons.coins),
-                spacing: 12,
-                maxWidth: 80,
-                maxHeight: 80,
-                fullWidth: true,
-                aligment: .bottom,
-                action: onDiscover
-            )
-            .accessibilityIdentifier("scan-discover-button")
         }
         .padding(.bottom, 10)
     }

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -21,9 +21,22 @@
 	<array>
 		<dict>
 			<key>UIApplicationShortcutItemType</key>
+			<string>com.flipcash.shortcut.discover</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Discover</string>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>binoculars</string>
+			<key>UIApplicationShortcutItemUserInfo</key>
+			<dict>
+				<key>url</key>
+				<string>flipcash://discover</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
 			<string>com.flipcash.shortcut.give</string>
 			<key>UIApplicationShortcutItemTitle</key>
-			<string>Give</string>
+			<string>Cash</string>
 			<key>UIApplicationShortcutItemIconSymbolName</key>
 			<string>banknote</string>
 			<key>UIApplicationShortcutItemUserInfo</key>
@@ -43,19 +56,6 @@
 			<dict>
 				<key>url</key>
 				<string>flipcash://balance</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>UIApplicationShortcutItemType</key>
-			<string>com.flipcash.shortcut.discover</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>Discover</string>
-			<key>UIApplicationShortcutItemIconSymbolName</key>
-			<string>binoculars</string>
-			<key>UIApplicationShortcutItemUserInfo</key>
-			<dict>
-				<key>url</key>
-				<string>flipcash://discover</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
## Summary
Renames the "Give" tab to "Cash" and reorders the bottom bar so it now reads Discover, Cash, Wallet. The Home Screen Quick Actions get the same rename and reorder so they line up with the in-app order.

Underlying flow, deeplink URL, and shortcut identifier are unchanged — this is purely a label and ordering pass, so existing pinned shortcuts and any shared links keep working. The "Give" label on the currency detail screen's secondary action button stays as-is.

## Test plan
- [x] Tab bar shows Discover, Cash, Wallet from left to right
- [x] Tapping Cash opens the same flow Give used to open
- [x] Long-pressing the app icon shows Discover, Cash, Wallet shortcuts, and the Cash shortcut opens the cash flow