### PR TITLE
feat: USDF label and Solana icon on deposit screen

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -137,7 +137,7 @@ struct DestinationView: View {
                         mint: mint,
                         timeAuthority: vmAuthority
                     ).depositPublicKey.base58,
-                    name: balance.name
+                    name: mint == .usdf ? balance.symbol : balance.name
                 )
             }
 

--- a/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
+++ b/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
@@ -185,8 +185,7 @@ private struct AmountLabel: View {
                 Text(amount.formatted())
                     .font(.appTextCaption)
                     .foregroundStyle(Color.textSecondary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
+                    .padding(4)
                     .overlay(
                         RoundedRectangle(cornerRadius: 5)
                             .inset(by: 0.5)

--- a/Flipcash/Core/Screens/Settings/Deposit/DepositCurrencyListScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Deposit/DepositCurrencyListScreen.swift
@@ -51,6 +51,7 @@ struct DepositCurrencyListScreen: View {
                     }
                 }
                 .listRowInsets(EdgeInsets())
+                .listSectionSeparator(.hidden, edges: .top)
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)

--- a/Flipcash/Core/Screens/Settings/Deposit/DepositScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Deposit/DepositScreen.swift
@@ -32,7 +32,7 @@ struct DepositScreen: View {
                 Button {
                     copyAddress()
                 } label: {
-                    ImmutableField(address)
+                    ImmutableField(address, leadingIcon: Image(.Icons.solana))
                 }
 
                 Spacer()

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
@@ -53,6 +53,7 @@ struct WithdrawScreen: View {
                         }
                     }
                     .listRowInsets(EdgeInsets())
+                    .listSectionSeparator(.hidden, edges: .top)
                 }
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)

--- a/FlipcashUI/Sources/FlipcashUI/Views/ImmutableField.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/ImmutableField.swift
@@ -9,30 +9,25 @@
 import SwiftUI
 
 public struct ImmutableField: View {
-    
+
     private var content: String
     private var state: State?
-    private var configuration: Configuration
-    
-    public init(_ content: String, state: State? = nil, configuration: Configuration = .default) {
+    private var leadingIcon: Image?
+
+    public init(_ content: String, leadingIcon: Image? = nil, state: State? = nil) {
         self.content = content
+        self.leadingIcon = leadingIcon
         self.state = state
-        self.configuration = configuration
     }
-    
+
     public var body: some View {
         InputContainer {
             HStack(spacing: 2) {
-                Group {
-                    switch configuration {
-                    case .default:
-                        Text(content)
-                            .truncationMode(.middle)
-                            .lineLimit(1)
-                    }
-                }
-                .frame(minHeight: 26)
-                
+                Text(content)
+                    .truncationMode(.middle)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, minHeight: 26, alignment: .leading)
+
                 if let state = state {
                     Spacer()
                     state.image
@@ -42,8 +37,22 @@ public struct ImmutableField: View {
                 }
             }
             .padding(15)
+            // 29pt extra leading clears the 18×14 icon at 15pt inset (icon's
+            // right edge = 33pt; content starts at 15 + 29 = 44pt → 11pt gap).
+            // If the icon geometry changes, this offset must change in lockstep.
+            .padding(.leading, leadingIcon != nil ? 29 : 0)
             .font(.appTextMedium)
             .foregroundStyle(.textMain)
+            .overlay(alignment: .leading) {
+                if let leadingIcon {
+                    leadingIcon
+                        .resizable()
+                        .frame(width: 18, height: 14)
+                        .padding(.leading, 15)
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
+            }
         }
     }
 }
@@ -73,14 +82,6 @@ public extension ImmutableField {
                 return .textSecondary
             }
         }
-    }
-}
-
-// MARK: - Configuration -
-
-extension ImmutableField {
-    public enum Configuration {
-        case `default`
     }
 }
 


### PR DESCRIPTION
## Summary
Carries the USDF symbol override from the deposit currency picker into the address screen, so the title and description say "USDF" instead of "USD on Flipcash". Adds the Solana chain icon to the deposit address field to match the Withdraw flow, and removes the thin horizontal line above the first row in the deposit and withdraw currency pickers. Also groups the deposit screens under their own folder for parity with Withdraw, and tightens the amount-pill padding so it sits more snugly around the value.

## Test plan
- [x] Open Deposit, pick USDF, verify title and description say "USDF"
- [x] Open Deposit, pick a different currency, verify title shows that currency's name
- [x] Verify the deposit address row shows the Solana chain icon at the leading edge
- [x] Open the deposit currency picker and confirm there is no line above the first row
- [x] Open the withdraw picker (Withdraw Other Currencies) and confirm the same
- [x] Verify the amount pill on currency rows reads with the tightened padding and still looks balanced for short and long amounts