### PR TITLE
chore: increase font weight in the amount pill

### DIFF
--- a/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
+++ b/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
@@ -183,7 +183,7 @@ private struct AmountLabel: View {
                     .foregroundStyle(Color.textMain)
             case .pill:
                 Text(amount.formatted())
-                    .font(.appTextCaption)
+                    .font(.appTextHeading)
                     .foregroundStyle(Color.textSecondary)
                     .padding(4)
                     .overlay(


### PR DESCRIPTION
This pull request makes a small UI update to the `AmountLabel` component. The font used for the `.pill` style has been changed to improve visual hierarchy and consistency.