### PR TITLE
feat: contact sync state machine and triggers

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -114,6 +114,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             lastBackgroundedAt = nil
             sessionContainer?.session.didBecomeActive()
             sessionContainer?.usdcSweepOperation.start()
+            sessionContainer?.contactSyncController.didBecomeActive()
         case .inactive:
             break
         @unknown default:

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -57,10 +57,14 @@ nonisolated private let logger = Logger(label: "flipcash.contact-sync-controller
 ///
 /// **Concurrency.** The class is implicitly `@MainActor` (Flipcash module
 /// default) for state coordination (`isSyncing`, `syncTask`, `observerTask`,
-/// `needsResync`). Heavy work — `CNContactStore.enumerateContacts`, synchronous
-/// SQLite I/O, and the server RPCs — runs off the main actor via
-/// `Task { @concurrent in … }` in ``sync()``. The `let` dependencies are
-/// `nonisolated` so the off-main work can read them without hopping.
+/// `needsResync`). Heavy work — `CNContactStore.enumerateContacts`,
+/// synchronous SQLite I/O, and the server RPCs — runs off the main actor
+/// because ``runSync()`` is declared `nonisolated async` and the Task body
+/// in ``sync()`` inherits non-main isolation through the
+/// `NonisolatedNonsendingByDefault` upcoming feature. The `let` dependencies
+/// are `nonisolated` so the off-main work can read them without hopping. Do
+/// NOT drop the `nonisolated` from ``runSync()``/``performSync(contacts:)``
+/// while refactoring — without them the heavy work falls back onto main.
 ///
 /// The `change_history` column on `Database.ContactSyncState` is always
 /// persisted as `nil`: `CNContactStore.enumeratorForChangeHistoryFetchRequest:`
@@ -158,11 +162,11 @@ final class ContactSyncController {
     // MARK: - Sync -
 
     /// Coalesces if a sync is already in flight (re-runs once the current one
-    /// completes). Heavy work currently runs on the main actor — matches the
-    /// sibling `HistoryController` / `RatesController` pattern. An earlier
-    /// `Task { @concurrent in ... }` attempt to push work off-main caused
-    /// scheduling hangs in the test suite; revisit when the runtime around
-    /// `@concurrent` + protocol-existential dispatch is more settled.
+    /// completes via the `needsResync` flag). Heavy work off-main comes from
+    /// `runSync` being `nonisolated async` — calls hop to the cooperative
+    /// pool. The post-await cleanup hops back to main inside `MainActor.run`
+    /// so the `isSyncing`/`syncTask`/`needsResync` triple-read is atomic
+    /// against any concurrent `sync()` on main.
     func sync() {
         guard !isSyncing else {
             needsResync = true
@@ -173,11 +177,14 @@ final class ContactSyncController {
         needsResync = false
         syncTask = Task { [weak self] in
             await self?.runSync()
-            self?.isSyncing = false
-            self?.syncTask = nil
-            if self?.needsResync == true {
-                self?.needsResync = false
-                self?.sync()
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.isSyncing = false
+                self.syncTask = nil
+                if self.needsResync {
+                    self.needsResync = false
+                    self.sync()
+                }
             }
         }
     }
@@ -222,46 +229,55 @@ final class ContactSyncController {
                 checksum: storedChecksum,
                 owner:    ownerKeyPair
             )
-            if case .ok = result {
+            // Exhaustive switch — per CLAUDE.md hard rule, never use `if case`
+            // on an enum we control. Adding a new `CheckSyncResult` case
+            // forces a compile error here instead of silently routing to drift.
+            switch result {
+            case .ok:
                 logger.info("Sync skipped — local unchanged, server agrees")
                 return
+            case .outOfSync:
+                // A delta would compute empty adds/removes with `old == new`
+                // and is structurally guaranteed to be rejected as
+                // `checksumDrift`. Skip straight to full upload.
+                serverDrifted = true
+                logger.info("Server reported drift on idle probe — uploading full set")
             }
-            // Server reports drift but our checksum hasn't changed — a delta
-            // would compute empty adds/removes with `old == new` and is
-            // structurally guaranteed to be rejected as `checksumDrift`. Skip
-            // straight to full upload.
-            serverDrifted = true
-            logger.info("Server reported drift on idle probe — uploading full set")
         }
-
-        let snapshot = try database.localContactsSnapshot()
 
         // Step 2 — choose upload path. Server drift forces full; otherwise
         // delta-if-available, full-on-first-sync. Delta with `.checksumDrift`
-        // falls back to full in the same call.
+        // falls back to full in the same call. Snapshot load is hoisted into
+        // the delta branch so the drift-recovery path doesn't depend on the
+        // snapshot table being readable.
         if serverDrifted {
             try await uploadFull(phones: phones, checksum: newChecksum)
-        } else if let oldChecksum = storedState.checksum, !snapshot.isEmpty {
-            let (adds, removes) = Self.delta(
-                oldSnapshot: snapshot.map(\.e164),
-                newContacts: phones
-            )
-            let result = try await client.uploadContactDelta(
-                adds:        adds,
-                removes:     removes,
-                oldChecksum: oldChecksum,
-                newChecksum: newChecksum,
-                owner:       ownerKeyPair
-            )
-            switch result {
-            case .ok:
-                logger.info("Delta upload OK", metadata: [
-                    "adds":    "\(adds.count)",
-                    "removes": "\(removes.count)",
-                ])
-            case .checksumDrift:
-                logger.warning("Delta upload reported checksumDrift — falling back to full upload")
+        } else if let oldChecksum = storedState.checksum {
+            let snapshot = try database.localContactsSnapshot()
+            if snapshot.isEmpty {
                 try await uploadFull(phones: phones, checksum: newChecksum)
+            } else {
+                let (adds, removes) = Self.delta(
+                    oldSnapshot: snapshot.map(\.e164),
+                    newContacts: phones
+                )
+                let result = try await client.uploadContactDelta(
+                    adds:        adds,
+                    removes:     removes,
+                    oldChecksum: oldChecksum,
+                    newChecksum: newChecksum,
+                    owner:       ownerKeyPair
+                )
+                switch result {
+                case .ok:
+                    logger.info("Delta upload OK", metadata: [
+                        "adds":    "\(adds.count)",
+                        "removes": "\(removes.count)",
+                    ])
+                case .checksumDrift:
+                    logger.warning("Delta upload reported checksumDrift — falling back to full upload")
+                    try await uploadFull(phones: phones, checksum: newChecksum)
+                }
             }
         } else {
             try await uploadFull(phones: phones, checksum: newChecksum)
@@ -272,14 +288,17 @@ final class ContactSyncController {
         // mismatch (or a server-state delta) and re-runs the full flow.
         try await refreshFlipcashContacts(checksum: newChecksum)
 
-        // Step 4 — persist new state only after both upload AND stream
-        // succeeded. `changeHistory` stays nil per the type doc-comment.
-        try database.replaceLocalContactsSnapshot(contacts)
-        try database.setContactSyncState(.init(
-            checksum:      newChecksum,
-            changeHistory: nil,
-            lastSyncedAt:  .now
-        ))
+        // Step 4 — persist snapshot + checksum atomically in a single SQLite
+        // transaction so a crash between them can't leave them out of sync.
+        // `changeHistory` stays nil per the type doc-comment.
+        try database.updateContactSyncSnapshotAndState(
+            snapshot: contacts,
+            state: .init(
+                checksum:      newChecksum,
+                changeHistory: nil,
+                lastSyncedAt:  .now
+            )
+        )
     }
 
     nonisolated private func uploadFull(phones: [String], checksum: Data) async throws {
@@ -307,14 +326,13 @@ final class ContactSyncController {
 
     // MARK: - Address book -
 
-    /// Enumerate the local store, normalize phones to E.164, dedupe by E.164
-    /// keeping the first occurrence's `contactId` (linked contacts commonly
-    /// share a number).
-    ///
-    /// A fresh `CNContactStore` is constructed per call — the type is not
-    /// declared `Sendable` so it can't be stored as a `nonisolated let`, and
-    /// `CNContactStore()` is documented as thread-safe and cheap to allocate
-    /// (it's a handle to the OS store, not the data itself).
+    /// Enumerate the local store and hand the raw `(stringValue, identifier)`
+    /// pairs to ``normalizeContacts(rawNumbers:region:)`` for E.164
+    /// normalization. A fresh `CNContactStore` is constructed per call — the
+    /// type is not declared `Sendable` so it can't be stored as a
+    /// `nonisolated let`, and `CNContactStore()` is documented as thread-safe
+    /// and cheap to allocate (it's a handle to the OS store, not the data
+    /// itself).
     nonisolated private func readContacts() throws -> [Database.LocalContact] {
         let store = CNContactStore()
         let request = CNContactFetchRequest(keysToFetch: [
@@ -322,15 +340,35 @@ final class ContactSyncController {
             CNContactIdentifierKey   as CNKeyDescriptor,
         ])
 
-        var seen:   Set<String> = []
-        var locals: [Database.LocalContact] = []
-
+        var rawNumbers: [(raw: String, contactId: String)] = []
         try store.enumerateContacts(with: request) { contact, _ in
             for labelled in contact.phoneNumbers {
-                guard let phone = Phone(labelled.value.stringValue) else { continue }
-                if seen.insert(phone.e164).inserted {
-                    locals.append(.init(e164: phone.e164, contactId: contact.identifier))
-                }
+                rawNumbers.append((labelled.value.stringValue, contact.identifier))
+            }
+        }
+
+        // Most contacts on a typical iPhone are stored in the user's local
+        // format (no `+` prefix); we need a region hint to parse them. Fall
+        // back to `.us` if the device has no region — matches PhoneNumberKit's
+        // own default.
+        let region = Region.current ?? .us
+        return Self.normalizeContacts(rawNumbers: rawNumbers, region: region)
+    }
+
+    /// Pure normalization helper — extracted from ``readContacts()`` so unit
+    /// tests can drive it with synthetic input and verify national-format
+    /// numbers parse against `region`. Dedupes by E.164, keeping the first
+    /// occurrence's `contactId` (linked iOS contacts commonly share a number).
+    nonisolated static func normalizeContacts(
+        rawNumbers: [(raw: String, contactId: String)],
+        region: Region
+    ) -> [Database.LocalContact] {
+        var seen:   Set<String> = []
+        var locals: [Database.LocalContact] = []
+        for entry in rawNumbers {
+            guard let phone = Phone(entry.raw, defaultRegion: region) else { continue }
+            if seen.insert(phone.e164).inserted {
+                locals.append(.init(e164: phone.e164, contactId: entry.contactId))
             }
         }
         return locals

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -11,68 +11,10 @@ nonisolated private let logger = Logger(label: "flipcash.contact-sync-controller
 
 /// Synchronizes the local address book with the server's contact-match service.
 ///
-/// State machine, single entry point ``sync()``:
-/// 1. Enumerate `CNContactStore`, normalize phones to E.164 (deduped), compute the
-///    new checksum.
-/// 2. If the new checksum equals the stored one, probe `CheckSync`. If the server
-///    agrees, return; if it reports drift, go straight to a full upload (a delta
-///    with `old == new` is structurally guaranteed to be rejected).
-/// 3. Upload — delta vs. the local snapshot (or full on first sync / empty
-///    snapshot / server-drift). On `.checksumDrift`, fall back to full upload in
-///    the same call.
-/// 4. Stream `GetFlipcashContacts` and replace the matched-set table.
-/// 5. Only after both the upload AND the stream succeed, persist the new
-///    snapshot, checksum, and `lastSyncedAt` — so a mid-flight failure of either
-///    leaves the next sync's probe seeing a mismatch and re-running end-to-end.
-///
-/// Step 1 lives in ``runSync()`` (it depends on the live `CNContactStore`);
-/// Steps 2–5 live in ``performSync(contacts:)`` so tests can drive them with
-/// synthetic input.
-///
-/// **Trigger model — the controller is dormant at construction.** Nothing runs
-/// until Phase 4 UI explicitly calls ``activate()``. That call:
-/// 1. Registers a `CNContactStoreDidChange` AsyncSequence observer.
-/// 2. Kicks off the first ``sync()``.
-///
-/// ``didBecomeActive()`` (from `AppDelegate.scenePhaseChanged(.active)`) is a
-/// no-op until ``activate()`` has been called at least once this session — so
-/// cold launches and pre-Send foregrounds do zero contact work. Once Phase 4
-/// has activated the controller (the user opened Send with permission
-/// granted), subsequent foregrounds trigger ``sync()``.
-///
-/// Triggers that arrive while a sync is in flight are coalesced into a single
-/// re-run that fires when the current sync completes — bursts of contact edits
-/// during sync don't leave the snapshot stale until the next foreground.
-///
-/// **Login gating is structural.** The controller is only constructed inside
-/// a logged-in `SessionContainer` (`SessionAuthenticator.createSessionContainer`)
-/// and is released on logout via `state = .loggedOut`, so syncing while logged
-/// out is structurally impossible.
-///
-/// **No permission prompt is ever issued from this controller.** The only API
-/// that prompts is `CNContactStore.requestAccess(for:)`, which is reachable
-/// only via `ContactsAuthorizer.authorize()` from the Phase 4 button. Within
-/// `runSync`, the injectable `authorizationStatusProvider` is read-only and
-/// short-circuits when the status is anything but `.authorized`.
-///
-/// **Concurrency.** The class is implicitly `@MainActor` (Flipcash module
-/// default) for state coordination (`isSyncing`, `syncTask`, `observerTask`,
-/// `needsResync`). Heavy work — `CNContactStore.enumerateContacts`,
-/// synchronous SQLite I/O, and the server RPCs — runs off the main actor
-/// because ``runSync()`` is declared `nonisolated async` and the Task body
-/// in ``sync()`` inherits non-main isolation through the
-/// `NonisolatedNonsendingByDefault` upcoming feature. The `let` dependencies
-/// are `nonisolated` so the off-main work can read them without hopping. Do
-/// NOT drop the `nonisolated` from ``runSync()``/``performSync(contacts:)``
-/// while refactoring — without them the heavy work falls back onto main.
-///
-/// The `change_history` column on `Database.ContactSyncState` is always
-/// persisted as `nil`: `CNContactStore.enumeratorForChangeHistoryFetchRequest:`
-/// is `NS_SWIFT_UNAVAILABLE` (see `CNContactStore.h`), so the local
-/// "did anything change since last cursor" pre-read can't be done from Swift
-/// without an Objective-C bridge. Every trigger re-enumerates `CNContactStore`;
-/// the upload (and matched-set stream) are still skipped when the new
-/// checksum matches and the server probe agrees.
+/// Dormant at construction. ``activate()`` registers the CN-change observer
+/// and triggers the first sync; ``didBecomeActive()`` is a no-op until that
+/// happens. Callers MUST verify contact authorization before invoking
+/// ``activate()`` — this type never prompts.
 ///
 /// Inject via `@Environment(ContactSyncController.self)`.
 @Observable
@@ -83,22 +25,9 @@ final class ContactSyncController {
     @ObservationIgnored nonisolated private let owner: AccountCluster
     @ObservationIgnored nonisolated private let authorizationStatusProvider: @Sendable () -> CNAuthorizationStatus
 
-    /// `internal` (not `private`) so `FlipcashTests` can assert the coalescing /
-    /// debouncing behavior via `@testable import Flipcash`. Never written from
-    /// test code; production callers don't need it.
     @ObservationIgnored internal private(set) var isSyncing = false
-
-    /// `internal` (not `private`) so tests can await sync completion via
-    /// `syncTask?.value`. Never written from test code.
     @ObservationIgnored internal private(set) var syncTask: Task<Void, Never>?
-
-    /// `internal` (not `private`) so tests can assert ``activate()`` idempotency
-    /// and ``didBecomeActive()`` gating. Never written from test code.
     @ObservationIgnored internal private(set) var observerTask: Task<Void, Never>?
-
-    /// Set true when ``sync()`` is called while another sync is in flight. The
-    /// running sync's completion block consumes the flag and re-triggers, so
-    /// CN-change bursts during sync don't get lost.
     @ObservationIgnored private var needsResync = false
 
     nonisolated private var ownerKeyPair: KeyPair {
@@ -128,15 +57,9 @@ final class ContactSyncController {
 
     // MARK: - Lifecycle -
 
-    /// Idempotent. Called by Phase 4 UI when the user is in a Send-related
-    /// context AND contact authorization is `.authorized`. Registers the CN
-    /// change observer (if not already) and triggers a sync. After this is
-    /// called once in a session, ``didBecomeActive()`` is no longer a no-op.
-    ///
-    /// Caller MUST verify authorization status before calling — this method
-    /// does not prompt or check. `CNContactStore.requestAccess` lives in
-    /// `ContactsAuthorizer.authorize()` and is invoked from the Send permission
-    /// screen; only after that resolves to `.authorized` should this be called.
+    /// Idempotent. Registers the CN-change observer and triggers a sync.
+    /// Caller must verify `CNContactStore.authorizationStatus(for: .contacts)
+    /// == .authorized` before calling — this method does not prompt.
     func activate() {
         if observerTask == nil {
             observerTask = Task { [weak self] in
@@ -149,9 +72,7 @@ final class ContactSyncController {
         sync()
     }
 
-    /// Called from `AppDelegate.scenePhaseChanged(.active)` as a one-liner per
-    /// the codebase's fire-and-forget convention. No-op until the controller
-    /// has been ``activate()``'d in this session.
+    /// No-op until ``activate()`` has been called this session.
     nonisolated func didBecomeActive() {
         Task { @MainActor [weak self] in
             guard let self, self.observerTask != nil else { return }
@@ -161,12 +82,8 @@ final class ContactSyncController {
 
     // MARK: - Sync -
 
-    /// Coalesces if a sync is already in flight (re-runs once the current one
-    /// completes via the `needsResync` flag). Heavy work off-main comes from
-    /// `runSync` being `nonisolated async` — calls hop to the cooperative
-    /// pool. The post-await cleanup hops back to main inside `MainActor.run`
-    /// so the `isSyncing`/`syncTask`/`needsResync` triple-read is atomic
-    /// against any concurrent `sync()` on main.
+    /// Coalesces an in-flight trigger via `needsResync`; the completion block
+    /// re-fires once the current sync finishes.
     func sync() {
         guard !isSyncing else {
             needsResync = true
@@ -189,6 +106,8 @@ final class ContactSyncController {
         }
     }
 
+    /// `nonisolated` so the heavy work (CN enumeration, SQLite I/O, RPCs)
+    /// runs off the main actor — do NOT drop the annotation.
     nonisolated private func runSync() async {
         let status = authorizationStatusProvider()
         guard status == .authorized else {
@@ -212,44 +131,29 @@ final class ContactSyncController {
         }
     }
 
-    /// Drives the state machine against the provided contacts. `internal` (not
-    /// `private`) so tests can drive it with synthetic input — the real CN
-    /// enumeration (``readContacts()``) is the only path that's hard to mock
-    /// from the tests, and splitting it out makes the rest verifiable.
+    /// `internal` for testing — also `nonisolated` so off-main isolation is
+    /// preserved when called through the production `runSync` path.
     internal nonisolated func performSync(contacts: [Database.LocalContact]) async throws {
         let storedState = try database.contactSyncState()
         let phones      = contacts.map(\.e164)
         let newChecksum = Self.checksum(of: phones)
 
-        // Step 1 — steady-state idle probe. If local hasn't changed since last
-        // sync, ask the server if it still agrees.
         var serverDrifted = false
         if let storedChecksum = storedState.checksum, storedChecksum == newChecksum {
             let result = try await client.checkContactSync(
                 checksum: storedChecksum,
                 owner:    ownerKeyPair
             )
-            // Exhaustive switch — per CLAUDE.md hard rule, never use `if case`
-            // on an enum we control. Adding a new `CheckSyncResult` case
-            // forces a compile error here instead of silently routing to drift.
             switch result {
             case .ok:
                 logger.info("Sync skipped — local unchanged, server agrees")
                 return
             case .outOfSync:
-                // A delta would compute empty adds/removes with `old == new`
-                // and is structurally guaranteed to be rejected as
-                // `checksumDrift`. Skip straight to full upload.
                 serverDrifted = true
                 logger.info("Server reported drift on idle probe — uploading full set")
             }
         }
 
-        // Step 2 — choose upload path. Server drift forces full; otherwise
-        // delta-if-available, full-on-first-sync. Delta with `.checksumDrift`
-        // falls back to full in the same call. Snapshot load is hoisted into
-        // the delta branch so the drift-recovery path doesn't depend on the
-        // snapshot table being readable.
         if serverDrifted {
             try await uploadFull(phones: phones, checksum: newChecksum)
         } else if let oldChecksum = storedState.checksum {
@@ -283,14 +187,10 @@ final class ContactSyncController {
             try await uploadFull(phones: phones, checksum: newChecksum)
         }
 
-        // Step 3 — refresh matched-set table FIRST so a stream failure leaves
-        // checksum and snapshot unmodified; the next sync's probe sees a
-        // mismatch (or a server-state delta) and re-runs the full flow.
+        // Refresh before persist so a stream failure leaves checksum + snapshot
+        // unchanged and the next sync re-runs end-to-end.
         try await refreshFlipcashContacts(checksum: newChecksum)
 
-        // Step 4 — persist snapshot + checksum atomically in a single SQLite
-        // transaction so a crash between them can't leave them out of sync.
-        // `changeHistory` stays nil per the type doc-comment.
         try database.updateContactSyncSnapshotAndState(
             snapshot: contacts,
             state: .init(
@@ -311,8 +211,8 @@ final class ContactSyncController {
     }
 
     nonisolated private func refreshFlipcashContacts(checksum: Data) async throws {
-        // `streamFlipcashContacts` is a sync function on `@MainActor` FlipClient
-        // — hop to obtain the AsyncThrowingStream, then iterate off-main.
+        // FlipClient is @MainActor and streamFlipcashContacts is sync — hop to
+        // obtain the stream, iterate off-main.
         let stream = await MainActor.run {
             client.streamFlipcashContacts(checksum: checksum, owner: ownerKeyPair)
         }
@@ -326,13 +226,6 @@ final class ContactSyncController {
 
     // MARK: - Address book -
 
-    /// Enumerate the local store and hand the raw `(stringValue, identifier)`
-    /// pairs to ``normalizeContacts(rawNumbers:region:)`` for E.164
-    /// normalization. A fresh `CNContactStore` is constructed per call — the
-    /// type is not declared `Sendable` so it can't be stored as a
-    /// `nonisolated let`, and `CNContactStore()` is documented as thread-safe
-    /// and cheap to allocate (it's a handle to the OS store, not the data
-    /// itself).
     nonisolated private func readContacts() throws -> [Database.LocalContact] {
         let store = CNContactStore()
         let request = CNContactFetchRequest(keysToFetch: [
@@ -347,18 +240,11 @@ final class ContactSyncController {
             }
         }
 
-        // Most contacts on a typical iPhone are stored in the user's local
-        // format (no `+` prefix); we need a region hint to parse them. Fall
-        // back to `.us` if the device has no region — matches PhoneNumberKit's
-        // own default.
-        let region = Region.current ?? .us
-        return Self.normalizeContacts(rawNumbers: rawNumbers, region: region)
+        return Self.normalizeContacts(rawNumbers: rawNumbers, region: Region.current ?? .us)
     }
 
-    /// Pure normalization helper — extracted from ``readContacts()`` so unit
-    /// tests can drive it with synthetic input and verify national-format
-    /// numbers parse against `region`. Dedupes by E.164, keeping the first
-    /// occurrence's `contactId` (linked iOS contacts commonly share a number).
+    /// Parses each raw number against `region`, normalizes to E.164, dedupes
+    /// keeping the first occurrence's `contactId`.
     nonisolated static func normalizeContacts(
         rawNumbers: [(raw: String, contactId: String)],
         region: Region
@@ -374,11 +260,9 @@ final class ContactSyncController {
         return locals
     }
 
-    // MARK: - Pure helpers (exposed `internal` for unit tests) -
+    // MARK: - Pure helpers -
 
-    /// 32-byte XOR-of-SHA256 over E.164 strings. Order-independent (XOR is
-    /// commutative) so contact reorderings produce the same checksum — matches
-    /// the server's algorithm.
+    /// 32-byte XOR-of-SHA256 over E.164 strings. Order-independent.
     nonisolated static func checksum(of phones: [String]) -> Data {
         var acc = [UInt8](repeating: 0, count: 32)
         for phone in phones {
@@ -390,8 +274,7 @@ final class ContactSyncController {
         return Data(acc)
     }
 
-    /// Adds/removes between an old snapshot and a new contact list. Sorted for
-    /// deterministic on-wire bytes and log diff-ability.
+    /// Adds/removes between an old snapshot and a new contact list, sorted.
     nonisolated static func delta(oldSnapshot: [String], newContacts: [String]) -> (adds: [String], removes: [String]) {
         let oldSet = Set(oldSnapshot)
         let newSet = Set(newContacts)
@@ -403,8 +286,6 @@ final class ContactSyncController {
 
     // MARK: - Error handling -
 
-    /// Logging is nonisolated (swift-log `Logger` is a `Sendable` value); the
-    /// `ErrorReporting` hops to the main actor inside ``reportError(_:reason:)``.
     nonisolated private func handleSyncError(_ error: ErrorContactSync) async {
         switch error {
         case .ok:

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -1,0 +1,358 @@
+//
+//  ContactSyncController.swift
+//  Flipcash
+//
+
+import Contacts
+import Foundation
+import FlipcashCore
+
+nonisolated private let logger = Logger(label: "flipcash.contact-sync-controller")
+
+/// Synchronizes the local address book with the server's contact-match service.
+///
+/// State machine, single entry point ``sync()``:
+/// 1. Enumerate `CNContactStore`, normalize phones to E.164 (deduped), compute the
+///    new checksum.
+/// 2. If the new checksum equals the stored one, probe `CheckSync` to detect
+///    server drift. If the server agrees, return.
+/// 3. Upload — delta vs. the local snapshot (or full on first sync / empty
+///    snapshot). On `.checksumDrift`, fall back to full upload in the same call.
+/// 4. Persist the new snapshot, checksum, and `lastSyncedAt`.
+/// 5. Stream `GetFlipcashContacts` and replace the matched-set table.
+///
+/// Step 1 lives in ``runSync()`` (it depends on the live `CNContactStore`);
+/// Steps 2–5 live in ``performSync(contacts:)`` so tests can drive them with
+/// synthetic input.
+///
+/// **Trigger model — the controller is dormant at construction.** Nothing runs
+/// until Phase 4 UI explicitly calls ``activate()``. That call:
+/// 1. Registers a `CNContactStoreDidChange` AsyncSequence observer.
+/// 2. Kicks off the first ``sync()``.
+///
+/// ``didBecomeActive()`` (from `AppDelegate.scenePhaseChanged(.active)`) is a
+/// no-op until ``activate()`` has been called at least once this session — so
+/// cold launches and pre-Send foregrounds do zero contact work. Once Phase 4
+/// has activated the controller (the user opened Send with permission
+/// granted), subsequent foregrounds trigger ``sync()``.
+///
+/// **Login gating is structural.** The controller is only constructed inside
+/// a logged-in `SessionContainer` (`SessionAuthenticator.createSessionContainer`)
+/// and is released on logout via `state = .loggedOut`, so syncing while logged
+/// out is structurally impossible.
+///
+/// **No permission prompt is ever issued from this controller.** The only API
+/// that prompts is `CNContactStore.requestAccess(for:)`, which is reachable
+/// only via `ContactsAuthorizer.authorize()` from the Phase 4 button. Within
+/// `runSync`, `CNContactStore.authorizationStatus(for:)` is read-only and
+/// short-circuits when the status is anything but `.authorized`. The CN
+/// enumeration call would throw rather than prompt if reached without
+/// authorization, but the status gate prevents that.
+///
+/// **Concurrency.** The class is implicitly `@MainActor` (Flipcash module
+/// default) for state coordination (`isSyncing`, `syncTask`, `observerTask`).
+/// Heavy work — `CNContactStore.enumerateContacts`, synchronous SQLite I/O,
+/// and the server RPCs — runs off the main actor via `@concurrent nonisolated`
+/// on ``runSync()``. The `let` dependencies are `nonisolated` so the off-main
+/// work can read them without hopping.
+///
+/// The `change_history` column on `Database.ContactSyncState` is always
+/// persisted as `nil`: `CNContactStore.enumeratorForChangeHistoryFetchRequest:`
+/// is `NS_SWIFT_UNAVAILABLE` (see `CNContactStore.h`), so the local
+/// "did anything change since last cursor" pre-read can't be done from Swift
+/// without an Objective-C bridge. Every trigger re-enumerates `CNContactStore`;
+/// the upload (and matched-set stream) are still skipped when the new
+/// checksum matches.
+///
+/// Inject via `@Environment(ContactSyncController.self)`.
+@Observable
+final class ContactSyncController {
+
+    @ObservationIgnored nonisolated private let client: any ContactSyncing
+    @ObservationIgnored nonisolated private let database: Database
+    @ObservationIgnored nonisolated private let owner: AccountCluster
+
+    /// `internal` (not `private`) so `FlipcashTests` can assert the dropped
+    /// trigger / debouncing behavior via `@testable import Flipcash`. Never
+    /// written from test code; production callers don't need it.
+    @ObservationIgnored internal private(set) var isSyncing = false
+
+    /// `internal` (not `private`) so tests can await sync completion via
+    /// `syncTask?.value`. Never written from test code.
+    @ObservationIgnored internal private(set) var syncTask: Task<Void, Never>?
+
+    /// `internal` (not `private`) so tests can assert ``activate()`` idempotency
+    /// and ``didBecomeActive()`` gating. Never written from test code.
+    @ObservationIgnored internal private(set) var observerTask: Task<Void, Never>?
+
+    nonisolated private var ownerKeyPair: KeyPair {
+        owner.authority.keyPair
+    }
+
+    // MARK: - Init -
+
+    init(client: any ContactSyncing, database: Database, owner: AccountCluster) {
+        self.client   = client
+        self.database = database
+        self.owner    = owner
+    }
+
+    deinit {
+        syncTask?.cancel()
+        observerTask?.cancel()
+    }
+
+    // MARK: - Lifecycle -
+
+    /// Idempotent. Called by Phase 4 UI when the user is in a Send-related
+    /// context AND contact authorization is `.authorized`. Registers the CN
+    /// change observer (if not already) and triggers a sync. After this is
+    /// called once in a session, ``didBecomeActive()`` is no longer a no-op.
+    ///
+    /// Caller MUST verify authorization status before calling — this method
+    /// does not prompt or check. `CNContactStore.requestAccess` lives in
+    /// `ContactsAuthorizer.authorize()` and is invoked from the Send permission
+    /// screen; only after that resolves to `.authorized` should this be called.
+    func activate() {
+        if observerTask == nil {
+            observerTask = Task { [weak self] in
+                for await _ in NotificationCenter.default.notifications(named: .CNContactStoreDidChange) {
+                    guard let self else { return }
+                    self.sync()
+                }
+            }
+        }
+        sync()
+    }
+
+    /// Called from `AppDelegate.scenePhaseChanged(.active)` as a one-liner per
+    /// the codebase's fire-and-forget convention. **No-op until the controller
+    /// has been ``activate()``'d in this session** — cold launches and
+    /// pre-Send foregrounds do zero contact work.
+    nonisolated func didBecomeActive() {
+        Task { @MainActor [weak self] in
+            guard let self, self.observerTask != nil else { return }
+            self.sync()
+        }
+    }
+
+    // MARK: - Sync -
+
+    /// Drops if a sync is already in flight; otherwise launches one. Heavy
+    /// work hops off the main actor via the `@concurrent nonisolated` ``runSync()``.
+    func sync() {
+        guard !isSyncing else {
+            logger.debug("Sync already in flight — dropping trigger")
+            return
+        }
+        isSyncing = true
+        syncTask = Task { [weak self] in
+            await self?.runSync()
+            self?.isSyncing = false
+            self?.syncTask = nil
+        }
+    }
+
+    @concurrent nonisolated private func runSync() async {
+        let status = CNContactStore.authorizationStatus(for: .contacts)
+        guard status == .authorized else {
+            logger.debug("Skipping sync — contacts not authorized", metadata: [
+                "status": "\(status.rawValue)",
+            ])
+            return
+        }
+        do {
+            let contacts = try readContacts()
+            try await performSync(contacts: contacts)
+        } catch let error as ErrorContactSync {
+            await handleSyncError(error)
+        } catch is CancellationError {
+            return
+        } catch {
+            logger.error("Sync failed with unexpected error", metadata: [
+                "error": "\(error)",
+            ])
+            await reportError(error, reason: "Contact sync failed")
+        }
+    }
+
+    /// Drives the state machine against the provided contacts. `internal` (not
+    /// `private`) so tests can drive it with synthetic input — the real CN
+    /// enumeration (``readContacts()``) is the only path that's hard to mock
+    /// from the tests, and splitting it out makes the rest verifiable.
+    internal nonisolated func performSync(contacts: [Database.LocalContact]) async throws {
+        let storedState = try database.contactSyncState()
+        let phones      = contacts.map(\.e164)
+        let newChecksum = Self.checksum(of: phones)
+
+        // Step 1 — steady-state idle: local unchanged AND server agrees.
+        if let storedChecksum = storedState.checksum, storedChecksum == newChecksum {
+            let result = try await client.checkContactSync(
+                checksum: storedChecksum,
+                owner:    ownerKeyPair
+            )
+            if case .ok = result {
+                logger.info("Sync skipped — local unchanged, server agrees")
+                return
+            }
+            logger.info("Server reported drift — re-uploading")
+        }
+
+        let snapshot = try database.localContactsSnapshot()
+
+        // Step 2 — full or delta upload. Drift on delta falls back to full in
+        // the same call.
+        if let oldChecksum = storedState.checksum, !snapshot.isEmpty {
+            let (adds, removes) = Self.delta(
+                oldSnapshot: snapshot.map(\.e164),
+                newContacts: phones
+            )
+            let result = try await client.uploadContactDelta(
+                adds:        adds,
+                removes:     removes,
+                oldChecksum: oldChecksum,
+                newChecksum: newChecksum,
+                owner:       ownerKeyPair
+            )
+            switch result {
+            case .ok:
+                logger.info("Delta upload OK", metadata: [
+                    "adds":    "\(adds.count)",
+                    "removes": "\(removes.count)",
+                ])
+            case .checksumDrift:
+                logger.warning("Delta upload reported checksumDrift — falling back to full upload")
+                try await uploadFull(phones: phones, checksum: newChecksum)
+            }
+        } else {
+            try await uploadFull(phones: phones, checksum: newChecksum)
+        }
+
+        // Step 3 — persist new state. `changeHistory` stays nil per the
+        // doc-comment.
+        try database.replaceLocalContactsSnapshot(contacts)
+        try database.setContactSyncState(.init(
+            checksum:      newChecksum,
+            changeHistory: nil,
+            lastSyncedAt:  .now
+        ))
+
+        // Step 4 — refresh matched-set table from the server stream.
+        try await refreshFlipcashContacts(checksum: newChecksum)
+    }
+
+    nonisolated private func uploadFull(phones: [String], checksum: Data) async throws {
+        try await client.uploadAllContacts(
+            phones:   phones,
+            checksum: checksum,
+            owner:    ownerKeyPair
+        )
+        logger.info("Full upload OK", metadata: ["count": "\(phones.count)"])
+    }
+
+    nonisolated private func refreshFlipcashContacts(checksum: Data) async throws {
+        // `streamFlipcashContacts` is a sync function on `@MainActor` FlipClient
+        // — hop to obtain the AsyncThrowingStream, then iterate off-main.
+        let stream = await MainActor.run {
+            client.streamFlipcashContacts(checksum: checksum, owner: ownerKeyPair)
+        }
+        var matched: [String] = []
+        for try await e164 in stream {
+            matched.append(e164)
+        }
+        try database.replaceFlipcashContacts(matched, matchedAt: .now)
+        logger.info("Refreshed flipcash contacts", metadata: ["matched": "\(matched.count)"])
+    }
+
+    // MARK: - Address book -
+
+    /// Enumerate the local store, normalize phones to E.164, dedupe by E.164
+    /// keeping the first occurrence's `contactId` (linked contacts commonly
+    /// share a number).
+    ///
+    /// A fresh `CNContactStore` is constructed per call — the type is not
+    /// declared `Sendable` so it can't be stored as a `nonisolated let`, and
+    /// `CNContactStore()` is documented as thread-safe and cheap to allocate
+    /// (it's a handle to the OS store, not the data itself).
+    nonisolated private func readContacts() throws -> [Database.LocalContact] {
+        let store = CNContactStore()
+        let request = CNContactFetchRequest(keysToFetch: [
+            CNContactPhoneNumbersKey as CNKeyDescriptor,
+            CNContactIdentifierKey   as CNKeyDescriptor,
+        ])
+
+        var seen:   Set<String> = []
+        var locals: [Database.LocalContact] = []
+
+        try store.enumerateContacts(with: request) { contact, _ in
+            for labelled in contact.phoneNumbers {
+                guard let phone = Phone(labelled.value.stringValue) else { continue }
+                if seen.insert(phone.e164).inserted {
+                    locals.append(.init(e164: phone.e164, contactId: contact.identifier))
+                }
+            }
+        }
+        return locals
+    }
+
+    // MARK: - Pure helpers (exposed `internal` for unit tests) -
+
+    /// 32-byte XOR-of-SHA256 over E.164 strings. Order-independent (XOR is
+    /// commutative) so contact reorderings produce the same checksum — matches
+    /// the server's algorithm.
+    nonisolated static func checksum(of phones: [String]) -> Data {
+        var acc = [UInt8](repeating: 0, count: 32)
+        for phone in phones {
+            let hash = SHA256.digest(phone)
+            for (i, byte) in hash.enumerated() {
+                acc[i] ^= byte
+            }
+        }
+        return Data(acc)
+    }
+
+    /// Adds/removes between an old snapshot and a new contact list. Sorted for
+    /// deterministic on-wire bytes and log diff-ability.
+    nonisolated static func delta(oldSnapshot: [String], newContacts: [String]) -> (adds: [String], removes: [String]) {
+        let oldSet = Set(oldSnapshot)
+        let newSet = Set(newContacts)
+        return (
+            adds:    Array(newSet.subtracting(oldSet)).sorted(),
+            removes: Array(oldSet.subtracting(newSet)).sorted()
+        )
+    }
+
+    // MARK: - Error handling -
+
+    /// Logging is nonisolated (swift-log `Logger` is a `Sendable` value); the
+    /// `ErrorReporting` hops to the main actor inside ``reportError(_:reason:)``.
+    nonisolated private func handleSyncError(_ error: ErrorContactSync) async {
+        switch error {
+        case .ok:
+            return
+        case .networkError:
+            logger.info("Sync deferred — network error (will retry on next trigger)")
+        case .checksumDrift:
+            logger.info("Sync deferred — checksum drift (will retry on next trigger)")
+        case .checksumMismatch:
+            logger.error("Sync failed — checksumMismatch (algorithm divergence)")
+            await reportError(error, reason: "Contact sync checksum mismatch")
+        case .denied:
+            logger.warning("Sync stopped — user not registered as Flipcash")
+        case .tooManyContacts:
+            logger.warning("Sync stopped — contact count exceeds server cap")
+        case .notFound:
+            logger.error("Sync failed — phone not found")
+            await reportError(error, reason: "Contact sync NOT_FOUND")
+        case .unknown:
+            logger.error("Sync failed — unknown error")
+            await reportError(error, reason: "Contact sync unknown error")
+        }
+    }
+
+    nonisolated private func reportError(_ error: Error, reason: String) async {
+        await MainActor.run {
+            ErrorReporting.captureError(error, reason: reason)
+        }
+    }
+}

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -14,12 +14,16 @@ nonisolated private let logger = Logger(label: "flipcash.contact-sync-controller
 /// State machine, single entry point ``sync()``:
 /// 1. Enumerate `CNContactStore`, normalize phones to E.164 (deduped), compute the
 ///    new checksum.
-/// 2. If the new checksum equals the stored one, probe `CheckSync` to detect
-///    server drift. If the server agrees, return.
+/// 2. If the new checksum equals the stored one, probe `CheckSync`. If the server
+///    agrees, return; if it reports drift, go straight to a full upload (a delta
+///    with `old == new` is structurally guaranteed to be rejected).
 /// 3. Upload — delta vs. the local snapshot (or full on first sync / empty
-///    snapshot). On `.checksumDrift`, fall back to full upload in the same call.
-/// 4. Persist the new snapshot, checksum, and `lastSyncedAt`.
-/// 5. Stream `GetFlipcashContacts` and replace the matched-set table.
+///    snapshot / server-drift). On `.checksumDrift`, fall back to full upload in
+///    the same call.
+/// 4. Stream `GetFlipcashContacts` and replace the matched-set table.
+/// 5. Only after both the upload AND the stream succeed, persist the new
+///    snapshot, checksum, and `lastSyncedAt` — so a mid-flight failure of either
+///    leaves the next sync's probe seeing a mismatch and re-running end-to-end.
 ///
 /// Step 1 lives in ``runSync()`` (it depends on the live `CNContactStore`);
 /// Steps 2–5 live in ``performSync(contacts:)`` so tests can drive them with
@@ -36,6 +40,10 @@ nonisolated private let logger = Logger(label: "flipcash.contact-sync-controller
 /// has activated the controller (the user opened Send with permission
 /// granted), subsequent foregrounds trigger ``sync()``.
 ///
+/// Triggers that arrive while a sync is in flight are coalesced into a single
+/// re-run that fires when the current sync completes — bursts of contact edits
+/// during sync don't leave the snapshot stale until the next foreground.
+///
 /// **Login gating is structural.** The controller is only constructed inside
 /// a logged-in `SessionContainer` (`SessionAuthenticator.createSessionContainer`)
 /// and is released on logout via `state = .loggedOut`, so syncing while logged
@@ -44,17 +52,15 @@ nonisolated private let logger = Logger(label: "flipcash.contact-sync-controller
 /// **No permission prompt is ever issued from this controller.** The only API
 /// that prompts is `CNContactStore.requestAccess(for:)`, which is reachable
 /// only via `ContactsAuthorizer.authorize()` from the Phase 4 button. Within
-/// `runSync`, `CNContactStore.authorizationStatus(for:)` is read-only and
-/// short-circuits when the status is anything but `.authorized`. The CN
-/// enumeration call would throw rather than prompt if reached without
-/// authorization, but the status gate prevents that.
+/// `runSync`, the injectable `authorizationStatusProvider` is read-only and
+/// short-circuits when the status is anything but `.authorized`.
 ///
 /// **Concurrency.** The class is implicitly `@MainActor` (Flipcash module
-/// default) for state coordination (`isSyncing`, `syncTask`, `observerTask`).
-/// Heavy work — `CNContactStore.enumerateContacts`, synchronous SQLite I/O,
-/// and the server RPCs — runs off the main actor via `@concurrent nonisolated`
-/// on ``runSync()``. The `let` dependencies are `nonisolated` so the off-main
-/// work can read them without hopping.
+/// default) for state coordination (`isSyncing`, `syncTask`, `observerTask`,
+/// `needsResync`). Heavy work — `CNContactStore.enumerateContacts`, synchronous
+/// SQLite I/O, and the server RPCs — runs off the main actor via
+/// `Task { @concurrent in … }` in ``sync()``. The `let` dependencies are
+/// `nonisolated` so the off-main work can read them without hopping.
 ///
 /// The `change_history` column on `Database.ContactSyncState` is always
 /// persisted as `nil`: `CNContactStore.enumeratorForChangeHistoryFetchRequest:`
@@ -62,7 +68,7 @@ nonisolated private let logger = Logger(label: "flipcash.contact-sync-controller
 /// "did anything change since last cursor" pre-read can't be done from Swift
 /// without an Objective-C bridge. Every trigger re-enumerates `CNContactStore`;
 /// the upload (and matched-set stream) are still skipped when the new
-/// checksum matches.
+/// checksum matches and the server probe agrees.
 ///
 /// Inject via `@Environment(ContactSyncController.self)`.
 @Observable
@@ -71,10 +77,11 @@ final class ContactSyncController {
     @ObservationIgnored nonisolated private let client: any ContactSyncing
     @ObservationIgnored nonisolated private let database: Database
     @ObservationIgnored nonisolated private let owner: AccountCluster
+    @ObservationIgnored nonisolated private let authorizationStatusProvider: @Sendable () -> CNAuthorizationStatus
 
-    /// `internal` (not `private`) so `FlipcashTests` can assert the dropped
-    /// trigger / debouncing behavior via `@testable import Flipcash`. Never
-    /// written from test code; production callers don't need it.
+    /// `internal` (not `private`) so `FlipcashTests` can assert the coalescing /
+    /// debouncing behavior via `@testable import Flipcash`. Never written from
+    /// test code; production callers don't need it.
     @ObservationIgnored internal private(set) var isSyncing = false
 
     /// `internal` (not `private`) so tests can await sync completion via
@@ -85,16 +92,29 @@ final class ContactSyncController {
     /// and ``didBecomeActive()`` gating. Never written from test code.
     @ObservationIgnored internal private(set) var observerTask: Task<Void, Never>?
 
+    /// Set true when ``sync()`` is called while another sync is in flight. The
+    /// running sync's completion block consumes the flag and re-triggers, so
+    /// CN-change bursts during sync don't get lost.
+    @ObservationIgnored private var needsResync = false
+
     nonisolated private var ownerKeyPair: KeyPair {
         owner.authority.keyPair
     }
 
     // MARK: - Init -
 
-    init(client: any ContactSyncing, database: Database, owner: AccountCluster) {
-        self.client   = client
-        self.database = database
-        self.owner    = owner
+    init(
+        client: any ContactSyncing,
+        database: Database,
+        owner: AccountCluster,
+        authorizationStatusProvider: @escaping @Sendable () -> CNAuthorizationStatus = {
+            CNContactStore.authorizationStatus(for: .contacts)
+        }
+    ) {
+        self.client                       = client
+        self.database                     = database
+        self.owner                        = owner
+        self.authorizationStatusProvider  = authorizationStatusProvider
     }
 
     deinit {
@@ -126,9 +146,8 @@ final class ContactSyncController {
     }
 
     /// Called from `AppDelegate.scenePhaseChanged(.active)` as a one-liner per
-    /// the codebase's fire-and-forget convention. **No-op until the controller
-    /// has been ``activate()``'d in this session** — cold launches and
-    /// pre-Send foregrounds do zero contact work.
+    /// the codebase's fire-and-forget convention. No-op until the controller
+    /// has been ``activate()``'d in this session.
     nonisolated func didBecomeActive() {
         Task { @MainActor [weak self] in
             guard let self, self.observerTask != nil else { return }
@@ -138,23 +157,33 @@ final class ContactSyncController {
 
     // MARK: - Sync -
 
-    /// Drops if a sync is already in flight; otherwise launches one. Heavy
-    /// work hops off the main actor via the `@concurrent nonisolated` ``runSync()``.
+    /// Coalesces if a sync is already in flight (re-runs once the current one
+    /// completes). Heavy work currently runs on the main actor — matches the
+    /// sibling `HistoryController` / `RatesController` pattern. An earlier
+    /// `Task { @concurrent in ... }` attempt to push work off-main caused
+    /// scheduling hangs in the test suite; revisit when the runtime around
+    /// `@concurrent` + protocol-existential dispatch is more settled.
     func sync() {
         guard !isSyncing else {
-            logger.debug("Sync already in flight — dropping trigger")
+            needsResync = true
+            logger.debug("Sync already in flight — coalescing trigger")
             return
         }
         isSyncing = true
+        needsResync = false
         syncTask = Task { [weak self] in
             await self?.runSync()
             self?.isSyncing = false
             self?.syncTask = nil
+            if self?.needsResync == true {
+                self?.needsResync = false
+                self?.sync()
+            }
         }
     }
 
-    @concurrent nonisolated private func runSync() async {
-        let status = CNContactStore.authorizationStatus(for: .contacts)
+    nonisolated private func runSync() async {
+        let status = authorizationStatusProvider()
         guard status == .authorized else {
             logger.debug("Skipping sync — contacts not authorized", metadata: [
                 "status": "\(status.rawValue)",
@@ -185,7 +214,9 @@ final class ContactSyncController {
         let phones      = contacts.map(\.e164)
         let newChecksum = Self.checksum(of: phones)
 
-        // Step 1 — steady-state idle: local unchanged AND server agrees.
+        // Step 1 — steady-state idle probe. If local hasn't changed since last
+        // sync, ask the server if it still agrees.
+        var serverDrifted = false
         if let storedChecksum = storedState.checksum, storedChecksum == newChecksum {
             let result = try await client.checkContactSync(
                 checksum: storedChecksum,
@@ -195,14 +226,22 @@ final class ContactSyncController {
                 logger.info("Sync skipped — local unchanged, server agrees")
                 return
             }
-            logger.info("Server reported drift — re-uploading")
+            // Server reports drift but our checksum hasn't changed — a delta
+            // would compute empty adds/removes with `old == new` and is
+            // structurally guaranteed to be rejected as `checksumDrift`. Skip
+            // straight to full upload.
+            serverDrifted = true
+            logger.info("Server reported drift on idle probe — uploading full set")
         }
 
         let snapshot = try database.localContactsSnapshot()
 
-        // Step 2 — full or delta upload. Drift on delta falls back to full in
-        // the same call.
-        if let oldChecksum = storedState.checksum, !snapshot.isEmpty {
+        // Step 2 — choose upload path. Server drift forces full; otherwise
+        // delta-if-available, full-on-first-sync. Delta with `.checksumDrift`
+        // falls back to full in the same call.
+        if serverDrifted {
+            try await uploadFull(phones: phones, checksum: newChecksum)
+        } else if let oldChecksum = storedState.checksum, !snapshot.isEmpty {
             let (adds, removes) = Self.delta(
                 oldSnapshot: snapshot.map(\.e164),
                 newContacts: phones
@@ -228,17 +267,19 @@ final class ContactSyncController {
             try await uploadFull(phones: phones, checksum: newChecksum)
         }
 
-        // Step 3 — persist new state. `changeHistory` stays nil per the
-        // doc-comment.
+        // Step 3 — refresh matched-set table FIRST so a stream failure leaves
+        // checksum and snapshot unmodified; the next sync's probe sees a
+        // mismatch (or a server-state delta) and re-runs the full flow.
+        try await refreshFlipcashContacts(checksum: newChecksum)
+
+        // Step 4 — persist new state only after both upload AND stream
+        // succeeded. `changeHistory` stays nil per the type doc-comment.
         try database.replaceLocalContactsSnapshot(contacts)
         try database.setContactSyncState(.init(
             checksum:      newChecksum,
             changeHistory: nil,
             lastSyncedAt:  .now
         ))
-
-        // Step 4 — refresh matched-set table from the server stream.
-        try await refreshFlipcashContacts(checksum: newChecksum)
     }
 
     nonisolated private func uploadFull(phones: [String], checksum: Data) async throws {

--- a/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
+++ b/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
@@ -114,4 +114,42 @@ nonisolated extension Database {
             }
         }
     }
+
+    // MARK: - Combined writes -
+
+    /// Atomically replace the local snapshot AND upsert the sync state in a
+    /// single transaction. Used at the end of a successful sync so a crash
+    /// between the two writes can't leave snapshot and checksum out of sync.
+    func updateContactSyncSnapshotAndState(
+        snapshot contacts: [LocalContact],
+        state: ContactSyncState
+    ) throws {
+        let snapshotTable = LocalContactsSnapshotTable()
+        let stateTable    = ContactSyncStateTable()
+
+        var seen: Set<String> = []
+        let dedupedSnapshot = contacts.filter { seen.insert($0.e164).inserted }
+
+        try writer.transaction {
+            try writer.run(snapshotTable.table.delete())
+            for contact in dedupedSnapshot {
+                try writer.run(
+                    snapshotTable.table.insert(
+                        snapshotTable.e164 <- contact.e164,
+                        snapshotTable.contactId <- contact.contactId
+                    )
+                )
+            }
+
+            try writer.run(
+                stateTable.table.upsert(
+                    stateTable.id <- 1,
+                    stateTable.checksum <- state.checksum,
+                    stateTable.changeHistory <- state.changeHistory,
+                    stateTable.lastSyncedAt <- state.lastSyncedAt,
+                    onConflictOf: stateTable.id
+                )
+            )
+        }
+    }
 }

--- a/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
+++ b/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
@@ -117,9 +117,7 @@ nonisolated extension Database {
 
     // MARK: - Combined writes -
 
-    /// Atomically replace the local snapshot AND upsert the sync state in a
-    /// single transaction. Used at the end of a successful sync so a crash
-    /// between the two writes can't leave snapshot and checksum out of sync.
+    /// Replace the snapshot AND upsert the sync state in one transaction.
     func updateContactSyncSnapshotAndState(
         snapshot contacts: [LocalContact],
         state: ContactSyncState

--- a/Flipcash/Core/Controllers/FlipClient+Protocols.swift
+++ b/Flipcash/Core/Controllers/FlipClient+Protocols.swift
@@ -36,4 +36,26 @@ protocol OnrampAuthorizing: AnyObject {
     ) async throws -> String
 }
 
-extension FlipClient: ContactVerifying, OnrampAuthorizing {}
+/// Contact-sync RPC surface used by `ContactSyncController`. Each method maps
+/// 1:1 to a `flipcash.contact.v1.ContactList` server RPC (plus the matched-set
+/// stream); the controller drives the state machine and the conformer issues
+/// the calls. `Sendable` so the controller can hold `any ContactSyncing` as a
+/// `nonisolated let` and call it from off-main `@concurrent` work.
+protocol ContactSyncing: AnyObject, Sendable {
+
+    func checkContactSync(checksum: Data, owner: KeyPair) async throws -> CheckSyncResult
+
+    func uploadContactDelta(
+        adds: [String],
+        removes: [String],
+        oldChecksum: Data,
+        newChecksum: Data,
+        owner: KeyPair
+    ) async throws -> DeltaUploadResult
+
+    func uploadAllContacts(phones: [String], checksum: Data, owner: KeyPair) async throws
+
+    func streamFlipcashContacts(checksum: Data, owner: KeyPair) -> AsyncThrowingStream<String, Error>
+}
+
+extension FlipClient: ContactVerifying, OnrampAuthorizing, ContactSyncing {}

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -225,17 +225,27 @@ final class SessionAuthenticator {
             owner: owner
         )
         historyController.sync()
-        
+
         let ratesController = RatesController(
             container: container,
             database: database
         )
-        
+
         let pushController = PushController(
             owner: owner.authority.keyPair,
             client: container.flipClient
         )
-        
+
+        // Constructed dormant — no observer, no sync, no contact framework
+        // access of any kind. Phase 4 UI calls `activate()` after the user
+        // opens Send with permission granted. `AppDelegate`'s
+        // `didBecomeActive()` is a no-op until that first activation.
+        let contactSyncController = ContactSyncController(
+            client: container.flipClient,
+            database: database,
+            owner: owner
+        )
+
         let session = Session(
             container: container,
             historyController: historyController,
@@ -245,7 +255,7 @@ final class SessionAuthenticator {
             owner: owner,
             userID: initializedAccount.userID
         )
-        
+
         let walletConnection = WalletConnection(owner: owner)
 
         return SessionContainer(
@@ -256,6 +266,7 @@ final class SessionAuthenticator {
             ratesController: ratesController,
             historyController: historyController,
             pushController: pushController,
+            contactSyncController: contactSyncController,
             flipClient: container.flipClient
         )
     }
@@ -424,6 +435,7 @@ struct SessionContainer {
     let ratesController: RatesController
     let historyController: HistoryController
     let pushController: PushController
+    let contactSyncController: ContactSyncController
     let flipClient: FlipClient
     let onrampDeeplinkInbox: OnrampDeeplinkInbox
     let verificationCoordinator: VerificationCoordinator
@@ -439,6 +451,7 @@ struct SessionContainer {
         ratesController: RatesController,
         historyController: HistoryController,
         pushController: PushController,
+        contactSyncController: ContactSyncController,
         flipClient: FlipClient
     ) {
         self.session = session
@@ -447,6 +460,7 @@ struct SessionContainer {
         self.ratesController = ratesController
         self.historyController = historyController
         self.pushController = pushController
+        self.contactSyncController = contactSyncController
         self.flipClient = flipClient
         let deeplinkInbox = OnrampDeeplinkInbox()
         self.onrampDeeplinkInbox = deeplinkInbox
@@ -496,6 +510,7 @@ struct SessionContainer {
             .environment(ratesController)
             .environment(historyController)
             .environment(pushController)
+            .environment(contactSyncController)
             .environment(walletConnection)
             .environment(verificationCoordinator)
             .environment(coinbaseService)

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -236,10 +236,6 @@ final class SessionAuthenticator {
             client: container.flipClient
         )
 
-        // Constructed dormant — no observer, no sync, no contact framework
-        // access of any kind. Phase 4 UI calls `activate()` after the user
-        // opens Send with permission granted. `AppDelegate`'s
-        // `didBecomeActive()` is a no-op until that first activation.
         let contactSyncController = ContactSyncController(
             client: container.flipClient,
             database: database,

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
@@ -292,14 +292,7 @@ public enum ErrorContactSync: Int, Error {
 extension ErrorContactSync: ServerError {
     public var isReportable: Bool {
         switch self {
-        // Expected outcomes / transient transport / server-driven recovery
-        // signals — not actionable, never report.
         case .ok, .denied, .tooManyContacts, .checksumDrift, .networkError: false
-        // Genuine bugs we want operator visibility on. `.checksumMismatch`
-        // is an algorithm divergence (client/server XOR-SHA256 disagree);
-        // `.notFound` after the Phase 4 gate means a phone we expected to
-        // be linked vanished server-side. `.unknown` is the proto-recognized
-        // catch-all.
         case .checksumMismatch, .notFound, .unknown: true
         }
     }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
@@ -292,8 +292,15 @@ public enum ErrorContactSync: Int, Error {
 extension ErrorContactSync: ServerError {
     public var isReportable: Bool {
         switch self {
-        case .ok, .denied, .checksumMismatch, .tooManyContacts, .notFound, .checksumDrift, .networkError: false
-        case .unknown: true
+        // Expected outcomes / transient transport / server-driven recovery
+        // signals — not actionable, never report.
+        case .ok, .denied, .tooManyContacts, .checksumDrift, .networkError: false
+        // Genuine bugs we want operator visibility on. `.checksumMismatch`
+        // is an algorithm divergence (client/server XOR-SHA256 disagree);
+        // `.notFound` after the Phase 4 gate means a phone we expected to
+        // be linked vanished server-side. `.unknown` is the proto-recognized
+        // catch-all.
+        case .checksumMismatch, .notFound, .unknown: true
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Phone.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Phone.swift
@@ -17,14 +17,9 @@ public struct Phone: Codable, Equatable, Hashable, Sendable {
 
     private let phoneNumber: PhoneNumber
 
-    /// Legacy parse — calls PhoneNumberKit's `parse(_:)` which silently
-    /// defaults `withRegion: "US"`. This works for inputs the UI has already
-    /// prepended with `+<countryCode>` (e.g. `PhoneVerificationViewModel`
-    /// formats input as `+<countryCode><digits>` before constructing
-    /// `Phone(_:)`), but bare national-format strings get interpreted as US
-    /// numbers regardless of the device's region. For raw inputs that may
-    /// be in any device locale (e.g. `CNContactStore.enumerateContacts`),
-    /// prefer ``init?(_:defaultRegion:)``.
+    /// Parses against PhoneNumberKit's implicit `US` default — national-format
+    /// inputs always parse as US numbers. Prefer ``init?(_:defaultRegion:)``
+    /// for any input not already prefixed with `+<countryCode>`.
     public init?(_ string: String) {
         guard let phoneNumber = try? Self.phoneNumberUtility.parse(string) else {
             return nil
@@ -35,16 +30,8 @@ public struct Phone: Codable, Equatable, Hashable, Sendable {
         self.national    = Self.phoneNumberUtility.format(phoneNumber, toType: PhoneNumberFormat.national)
     }
 
-    /// Region-aware parse — accepts both international (`+44 20 1234 5678`)
-    /// AND national-format (`020 1234 5678`) strings. National-format strings
-    /// are interpreted against `defaultRegion`. Use this for inputs that
-    /// arrive without UI mediation — e.g. `CNContactStore.enumerateContacts`
-    /// returns raw `stringValue`s in whatever format the user stored them
-    /// (typically national-format for the device's own region).
-    ///
-    /// International-format strings ignore `defaultRegion` and are parsed
-    /// using their own prefix, so a UK contact stored as `+44…` on a US
-    /// device still parses correctly when `defaultRegion: .us` is passed.
+    /// Parses national-format strings against `defaultRegion`; international-
+    /// format strings ignore it and parse via their own prefix.
     public init?(_ string: String, defaultRegion: Region) {
         guard let phoneNumber = try? Self.phoneNumberUtility.parse(
             string,

--- a/FlipcashCore/Sources/FlipcashCore/Models/Phone.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Phone.swift
@@ -17,8 +17,40 @@ public struct Phone: Codable, Equatable, Hashable, Sendable {
 
     private let phoneNumber: PhoneNumber
 
+    /// Legacy parse — calls PhoneNumberKit's `parse(_:)` which silently
+    /// defaults `withRegion: "US"`. This works for inputs the UI has already
+    /// prepended with `+<countryCode>` (e.g. `PhoneVerificationViewModel`
+    /// formats input as `+<countryCode><digits>` before constructing
+    /// `Phone(_:)`), but bare national-format strings get interpreted as US
+    /// numbers regardless of the device's region. For raw inputs that may
+    /// be in any device locale (e.g. `CNContactStore.enumerateContacts`),
+    /// prefer ``init?(_:defaultRegion:)``.
     public init?(_ string: String) {
         guard let phoneNumber = try? Self.phoneNumberUtility.parse(string) else {
+            return nil
+        }
+
+        self.phoneNumber = phoneNumber
+        self.e164        = Self.phoneNumberUtility.format(phoneNumber, toType: PhoneNumberFormat.e164)
+        self.national    = Self.phoneNumberUtility.format(phoneNumber, toType: PhoneNumberFormat.national)
+    }
+
+    /// Region-aware parse — accepts both international (`+44 20 1234 5678`)
+    /// AND national-format (`020 1234 5678`) strings. National-format strings
+    /// are interpreted against `defaultRegion`. Use this for inputs that
+    /// arrive without UI mediation — e.g. `CNContactStore.enumerateContacts`
+    /// returns raw `stringValue`s in whatever format the user stored them
+    /// (typically national-format for the device's own region).
+    ///
+    /// International-format strings ignore `defaultRegion` and are parsed
+    /// using their own prefix, so a UK contact stored as `+44…` on a US
+    /// device still parses correctly when `defaultRegion: .us` is passed.
+    public init?(_ string: String, defaultRegion: Region) {
+        guard let phoneNumber = try? Self.phoneNumberUtility.parse(
+            string,
+            withRegion: defaultRegion.rawValue.uppercased(),
+            ignoreType: true
+        ) else {
             return nil
         }
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/ContactSyncTypesTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ContactSyncTypesTests.swift
@@ -37,15 +37,15 @@ struct ContactSyncTypesTests {
     // MARK: - ErrorContactSync reportability -
 
     @Test(
-        "transient and recoverable cases are non-reportable; only .unknown bugsnags",
+        "transient/recoverable cases non-reportable; .checksumMismatch / .notFound / .unknown bugsnag",
         arguments: [
             (ErrorContactSync.ok,              false),
             (.denied,            false),
-            (.checksumMismatch,  false),
             (.tooManyContacts,   false),
-            (.notFound,          false),
             (.checksumDrift,     false),
             (.networkError,      false),
+            (.checksumMismatch,  true),
+            (.notFound,          true),
             (.unknown,           true),
         ]
     )

--- a/FlipcashCore/Tests/FlipcashCoreTests/PhoneTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/PhoneTests.swift
@@ -1,0 +1,115 @@
+//
+//  PhoneTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("Phone")
+struct PhoneTests {
+
+    // MARK: - Legacy implicit-US-default initializer
+
+    /// `Phone(_:)` calls PhoneNumberKit's `parse(_:)` which silently defaults
+    /// `withRegion: "US"`. So bare national-format strings DO parse — but
+    /// always as US numbers, which is wrong for non-US users. This is the
+    /// motivation for the `init?(_:defaultRegion:)` overload below.
+    /// `PhoneVerificationViewModel` works around the issue by pre-formatting
+    /// input as `+<countryCode><digits>` before constructing `Phone(_:)`.
+    @Suite("init?(_:) — implicit US default")
+    struct ImplicitUSDefaultTests {
+
+        @Test("Parses a well-formed E.164 string")
+        func parsesE164() {
+            let phone = Phone("+14155550100")
+            #expect(phone?.e164 == "+14155550100")
+        }
+
+        @Test("Parses an international string with spaces / parens")
+        func parsesFormattedInternational() {
+            let phone = Phone("+1 (415) 555-0100")
+            #expect(phone?.e164 == "+14155550100")
+        }
+
+        @Test("National-format input parses against the implicit US default")
+        func parsesNationalAgainstImplicitUS() {
+            // Surprise behavior — `parse(_:)` defaults to `withRegion: \"US\"`,
+            // so a bare local-format string IS accepted, just always
+            // interpreted as a US number. Wrong for non-US users; correct
+            // when the UI has already validated the country (the existing
+            // verification flow).
+            let phone = Phone("4155550100")
+            #expect(phone?.e164 == "+14155550100")
+        }
+
+        @Test("Rejects garbage")
+        func rejectsGarbage() {
+            #expect(Phone("not-a-phone") == nil)
+            #expect(Phone("") == nil)
+        }
+    }
+
+    // MARK: - Region-aware initializer
+
+    @Suite("init?(_:defaultRegion:)")
+    struct RegionAwareTests {
+
+        @Test("Parses a US national-format string with .us as the default region")
+        func parsesUSNationalWithUSDefault() {
+            let phone = Phone("415-555-0100", defaultRegion: .us)
+            #expect(phone?.e164 == "+14155550100")
+        }
+
+        @Test("Parses a UK national-format string with .gb as the default region")
+        func parsesUKNationalWithGBDefault() {
+            // UK landline: 020 7946 0958 is the BBC-style example number for
+            // London (+44 20 7946 0958 in E.164).
+            let phone = Phone("020 7946 0958", defaultRegion: .gb)
+            #expect(phone?.e164 == "+442079460958")
+        }
+
+        @Test("International-format input ignores defaultRegion and parses via its own prefix")
+        func internationalIgnoresDefaultRegion() {
+            // A UK number stored as `+44 ...` on a US device must still parse
+            // as UK, not be misinterpreted as US.
+            let phone = Phone("+44 20 7946 0958", defaultRegion: .us)
+            #expect(phone?.e164 == "+442079460958")
+        }
+
+        @Test("E.164 input ignores defaultRegion")
+        func e164IgnoresDefaultRegion() {
+            let phone = Phone("+14155550100", defaultRegion: .gb)
+            #expect(phone?.e164 == "+14155550100")
+        }
+
+        @Test("National-format input parsed against the wrong region produces a different / invalid number")
+        func wrongRegionMisparsesOrFails() {
+            // US-style `(415) 555-0100` parsed against UK region: PhoneNumberKit
+            // will either fail to parse or produce a non-US number. Either way
+            // it must NOT round-trip to the correct US e164. The test asserts
+            // the loose property: the result isn't the US e164.
+            let phone = Phone("(415) 555-0100", defaultRegion: .gb)
+            #expect(phone?.e164 != "+14155550100")
+        }
+
+        @Test("Empty / garbage inputs return nil regardless of region")
+        func emptyGarbageReturnsNil() {
+            #expect(Phone("", defaultRegion: .us) == nil)
+            #expect(Phone("not-a-phone", defaultRegion: .us) == nil)
+        }
+
+        @Test("Region rawValue is uppercased internally — lowercase enum still parses")
+        func regionCaseInsensitive() {
+            // Region.rawValue is lowercase (`us`, `gb`); PhoneNumberKit expects
+            // ISO 3166-1 alpha-2 uppercase. The initializer uppercases
+            // internally — verify by parsing the same number twice with
+            // .us and confirming consistent output.
+            let first = Phone("415-555-0100", defaultRegion: .us)
+            let second = Phone("4155550100", defaultRegion: .us)
+            #expect(first?.e164 == "+14155550100")
+            #expect(second?.e164 == "+14155550100")
+        }
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/PhoneTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/PhoneTests.swift
@@ -10,14 +10,6 @@ import Testing
 @Suite("Phone")
 struct PhoneTests {
 
-    // MARK: - Legacy implicit-US-default initializer
-
-    /// `Phone(_:)` calls PhoneNumberKit's `parse(_:)` which silently defaults
-    /// `withRegion: "US"`. So bare national-format strings DO parse — but
-    /// always as US numbers, which is wrong for non-US users. This is the
-    /// motivation for the `init?(_:defaultRegion:)` overload below.
-    /// `PhoneVerificationViewModel` works around the issue by pre-formatting
-    /// input as `+<countryCode><digits>` before constructing `Phone(_:)`.
     @Suite("init?(_:) — implicit US default")
     struct ImplicitUSDefaultTests {
 
@@ -35,11 +27,6 @@ struct PhoneTests {
 
         @Test("National-format input parses against the implicit US default")
         func parsesNationalAgainstImplicitUS() {
-            // Surprise behavior — `parse(_:)` defaults to `withRegion: \"US\"`,
-            // so a bare local-format string IS accepted, just always
-            // interpreted as a US number. Wrong for non-US users; correct
-            // when the UI has already validated the country (the existing
-            // verification flow).
             let phone = Phone("4155550100")
             #expect(phone?.e164 == "+14155550100")
         }
@@ -64,16 +51,12 @@ struct PhoneTests {
 
         @Test("Parses a UK national-format string with .gb as the default region")
         func parsesUKNationalWithGBDefault() {
-            // UK landline: 020 7946 0958 is the BBC-style example number for
-            // London (+44 20 7946 0958 in E.164).
             let phone = Phone("020 7946 0958", defaultRegion: .gb)
             #expect(phone?.e164 == "+442079460958")
         }
 
         @Test("International-format input ignores defaultRegion and parses via its own prefix")
         func internationalIgnoresDefaultRegion() {
-            // A UK number stored as `+44 ...` on a US device must still parse
-            // as UK, not be misinterpreted as US.
             let phone = Phone("+44 20 7946 0958", defaultRegion: .us)
             #expect(phone?.e164 == "+442079460958")
         }
@@ -86,10 +69,6 @@ struct PhoneTests {
 
         @Test("National-format input parsed against the wrong region produces a different / invalid number")
         func wrongRegionMisparsesOrFails() {
-            // US-style `(415) 555-0100` parsed against UK region: PhoneNumberKit
-            // will either fail to parse or produce a non-US number. Either way
-            // it must NOT round-trip to the correct US e164. The test asserts
-            // the loose property: the result isn't the US e164.
             let phone = Phone("(415) 555-0100", defaultRegion: .gb)
             #expect(phone?.e164 != "+14155550100")
         }
@@ -102,10 +81,6 @@ struct PhoneTests {
 
         @Test("Region rawValue is uppercased internally — lowercase enum still parses")
         func regionCaseInsensitive() {
-            // Region.rawValue is lowercase (`us`, `gb`); PhoneNumberKit expects
-            // ISO 3166-1 alpha-2 uppercase. The initializer uppercases
-            // internally — verify by parsing the same number twice with
-            // .us and confirming consistent output.
             let first = Phone("415-555-0100", defaultRegion: .us)
             let second = Phone("4155550100", defaultRegion: .us)
             #expect(first?.e164 == "+14155550100")

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -204,6 +204,84 @@ struct ContactSyncControllerTests {
         }
     }
 
+    // MARK: - normalizeContacts (CN string → E.164 dedupe)
+
+    @Suite("normalizeContacts(rawNumbers:region:)")
+    struct NormalizeContactsTests {
+
+        @Test("National-format US numbers parse against .us region")
+        func nationalUSParses() {
+            let result = ContactSyncController.normalizeContacts(
+                rawNumbers: [
+                    ("415-555-0100", "alice"),
+                    ("(415) 555-0101", "bob"),
+                    ("4155550102", "carol"),
+                ],
+                region: .us
+            )
+            #expect(result.map(\.e164) == ["+14155550100", "+14155550101", "+14155550102"])
+            #expect(result.map(\.contactId) == ["alice", "bob", "carol"])
+        }
+
+        @Test("National-format UK numbers parse against .gb region")
+        func nationalUKParses() {
+            let result = ContactSyncController.normalizeContacts(
+                rawNumbers: [("020 7946 0958", "alice")],
+                region: .gb
+            )
+            #expect(result.first?.e164 == "+442079460958")
+        }
+
+        @Test("International-format numbers parse regardless of region hint")
+        func internationalIgnoresRegion() {
+            // A US iPhone with a UK contact stored as +44 — must still parse
+            // correctly even though the device's region is .us.
+            let result = ContactSyncController.normalizeContacts(
+                rawNumbers: [("+44 20 7946 0958", "alice")],
+                region: .us
+            )
+            #expect(result.first?.e164 == "+442079460958")
+        }
+
+        @Test("Unparseable entries are silently skipped")
+        func unparseableSkipped() {
+            let result = ContactSyncController.normalizeContacts(
+                rawNumbers: [
+                    ("not-a-phone", "alice"),
+                    ("415-555-0100", "bob"),
+                    ("", "carol"),
+                ],
+                region: .us
+            )
+            #expect(result.count == 1)
+            #expect(result.first?.contactId == "bob")
+        }
+
+        @Test("Dedupe by E.164 keeps the first occurrence's contactId")
+        func dedupeKeepsFirst() {
+            // Linked iOS contacts commonly produce the same E.164 for multiple
+            // CNContact records; we keep the first one's identifier.
+            let result = ContactSyncController.normalizeContacts(
+                rawNumbers: [
+                    ("415-555-0100", "alice"),
+                    ("(415) 555-0100", "alice-work"),
+                    ("+14155550100", "alice-home"),
+                ],
+                region: .us
+            )
+            #expect(result.count == 1)
+            let first = result.first!
+            #expect(first.e164 == "+14155550100")
+            #expect(first.contactId == "alice")
+        }
+
+        @Test("Empty input returns empty result")
+        func emptyInput() {
+            let result = ContactSyncController.normalizeContacts(rawNumbers: [], region: .us)
+            #expect(result.isEmpty)
+        }
+    }
+
     // MARK: - Lifecycle
 
     /// `.serialized` because each test spawns an observer Task that subscribes
@@ -321,6 +399,56 @@ struct ContactSyncControllerTests {
             #expect(counter.count == 2)
         }
 
+        @Test("sync() coalesces a trigger that arrives while in flight and re-runs once the first completes")
+        func syncCoalescesInFlightTriggerAndRerunsAfterCompletion() async throws {
+            let counter = AuthCounter()
+            let controller = ContactSyncController(
+                client:                      MockContactSync(),
+                database:                    .mock,
+                owner:                       .mock,
+                authorizationStatusProvider: counter.bumpAndReturnNotDetermined
+            )
+
+            // sync() is synchronous on main: it sets isSyncing=true and
+            // spawns Task A, then returns BEFORE Task A's body runs (the
+            // body suspends at the first `await self?.runSync()`). So a
+            // second sync() call right after — still on the same main
+            // synchronous tick — observes isSyncing==true and gets coalesced.
+            controller.sync()
+            #expect(controller.isSyncing == true)
+
+            controller.sync()
+            #expect(controller.isSyncing == true)  // still — the second call was coalesced, not dropped silently
+
+            // Yield until both runs land: Task A's runSync (auth bump #1) +
+            // the post-await cleanup that re-fires sync() because
+            // needsResync was set by the second call → Task B's runSync
+            // (auth bump #2). Bounded at 1s so a regression that drops the
+            // re-fire surfaces as a fast failure instead of a hang.
+            try await Self.awaitCounter(counter, atLeast: 2, controller: controller)
+            // Awaiting the counter only proves the auth check ran twice — Task
+            // B's MainActor.run cleanup may not have flipped `isSyncing` /
+            // cleared `syncTask` yet. Drain the cleanup before final asserts.
+            try await Self.awaitSyncIdle(controller: controller)
+
+            #expect(counter.count == 2)
+            #expect(controller.isSyncing == false)
+            #expect(controller.syncTask == nil)
+        }
+
+        /// Wait for the controller to be fully idle (`isSyncing == false`,
+        /// `syncTask == nil`). Bounded at 1s.
+        private static func awaitSyncIdle(controller: ContactSyncController) async throws {
+            let deadline = Date.now.addingTimeInterval(1.0)
+            while (controller.isSyncing || controller.syncTask != nil), Date.now < deadline {
+                if let task = controller.syncTask {
+                    await task.value
+                } else {
+                    await Task.yield()
+                }
+            }
+        }
+
         /// Bounded wait — the spawned `Task { @MainActor in sync() }` from
         /// `didBecomeActive` runs after a few yields. 1s is generous; a real
         /// hang fails fast instead of waiting on a suite-level timeLimit.
@@ -400,8 +528,10 @@ struct ContactSyncControllerTests {
             #expect(storedState.checksum == ContactSyncController.checksum(of: contacts.map(\.e164)))
             try #require(storedState.lastSyncedAt != nil)
 
-            #expect(try database.localContactsSnapshot().map(\.e164) == contacts.map(\.e164))
-            #expect(try database.flipcashContacts() == ["+14155550101"])
+            // Database+ContactSync's SELECTs have no ORDER BY — compare via
+            // Set so the test stays stable as table pages rearrange.
+            #expect(Set(try database.localContactsSnapshot().map(\.e164)) == Set(contacts.map(\.e164)))
+            #expect(Set(try database.flipcashContacts()) == ["+14155550101"])
         }
 
         @Test("Steady-state — local unchanged + server agrees → no upload, no stream")
@@ -535,24 +665,38 @@ struct ContactSyncControllerTests {
             #expect(try database.flipcashContacts().isEmpty)
         }
 
-        @Test("Stream failure leaves state unmodified so next sync re-runs end-to-end")
-        func streamFailure_doesNotPersist() async throws {
+        @Test("Stream failure leaves state unmodified — including pre-existing matched-set rows")
+        func streamFailure_doesNotPersistAndLeavesMatchedSetIntact() async throws {
             let mock = MockContactSync()
             mock.streamTerminalError = ErrorContactSync.networkError
             let database = Database.mock
             let controller = Self.makeController(mock: mock, database: database)
 
+            // Seed a prior successful sync: stored checksum + snapshot of
+            // alice + matched-set containing bob. The new sync about to run
+            // will upload a different contact set, but its stream throws —
+            // we need to verify that none of the four DB tables get clobbered.
+            let priorChecksum = ContactSyncController.checksum(of: [Self.aliceContact.e164])
+            try Self.seedDatabase(database, checksum: priorChecksum, snapshot: [Self.aliceContact])
+            try database.replaceFlipcashContacts([Self.bobContact.e164], matchedAt: .now)
+
             await #expect(throws: ErrorContactSync.networkError) {
-                try await controller.performSync(contacts: [Self.aliceContact])
+                try await controller.performSync(contacts: [Self.bobContact, Self.carolContact])
             }
 
-            // Upload succeeded but stream failed AFTER it — checksum and
-            // snapshot stay empty so the next sync's probe sees a mismatch
-            // and re-runs end-to-end (recovering matched-set freshness).
-            #expect(mock.fullCalls.count == 1)
+            // Path taken: snapshot non-empty + oldChecksum present + new
+            // checksum differs → delta upload (alice removed, bob+carol
+            // added), succeeds .ok, then stream throws. With persist-after-
+            // refresh ordering, NONE of the local writes ran — so checksum,
+            // snapshot, AND the prior matched-set rows all stay at their
+            // pre-sync values.
+            #expect(mock.deltaCalls.count == 1)
+            #expect(mock.fullCalls.isEmpty)
             #expect(mock.streamCalls.count == 1)
-            #expect(try database.contactSyncState() == .empty)
-            #expect(try database.localContactsSnapshot().isEmpty)
+            let storedState = try database.contactSyncState()
+            #expect(storedState.checksum == priorChecksum)
+            #expect(Set(try database.localContactsSnapshot().map(\.e164)) == [Self.aliceContact.e164])
+            #expect(Set(try database.flipcashContacts()) == [Self.bobContact.e164])
         }
 
         @Test("CheckSync `.denied` from server propagates")

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -9,19 +9,6 @@ import Testing
 import FlipcashCore
 @testable import Flipcash
 
-/// Tests cover:
-/// - `nonisolated static` pure helpers (`checksum`, `delta`) — direct call
-/// - Lifecycle (``activate()``, ``didBecomeActive()``) — observed via internal
-///   `observerTask` / `syncTask` accessors and mock-call-count side effects
-///   (with an injected `authorizationStatusProvider` returning `.authorized` so
-///   the runSync auth gate doesn't short-circuit)
-/// - The state machine ``performSync(contacts:)`` — driven with synthetic
-///   contacts and a `MockContactSync` conformer of `ContactSyncing`
-///
-/// `readContacts()` isn't directly covered: it depends on the real
-/// `CNContactStore`, and a synthetic CN backend would be more code than the
-/// shim it would replace. It's exercised end-to-end via the dev-backend
-/// verification gate.
 @Suite("ContactSyncController")
 struct ContactSyncControllerTests {
 
@@ -64,10 +51,6 @@ struct ContactSyncControllerTests {
 
         @Test("Duplicates collapse to identity (XOR cancellation)")
         func duplicatePairsCancel() {
-            // The controller dedupes before calling checksum, but the
-            // algorithm itself must round-trip: XOR-ing the same value twice
-            // is identity. Two identical phones should produce the same bytes
-            // as the empty input.
             let phones = ["+14155550100", "+14155550100"]
             let checksum = ContactSyncController.checksum(of: phones)
             #expect(checksum.count == 32)
@@ -96,8 +79,6 @@ struct ContactSyncControllerTests {
             let added   = base + ["+819012345678"]
             let baseSum  = ContactSyncController.checksum(of: base)
             let addedSum = ContactSyncController.checksum(of: added)
-            // XOR-ing the added phone's SHA256 onto the expanded checksum
-            // must restore the base checksum (XOR is its own inverse).
             let extraHash = SHA256.digest("+819012345678")
             var restored = [UInt8](addedSum)
             for (i, byte) in extraHash.enumerated() {
@@ -234,8 +215,6 @@ struct ContactSyncControllerTests {
 
         @Test("International-format numbers parse regardless of region hint")
         func internationalIgnoresRegion() {
-            // A US iPhone with a UK contact stored as +44 — must still parse
-            // correctly even though the device's region is .us.
             let result = ContactSyncController.normalizeContacts(
                 rawNumbers: [("+44 20 7946 0958", "alice")],
                 region: .us
@@ -259,8 +238,6 @@ struct ContactSyncControllerTests {
 
         @Test("Dedupe by E.164 keeps the first occurrence's contactId")
         func dedupeKeepsFirst() {
-            // Linked iOS contacts commonly produce the same E.164 for multiple
-            // CNContact records; we keep the first one's identifier.
             let result = ContactSyncController.normalizeContacts(
                 rawNumbers: [
                     ("415-555-0100", "alice"),
@@ -284,16 +261,9 @@ struct ContactSyncControllerTests {
 
     // MARK: - Lifecycle
 
-    /// `.serialized` because each test spawns an observer Task that subscribes
-    /// to `NotificationCenter.default.notifications`; under parallel execution
-    /// those Tasks accumulate and starve the test scheduler.
-    ///
-    /// Default auth status is `.notDetermined` so `runSync` short-circuits
-    /// before reaching `readContacts()` — otherwise iOS would treat the test
-    /// process's first `enumerateContacts` call as a permission request and
-    /// raise a system prompt mid-suite. Tests that need to observe "sync was
-    /// triggered" use the `AuthCounter` pattern instead of letting the sync
-    /// reach CN.
+    /// `.serialized` so parallel observer Tasks don't starve the scheduler.
+    /// Default auth status is `.notDetermined` — never let runSync reach
+    /// real `CNContactStore` access in tests.
     @Suite("Lifecycle", .serialized)
     @MainActor
     struct LifecycleTests {
@@ -311,9 +281,8 @@ struct ContactSyncControllerTests {
             )
         }
 
-        /// Lets a test count how many times `runSync` reached its auth check
-        /// without ever letting `readContacts()` run (closure returns
-        /// `.notDetermined`, so runSync exits early — no CN access).
+        /// Counts auth checks and returns `.notDetermined` so `runSync` exits
+        /// before any CN access.
         private final class AuthCounter: @unchecked Sendable {
             private let lock = NSLock()
             private var _count = 0
@@ -351,9 +320,6 @@ struct ContactSyncControllerTests {
             controller.activate()
             await controller.syncTask?.value
 
-            // The guard `observerTask == nil` is the only assignment site, so
-            // a second activate() must leave the same task in place. `Task`
-            // conforms to `Hashable` via task identity — `==` is identity.
             #expect(controller.observerTask == firstObserver)
         }
 
@@ -370,8 +336,6 @@ struct ContactSyncControllerTests {
             await Task.yield()
             await Task.yield()
 
-            // No sync was launched: didBecomeActive bailed on the observerTask
-            // guard before spawning sync(), so runSync was never called.
             #expect(controller.syncTask == nil)
             #expect(controller.isSyncing == false)
             #expect(counter.count == 0)
@@ -387,12 +351,10 @@ struct ContactSyncControllerTests {
                 authorizationStatusProvider: counter.bumpAndReturnNotDetermined
             )
 
-            // activate() runs sync() → runSync() → auth check (bump 1) → bail.
             controller.activate()
             await controller.syncTask?.value
             #expect(counter.count == 1)
 
-            // didBecomeActive() → Task @MainActor → sync() → runSync() → bump 2.
             controller.didBecomeActive()
             try await Self.awaitCounter(counter, atLeast: 2, controller: controller)
 
@@ -409,26 +371,13 @@ struct ContactSyncControllerTests {
                 authorizationStatusProvider: counter.bumpAndReturnNotDetermined
             )
 
-            // sync() is synchronous on main: it sets isSyncing=true and
-            // spawns Task A, then returns BEFORE Task A's body runs (the
-            // body suspends at the first `await self?.runSync()`). So a
-            // second sync() call right after — still on the same main
-            // synchronous tick — observes isSyncing==true and gets coalesced.
             controller.sync()
             #expect(controller.isSyncing == true)
 
             controller.sync()
-            #expect(controller.isSyncing == true)  // still — the second call was coalesced, not dropped silently
+            #expect(controller.isSyncing == true)
 
-            // Yield until both runs land: Task A's runSync (auth bump #1) +
-            // the post-await cleanup that re-fires sync() because
-            // needsResync was set by the second call → Task B's runSync
-            // (auth bump #2). Bounded at 1s so a regression that drops the
-            // re-fire surfaces as a fast failure instead of a hang.
             try await Self.awaitCounter(counter, atLeast: 2, controller: controller)
-            // Awaiting the counter only proves the auth check ran twice — Task
-            // B's MainActor.run cleanup may not have flipped `isSyncing` /
-            // cleared `syncTask` yet. Drain the cleanup before final asserts.
             try await Self.awaitSyncIdle(controller: controller)
 
             #expect(counter.count == 2)
@@ -436,8 +385,6 @@ struct ContactSyncControllerTests {
             #expect(controller.syncTask == nil)
         }
 
-        /// Wait for the controller to be fully idle (`isSyncing == false`,
-        /// `syncTask == nil`). Bounded at 1s.
         private static func awaitSyncIdle(controller: ContactSyncController) async throws {
             let deadline = Date.now.addingTimeInterval(1.0)
             while (controller.isSyncing || controller.syncTask != nil), Date.now < deadline {
@@ -449,9 +396,6 @@ struct ContactSyncControllerTests {
             }
         }
 
-        /// Bounded wait — the spawned `Task { @MainActor in sync() }` from
-        /// `didBecomeActive` runs after a few yields. 1s is generous; a real
-        /// hang fails fast instead of waiting on a suite-level timeLimit.
         private static func awaitCounter(
             _ counter: AuthCounter,
             atLeast target: Int,
@@ -470,10 +414,6 @@ struct ContactSyncControllerTests {
 
     // MARK: - State machine
 
-    /// `.serialized` because parallel `@MainActor` tests starve each other on
-    /// main when one drives a Task-spawning sync path; each `performSync` is
-    /// fast on its own (sub-second). No `.timeLimit` — every test has a
-    /// deterministic exit path through `performSync(contacts:)`.
     @Suite("performSync(contacts:)", .serialized)
     @MainActor
     struct PerformSyncTests {
@@ -485,9 +425,6 @@ struct ContactSyncControllerTests {
             ContactSyncController(client: mock, database: database, owner: .mock)
         }
 
-        /// Seeds `contact_sync_state` (and optionally `local_contacts_snapshot`)
-        /// so a test can rehearse a non-empty starting condition without the
-        /// `setContactSyncState` + `replaceLocalContactsSnapshot` boilerplate.
         private static func seedDatabase(
             _ database: Database,
             checksum: Data,
@@ -528,8 +465,6 @@ struct ContactSyncControllerTests {
             #expect(storedState.checksum == ContactSyncController.checksum(of: contacts.map(\.e164)))
             try #require(storedState.lastSyncedAt != nil)
 
-            // Database+ContactSync's SELECTs have no ORDER BY — compare via
-            // Set so the test stays stable as table pages rearrange.
             #expect(Set(try database.localContactsSnapshot().map(\.e164)) == Set(contacts.map(\.e164)))
             #expect(Set(try database.flipcashContacts()) == ["+14155550101"])
         }
@@ -575,7 +510,6 @@ struct ContactSyncControllerTests {
             #expect(deltaCall.newChecksum == ContactSyncController.checksum(of: newContacts.map(\.e164)))
             #expect(mock.fullCalls.isEmpty)
             #expect(mock.streamCalls.count == 1)
-            // Checksum differs from stored, so the idle probe is skipped entirely.
             #expect(mock.checkSyncCalls.isEmpty)
         }
 
@@ -599,8 +533,6 @@ struct ContactSyncControllerTests {
             #expect(fullCall.phones == newContacts.map(\.e164))
             #expect(mock.streamCalls.count == 1)
 
-            // State persisted with the new checksum after the fallback (only
-            // because the stream succeeded — see persist-after-refresh ordering).
             let storedState = try database.contactSyncState()
             #expect(storedState.checksum == ContactSyncController.checksum(of: newContacts.map(\.e164)))
         }
@@ -618,10 +550,6 @@ struct ContactSyncControllerTests {
 
             try await controller.performSync(contacts: contacts)
 
-            // Probe fired, returned outOfSync → since old == new (local
-            // unchanged), a delta would compute empty adds/removes and the
-            // server would always reject it; the controller goes straight to
-            // full upload to avoid the wasted round-trip.
             #expect(mock.checkSyncCalls == [storedChecksum])
             #expect(mock.deltaCalls.isEmpty)
             let fullCall = try #require(mock.fullCalls.first)
@@ -637,8 +565,6 @@ struct ContactSyncControllerTests {
             let database = Database.mock
             let controller = Self.makeController(mock: mock, database: database)
 
-            // Stored checksum without a snapshot — e.g. snapshot was wiped
-            // (SQLiteVersion bump preserved sync_state but lost snapshot).
             try Self.seedDatabase(database, checksum: Data(repeating: 0xFF, count: 32))
 
             let contacts = [Self.aliceContact]
@@ -659,7 +585,6 @@ struct ContactSyncControllerTests {
                 try await controller.performSync(contacts: [Self.aliceContact])
             }
 
-            // Pre-upload state untouched.
             #expect(try database.contactSyncState() == .empty)
             #expect(try database.localContactsSnapshot().isEmpty)
             #expect(try database.flipcashContacts().isEmpty)
@@ -672,10 +597,6 @@ struct ContactSyncControllerTests {
             let database = Database.mock
             let controller = Self.makeController(mock: mock, database: database)
 
-            // Seed a prior successful sync: stored checksum + snapshot of
-            // alice + matched-set containing bob. The new sync about to run
-            // will upload a different contact set, but its stream throws —
-            // we need to verify that none of the four DB tables get clobbered.
             let priorChecksum = ContactSyncController.checksum(of: [Self.aliceContact.e164])
             try Self.seedDatabase(database, checksum: priorChecksum, snapshot: [Self.aliceContact])
             try database.replaceFlipcashContacts([Self.bobContact.e164], matchedAt: .now)
@@ -684,12 +605,6 @@ struct ContactSyncControllerTests {
                 try await controller.performSync(contacts: [Self.bobContact, Self.carolContact])
             }
 
-            // Path taken: snapshot non-empty + oldChecksum present + new
-            // checksum differs → delta upload (alice removed, bob+carol
-            // added), succeeds .ok, then stream throws. With persist-after-
-            // refresh ordering, NONE of the local writes ran — so checksum,
-            // snapshot, AND the prior matched-set rows all stay at their
-            // pre-sync values.
             #expect(mock.deltaCalls.count == 1)
             #expect(mock.fullCalls.isEmpty)
             #expect(mock.streamCalls.count == 1)

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -3,6 +3,7 @@
 //  FlipcashTests
 //
 
+import Contacts
 import Foundation
 import Testing
 import FlipcashCore
@@ -11,14 +12,16 @@ import FlipcashCore
 /// Tests cover:
 /// - `nonisolated static` pure helpers (`checksum`, `delta`) — direct call
 /// - Lifecycle (``activate()``, ``didBecomeActive()``) — observed via internal
-///   `observerTask` / `syncTask` accessors
+///   `observerTask` / `syncTask` accessors and mock-call-count side effects
+///   (with an injected `authorizationStatusProvider` returning `.authorized` so
+///   the runSync auth gate doesn't short-circuit)
 /// - The state machine ``performSync(contacts:)`` — driven with synthetic
 ///   contacts and a `MockContactSync` conformer of `ContactSyncing`
 ///
-/// `runSync()` and `readContacts()` aren't directly covered: the former depends
-/// on `CNContactStore.authorizationStatus(for:)` (OS state, can't be mocked
-/// without further extraction); the latter is a thin shim over CN enumeration.
-/// They're exercised end-to-end via the dev-backend verification gate.
+/// `readContacts()` isn't directly covered: it depends on the real
+/// `CNContactStore`, and a synthetic CN backend would be more code than the
+/// shim it would replace. It's exercised end-to-end via the dev-backend
+/// verification gate.
 @Suite("ContactSyncController")
 struct ContactSyncControllerTests {
 
@@ -203,15 +206,44 @@ struct ContactSyncControllerTests {
 
     // MARK: - Lifecycle
 
-    @Suite("Lifecycle")
+    /// `.serialized` because each test spawns an observer Task that subscribes
+    /// to `NotificationCenter.default.notifications`; under parallel execution
+    /// those Tasks accumulate and starve the test scheduler.
+    ///
+    /// Default auth status is `.notDetermined` so `runSync` short-circuits
+    /// before reaching `readContacts()` — otherwise iOS would treat the test
+    /// process's first `enumerateContacts` call as a permission request and
+    /// raise a system prompt mid-suite. Tests that need to observe "sync was
+    /// triggered" use the `AuthCounter` pattern instead of letting the sync
+    /// reach CN.
+    @Suite("Lifecycle", .serialized)
     @MainActor
     struct LifecycleTests {
 
         private static func makeController(
             mock: MockContactSync = .init(),
-            database: Database = .mock
+            database: Database = .mock,
+            status: CNAuthorizationStatus = .notDetermined
         ) -> ContactSyncController {
-            ContactSyncController(client: mock, database: database, owner: .mock)
+            ContactSyncController(
+                client:                      mock,
+                database:                    database,
+                owner:                       .mock,
+                authorizationStatusProvider: { status }
+            )
+        }
+
+        /// Lets a test count how many times `runSync` reached its auth check
+        /// without ever letting `readContacts()` run (closure returns
+        /// `.notDetermined`, so runSync exits early — no CN access).
+        private final class AuthCounter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _count = 0
+            var count: Int { lock.withLock { _count } }
+            func bumpAndReturnNotDetermined() -> CNAuthorizationStatus {
+                lock.withLock { _count += 1 }
+                return .notDetermined
+            }
         }
 
         @Test("Construction is dormant — no observer, no sync, no task")
@@ -249,38 +281,72 @@ struct ContactSyncControllerTests {
 
         @Test("didBecomeActive() is a no-op before activate()")
         func didBecomeActiveNoOpBeforeActivate() async {
-            let controller = Self.makeController()
+            let counter = AuthCounter()
+            let controller = ContactSyncController(
+                client:                      MockContactSync(),
+                database:                    .mock,
+                owner:                       .mock,
+                authorizationStatusProvider: counter.bumpAndReturnNotDetermined
+            )
             controller.didBecomeActive()
-            // didBecomeActive spawns a main-actor Task that bails on the
-            // observerTask guard. Yield twice — once for the spawn, once for
-            // the guard check — then assert nothing started.
             await Task.yield()
             await Task.yield()
+
+            // No sync was launched: didBecomeActive bailed on the observerTask
+            // guard before spawning sync(), so runSync was never called.
             #expect(controller.syncTask == nil)
             #expect(controller.isSyncing == false)
+            #expect(counter.count == 0)
         }
 
-        @Test("didBecomeActive() triggers sync once activate() has been called")
-        func didBecomeActiveAfterActivate() async {
-            let controller = Self.makeController()
+        @Test("didBecomeActive() actually triggers a sync after activate()")
+        func didBecomeActiveTriggersSyncAfterActivate() async throws {
+            let counter = AuthCounter()
+            let controller = ContactSyncController(
+                client:                      MockContactSync(),
+                database:                    .mock,
+                owner:                       .mock,
+                authorizationStatusProvider: counter.bumpAndReturnNotDetermined
+            )
+
+            // activate() runs sync() → runSync() → auth check (bump 1) → bail.
             controller.activate()
             await controller.syncTask?.value
-            #expect(controller.syncTask == nil)
+            #expect(counter.count == 1)
 
+            // didBecomeActive() → Task @MainActor → sync() → runSync() → bump 2.
             controller.didBecomeActive()
-            await Task.yield()
-            await Task.yield()
-            // The didBecomeActive's main-actor Task should have hit sync() by
-            // now, which sets syncTask. Either it's still in flight or it has
-            // already completed and cleared itself — but `isSyncing` was
-            // briefly true and observerTask remains set.
-            #expect(controller.observerTask != nil)
+            try await Self.awaitCounter(counter, atLeast: 2, controller: controller)
+
+            #expect(counter.count == 2)
+        }
+
+        /// Bounded wait — the spawned `Task { @MainActor in sync() }` from
+        /// `didBecomeActive` runs after a few yields. 1s is generous; a real
+        /// hang fails fast instead of waiting on a suite-level timeLimit.
+        private static func awaitCounter(
+            _ counter: AuthCounter,
+            atLeast target: Int,
+            controller: ContactSyncController
+        ) async throws {
+            let deadline = Date.now.addingTimeInterval(1.0)
+            while counter.count < target, Date.now < deadline {
+                if let task = controller.syncTask {
+                    await task.value
+                } else {
+                    await Task.yield()
+                }
+            }
         }
     }
 
     // MARK: - State machine
 
-    @Suite("performSync(contacts:)")
+    /// `.serialized` because parallel `@MainActor` tests starve each other on
+    /// main when one drives a Task-spawning sync path; each `performSync` is
+    /// fast on its own (sub-second). No `.timeLimit` — every test has a
+    /// deterministic exit path through `performSync(contacts:)`.
+    @Suite("performSync(contacts:)", .serialized)
     @MainActor
     struct PerformSyncTests {
 
@@ -289,6 +355,24 @@ struct ContactSyncControllerTests {
             database: Database
         ) -> ContactSyncController {
             ContactSyncController(client: mock, database: database, owner: .mock)
+        }
+
+        /// Seeds `contact_sync_state` (and optionally `local_contacts_snapshot`)
+        /// so a test can rehearse a non-empty starting condition without the
+        /// `setContactSyncState` + `replaceLocalContactsSnapshot` boilerplate.
+        private static func seedDatabase(
+            _ database: Database,
+            checksum: Data,
+            snapshot: [Database.LocalContact] = []
+        ) throws {
+            try database.setContactSyncState(.init(
+                checksum:      checksum,
+                changeHistory: nil,
+                lastSyncedAt:  Date(timeIntervalSince1970: 1_716_000_000)
+            ))
+            if !snapshot.isEmpty {
+                try database.replaceLocalContactsSnapshot(snapshot)
+            }
         }
 
         private static let aliceContact = Database.LocalContact(e164: "+14155550100", contactId: "alice")
@@ -307,13 +391,14 @@ struct ContactSyncControllerTests {
 
             #expect(mock.checkSyncCalls.isEmpty)
             #expect(mock.deltaCalls.isEmpty)
+            let fullCall = try #require(mock.fullCalls.first)
             #expect(mock.fullCalls.count == 1)
-            #expect(mock.fullCalls[0].phones == contacts.map(\.e164))
+            #expect(fullCall.phones == contacts.map(\.e164))
             #expect(mock.streamCalls.count == 1)
 
             let storedState = try database.contactSyncState()
             #expect(storedState.checksum == ContactSyncController.checksum(of: contacts.map(\.e164)))
-            #expect(storedState.lastSyncedAt != nil)
+            try #require(storedState.lastSyncedAt != nil)
 
             #expect(try database.localContactsSnapshot().map(\.e164) == contacts.map(\.e164))
             #expect(try database.flipcashContacts() == ["+14155550101"])
@@ -328,12 +413,7 @@ struct ContactSyncControllerTests {
 
             let contacts = [Self.aliceContact, Self.bobContact]
             let storedChecksum = ContactSyncController.checksum(of: contacts.map(\.e164))
-            try database.setContactSyncState(.init(
-                checksum:      storedChecksum,
-                changeHistory: nil,
-                lastSyncedAt:  .now
-            ))
-            try database.replaceLocalContactsSnapshot(contacts)
+            try Self.seedDatabase(database, checksum: storedChecksum, snapshot: contacts)
 
             try await controller.performSync(contacts: contacts)
 
@@ -347,31 +427,26 @@ struct ContactSyncControllerTests {
         func localChanged_deltaUploadAndStream() async throws {
             let mock = MockContactSync()
             mock.deltaUploadResult = .success(.ok)
-            mock.streamYields = []
             let database = Database.mock
             let controller = Self.makeController(mock: mock, database: database)
 
             let oldSnapshot = [Self.aliceContact]
             let oldChecksum = ContactSyncController.checksum(of: oldSnapshot.map(\.e164))
-            try database.setContactSyncState(.init(
-                checksum:      oldChecksum,
-                changeHistory: nil,
-                lastSyncedAt:  .now
-            ))
-            try database.replaceLocalContactsSnapshot(oldSnapshot)
+            try Self.seedDatabase(database, checksum: oldChecksum, snapshot: oldSnapshot)
 
             let newContacts = [Self.aliceContact, Self.bobContact]
             try await controller.performSync(contacts: newContacts)
 
+            let deltaCall = try #require(mock.deltaCalls.first)
             #expect(mock.deltaCalls.count == 1)
-            let call = mock.deltaCalls[0]
-            #expect(call.adds == ["+14155550101"])
-            #expect(call.removes.isEmpty)
-            #expect(call.oldChecksum == oldChecksum)
-            #expect(call.newChecksum == ContactSyncController.checksum(of: newContacts.map(\.e164)))
+            #expect(deltaCall.adds == ["+14155550101"])
+            #expect(deltaCall.removes.isEmpty)
+            #expect(deltaCall.oldChecksum == oldChecksum)
+            #expect(deltaCall.newChecksum == ContactSyncController.checksum(of: newContacts.map(\.e164)))
             #expect(mock.fullCalls.isEmpty)
             #expect(mock.streamCalls.count == 1)
-            #expect(mock.checkSyncCalls.isEmpty)  // checksum differs from stored, so the idle probe is skipped
+            // Checksum differs from stored, so the idle probe is skipped entirely.
+            #expect(mock.checkSyncCalls.isEmpty)
         }
 
         @Test("CHECKSUM_DRIFT on delta → fallback to full upload in same call")
@@ -383,53 +458,45 @@ struct ContactSyncControllerTests {
 
             let oldSnapshot = [Self.aliceContact]
             let oldChecksum = ContactSyncController.checksum(of: oldSnapshot.map(\.e164))
-            try database.setContactSyncState(.init(
-                checksum:      oldChecksum,
-                changeHistory: nil,
-                lastSyncedAt:  .now
-            ))
-            try database.replaceLocalContactsSnapshot(oldSnapshot)
+            try Self.seedDatabase(database, checksum: oldChecksum, snapshot: oldSnapshot)
 
             let newContacts = [Self.aliceContact, Self.bobContact, Self.carolContact]
             try await controller.performSync(contacts: newContacts)
 
             #expect(mock.deltaCalls.count == 1)
+            let fullCall = try #require(mock.fullCalls.first)
             #expect(mock.fullCalls.count == 1)
-            #expect(mock.fullCalls[0].phones == newContacts.map(\.e164))
+            #expect(fullCall.phones == newContacts.map(\.e164))
             #expect(mock.streamCalls.count == 1)
 
-            // State still persisted with the new checksum after the fallback.
+            // State persisted with the new checksum after the fallback (only
+            // because the stream succeeded — see persist-after-refresh ordering).
             let storedState = try database.contactSyncState()
             #expect(storedState.checksum == ContactSyncController.checksum(of: newContacts.map(\.e164)))
         }
 
-        @Test("Server drift on idle probe — falls through to upload")
-        func serverDriftOnProbe_fallsThroughToUpload() async throws {
+        @Test("Server drift on idle probe → straight to full upload (skips doomed delta)")
+        func serverDriftOnProbe_goesStraightToFullUpload() async throws {
             let mock = MockContactSync()
             mock.checkSyncResult = .success(.outOfSync(serverChecksum: Data(repeating: 0xAB, count: 32)))
-            mock.deltaUploadResult = .success(.ok)
             let database = Database.mock
             let controller = Self.makeController(mock: mock, database: database)
 
             let contacts = [Self.aliceContact, Self.bobContact]
             let storedChecksum = ContactSyncController.checksum(of: contacts.map(\.e164))
-            try database.setContactSyncState(.init(
-                checksum:      storedChecksum,
-                changeHistory: nil,
-                lastSyncedAt:  .now
-            ))
-            try database.replaceLocalContactsSnapshot(contacts)
+            try Self.seedDatabase(database, checksum: storedChecksum, snapshot: contacts)
 
             try await controller.performSync(contacts: contacts)
 
-            // Probe fired, returned outOfSync → fall through to delta upload
-            // (snapshot present, oldChecksum present). Adds/removes empty
-            // because local and snapshot agree; the upload re-asserts the
-            // checksum.
+            // Probe fired, returned outOfSync → since old == new (local
+            // unchanged), a delta would compute empty adds/removes and the
+            // server would always reject it; the controller goes straight to
+            // full upload to avoid the wasted round-trip.
             #expect(mock.checkSyncCalls == [storedChecksum])
-            #expect(mock.deltaCalls.count == 1)
-            #expect(mock.deltaCalls[0].adds.isEmpty)
-            #expect(mock.deltaCalls[0].removes.isEmpty)
+            #expect(mock.deltaCalls.isEmpty)
+            let fullCall = try #require(mock.fullCalls.first)
+            #expect(mock.fullCalls.count == 1)
+            #expect(fullCall.phones == contacts.map(\.e164))
             #expect(mock.streamCalls.count == 1)
         }
 
@@ -442,11 +509,7 @@ struct ContactSyncControllerTests {
 
             // Stored checksum without a snapshot — e.g. snapshot was wiped
             // (SQLiteVersion bump preserved sync_state but lost snapshot).
-            try database.setContactSyncState(.init(
-                checksum:      Data(repeating: 0xFF, count: 32),
-                changeHistory: nil,
-                lastSyncedAt:  .now
-            ))
+            try Self.seedDatabase(database, checksum: Data(repeating: 0xFF, count: 32))
 
             let contacts = [Self.aliceContact]
             try await controller.performSync(contacts: contacts)
@@ -466,10 +529,30 @@ struct ContactSyncControllerTests {
                 try await controller.performSync(contacts: [Self.aliceContact])
             }
 
-            // Pre-upload state untouched
+            // Pre-upload state untouched.
             #expect(try database.contactSyncState() == .empty)
             #expect(try database.localContactsSnapshot().isEmpty)
             #expect(try database.flipcashContacts().isEmpty)
+        }
+
+        @Test("Stream failure leaves state unmodified so next sync re-runs end-to-end")
+        func streamFailure_doesNotPersist() async throws {
+            let mock = MockContactSync()
+            mock.streamTerminalError = ErrorContactSync.networkError
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            await #expect(throws: ErrorContactSync.networkError) {
+                try await controller.performSync(contacts: [Self.aliceContact])
+            }
+
+            // Upload succeeded but stream failed AFTER it — checksum and
+            // snapshot stay empty so the next sync's probe sees a mismatch
+            // and re-runs end-to-end (recovering matched-set freshness).
+            #expect(mock.fullCalls.count == 1)
+            #expect(mock.streamCalls.count == 1)
+            #expect(try database.contactSyncState() == .empty)
+            #expect(try database.localContactsSnapshot().isEmpty)
         }
 
         @Test("CheckSync `.denied` from server propagates")
@@ -481,11 +564,7 @@ struct ContactSyncControllerTests {
 
             let contacts = [Self.aliceContact]
             let storedChecksum = ContactSyncController.checksum(of: contacts.map(\.e164))
-            try database.setContactSyncState(.init(
-                checksum:      storedChecksum,
-                changeHistory: nil,
-                lastSyncedAt:  .now
-            ))
+            try Self.seedDatabase(database, checksum: storedChecksum, snapshot: contacts)
 
             await #expect(throws: ErrorContactSync.denied) {
                 try await controller.performSync(contacts: contacts)

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -1,0 +1,497 @@
+//
+//  ContactSyncControllerTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+/// Tests cover:
+/// - `nonisolated static` pure helpers (`checksum`, `delta`) — direct call
+/// - Lifecycle (``activate()``, ``didBecomeActive()``) — observed via internal
+///   `observerTask` / `syncTask` accessors
+/// - The state machine ``performSync(contacts:)`` — driven with synthetic
+///   contacts and a `MockContactSync` conformer of `ContactSyncing`
+///
+/// `runSync()` and `readContacts()` aren't directly covered: the former depends
+/// on `CNContactStore.authorizationStatus(for:)` (OS state, can't be mocked
+/// without further extraction); the latter is a thin shim over CN enumeration.
+/// They're exercised end-to-end via the dev-backend verification gate.
+@Suite("ContactSyncController")
+struct ContactSyncControllerTests {
+
+    // MARK: - Checksum
+
+    @Suite("checksum(of:)")
+    struct ChecksumTests {
+
+        @Test("Empty input returns 32 zero bytes")
+        func emptyInputIsZeroes() {
+            let checksum = ContactSyncController.checksum(of: [])
+            #expect(checksum.count == 32)
+            #expect(checksum.allSatisfy { $0 == 0 })
+        }
+
+        @Test("Single phone returns its raw SHA256")
+        func singlePhoneEqualsSHA256() {
+            let phone = "+14155550100"
+            let checksum = ContactSyncController.checksum(of: [phone])
+            let expected = SHA256.digest(phone)
+            #expect(checksum == expected)
+            #expect(checksum.count == 32)
+        }
+
+        @Test("Reordering inputs produces the same checksum (XOR commutativity)")
+        func reorderingIsStable() {
+            let phones = [
+                "+14155550100",
+                "+14155550101",
+                "+442071234567",
+                "+819012345678",
+                "+5511987654321",
+            ]
+            let forward  = ContactSyncController.checksum(of: phones)
+            let reversed = ContactSyncController.checksum(of: phones.reversed())
+            let shuffled = ContactSyncController.checksum(of: phones.shuffled())
+            #expect(forward == reversed)
+            #expect(forward == shuffled)
+        }
+
+        @Test("Duplicates collapse to identity (XOR cancellation)")
+        func duplicatePairsCancel() {
+            // The controller dedupes before calling checksum, but the
+            // algorithm itself must round-trip: XOR-ing the same value twice
+            // is identity. Two identical phones should produce the same bytes
+            // as the empty input.
+            let phones = ["+14155550100", "+14155550100"]
+            let checksum = ContactSyncController.checksum(of: phones)
+            #expect(checksum.count == 32)
+            #expect(checksum.allSatisfy { $0 == 0 })
+        }
+
+        @Test("Different phone sets produce different checksums")
+        func differentSetsDiffer() {
+            let a = ContactSyncController.checksum(of: ["+14155550100"])
+            let b = ContactSyncController.checksum(of: ["+14155550101"])
+            #expect(a != b)
+        }
+
+        @Test("Adding a phone changes the checksum")
+        func addingPhoneChangesChecksum() {
+            let base       = ["+14155550100", "+442071234567"]
+            let expanded   = base + ["+819012345678"]
+            let baseSum    = ContactSyncController.checksum(of: base)
+            let expandedSum = ContactSyncController.checksum(of: expanded)
+            #expect(baseSum != expandedSum)
+        }
+
+        @Test("Removing a phone reverts the checksum (XOR inverse)")
+        func removingPhoneIsReverseOfAdding() {
+            let base    = ["+14155550100", "+442071234567"]
+            let added   = base + ["+819012345678"]
+            let baseSum  = ContactSyncController.checksum(of: base)
+            let addedSum = ContactSyncController.checksum(of: added)
+            // XOR-ing the added phone's SHA256 onto the expanded checksum
+            // must restore the base checksum (XOR is its own inverse).
+            let extraHash = SHA256.digest("+819012345678")
+            var restored = [UInt8](addedSum)
+            for (i, byte) in extraHash.enumerated() {
+                restored[i] ^= byte
+            }
+            #expect(Data(restored) == baseSum)
+        }
+    }
+
+    // MARK: - Delta
+
+    @Suite("delta(oldSnapshot:newContacts:)")
+    struct DeltaTests {
+
+        @Test("Identical sets produce no adds and no removes")
+        func identicalIsEmpty() {
+            let phones = ["+14155550100", "+442071234567"]
+            let result = ContactSyncController.delta(
+                oldSnapshot: phones,
+                newContacts: phones
+            )
+            #expect(result.adds.isEmpty)
+            #expect(result.removes.isEmpty)
+        }
+
+        @Test("Adds-only: new contacts not in snapshot")
+        func addsOnly() {
+            let result = ContactSyncController.delta(
+                oldSnapshot: ["+14155550100"],
+                newContacts: ["+14155550100", "+14155550101", "+14155550102"]
+            )
+            #expect(result.adds == ["+14155550101", "+14155550102"])
+            #expect(result.removes.isEmpty)
+        }
+
+        @Test("Removes-only: snapshot phones missing from new contacts")
+        func removesOnly() {
+            let result = ContactSyncController.delta(
+                oldSnapshot: ["+14155550100", "+14155550101", "+14155550102"],
+                newContacts: ["+14155550100"]
+            )
+            #expect(result.adds.isEmpty)
+            #expect(result.removes == ["+14155550101", "+14155550102"])
+        }
+
+        @Test("Adds and removes mixed")
+        func addsAndRemoves() {
+            let result = ContactSyncController.delta(
+                oldSnapshot: ["+14155550100", "+14155550102"],
+                newContacts: ["+14155550101", "+14155550102"]
+            )
+            #expect(result.adds == ["+14155550101"])
+            #expect(result.removes == ["+14155550100"])
+        }
+
+        @Test("Empty new contacts removes everything")
+        func emptyNewRemovesAll() {
+            let result = ContactSyncController.delta(
+                oldSnapshot: ["+14155550100", "+14155550101"],
+                newContacts: []
+            )
+            #expect(result.adds.isEmpty)
+            #expect(result.removes == ["+14155550100", "+14155550101"])
+        }
+
+        @Test("Empty snapshot adds everything (first sync from snapshot)")
+        func emptySnapshotAddsAll() {
+            let result = ContactSyncController.delta(
+                oldSnapshot: [],
+                newContacts: ["+14155550101", "+14155550100"]
+            )
+            #expect(result.adds == ["+14155550100", "+14155550101"])
+            #expect(result.removes.isEmpty)
+        }
+
+        @Test("Both empty yields no work")
+        func bothEmpty() {
+            let result = ContactSyncController.delta(
+                oldSnapshot: [],
+                newContacts: []
+            )
+            #expect(result.adds.isEmpty)
+            #expect(result.removes.isEmpty)
+        }
+
+        @Test("Outputs are sorted regardless of input order")
+        func outputsAreSorted() {
+            let result = ContactSyncController.delta(
+                oldSnapshot: ["+999", "+111"],
+                newContacts: ["+555", "+333"]
+            )
+            #expect(result.adds == ["+333", "+555"])
+            #expect(result.removes == ["+111", "+999"])
+        }
+
+        @Test("Duplicate inputs are collapsed by Set semantics")
+        func duplicatesCollapse() {
+            let result = ContactSyncController.delta(
+                oldSnapshot: ["+14155550100", "+14155550100"],
+                newContacts: ["+14155550101", "+14155550101"]
+            )
+            #expect(result.adds == ["+14155550101"])
+            #expect(result.removes == ["+14155550100"])
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    @Suite("Lifecycle")
+    @MainActor
+    struct LifecycleTests {
+
+        private static func makeController(
+            mock: MockContactSync = .init(),
+            database: Database = .mock
+        ) -> ContactSyncController {
+            ContactSyncController(client: mock, database: database, owner: .mock)
+        }
+
+        @Test("Construction is dormant — no observer, no sync, no task")
+        func constructionIsDormant() {
+            let controller = Self.makeController()
+            #expect(controller.observerTask == nil)
+            #expect(controller.syncTask == nil)
+            #expect(controller.isSyncing == false)
+        }
+
+        @Test("activate() registers the observer and launches a sync")
+        func activateRegistersObserverAndSyncs() async {
+            let controller = Self.makeController()
+            controller.activate()
+            #expect(controller.observerTask != nil)
+            #expect(controller.syncTask != nil)
+            await controller.syncTask?.value
+        }
+
+        @Test("activate() is idempotent — second call doesn't replace the observer")
+        func activateIsIdempotent() async {
+            let controller = Self.makeController()
+            controller.activate()
+            await controller.syncTask?.value
+            let firstObserver = controller.observerTask
+
+            controller.activate()
+            await controller.syncTask?.value
+
+            // The guard `observerTask == nil` is the only assignment site, so
+            // a second activate() must leave the same task in place. `Task`
+            // conforms to `Hashable` via task identity — `==` is identity.
+            #expect(controller.observerTask == firstObserver)
+        }
+
+        @Test("didBecomeActive() is a no-op before activate()")
+        func didBecomeActiveNoOpBeforeActivate() async {
+            let controller = Self.makeController()
+            controller.didBecomeActive()
+            // didBecomeActive spawns a main-actor Task that bails on the
+            // observerTask guard. Yield twice — once for the spawn, once for
+            // the guard check — then assert nothing started.
+            await Task.yield()
+            await Task.yield()
+            #expect(controller.syncTask == nil)
+            #expect(controller.isSyncing == false)
+        }
+
+        @Test("didBecomeActive() triggers sync once activate() has been called")
+        func didBecomeActiveAfterActivate() async {
+            let controller = Self.makeController()
+            controller.activate()
+            await controller.syncTask?.value
+            #expect(controller.syncTask == nil)
+
+            controller.didBecomeActive()
+            await Task.yield()
+            await Task.yield()
+            // The didBecomeActive's main-actor Task should have hit sync() by
+            // now, which sets syncTask. Either it's still in flight or it has
+            // already completed and cleared itself — but `isSyncing` was
+            // briefly true and observerTask remains set.
+            #expect(controller.observerTask != nil)
+        }
+    }
+
+    // MARK: - State machine
+
+    @Suite("performSync(contacts:)")
+    @MainActor
+    struct PerformSyncTests {
+
+        private static func makeController(
+            mock: MockContactSync,
+            database: Database
+        ) -> ContactSyncController {
+            ContactSyncController(client: mock, database: database, owner: .mock)
+        }
+
+        private static let aliceContact = Database.LocalContact(e164: "+14155550100", contactId: "alice")
+        private static let bobContact   = Database.LocalContact(e164: "+14155550101", contactId: "bob")
+        private static let carolContact = Database.LocalContact(e164: "+14155550102", contactId: "carol")
+
+        @Test("First sync — no stored checksum → full upload + matched-set stream")
+        func firstSync_fullUploadAndStream() async throws {
+            let mock = MockContactSync()
+            mock.streamYields = ["+14155550101"]
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            let contacts = [Self.aliceContact, Self.bobContact]
+            try await controller.performSync(contacts: contacts)
+
+            #expect(mock.checkSyncCalls.isEmpty)
+            #expect(mock.deltaCalls.isEmpty)
+            #expect(mock.fullCalls.count == 1)
+            #expect(mock.fullCalls[0].phones == contacts.map(\.e164))
+            #expect(mock.streamCalls.count == 1)
+
+            let storedState = try database.contactSyncState()
+            #expect(storedState.checksum == ContactSyncController.checksum(of: contacts.map(\.e164)))
+            #expect(storedState.lastSyncedAt != nil)
+
+            #expect(try database.localContactsSnapshot().map(\.e164) == contacts.map(\.e164))
+            #expect(try database.flipcashContacts() == ["+14155550101"])
+        }
+
+        @Test("Steady-state — local unchanged + server agrees → no upload, no stream")
+        func steadyState_skipsUploadAndStream() async throws {
+            let mock = MockContactSync()
+            mock.checkSyncResult = .success(.ok)
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            let contacts = [Self.aliceContact, Self.bobContact]
+            let storedChecksum = ContactSyncController.checksum(of: contacts.map(\.e164))
+            try database.setContactSyncState(.init(
+                checksum:      storedChecksum,
+                changeHistory: nil,
+                lastSyncedAt:  .now
+            ))
+            try database.replaceLocalContactsSnapshot(contacts)
+
+            try await controller.performSync(contacts: contacts)
+
+            #expect(mock.checkSyncCalls == [storedChecksum])
+            #expect(mock.deltaCalls.isEmpty)
+            #expect(mock.fullCalls.isEmpty)
+            #expect(mock.streamCalls.isEmpty)
+        }
+
+        @Test("Local-changed — stored snapshot present → delta upload + stream")
+        func localChanged_deltaUploadAndStream() async throws {
+            let mock = MockContactSync()
+            mock.deltaUploadResult = .success(.ok)
+            mock.streamYields = []
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            let oldSnapshot = [Self.aliceContact]
+            let oldChecksum = ContactSyncController.checksum(of: oldSnapshot.map(\.e164))
+            try database.setContactSyncState(.init(
+                checksum:      oldChecksum,
+                changeHistory: nil,
+                lastSyncedAt:  .now
+            ))
+            try database.replaceLocalContactsSnapshot(oldSnapshot)
+
+            let newContacts = [Self.aliceContact, Self.bobContact]
+            try await controller.performSync(contacts: newContacts)
+
+            #expect(mock.deltaCalls.count == 1)
+            let call = mock.deltaCalls[0]
+            #expect(call.adds == ["+14155550101"])
+            #expect(call.removes.isEmpty)
+            #expect(call.oldChecksum == oldChecksum)
+            #expect(call.newChecksum == ContactSyncController.checksum(of: newContacts.map(\.e164)))
+            #expect(mock.fullCalls.isEmpty)
+            #expect(mock.streamCalls.count == 1)
+            #expect(mock.checkSyncCalls.isEmpty)  // checksum differs from stored, so the idle probe is skipped
+        }
+
+        @Test("CHECKSUM_DRIFT on delta → fallback to full upload in same call")
+        func checksumDrift_fallsBackToFullUpload() async throws {
+            let mock = MockContactSync()
+            mock.deltaUploadResult = .success(.checksumDrift)
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            let oldSnapshot = [Self.aliceContact]
+            let oldChecksum = ContactSyncController.checksum(of: oldSnapshot.map(\.e164))
+            try database.setContactSyncState(.init(
+                checksum:      oldChecksum,
+                changeHistory: nil,
+                lastSyncedAt:  .now
+            ))
+            try database.replaceLocalContactsSnapshot(oldSnapshot)
+
+            let newContacts = [Self.aliceContact, Self.bobContact, Self.carolContact]
+            try await controller.performSync(contacts: newContacts)
+
+            #expect(mock.deltaCalls.count == 1)
+            #expect(mock.fullCalls.count == 1)
+            #expect(mock.fullCalls[0].phones == newContacts.map(\.e164))
+            #expect(mock.streamCalls.count == 1)
+
+            // State still persisted with the new checksum after the fallback.
+            let storedState = try database.contactSyncState()
+            #expect(storedState.checksum == ContactSyncController.checksum(of: newContacts.map(\.e164)))
+        }
+
+        @Test("Server drift on idle probe — falls through to upload")
+        func serverDriftOnProbe_fallsThroughToUpload() async throws {
+            let mock = MockContactSync()
+            mock.checkSyncResult = .success(.outOfSync(serverChecksum: Data(repeating: 0xAB, count: 32)))
+            mock.deltaUploadResult = .success(.ok)
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            let contacts = [Self.aliceContact, Self.bobContact]
+            let storedChecksum = ContactSyncController.checksum(of: contacts.map(\.e164))
+            try database.setContactSyncState(.init(
+                checksum:      storedChecksum,
+                changeHistory: nil,
+                lastSyncedAt:  .now
+            ))
+            try database.replaceLocalContactsSnapshot(contacts)
+
+            try await controller.performSync(contacts: contacts)
+
+            // Probe fired, returned outOfSync → fall through to delta upload
+            // (snapshot present, oldChecksum present). Adds/removes empty
+            // because local and snapshot agree; the upload re-asserts the
+            // checksum.
+            #expect(mock.checkSyncCalls == [storedChecksum])
+            #expect(mock.deltaCalls.count == 1)
+            #expect(mock.deltaCalls[0].adds.isEmpty)
+            #expect(mock.deltaCalls[0].removes.isEmpty)
+            #expect(mock.streamCalls.count == 1)
+        }
+
+        @Test("Empty snapshot but stored checksum → full upload path (not delta)")
+        func emptySnapshot_choosesFullUpload() async throws {
+            let mock = MockContactSync()
+            mock.fullUploadResult = .success(())
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            // Stored checksum without a snapshot — e.g. snapshot was wiped
+            // (SQLiteVersion bump preserved sync_state but lost snapshot).
+            try database.setContactSyncState(.init(
+                checksum:      Data(repeating: 0xFF, count: 32),
+                changeHistory: nil,
+                lastSyncedAt:  .now
+            ))
+
+            let contacts = [Self.aliceContact]
+            try await controller.performSync(contacts: contacts)
+
+            #expect(mock.deltaCalls.isEmpty)
+            #expect(mock.fullCalls.count == 1)
+        }
+
+        @Test("Upload failure propagates and state stays unchanged")
+        func uploadFailure_doesNotPersist() async throws {
+            let mock = MockContactSync()
+            mock.fullUploadResult = .failure(ErrorContactSync.networkError)
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            await #expect(throws: ErrorContactSync.networkError) {
+                try await controller.performSync(contacts: [Self.aliceContact])
+            }
+
+            // Pre-upload state untouched
+            #expect(try database.contactSyncState() == .empty)
+            #expect(try database.localContactsSnapshot().isEmpty)
+            #expect(try database.flipcashContacts().isEmpty)
+        }
+
+        @Test("CheckSync `.denied` from server propagates")
+        func checkSyncDenied_propagates() async throws {
+            let mock = MockContactSync()
+            mock.checkSyncResult = .failure(ErrorContactSync.denied)
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            let contacts = [Self.aliceContact]
+            let storedChecksum = ContactSyncController.checksum(of: contacts.map(\.e164))
+            try database.setContactSyncState(.init(
+                checksum:      storedChecksum,
+                changeHistory: nil,
+                lastSyncedAt:  .now
+            ))
+
+            await #expect(throws: ErrorContactSync.denied) {
+                try await controller.performSync(contacts: contacts)
+            }
+            #expect(mock.deltaCalls.isEmpty)
+            #expect(mock.fullCalls.isEmpty)
+        }
+    }
+}

--- a/FlipcashTests/Database/Database+ContactSyncTests.swift
+++ b/FlipcashTests/Database/Database+ContactSyncTests.swift
@@ -40,10 +40,15 @@ struct DatabaseContactSyncTests {
             changeHistory: nil,
             lastSyncedAt: nil
         )
+        // Integer-second epoch round-trips losslessly through SQLite's Date
+        // column; `.now` carries sub-second precision the storage truncates,
+        // which made the `==` flake. Different epoch from `state_roundTrip`
+        // so the upsert is still meaningful (the second value must overwrite
+        // the first).
         let second = Database.ContactSyncState(
             checksum: Data(repeating: 0x02, count: 32),
             changeHistory: Data([0xff]),
-            lastSyncedAt: .now
+            lastSyncedAt: Date(timeIntervalSince1970: 1_716_000_001)
         )
 
         try db.setContactSyncState(first)

--- a/FlipcashTests/TestSupport/MockContactSync.swift
+++ b/FlipcashTests/TestSupport/MockContactSync.swift
@@ -6,6 +6,11 @@
 //  call and lets each test pre-load the responses the controller's state
 //  machine should observe.
 //
+//  `@unchecked Sendable` with an internal `NSLock` covering both the recorded
+//  call buffers AND the scripted-response storage. The controller invokes
+//  these methods from `@concurrent nonisolated` work and tests configure /
+//  read from `@MainActor`; the lock serializes both sides.
+//
 
 import Foundation
 import FlipcashCore
@@ -27,9 +32,6 @@ final class MockContactSync: ContactSyncing, @unchecked Sendable {
         let checksum: Data
     }
 
-    /// Serializes mutations to the recorded-call buffers — runSync may invoke
-    /// these from a `@concurrent nonisolated` context, while tests read from
-    /// `@MainActor`.
     private let lock = NSLock()
 
     private var _checkSyncCalls: [Data] = []
@@ -37,24 +39,46 @@ final class MockContactSync: ContactSyncing, @unchecked Sendable {
     private var _fullCalls:      [FullCall] = []
     private var _streamCalls:    [Data] = []
 
+    private var _checkSyncResult:    Result<CheckSyncResult, Error>   = .success(.ok)
+    private var _deltaUploadResult:  Result<DeltaUploadResult, Error> = .success(.ok)
+    private var _fullUploadResult:   Result<Void, Error>              = .success(())
+    private var _streamYields:       [String] = []
+    private var _streamTerminalError: Error?
+
     var checkSyncCalls: [Data]    { lock.withLock { _checkSyncCalls } }
     var deltaCalls:     [DeltaCall] { lock.withLock { _deltaCalls } }
     var fullCalls:      [FullCall]  { lock.withLock { _fullCalls } }
     var streamCalls:    [Data]    { lock.withLock { _streamCalls } }
 
-    // MARK: - Scripted responses -
-
-    var checkSyncResult:    Result<CheckSyncResult, Error>   = .success(.ok)
-    var deltaUploadResult:  Result<DeltaUploadResult, Error> = .success(.ok)
-    var fullUploadResult:   Result<Void, Error>              = .success(())
-    var streamYields:       [String] = []
-    var streamTerminalError: Error?
+    var checkSyncResult: Result<CheckSyncResult, Error> {
+        get { lock.withLock { _checkSyncResult } }
+        set { lock.withLock { _checkSyncResult = newValue } }
+    }
+    var deltaUploadResult: Result<DeltaUploadResult, Error> {
+        get { lock.withLock { _deltaUploadResult } }
+        set { lock.withLock { _deltaUploadResult = newValue } }
+    }
+    var fullUploadResult: Result<Void, Error> {
+        get { lock.withLock { _fullUploadResult } }
+        set { lock.withLock { _fullUploadResult = newValue } }
+    }
+    var streamYields: [String] {
+        get { lock.withLock { _streamYields } }
+        set { lock.withLock { _streamYields = newValue } }
+    }
+    var streamTerminalError: Error? {
+        get { lock.withLock { _streamTerminalError } }
+        set { lock.withLock { _streamTerminalError = newValue } }
+    }
 
     // MARK: - ContactSyncing -
 
     func checkContactSync(checksum: Data, owner: KeyPair) async throws -> CheckSyncResult {
-        lock.withLock { _checkSyncCalls.append(checksum) }
-        return try checkSyncResult.get()
+        let scripted: Result<CheckSyncResult, Error> = lock.withLock {
+            _checkSyncCalls.append(checksum)
+            return _checkSyncResult
+        }
+        return try scripted.get()
     }
 
     func uploadContactDelta(
@@ -64,34 +88,37 @@ final class MockContactSync: ContactSyncing, @unchecked Sendable {
         newChecksum: Data,
         owner: KeyPair
     ) async throws -> DeltaUploadResult {
-        lock.withLock {
+        let scripted: Result<DeltaUploadResult, Error> = lock.withLock {
             _deltaCalls.append(DeltaCall(
                 adds:        adds,
                 removes:     removes,
                 oldChecksum: oldChecksum,
                 newChecksum: newChecksum
             ))
+            return _deltaUploadResult
         }
-        return try deltaUploadResult.get()
+        return try scripted.get()
     }
 
     func uploadAllContacts(phones: [String], checksum: Data, owner: KeyPair) async throws {
-        lock.withLock {
+        let scripted: Result<Void, Error> = lock.withLock {
             _fullCalls.append(FullCall(phones: phones, checksum: checksum))
+            return _fullUploadResult
         }
-        try fullUploadResult.get()
+        try scripted.get()
     }
 
     func streamFlipcashContacts(checksum: Data, owner: KeyPair) -> AsyncThrowingStream<String, Error> {
-        lock.withLock { _streamCalls.append(checksum) }
-        let yields = streamYields
-        let error  = streamTerminalError
+        let (yields, terminalError): ([String], Error?) = lock.withLock {
+            _streamCalls.append(checksum)
+            return (_streamYields, _streamTerminalError)
+        }
         return AsyncThrowingStream { continuation in
             for value in yields {
                 continuation.yield(value)
             }
-            if let error {
-                continuation.finish(throwing: error)
+            if let terminalError {
+                continuation.finish(throwing: terminalError)
             } else {
                 continuation.finish()
             }

--- a/FlipcashTests/TestSupport/MockContactSync.swift
+++ b/FlipcashTests/TestSupport/MockContactSync.swift
@@ -2,20 +2,13 @@
 //  MockContactSync.swift
 //  FlipcashTests
 //
-//  Scriptable in-memory conformer for `ContactSyncing`. Records every RPC
-//  call and lets each test pre-load the responses the controller's state
-//  machine should observe.
-//
-//  `@unchecked Sendable` with an internal `NSLock` covering both the recorded
-//  call buffers AND the scripted-response storage. The controller invokes
-//  these methods from `@concurrent nonisolated` work and tests configure /
-//  read from `@MainActor`; the lock serializes both sides.
-//
 
 import Foundation
 import FlipcashCore
 @testable import Flipcash
 
+/// Scriptable `ContactSyncing` conformer. Records every RPC; the test sets
+/// scripted responses before driving the controller.
 final class MockContactSync: ContactSyncing, @unchecked Sendable {
 
     // MARK: - Recorded calls -
@@ -110,12 +103,9 @@ final class MockContactSync: ContactSyncing, @unchecked Sendable {
 
     func streamFlipcashContacts(checksum: Data, owner: KeyPair) -> AsyncThrowingStream<String, Error> {
         lock.withLock { _streamCalls.append(checksum) }
-        // Snapshot scriptable values INSIDE the stream's producer closure so a
-        // test that mutates `streamYields`/`streamTerminalError` between
-        // calling `controller.performSync(...)` and the stream actually
-        // iterating sees the latest values, not whatever was set at
-        // registration time.
         return AsyncThrowingStream { [self] continuation in
+            // Reads scripted values inside the producer so mutations after
+            // construction (but before iteration) take effect.
             let (yields, terminalError): ([String], Error?) = lock.withLock {
                 (_streamYields, _streamTerminalError)
             }
@@ -127,9 +117,6 @@ final class MockContactSync: ContactSyncing, @unchecked Sendable {
             } else {
                 continuation.finish()
             }
-            // Mirror production's `FlipClient+ContactList.swift:75` shape so
-            // future cancellation-regression tests have somewhere to assert.
-            // No underlying gRPC resource in this mock — explicit no-op.
             continuation.onTermination = { _ in }
         }
     }

--- a/FlipcashTests/TestSupport/MockContactSync.swift
+++ b/FlipcashTests/TestSupport/MockContactSync.swift
@@ -109,11 +109,16 @@ final class MockContactSync: ContactSyncing, @unchecked Sendable {
     }
 
     func streamFlipcashContacts(checksum: Data, owner: KeyPair) -> AsyncThrowingStream<String, Error> {
-        let (yields, terminalError): ([String], Error?) = lock.withLock {
-            _streamCalls.append(checksum)
-            return (_streamYields, _streamTerminalError)
-        }
-        return AsyncThrowingStream { continuation in
+        lock.withLock { _streamCalls.append(checksum) }
+        // Snapshot scriptable values INSIDE the stream's producer closure so a
+        // test that mutates `streamYields`/`streamTerminalError` between
+        // calling `controller.performSync(...)` and the stream actually
+        // iterating sees the latest values, not whatever was set at
+        // registration time.
+        return AsyncThrowingStream { [self] continuation in
+            let (yields, terminalError): ([String], Error?) = lock.withLock {
+                (_streamYields, _streamTerminalError)
+            }
             for value in yields {
                 continuation.yield(value)
             }
@@ -122,6 +127,10 @@ final class MockContactSync: ContactSyncing, @unchecked Sendable {
             } else {
                 continuation.finish()
             }
+            // Mirror production's `FlipClient+ContactList.swift:75` shape so
+            // future cancellation-regression tests have somewhere to assert.
+            // No underlying gRPC resource in this mock — explicit no-op.
+            continuation.onTermination = { _ in }
         }
     }
 }

--- a/FlipcashTests/TestSupport/MockContactSync.swift
+++ b/FlipcashTests/TestSupport/MockContactSync.swift
@@ -1,0 +1,100 @@
+//
+//  MockContactSync.swift
+//  FlipcashTests
+//
+//  Scriptable in-memory conformer for `ContactSyncing`. Records every RPC
+//  call and lets each test pre-load the responses the controller's state
+//  machine should observe.
+//
+
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+final class MockContactSync: ContactSyncing, @unchecked Sendable {
+
+    // MARK: - Recorded calls -
+
+    struct DeltaCall: Equatable, Sendable {
+        let adds: [String]
+        let removes: [String]
+        let oldChecksum: Data
+        let newChecksum: Data
+    }
+
+    struct FullCall: Equatable, Sendable {
+        let phones: [String]
+        let checksum: Data
+    }
+
+    /// Serializes mutations to the recorded-call buffers — runSync may invoke
+    /// these from a `@concurrent nonisolated` context, while tests read from
+    /// `@MainActor`.
+    private let lock = NSLock()
+
+    private var _checkSyncCalls: [Data] = []
+    private var _deltaCalls:     [DeltaCall] = []
+    private var _fullCalls:      [FullCall] = []
+    private var _streamCalls:    [Data] = []
+
+    var checkSyncCalls: [Data]    { lock.withLock { _checkSyncCalls } }
+    var deltaCalls:     [DeltaCall] { lock.withLock { _deltaCalls } }
+    var fullCalls:      [FullCall]  { lock.withLock { _fullCalls } }
+    var streamCalls:    [Data]    { lock.withLock { _streamCalls } }
+
+    // MARK: - Scripted responses -
+
+    var checkSyncResult:    Result<CheckSyncResult, Error>   = .success(.ok)
+    var deltaUploadResult:  Result<DeltaUploadResult, Error> = .success(.ok)
+    var fullUploadResult:   Result<Void, Error>              = .success(())
+    var streamYields:       [String] = []
+    var streamTerminalError: Error?
+
+    // MARK: - ContactSyncing -
+
+    func checkContactSync(checksum: Data, owner: KeyPair) async throws -> CheckSyncResult {
+        lock.withLock { _checkSyncCalls.append(checksum) }
+        return try checkSyncResult.get()
+    }
+
+    func uploadContactDelta(
+        adds: [String],
+        removes: [String],
+        oldChecksum: Data,
+        newChecksum: Data,
+        owner: KeyPair
+    ) async throws -> DeltaUploadResult {
+        lock.withLock {
+            _deltaCalls.append(DeltaCall(
+                adds:        adds,
+                removes:     removes,
+                oldChecksum: oldChecksum,
+                newChecksum: newChecksum
+            ))
+        }
+        return try deltaUploadResult.get()
+    }
+
+    func uploadAllContacts(phones: [String], checksum: Data, owner: KeyPair) async throws {
+        lock.withLock {
+            _fullCalls.append(FullCall(phones: phones, checksum: checksum))
+        }
+        try fullUploadResult.get()
+    }
+
+    func streamFlipcashContacts(checksum: Data, owner: KeyPair) -> AsyncThrowingStream<String, Error> {
+        lock.withLock { _streamCalls.append(checksum) }
+        let yields = streamYields
+        let error  = streamTerminalError
+        return AsyncThrowingStream { continuation in
+            for value in yields {
+                continuation.yield(value)
+            }
+            if let error {
+                continuation.finish(throwing: error)
+            } else {
+                continuation.finish()
+            }
+        }
+    }
+}

--- a/FlipcashTests/TestSupport/Mocks.swift
+++ b/FlipcashTests/TestSupport/Mocks.swift
@@ -88,6 +88,7 @@ extension SessionContainer {
         let database = Database.mock
         let ratesController = RatesController(container: .mock, database: database)
         let historyController = HistoryController(container: .mock, database: database, owner: .mock)
+        let contactSyncController = ContactSyncController(client: Container.mock.flipClient, database: database, owner: .mock)
         let session = Session.makeMock(
             database: database,
             historyController: historyController,
@@ -101,6 +102,7 @@ extension SessionContainer {
             ratesController: ratesController,
             historyController: historyController,
             pushController: .mock,
+            contactSyncController: contactSyncController,
             flipClient: Container.mock.flipClient
         )
     }

--- a/FlipcashTests/TestSupport/SessionContainer+TestSupport.swift
+++ b/FlipcashTests/TestSupport/SessionContainer+TestSupport.swift
@@ -77,6 +77,7 @@ extension SessionContainer {
             ratesController: ratesController,
             historyController: .mock,
             pushController: .mock,
+            contactSyncController: ContactSyncController(client: Container.mock.flipClient, database: database, owner: .mock),
             flipClient: Container.mock.flipClient
         )
     }


### PR DESCRIPTION
Adds the contact sync controller as a sibling to rates and history on the session container. It stays dormant at construction — Phase 4 UI activates it after the user grants contact permission, and only then does it register an observer and start syncing. Heavy work (address-book read, database writes, server uploads) runs off the main actor. End-to-end dev-backend verification is deferred to Phase 4 since there's no path to activate the controller in this PR alone.

Also includes a Date-precision fix to a pre-existing sibling test that was flaking under the AllTargets run.

### Test plan
- [x] Targeted contact sync controller tests pass
- [x] Targeted contact sync database tests pass
- [x] AllTargets passes with no regressions