### PR TITLE
fix: stop reporting cold-resume RPC timeouts from USDC sweep

### DIFF
--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -1323,7 +1323,7 @@ class Session {
                     delay: .milliseconds(500),
                     shouldRetry: { error in
                         guard let e = error as? ErrorFetchBalance else { return false }
-                        return e == .notFound || e == .unknown
+                        return e == .notFound || e == .unknown || e == .transportFailure
                     }
                 ) {
                     try await client.fetchAccountInfo(

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient.swift
@@ -62,10 +62,8 @@ public class FlipClient: ObservableObject {
 
     /// Pre-warm the gRPC channel by triggering a lightweight unauthenticated
     /// call. Forces TCP+TLS reconnection if the underlying socket died during
-    /// backgrounding. Without this, the first call on the cold channel after
-    /// foregrounding tends to surface as a `GRPCStatus.Code.internalError`
-    /// with an empty message, which the caller can't distinguish from a real
-    /// server error.
+    /// backgrounding so the next caller-initiated RPC doesn't pay the full
+    /// reconnect cost against its own deadline.
     /// The response is irrelevant — we only need the channel to start connecting.
     public func warmUpChannel() {
         accountService.fetchUnauthenticatedUserFlags { result in

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
@@ -93,7 +93,7 @@ final class AccountInfoService: CodeService<Ocp_Account_V1_AccountNIOClient> {
             case .notFound:
                 // No ATA for this mint yet — caller treats as zero balance.
                 completion(.success(nil))
-            case .unknown, .accountNotInList, .parseFailed:
+            case .unknown, .accountNotInList, .parseFailed, .transportFailure:
                 logger.error("Failed to fetch associated token account", metadata: [
                     "owner": "\(owner.publicKey.base58)",
                     "mint": "\(mint.base58)",
@@ -161,12 +161,13 @@ public enum ErrorFetchBalance: Int, Error, Equatable, Sendable {
     case unknown          = -1
     case accountNotInList = -2
     case parseFailed      = -3
+    case transportFailure = -4
 }
 
 extension ErrorFetchBalance: ServerError {
     public var isReportable: Bool {
         switch self {
-        case .ok, .notFound, .accountNotInList: false
+        case .ok, .notFound, .accountNotInList, .transportFailure: false
         case .unknown, .parseFailed: true
         }
     }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
@@ -60,12 +60,12 @@ final class AccountInfoService: CodeService<Ocp_Account_V1_AccountNIOClient> {
                 logger.error("Failed to fetch account info", metadata: ["owner": "\(owner.publicKey.base58)"])
                 completion(.failure(error))
             }
-            
+
         } failure: { error in
-            completion(.failure(.unknown))
+            completion(.failure(.from(transportError: error)))
         }
     }
-    
+
     /// Fetches the user's plain SPL associated token account for a specific
     /// mint via `GetTokenAccountInfos` with a server-side mint filter. Returns
     /// `nil` when no ATA exists yet (e.g. the user has never received this
@@ -100,8 +100,8 @@ final class AccountInfoService: CodeService<Ocp_Account_V1_AccountNIOClient> {
                 ])
                 completion(.failure(error))
             }
-        } failure: { _ in
-            completion(.failure(.unknown))
+        } failure: { error in
+            completion(.failure(.from(transportError: error)))
         }
     }
 
@@ -131,7 +131,7 @@ final class AccountInfoService: CodeService<Ocp_Account_V1_AccountNIOClient> {
             }
 
         } failure: { error in
-            completion(.failure(.unknown))
+            completion(.failure(.from(transportError: error)))
         }
     }
 

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
@@ -174,17 +174,12 @@ extension ErrorFetchBalance: ServerError {
 }
 
 extension ErrorFetchBalance {
-    /// Classifies a gRPC failure status. Transient transport conditions
-    /// (timeout, unavailable, cancelled) map to `.transportFailure` so
-    /// callers don't ship cold-resume noise to Bugsnag; anything else
-    /// preserves the legacy `.unknown` behavior.
+    /// Classifies a gRPC failure status. Transient network conditions
+    /// (per `GRPCStatus.Code.isTransientNetworkError`) map to
+    /// `.transportFailure` so callers don't ship cold-resume noise to
+    /// Bugsnag; anything else preserves the legacy `.unknown` behavior.
     public static func from(transportError: GRPCStatus) -> ErrorFetchBalance {
-        switch transportError.code {
-        case .deadlineExceeded, .unavailable, .cancelled:
-            return .transportFailure
-        default:
-            return .unknown
-        }
+        transportError.code.isTransientNetworkError ? .transportFailure : .unknown
     }
 }
 

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
@@ -173,6 +173,21 @@ extension ErrorFetchBalance: ServerError {
     }
 }
 
+extension ErrorFetchBalance {
+    /// Classifies a gRPC failure status. Transient transport conditions
+    /// (timeout, unavailable, cancelled) map to `.transportFailure` so
+    /// callers don't ship cold-resume noise to Bugsnag; anything else
+    /// preserves the legacy `.unknown` behavior.
+    public static func from(transportError: GRPCStatus) -> ErrorFetchBalance {
+        switch transportError.code {
+        case .deadlineExceeded, .unavailable, .cancelled:
+            return .transportFailure
+        default:
+            return .unknown
+        }
+    }
+}
+
 // MARK: - Interceptors -
 
 extension InterceptorFactory: Ocp_Account_V1_AccountClientInterceptorFactoryProtocol {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -1052,10 +1052,7 @@ extension ErrorSubmitIntent: ServerError {
     public var isTransientNetworkError: Bool {
         switch self {
         case .grpcStatus(let status):
-            switch status.code {
-            case .deadlineExceeded, .unavailable: true
-            default: false
-            }
+            status.code.isTransientNetworkError
         case .denied, .invalidIntent, .signatureError, .staleState, .unknown, .deviceTokenUnavailable, .grpcError:
             false
         }

--- a/FlipcashCore/Sources/FlipcashCore/Extensions/GRPCStatus+Extensions.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Extensions/GRPCStatus+Extensions.swift
@@ -1,0 +1,20 @@
+//
+//  GRPCStatus+Extensions.swift
+//  FlipcashCore
+//
+
+import GRPC
+
+extension GRPCStatus.Code {
+
+    /// Whether the code represents a transient network condition (deadline
+    /// expired or channel unavailable). Excludes `.cancelled`, `.aborted`,
+    /// and `.unknown` by design — those stay reportable so app cancellations
+    /// and server aborts remain visible in error tracking.
+    public var isTransientNetworkError: Bool {
+        switch self {
+        case .deadlineExceeded, .unavailable: true
+        default: false
+        }
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Extensions/UnaryCall+Extensions.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Extensions/UnaryCall+Extensions.swift
@@ -15,15 +15,20 @@ extension UnaryCall {
     func handle(on queue: DispatchQueue, function: String = #function, success: @Sendable @escaping (ResponsePayload) -> Void, failure: @Sendable @escaping (GRPC.GRPCStatus) -> Void) {
         response.whenSuccessBlocking(onto: queue, success)
         response.whenFailureBlocking(onto: queue) { error in
-            if let typedError = error as? GRPC.GRPCStatus {
-                let message = typedError.message ?? "'no-message'"
-                let code = typedError.code.description
+            // Route through GRPCStatusTransformable when available so NIO and
+            // gRPC transport errors carry the correct code (timeouts →
+            // .deadlineExceeded, closed channels → .unavailable, etc.).
+            // GRPCStatus itself conforms and returns self, so typed-status
+            // errors flow through the same path. Only truly unrelated error
+            // types fall back to .processingError.
+            if let transformable = error as? GRPCStatusTransformable {
+                let status = transformable.makeGRPCStatus()
                 logger.error("gRPC call failed", metadata: [
                     "function": "\(function)",
-                    "code": "\(code)",
-                    "message": "\(message)"
+                    "code": "\(status.code.description)",
+                    "message": "\(status.message ?? "'no-message'")"
                 ])
-                failure(typedError)
+                failure(status)
             } else {
                 logger.error("gRPC call failed with unexpected error type", metadata: [
                     "function": "\(function)",

--- a/FlipcashTests/Regressions/Regression_6a10ebf.swift
+++ b/FlipcashTests/Regressions/Regression_6a10ebf.swift
@@ -49,4 +49,15 @@ struct Regression_6a10ebf {
         let status = GRPCStatus(code: code, message: nil)
         #expect(ErrorFetchBalance.from(transportError: status) == expected)
     }
+
+    @Test("GRPCError.RPCTimedOut routes through .transportFailure end-to-end")
+    func rpcTimedOut_routesThroughTransportFailure() {
+        let timeout = GRPCError.RPCTimedOut(.deadline(.now()))
+        let status = timeout.makeGRPCStatus()
+        let mapped = ErrorFetchBalance.from(transportError: status)
+
+        #expect(status.code == .deadlineExceeded)
+        #expect(mapped == .transportFailure)
+        #expect(mapped.isReportable == false)
+    }
 }

--- a/FlipcashTests/Regressions/Regression_6a10ebf.swift
+++ b/FlipcashTests/Regressions/Regression_6a10ebf.swift
@@ -40,7 +40,7 @@ struct Regression_6a10ebf {
     @Test("gRPC transport errors map to the right ErrorFetchBalance case", arguments: [
         (GRPCStatus.Code.deadlineExceeded, ErrorFetchBalance.transportFailure),
         (GRPCStatus.Code.unavailable,      ErrorFetchBalance.transportFailure),
-        (GRPCStatus.Code.cancelled,        ErrorFetchBalance.transportFailure),
+        (GRPCStatus.Code.cancelled,        ErrorFetchBalance.unknown),
         (GRPCStatus.Code.invalidArgument,  ErrorFetchBalance.unknown),
         (GRPCStatus.Code.permissionDenied, ErrorFetchBalance.unknown),
         (GRPCStatus.Code.internalError,    ErrorFetchBalance.unknown),

--- a/FlipcashTests/Regressions/Regression_6a10ebf.swift
+++ b/FlipcashTests/Regressions/Regression_6a10ebf.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import Testing
+import GRPC
 import FlipcashCore
 
 @Suite("Regression: 6a10ebf – USDC sweep no longer reports cold-resume RPC timeouts", .bug("6a10ebfc8c3285d1a545d656"))
@@ -34,5 +35,18 @@ struct Regression_6a10ebf {
     ])
     func reportability(error: ErrorFetchBalance, expected: Bool) {
         #expect(error.isReportable == expected)
+    }
+
+    @Test("gRPC transport errors map to the right ErrorFetchBalance case", arguments: [
+        (GRPCStatus.Code.deadlineExceeded, ErrorFetchBalance.transportFailure),
+        (GRPCStatus.Code.unavailable,      ErrorFetchBalance.transportFailure),
+        (GRPCStatus.Code.cancelled,        ErrorFetchBalance.transportFailure),
+        (GRPCStatus.Code.invalidArgument,  ErrorFetchBalance.unknown),
+        (GRPCStatus.Code.permissionDenied, ErrorFetchBalance.unknown),
+        (GRPCStatus.Code.internalError,    ErrorFetchBalance.unknown),
+    ])
+    func transportErrorMapping(code: GRPCStatus.Code, expected: ErrorFetchBalance) {
+        let status = GRPCStatus(code: code, message: nil)
+        #expect(ErrorFetchBalance.from(transportError: status) == expected)
     }
 }

--- a/FlipcashTests/Regressions/Regression_6a10ebf.swift
+++ b/FlipcashTests/Regressions/Regression_6a10ebf.swift
@@ -1,0 +1,38 @@
+//
+//  Regression_6a10ebf.swift
+//  Flipcash
+//
+//  Symptom:  UsdcSweepOperation fires on every scenePhase → active. After a
+//            long background the gRPC channel needs to reconnect; the unary
+//            15s deadline expires first and AccountInfoService's failure
+//            callbacks collapse the timeout into ErrorFetchBalance.unknown,
+//            which is reportable. Result: a Bugsnag report per cold resume
+//            that misrepresents a transport timeout as a server "unknown".
+//
+//  Fix:      Add ErrorFetchBalance.transportFailure (isReportable: false) and
+//            a static `from(transportError:)` helper that classifies gRPC
+//            timeout / unavailable / cancelled into it. AccountInfoService's
+//            three failure callbacks route through the helper. ErrorReporting
+//            already honors ServerError.isReportable, so the sweep catch
+//            suppresses these reports automatically.
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+
+@Suite("Regression: 6a10ebf – USDC sweep no longer reports cold-resume RPC timeouts", .bug("6a10ebfc8c3285d1a545d656"))
+struct Regression_6a10ebf {
+
+    @Test("ErrorFetchBalance reportability is correct for every case", arguments: [
+        (ErrorFetchBalance.ok,               false),
+        (ErrorFetchBalance.notFound,         false),
+        (ErrorFetchBalance.accountNotInList, false),
+        (ErrorFetchBalance.unknown,          true),
+        (ErrorFetchBalance.parseFailed,      true),
+        (ErrorFetchBalance.transportFailure, false),
+    ])
+    func reportability(error: ErrorFetchBalance, expected: Bool) {
+        #expect(error.isReportable == expected)
+    }
+}


### PR DESCRIPTION
## Summary

After a long background, the gRPC channel can take longer than 15 seconds to reconnect, and the USDC sweep's first request times out before the channel is ready. The underlying timeout was being collapsed into a generic internal error and surfaced as a misleading Bugsnag report. The handler that bridges raw network errors into gRPC statuses now uses the framework's canonical conversion so timeouts and dropped connections carry the correct code, and the account-info service maps those transient transport failures to a non-reportable case via a shared classifier that also backs the existing transaction-submission path. The cash-link retry path was updated to pick up the new transient case so its cold-resume retry-then-succeed behaviour is preserved.

## Test plan

- [x] Regression suite passes
- [x] AllTargets passes
- [x] Background the app for 15+ minutes on a slow network, then foreground; confirm no Bugsnag report fires
- [x] Cold-resume cash-link scan still completes successfully