### PR TITLE
refactor: rename Circulating Value label to Market Cap

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoMarketCapSection.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoMarketCapSection.swift
@@ -18,7 +18,7 @@ struct CurrencyInfoMarketCapSection: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text("Circulating Value")
+            Text("Market Cap")
                 .foregroundStyle(Color.textSecondary)
                 .font(.appTextMedium)
                 .padding(.horizontal, 20)


### PR DESCRIPTION
## Summary
Updates the Currency Info screen's chart section header from "Circulating Value" to "Market Cap" so the user-facing label matches the underlying concept (and the rest of the codebase, which already uses `MarketCap` / `marketCap` / `MarketCapController`).

## Test plan
- [x] Open a currency info screen and confirm the chart section header reads "Market Cap"