### PR TITLE
test: backfill unit-test coverage for crypto, Solana, onramp, activity

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Solana/Programs/AssociatedTokenProgram.CreateIdempotent.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/Programs/AssociatedTokenProgram.CreateIdempotent.swift
@@ -19,6 +19,7 @@ extension AssociatedTokenProgram {
     ///   3. [] The token mint for the new associated token account
     ///   4. [] System program
     ///   5. [] SPL Token program
+    ///   6. [] Rent sysvar (legacy compatibility — accepted but unused by the modern processor)
     ///
     ///   Reference:
     ///   https://github.com/solana-labs/solana-program-library/blob/master/associated-token-account/program/src/processor.rs

--- a/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
@@ -1,0 +1,153 @@
+//
+//  ActivityProtoMappingTests.swift
+//  FlipcashCore
+//
+
+import Foundation
+import SwiftProtobuf
+import Testing
+import FlipcashAPI
+@testable import FlipcashCore
+
+@Suite("Activity proto → model mapping")
+struct ActivityProtoMappingTests {
+
+    private static let notificationId = Data((0..<32).map { Byte($0) })
+    private static let mintBytes = Data(repeating: 1, count: 32)
+    private static let vaultBytes = Data(repeating: 42, count: 32)
+
+    private static func basePaymentAmount() -> Flipcash_Common_V1_CryptoPaymentAmount {
+        var amount = Flipcash_Common_V1_CryptoPaymentAmount()
+        amount.currency = "usd"
+        amount.nativeAmount = 5.0
+        amount.quarks = 5_000_000
+        amount.mint.value = Self.mintBytes
+        return amount
+    }
+
+    private func baseNotification(
+        state: Flipcash_Activity_V1_NotificationState = .completed,
+        metadata: Flipcash_Activity_V1_Notification.OneOf_AdditionalMetadata? = nil,
+        timestampSeconds: Int64 = 1_700_000_000,
+    ) -> Flipcash_Activity_V1_Notification {
+        var proto = Flipcash_Activity_V1_Notification()
+        proto.id.value = Self.notificationId
+        proto.localizedText = "Test notification"
+        var ts = SwiftProtobuf.Google_Protobuf_Timestamp()
+        ts.seconds = timestampSeconds
+        proto.ts = ts
+        proto.state = state
+        proto.paymentAmount = Self.basePaymentAmount()
+        if let metadata { proto.additionalMetadata = metadata }
+        return proto
+    }
+
+    // MARK: Top-level fields
+
+    @Test("Localized text and timestamp pass through")
+    func textAndTimestamp() throws {
+        let proto = baseNotification(timestampSeconds: 1_700_000_000)
+        let activity = try Activity(proto)
+        #expect(activity.title == "Test notification")
+        #expect(activity.date == Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    @Test("Activity id is decoded from the proto bytes")
+    func idDecoded() throws {
+        let proto = baseNotification()
+        let activity = try Activity(proto)
+        #expect(activity.id.bytes == [Byte](Self.notificationId))
+    }
+
+    // MARK: State mapping
+    //
+    // `Flipcash_Activity_V1_NotificationState` is not `Sendable`, so it can't be
+    // passed via @Test arguments — three small tests instead of parameterization.
+
+    @Test("NOTIFICATION_STATE_UNKNOWN maps to .unknown")
+    func stateUnknown() throws {
+        let activity = try Activity(baseNotification(state: .unknown))
+        #expect(activity.state == .unknown)
+    }
+
+    @Test("NOTIFICATION_STATE_PENDING maps to .pending")
+    func statePending() throws {
+        let activity = try Activity(baseNotification(state: .pending))
+        #expect(activity.state == .pending)
+    }
+
+    @Test("NOTIFICATION_STATE_COMPLETED maps to .completed")
+    func stateCompleted() throws {
+        let activity = try Activity(baseNotification(state: .completed))
+        #expect(activity.state == .completed)
+    }
+
+    // MARK: Kind mapping — payload-less variants + nil (sentCrypto has its own test)
+
+    @Test("Notification metadata maps to Activity.Kind with no carried metadata", arguments: [
+        (
+            Flipcash_Activity_V1_Notification.OneOf_AdditionalMetadata.gaveCrypto(Flipcash_Activity_V1_GaveCryptoNotificationMetadata()),
+            Activity.Kind.gave,
+        ),
+        (
+            .receivedCrypto(Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata()),
+            .received,
+        ),
+        (
+            .withdrewCrypto(Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata()),
+            .withdrew,
+        ),
+        (
+            .depositedCrypto(Flipcash_Activity_V1_DepositedCryptoNotificationMetadata()),
+            .deposited,
+        ),
+        (
+            .boughtCrypto(Flipcash_Activity_V1_BoughtCryptoNotificationMetadata()),
+            .bought,
+        ),
+        (
+            .soldCrypto(Flipcash_Activity_V1_SoldCryptoNotificationMetadata()),
+            .sold,
+        ),
+    ] as [(Flipcash_Activity_V1_Notification.OneOf_AdditionalMetadata, Activity.Kind)])
+    func kindMappingWithoutPayload(
+        metadata: Flipcash_Activity_V1_Notification.OneOf_AdditionalMetadata,
+        expected: Activity.Kind,
+    ) throws {
+        let activity = try Activity(baseNotification(metadata: metadata))
+        #expect(activity.kind == expected)
+        #expect(activity.metadata == nil)
+    }
+
+    @Test("sentCrypto metadata maps to Kind.cashLink AND populates CashLinkMetadata")
+    func kindSentCashLink() throws {
+        var sent = Flipcash_Activity_V1_SentCryptoNotificationMetadata()
+        sent.vault.value = Self.vaultBytes
+        sent.canInitiateCancelAction = true
+
+        let activity = try Activity(baseNotification(metadata: .sentCrypto(sent)))
+        let expectedVault = try PublicKey(Self.vaultBytes)
+
+        #expect(activity.kind == .cashLink)
+        #expect(activity.metadata == .cashLink(.init(vault: expectedVault, canCancel: true)))
+    }
+
+    @Test("Missing additionalMetadata maps to Kind.unknown with no Metadata")
+    func kindUnknownWhenAbsent() throws {
+        let activity = try Activity(baseNotification(metadata: nil))
+        #expect(activity.kind == .unknown)
+        #expect(activity.metadata == nil)
+    }
+
+    // MARK: Behaviour difference from Android
+
+    @Test("Notification without a payment amount throws (iOS-specific behaviour vs Android's nullable amount)")
+    func missingPaymentAmountThrows() {
+        var proto = Flipcash_Activity_V1_Notification()
+        proto.id.value = Self.notificationId
+        proto.localizedText = "no amount"
+        #expect(throws: (any Error).self) {
+            _ = try Activity(proto)
+        }
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
@@ -139,14 +139,20 @@ struct ActivityProtoMappingTests {
         #expect(activity.metadata == nil)
     }
 
-    // MARK: Missing payment amount
+    // MARK: Invalid payment amount
 
-    @Test("Notification without a payment amount throws")
-    func missingPaymentAmountThrows() {
+    // proto3 always materialises `paymentAmount` as a default
+    // `CryptoPaymentAmount` (currency=""), so the failure surfaces at currency
+    // lookup. Pin the specific error type so a future refactor that reorders
+    // the validation inside `Activity.init` fails this test instead of silently
+    // throwing from a different site.
+
+    @Test("Default-empty CryptoPaymentAmount fails at currency lookup with CurrencyCode.Error")
+    func emptyCurrencyInPaymentAmountThrows() {
         var proto = Flipcash_Activity_V1_Notification()
         proto.id.value = Self.notificationId
         proto.localizedText = "no amount"
-        #expect(throws: (any Error).self) {
+        #expect(throws: CurrencyCode.Error.self) {
             _ = try Activity(proto)
         }
     }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
@@ -139,9 +139,9 @@ struct ActivityProtoMappingTests {
         #expect(activity.metadata == nil)
     }
 
-    // MARK: Behaviour difference from Android
+    // MARK: Missing payment amount
 
-    @Test("Notification without a payment amount throws (iOS-specific behaviour vs Android's nullable amount)")
+    @Test("Notification without a payment amount throws")
     func missingPaymentAmountThrows() {
         var proto = Flipcash_Activity_V1_Notification()
         proto.id.value = Self.notificationId

--- a/FlipcashCore/Tests/FlipcashCoreTests/AssociatedTokenProgramCreateIdempotentTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/AssociatedTokenProgramCreateIdempotentTests.swift
@@ -1,0 +1,85 @@
+//
+//  AssociatedTokenProgramCreateIdempotentTests.swift
+//  FlipcashCore
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("AssociatedTokenProgram.CreateIdempotent")
+struct AssociatedTokenProgramCreateIdempotentTests {
+
+    private static let subsidizer = try! PublicKey(base58: "cash11ndAmdKFEnG2wrQQ5Zqvr1kN9htxxLyoPLYFUV")
+    private static let owner      = try! PublicKey(base58: "JACkaKsm2Rd6TNJwH4UB7G6tHrWUATJPTgNNnRVsg4ip")
+    private static let address    = try! PublicKey(base58: "FNdBL7w2pRxBoz349ygKdWfGvrzPN6Wjcqu9mmVXjmcx")
+    private static let mint       = try! PublicKey(base58: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")  // USDC
+
+    private func makeInstance() -> AssociatedTokenProgram.CreateIdempotent {
+        .init(
+            subsidizer: Self.subsidizer,
+            address: Self.address,
+            owner: Self.owner,
+            mint: Self.mint,
+        )
+    }
+
+    @Test("encode() emits the 8-byte command discriminator and nothing else")
+    func encodingDataLayout() {
+        let encoded = makeInstance().encode()
+        #expect(encoded.count == AssociatedTokenProgram.Command.createIdempotent.rawValue.bytes.count)
+        #expect(Array(encoded) == AssociatedTokenProgram.Command.createIdempotent.rawValue.bytes)
+    }
+
+    @Test("instruction() lays out the 7 accounts: subsidizer (write+signer), ATA (write), owner, mint, system, token, rent")
+    func instructionAccountLayout() {
+        let ix = makeInstance().instruction()
+        #expect(ix.accounts.count == 7)
+
+        #expect(ix.accounts[0].publicKey == Self.subsidizer)
+        #expect(ix.accounts[0].isSigner == true)
+        #expect(ix.accounts[0].isWritable == true)
+
+        #expect(ix.accounts[1].publicKey == Self.address)
+        #expect(ix.accounts[1].isWritable == true)
+        #expect(ix.accounts[1].isSigner == false)
+
+        #expect(ix.accounts[2].publicKey == Self.owner)
+        #expect(ix.accounts[2].isWritable == false)
+
+        #expect(ix.accounts[3].publicKey == Self.mint)
+        #expect(ix.accounts[3].isWritable == false)
+
+        #expect(ix.accounts[4].publicKey == SystemProgram.address)
+        #expect(ix.accounts[5].publicKey == TokenProgram.address)
+        #expect(ix.accounts[6].publicKey == SysVar.rent.address)
+    }
+
+    @Test("instruction() targets the associated token program")
+    func instructionTargetsAtaProgram() {
+        let ix = makeInstance().instruction()
+        #expect(ix.program == AssociatedTokenProgram.address)
+    }
+
+    @Test("init(instruction:) round-trips all four key fields from a built instruction")
+    func decodeRoundTrip() throws {
+        let original = makeInstance()
+        let decoded = try AssociatedTokenProgram.CreateIdempotent(instruction: original.instruction())
+
+        #expect(decoded.subsidizer == Self.subsidizer)
+        #expect(decoded.address == Self.address)
+        #expect(decoded.owner == Self.owner)
+        #expect(decoded.mint == Self.mint)
+    }
+
+    @Test("Convenience init derives the ATA address from owner + mint")
+    func conveniencInitDerivesAddress() {
+        let derived = AssociatedTokenProgram.CreateIdempotent(
+            subsidizer: Self.subsidizer,
+            owner: Self.owner,
+            mint: Self.mint,
+        )
+        let expected = PublicKey.deriveAssociatedAccount(from: Self.owner, mint: Self.mint)!.publicKey
+        #expect(derived.address == expected)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/AssociatedTokenProgramCreateIdempotentTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/AssociatedTokenProgramCreateIdempotentTests.swift
@@ -24,11 +24,10 @@ struct AssociatedTokenProgramCreateIdempotentTests {
         )
     }
 
-    @Test("encode() emits the 8-byte command discriminator and nothing else")
+    @Test("encode() emits a 1-byte command discriminator with value 0x01")
     func encodingDataLayout() {
         let encoded = makeInstance().encode()
-        #expect(encoded.count == AssociatedTokenProgram.Command.createIdempotent.rawValue.bytes.count)
-        #expect(Array(encoded) == AssociatedTokenProgram.Command.createIdempotent.rawValue.bytes)
+        #expect(Array(encoded) == [0x01])
     }
 
     @Test("instruction() lays out the 7 accounts: subsidizer (write+signer), ATA (write), owner, mint, system, token, rent")

--- a/FlipcashCore/Tests/FlipcashCoreTests/HMACTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/HMACTests.swift
@@ -1,0 +1,97 @@
+//
+//  HMACTests.swift
+//  FlipcashCore
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("HMAC")
+struct HMACTests {
+
+    private func hexString(_ bytes: [Byte]) -> String {
+        bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @Test("RFC 4231 §4.2 — HMAC-SHA256", arguments: [
+        (
+            Data(repeating: 0x0b, count: 20),
+            Data("Hi There".utf8),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        ),
+    ] as [(Data, Data, String)])
+    func sha256Vectors(key: Data, message: Data, expectedHex: String) {
+        var hmac = HMAC(algorithm: .sha256, key: key)
+        hmac.update(message)
+        #expect(hexString(hmac.digestBytes()) == expectedHex)
+    }
+
+    @Test("RFC 4231 §4.3–4.4 — HMAC-SHA512", arguments: [
+        (
+            Data(repeating: 0x0b, count: 20),
+            Data("Hi There".utf8),
+            "87aa7cdea5ef619d4ff0b4241a1d6cb0" +
+            "2379f4e2ce4ec2787ad0b30545e17cde" +
+            "daa833b7d6b8a702038b274eaea3f4e4" +
+            "be9d914eeb61f1702e696c203a126854"
+        ),
+        (
+            Data("Jefe".utf8),
+            Data("what do ya want for nothing?".utf8),
+            "164b7a7bfcf819e2e395fbe73b56e0a3" +
+            "87bd64222e831fd610270cd7ea250554" +
+            "9758bf75c05a994a6d034f65f8f0e6fd" +
+            "caeab1a34d4a6b4b636e070a38bce737"
+        ),
+    ] as [(Data, Data, String)])
+    func sha512Vectors(key: Data, message: Data, expectedHex: String) {
+        var hmac = HMAC(algorithm: .sha512, key: key)
+        hmac.update(message)
+        #expect(hexString(hmac.digestBytes()) == expectedHex)
+    }
+
+    @Test("Streaming update produces the same digest as a single update")
+    func streamingMatchesSingle() {
+        let key = Data("secret".utf8)
+        let chunkA = Data("hello ".utf8)
+        let chunkB = Data("world".utf8)
+        let combined = chunkA + chunkB
+
+        var streamed = HMAC(algorithm: .sha256, key: key)
+        streamed.update(chunkA)
+        streamed.update(chunkB)
+        let streamedDigest = streamed.digestBytes()
+
+        var single = HMAC(algorithm: .sha256, key: key)
+        single.update(combined)
+        let singleDigest = single.digestBytes()
+
+        #expect(streamedDigest == singleDigest)
+    }
+
+    @Test("digestBytes() is repeatable without consuming the context")
+    func digestBytesIsRepeatable() {
+        var hmac = HMAC(algorithm: .sha256, key: Data("k".utf8))
+        hmac.update(Data("m".utf8))
+        let first = hmac.digestBytes()
+        let second = hmac.digestBytes()
+        #expect(first == second)
+    }
+
+    @Test("String update overload matches Data update overload")
+    func stringOverloadMatchesData() {
+        var a = HMAC(algorithm: .sha512, key: Data("k".utf8))
+        a.update("payload")
+        var b = HMAC(algorithm: .sha512, key: Data("k".utf8))
+        b.update(Data("payload".utf8))
+        #expect(a.digestBytes() == b.digestBytes())
+    }
+
+    @Test("digestData() and digestBytes() return equivalent bytes")
+    func digestDataMatchesBytes() {
+        var hmac = HMAC(algorithm: .sha256, key: Data("k".utf8))
+        hmac.update("m")
+        #expect(Array(hmac.digestData()) == hmac.digestBytes())
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/PBKDFTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/PBKDFTests.swift
@@ -1,0 +1,55 @@
+//
+//  PBKDFTests.swift
+//  FlipcashCore
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("PBKDF2")
+struct PBKDFTests {
+
+    private func hexString(_ bytes: [Byte]) -> String {
+        bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @Test("PBKDF2-HMAC-SHA512: password=\"password\", salt=\"salt\", rounds=1")
+    func pbkdf2_sha512_rounds1() {
+        let bytes = PBKDF.deriveKey(algorithm: .sha512, password: "password", salt: "salt", rounds: 1)
+        #expect(bytes.count == 64)
+        #expect(hexString(bytes) ==
+            "867f70cf1ade02cff3752599a3a53dc4" +
+            "af34c7a669815ae5d513554e1c8cf252" +
+            "c02d470a285a0501bad999bfe943c08f" +
+            "050235d7d68b1da55e63f73b60a57fce"
+        )
+    }
+
+    @Test("Rounds parameter affects output")
+    func pbkdf2_sha512_roundsAffectsOutput() {
+        let round1 = PBKDF.deriveKey(algorithm: .sha512, password: "password", salt: "salt", rounds: 1)
+        let round2 = PBKDF.deriveKey(algorithm: .sha512, password: "password", salt: "salt", rounds: 2)
+        #expect(round1 != round2)
+    }
+
+    @Test("PBKDF2-HMAC-SHA256 output is exactly 32 bytes")
+    func pbkdf2_sha256_digestLength() {
+        let bytes = PBKDF.deriveKey(algorithm: .sha256, password: "password", salt: "salt", rounds: 10)
+        #expect(bytes.count == 32)
+    }
+
+    @Test("Identical inputs produce identical output")
+    func pbkdf2_deterministic() {
+        let a = PBKDF.deriveKey(algorithm: .sha512, password: "p", salt: "s", rounds: 8)
+        let b = PBKDF.deriveKey(algorithm: .sha512, password: "p", salt: "s", rounds: 8)
+        #expect(a == b)
+    }
+
+    @Test("Different salts produce different outputs")
+    func pbkdf2_saltMatters() {
+        let a = PBKDF.deriveKey(algorithm: .sha512, password: "p", salt: "sa", rounds: 4)
+        let b = PBKDF.deriveKey(algorithm: .sha512, password: "p", salt: "sb", rounds: 4)
+        #expect(a != b)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/SHA256Tests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SHA256Tests.swift
@@ -1,0 +1,52 @@
+//
+//  SHA256Tests.swift
+//  FlipcashCore
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("SHA256")
+struct SHA256Tests {
+
+    private func hexString(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @Test("FIPS 180-2 short-message vectors", arguments: [
+        (
+            "abc",
+            "ba7816bf8f01cfea414140de5dae2223" +
+            "b00361a396177a9cb410ff61f20015ad"
+        ),
+        (
+            "",
+            "e3b0c44298fc1c149afbf4c8996fb924" +
+            "27ae41e4649b934ca495991b7852b855"
+        ),
+    ])
+    func fips180_2_vectors(input: String, expectedHex: String) {
+        #expect(hexString(SHA256.digest(input)) == expectedHex)
+    }
+
+    @Test("Streaming update is bit-equivalent to a single update")
+    func streaming() {
+        var streamed = SHA256()
+        streamed.update("hello ")
+        streamed.update("world")
+        let streamedDigest = streamed.digestBytes()
+
+        let oneShot = SHA256.digest("hello world")
+        #expect(Array(oneShot) == streamedDigest)
+    }
+
+    @Test("Digest output is always 32 bytes regardless of input size", arguments: [
+        Data(),
+        Data("a".utf8),
+        Data(repeating: 0xff, count: 1024),
+    ])
+    func digestLength(input: Data) {
+        #expect(SHA256.digest(input).count == 32)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/SHA512Tests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SHA512Tests.swift
@@ -1,0 +1,56 @@
+//
+//  SHA512Tests.swift
+//  FlipcashCore
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("SHA512")
+struct SHA512Tests {
+
+    private func hexString(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @Test("FIPS 180-2 short-message vectors", arguments: [
+        (
+            "abc",
+            "ddaf35a193617abacc417349ae204131" +
+            "12e6fa4e89a97ea20a9eeee64b55d39a" +
+            "2192992a274fc1a836ba3c23a3feebbd" +
+            "454d4423643ce80e2a9ac94fa54ca49f"
+        ),
+        (
+            "",
+            "cf83e1357eefb8bdf1542850d66d8007" +
+            "d620e4050b5715dc83f4a921d36ce9ce" +
+            "47d0d13c5d85f2b0ff8318d2877eec2f" +
+            "63b931bd47417a81a538327af927da3e"
+        ),
+    ])
+    func fips180_2_vectors(input: String, expectedHex: String) {
+        #expect(hexString(SHA512.digest(input)) == expectedHex)
+    }
+
+    @Test("Streaming update is bit-equivalent to a single update")
+    func streaming() {
+        var streamed = SHA512()
+        streamed.update("hello ")
+        streamed.update("world")
+        let streamedDigest = streamed.digestBytes()
+
+        let oneShot = SHA512.digest("hello world")
+        #expect(Array(oneShot) == streamedDigest)
+    }
+
+    @Test("Digest output is always 64 bytes regardless of input size", arguments: [
+        Data(),
+        Data("a".utf8),
+        Data(repeating: 0xff, count: 1024),
+    ])
+    func digestLength(input: Data) {
+        #expect(SHA512.digest(input).count == 64)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/SystemProgramAdvanceNonceTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SystemProgramAdvanceNonceTests.swift
@@ -17,12 +17,10 @@ struct SystemProgramAdvanceNonceTests {
         .init(nonce: Self.nonce, authority: Self.authority)
     }
 
-    @Test("encode() emits the 4-byte advanceNonceAccount command")
+    @Test("encode() emits the advanceNonceAccount discriminator: UInt32(4) little-endian")
     func encodingDataLayout() {
         let encoded = makeInstance().encode()
-        let expectedBytes = SystemProgram.Command.advanceNonceAccount.rawValue.bytes
-        #expect(encoded.count == expectedBytes.count)
-        #expect(Array(encoded) == expectedBytes)
+        #expect(Array(encoded) == [0x04, 0x00, 0x00, 0x00])
     }
 
     @Test("instruction() targets the system program with 3 accounts: nonce, recentBlockhashes sysvar, authority signer")

--- a/FlipcashCore/Tests/FlipcashCoreTests/SystemProgramAdvanceNonceTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SystemProgramAdvanceNonceTests.swift
@@ -1,0 +1,50 @@
+//
+//  SystemProgramAdvanceNonceTests.swift
+//  FlipcashCore
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("SystemProgram.AdvanceNonce")
+struct SystemProgramAdvanceNonceTests {
+
+    private static let nonce     = try! PublicKey(base58: "JACkaKsm2Rd6TNJwH4UB7G6tHrWUATJPTgNNnRVsg4ip")
+    private static let authority = try! PublicKey(base58: "cash11ndAmdKFEnG2wrQQ5Zqvr1kN9htxxLyoPLYFUV")
+
+    private func makeInstance() -> SystemProgram.AdvanceNonce {
+        .init(nonce: Self.nonce, authority: Self.authority)
+    }
+
+    @Test("encode() emits the 4-byte advanceNonceAccount command")
+    func encodingDataLayout() {
+        let encoded = makeInstance().encode()
+        let expectedBytes = SystemProgram.Command.advanceNonceAccount.rawValue.bytes
+        #expect(encoded.count == expectedBytes.count)
+        #expect(Array(encoded) == expectedBytes)
+    }
+
+    @Test("instruction() targets the system program with 3 accounts: nonce, recentBlockhashes sysvar, authority signer")
+    func instructionAccountLayout() {
+        let ix = makeInstance().instruction()
+        #expect(ix.program == SystemProgram.address)
+        #expect(ix.accounts.count == 3)
+
+        #expect(ix.accounts[0].publicKey == Self.nonce)
+        #expect(ix.accounts[0].isWritable == true)
+
+        #expect(ix.accounts[1].publicKey == SysVar.recentBlockhashes.address)
+        #expect(ix.accounts[1].isWritable == false)
+
+        #expect(ix.accounts[2].publicKey == Self.authority)
+        #expect(ix.accounts[2].isSigner == true)
+    }
+
+    @Test("init(instruction:) round-trips nonce and authority (sysvar at index 1 is intentionally skipped)")
+    func decodeRoundTrip() throws {
+        let original = makeInstance()
+        let decoded = try SystemProgram.AdvanceNonce(instruction: original.instruction())
+        #expect(decoded == original)
+    }
+}

--- a/FlipcashTests/Onramp/OnrampOrderRequestTests.swift
+++ b/FlipcashTests/Onramp/OnrampOrderRequestTests.swift
@@ -1,0 +1,125 @@
+//
+//  OnrampOrderRequestTests.swift
+//  Flipcash
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@Suite("OnrampOrderRequest JSON encoding")
+struct OnrampOrderRequestTests {
+
+    private static let destination = try! PublicKey(base58: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")
+
+    private func makeRequest(
+        purchaseAmount: String = "10.00",
+        paymentCurrency: String = "USD",
+        purchaseCurrency: String? = "USDF",
+        isQuote: Bool = false,
+    ) -> OnrampOrderRequest {
+        OnrampOrderRequest(
+            purchaseAmount: purchaseAmount,
+            paymentCurrency: paymentCurrency,
+            purchaseCurrency: purchaseCurrency,
+            isQuote: isQuote,
+            destinationAddress: Self.destination,
+            email: "buyer@example.com",
+            phoneNumber: "+15555550123",
+            partnerOrderRef: "order-ref-1",
+            partnerUserRef: "user-ref-1",
+            phoneNumberVerifiedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            agreementAcceptedAt: Date(timeIntervalSince1970: 1_700_000_100),
+        )
+    }
+
+    private func encode(_ request: OnrampOrderRequest) throws -> [String: Any] {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(request)
+        return try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    }
+
+    @Test("destinationNetwork is hardcoded to \"solana\"")
+    func destinationNetworkHardcoded() throws {
+        let json = try encode(makeRequest())
+        #expect(json["destinationNetwork"] as? String == "solana")
+    }
+
+    @Test("paymentMethod is hardcoded to GUEST_CHECKOUT_APPLE_PAY")
+    func paymentMethodHardcoded() throws {
+        let json = try encode(makeRequest())
+        #expect(json["paymentMethod"] as? String == "GUEST_CHECKOUT_APPLE_PAY")
+    }
+
+    @Test("destinationAddress is encoded as the base58 form of the PublicKey")
+    func destinationAddressIsBase58() throws {
+        let json = try encode(makeRequest())
+        #expect(json["destinationAddress"] as? String == Self.destination.base58)
+    }
+
+    @Test("All required wire-contract fields are present")
+    func allRequiredKeysPresent() throws {
+        let json = try encode(makeRequest())
+        let required: [String] = [
+            "purchaseAmount",
+            "paymentCurrency",
+            "purchaseCurrency",
+            "isQuote",
+            "destinationAddress",
+            "destinationNetwork",
+            "email",
+            "phoneNumber",
+            "partnerOrderRef",
+            "partnerUserRef",
+            "phoneNumberVerifiedAt",
+            "agreementAcceptedAt",
+            "paymentMethod",
+        ]
+        for key in required {
+            #expect(json.keys.contains(key), "Missing key: \(key)")
+        }
+    }
+
+    @Test("Timestamp fields encode as non-empty ISO 8601 strings")
+    func timestampsAreIso8601Strings() throws {
+        let json = try encode(makeRequest())
+        let verifiedAt = json["phoneNumberVerifiedAt"] as? String
+        let acceptedAt = json["agreementAcceptedAt"] as? String
+        #expect(verifiedAt?.isEmpty == false)
+        #expect(acceptedAt?.isEmpty == false)
+        #expect(verifiedAt?.contains("T") == true)
+        #expect(verifiedAt?.hasSuffix("Z") == true)
+    }
+
+    @Test("purchaseCurrency is omitted from the JSON when nil")
+    func purchaseCurrencyNilOmitted() throws {
+        let json = try encode(makeRequest(purchaseCurrency: nil))
+        #expect(json["purchaseCurrency"] == nil)
+    }
+
+    @Test("Caller-supplied amounts and refs round-trip verbatim")
+    func userInputsPassThrough() throws {
+        let request = makeRequest(purchaseAmount: "42.75", paymentCurrency: "USD")
+        let json = try encode(request)
+        #expect(json["purchaseAmount"] as? String == "42.75")
+        #expect(json["paymentCurrency"] as? String == "USD")
+        #expect(json["email"] as? String == "buyer@example.com")
+        #expect(json["phoneNumber"] as? String == "+15555550123")
+        #expect(json["partnerOrderRef"] as? String == "order-ref-1")
+        #expect(json["partnerUserRef"] as? String == "user-ref-1")
+    }
+
+    @Test("isQuote defaults to false")
+    func isQuoteDefaultsFalse() throws {
+        let json = try encode(makeRequest())
+        #expect(json["isQuote"] as? Bool == false)
+    }
+
+    @Test("isQuote = true is encoded as true")
+    func isQuoteTrueRoundtrip() throws {
+        let json = try encode(makeRequest(isQuote: true))
+        #expect(json["isQuote"] as? Bool == true)
+    }
+}

--- a/FlipcashTests/Onramp/OnrampOrderRequestTests.swift
+++ b/FlipcashTests/Onramp/OnrampOrderRequestTests.swift
@@ -82,15 +82,15 @@ struct OnrampOrderRequestTests {
         }
     }
 
-    @Test("Timestamp fields encode as non-empty ISO 8601 strings")
+    @Test("Both timestamp fields encode as ISO 8601 strings with T separator and Z UTC suffix")
     func timestampsAreIso8601Strings() throws {
         let json = try encode(makeRequest())
-        let verifiedAt = json["phoneNumberVerifiedAt"] as? String
-        let acceptedAt = json["agreementAcceptedAt"] as? String
-        #expect(verifiedAt?.isEmpty == false)
-        #expect(acceptedAt?.isEmpty == false)
-        #expect(verifiedAt?.contains("T") == true)
-        #expect(verifiedAt?.hasSuffix("Z") == true)
+        let verifiedAt = try #require(json["phoneNumberVerifiedAt"] as? String)
+        let acceptedAt = try #require(json["agreementAcceptedAt"] as? String)
+        #expect(verifiedAt.contains("T"))
+        #expect(verifiedAt.hasSuffix("Z"))
+        #expect(acceptedAt.contains("T"))
+        #expect(acceptedAt.hasSuffix("Z"))
     }
 
     @Test("purchaseCurrency is omitted from the JSON when nil")


### PR DESCRIPTION
## Summary
Backfills unit-test coverage for four areas that had no direct tests on iOS: encryption primitives, Solana instruction encoding, the Coinbase onramp request body, and the activity feed proto-to-model mapping. Each area gets a dedicated suite that pins behaviour against published cryptographic vectors or explicit wire bytes so future regressions surface immediately. No production behaviour changes apart from a doc-comment correction on the associated-token-program create-idempotent instruction.

## Test plan
- [x] HMAC, SHA256, SHA512, PBKDF2 suites pass against RFC 4231 and FIPS 180-2 vectors
- [x] Associated-token-program create-idempotent suite passes (account layout, encode bytes, decode round-trip)
- [x] System-program advance-nonce suite passes (account layout, encode bytes, decode round-trip)
- [x] Coinbase onramp request encoding suite passes (hardcoded constants, required keys, ISO 8601 timestamps, base58 address)
- [x] Activity proto-to-model mapping suite passes (all seven notification metadata variants, state mapping, empty-payment-amount throw path)
- [ ] Full AllTargets suite passes locally