### PR TITLE
chore: add pre-commit hook to block committing secrets

### DIFF
--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -17,6 +17,13 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
+# Ensure the repo's versioned pre-commit hook is active. Idempotent — first
+# build of a fresh clone wires it up; subsequent runs are silent.
+if [[ "$(git config --get core.hooksPath 2>/dev/null || true)" != "Scripts/git-hooks" ]]; then
+    git config core.hooksPath Scripts/git-hooks
+    echo "✓ git hooks installed: core.hooksPath = Scripts/git-hooks"
+fi
+
 # Resolve a paired iOS device UDID via devicectl.
 #
 # Use devicectl, NOT `xcrun xctrace list devices` — xctrace often labels

--- a/Scripts/git-hooks/pre-commit
+++ b/Scripts/git-hooks/pre-commit
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Refuse commits that include sensitive files — credentials, signing keys,
+# CI scripts, or any file that flips between dummy/real values per local
+# environment. Most of these are gitignored, but `git add -f` bypasses
+# .gitignore and would silently commit secrets; this hook is the safety net.
+
+set -e
+
+# Exact paths.
+FORBIDDEN_PATHS=(
+    "Flipcash/Supporting Files/GoogleService-Info.plist"
+    "Configurations/secrets.xcconfig"
+    "Configurations/secrets.local.xcconfig"
+    ".env"
+    ".env.local"
+    "ci_scripts/ci_post_xcodebuild.sh"
+)
+
+# Glob patterns — match the staged path against each via `case`. The shell's
+# `*` does match `/`, so `*.p8` catches `AuthKey.p8` and `Subdir/Auth.p8`.
+FORBIDDEN_GLOBS=(
+    "*.p8"
+)
+
+block() {
+    cat >&2 <<EOF
+error: refusing to commit changes to '$1'.
+
+This path is on the secret-file blocklist (see Scripts/git-hooks/pre-commit).
+
+To unstage:
+  git restore --staged -- "$1"
+
+To discard the working-tree change too:
+  git restore -- "$1"
+EOF
+    exit 1
+}
+
+while IFS= read -r -d '' staged_path; do
+    for forbidden in "${FORBIDDEN_PATHS[@]}"; do
+        if [ "$staged_path" = "$forbidden" ]; then
+            block "$staged_path"
+        fi
+    done
+    for pattern in "${FORBIDDEN_GLOBS[@]}"; do
+        case "$staged_path" in
+            $pattern) block "$staged_path" ;;
+        esac
+    done
+done < <(git diff --cached --name-only -z)


### PR DESCRIPTION
## Summary

Adds a git pre-commit hook that refuses to stage credential and config files which flip between dummy and real values per local environment. The build script wires the hook in automatically on its first invocation in a fresh clone, so devs and CI are both protected without any manual setup step.

## Test Plan

- [x] First run of the build script prints that the hooks were installed.
- [x] Subsequent build script runs are silent about hooks.
- [x] Force-staging a dummy .env and attempting to commit is rejected with a helpful error.
- [x] Committing an ordinary source file succeeds.