### PR TITLE
fix: restore broken UI and unit test targets

### DIFF
--- a/FlipcashTests/TestSupport/Phone+TestSupport.swift
+++ b/FlipcashTests/TestSupport/Phone+TestSupport.swift
@@ -1,0 +1,12 @@
+//
+//  Phone+TestSupport.swift
+//  FlipcashTests
+//
+
+import Foundation
+import FlipcashCore
+
+extension Phone {
+
+    static let mock = Phone("+16472222222")!
+}

--- a/FlipcashUITests/Regression/GiveRegressionTests.swift
+++ b/FlipcashUITests/Regression/GiveRegressionTests.swift
@@ -5,7 +5,7 @@
 
 import XCTest
 
-/// Regression: tapping Give on an account with no giveable balance must
+/// Regression: tapping Cash on an account with no giveable balance must
 /// surface the "No Balance Yet" dialog *without* presenting the give amount
 /// entry sheet behind it. Previously the sheet was presented unconditionally
 /// alongside the dialog, leaving the user staring at a $0 keypad once the
@@ -24,12 +24,12 @@ final class GiveRegressionTests: BaseUITestCase {
         allowPushNotificationsIfNeeded()
         assertMainScreenReached()
 
-        waitAndTap(app.buttons["Give"])
+        waitAndTap(app.buttons["Cash"])
 
         let noBalanceTitle = app.staticTexts["No Balance Yet"]
         XCTAssertTrue(
             noBalanceTitle.waitForExistence(timeout: 10),
-            "Expected 'No Balance Yet' dialog after tapping Give on an empty account"
+            "Expected 'No Balance Yet' dialog after tapping Cash on an empty account"
         )
 
         // "Next" stands in for the amount-entry sheet being in the hierarchy.

--- a/FlipcashUITests/Smoke/ForceLogoutSmokeTests.swift
+++ b/FlipcashUITests/Smoke/ForceLogoutSmokeTests.swift
@@ -45,7 +45,7 @@ final class ForceLogoutSmokeTests: BaseUITestCase {
 
         // Main screen must NOT be reachable
         XCTAssertFalse(
-            app.buttons["Give"].exists,
+            app.buttons["Cash"].exists,
             "Main screen must not be reachable with an unlocked access key"
         )
     }

--- a/FlipcashUITests/Smoke/LoginSmokeTests.swift
+++ b/FlipcashUITests/Smoke/LoginSmokeTests.swift
@@ -10,7 +10,7 @@ final class LoginSmokeTests: BaseUITestCase {
 
     func testLoginViaAccessKey_reachesMainScreen() {
         assertMainScreenReached(
-            "Expected to reach the main screen with the Give button after login"
+            "Expected to reach the main screen with the Cash button after login"
         )
 
         let walletButton = app.buttons["Wallet"]

--- a/FlipcashUITests/Support/BaseUITestCase.swift
+++ b/FlipcashUITests/Support/BaseUITestCase.swift
@@ -77,10 +77,10 @@ class BaseUITestCase: XCTestCase {
         element.tap()
     }
 
-    /// Asserts that the main screen (ScanScreen) has been reached by checking for the Give button.
+    /// Asserts that the main screen (ScanScreen) has been reached by checking for the Cash button.
     func assertMainScreenReached(timeout: TimeInterval = 30, _ message: String = "Expected to reach the main screen") {
         XCTAssertTrue(
-            app.buttons["Give"].waitForExistence(timeout: timeout),
+            app.buttons["Cash"].waitForExistence(timeout: timeout),
             message
         )
     }
@@ -93,7 +93,7 @@ class BaseUITestCase: XCTestCase {
         let amountEntry = AmountEntryScreen(app: app)
 
         for attempt in 1...3 {
-            waitAndTap(app.buttons["Give"])
+            waitAndTap(app.buttons["Cash"])
             if amountEntry.keypadZero.waitForExistence(timeout: 10) { break }
 
             let ok = app.buttons["OK"]


### PR DESCRIPTION
## Summary
UI tests still reference the bottom-bar tab as "Give", but the label was renamed to "Cash" recently — every test that lands on the main screen fails to find it. Separately, the unit test target stopped compiling because a test-only phone fixture was deleted as "dead code" but is still used by two existing fixtures. This PR aligns the affected UI tests with the new label and restores the phone fixture as a test-only extension where it belongs.

## Test plan
- [x] Both test targets build successfully
- [x] Affected UI smoke and regression tests pass on the simulator
- [ ] Unit tests pass