### PR TITLE
feat: recipient picker with On Flipcash and Invite sections

### DIFF
--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -12,11 +12,21 @@ nonisolated private let logger = Logger(label: "flipcash.contact-directory")
 // MARK: - Resolved data -
 
 nonisolated struct ResolvedContact: Identifiable, Hashable, Sendable {
-    let id: String          // CNContact.identifier
+    /// `contactId` from `CNContact.identifier`. The same person may appear
+    /// in several `ResolvedContact`s, one per phone number, and the same
+    /// number may show up under several contactIds — so `contactId` alone
+    /// is NOT unique. Use ``id`` for `ForEach`. `contactId` is for things
+    /// scoped to the address-book record (image cache, send wire-up).
+    let contactId: String
     let displayName: String
     let phoneE164: String
     let nationalPhone: String
     let imageData: Data?
+
+    /// Composite identity for `ForEach`. A picker row corresponds to one
+    /// (contactId, e164) pair; the same address-book contact with three
+    /// phones is three rows with three distinct `id`s.
+    var id: String { "\(contactId)|\(phoneE164)" }
 }
 
 nonisolated struct ResolvedContacts: Equatable, Sendable {
@@ -57,51 +67,59 @@ nonisolated private extension ResolvedContact {
 /// the controller's cached output rather than re-loading on every appear.
 enum RecipientLoader {
 
-    /// One row per unique address-book contact, with the e164 we should
-    /// display chosen by ``placements(snapshot:flipcashSet:)``. The
-    /// snapshot table dedupes by `e164` only, so a single contact with
-    /// multiple phone-number entries (Home / Work / iPhone) yields
-    /// multiple snapshot rows that share `contactId`.
+    /// One placement per snapshot row. The snapshot now uses a composite
+    /// `(e164, contactId)` PK, so each pair survives — multiple phones on
+    /// one contact, or one phone shared across multiple contacts, all
+    /// come through here.
     nonisolated struct ContactPlacement: Equatable, Sendable {
         let contactId: String
         let e164: String
         let isOnFlipcash: Bool
     }
 
-    /// Group snapshot rows by `contactId` and pick a single e164 per
-    /// contact. Preference order:
-    /// 1. The first e164 we encounter that is in `flipcashSet` — that's
-    ///    the address the user can send to right now.
-    /// 2. Otherwise, the first e164 we encountered for that contact.
-    ///
-    /// Result order is first-seen, so callers can sort independently.
+    /// Direct map of every snapshot row to a placement, annotated with
+    /// whether the e164 is on Flipcash. No grouping or filtering.
     nonisolated static func placements(
         snapshot: [Database.LocalContact],
         flipcashSet: Set<String>,
     ) -> [ContactPlacement] {
-        var byContactId: [String: ContactPlacement] = [:]
-        var orderedIds: [String] = []
-        for entry in snapshot {
-            let isMatched = flipcashSet.contains(entry.e164)
-            if let existing = byContactId[entry.contactId] {
-                // Promote to a matched e164 if we haven't seen one yet.
-                if !existing.isOnFlipcash, isMatched {
-                    byContactId[entry.contactId] = ContactPlacement(
-                        contactId: entry.contactId,
-                        e164: entry.e164,
-                        isOnFlipcash: true,
-                    )
+        snapshot.map { entry in
+            ContactPlacement(
+                contactId: entry.contactId,
+                e164: entry.e164,
+                isOnFlipcash: flipcashSet.contains(entry.e164),
+            )
+        }
+    }
+
+    /// Collapse contacts that look identical to the user — same display
+    /// name and same nationally-formatted phone number — to a single
+    /// row. Different underlying e164s that format to the same national
+    /// string (extension trailers, formatting variants) count as the
+    /// same row. On a collision, prefer the variant whose e164 is on
+    /// Flipcash so the resulting row is the actionable one.
+    ///
+    /// Result preserves first-seen order, mirroring ``placements``.
+    nonisolated static func deduplicatedForDisplay(
+        _ contacts: [ResolvedContact],
+        flipcashSet: Set<String>,
+    ) -> [ResolvedContact] {
+        var byKey: [String: ResolvedContact] = [:]
+        var orderedKeys: [String] = []
+        for contact in contacts {
+            let key = "\(contact.displayName)|\(contact.nationalPhone)"
+            if let existing = byKey[key] {
+                let existingMatched = flipcashSet.contains(existing.phoneE164)
+                let newMatched      = flipcashSet.contains(contact.phoneE164)
+                if !existingMatched, newMatched {
+                    byKey[key] = contact
                 }
             } else {
-                byContactId[entry.contactId] = ContactPlacement(
-                    contactId: entry.contactId,
-                    e164: entry.e164,
-                    isOnFlipcash: isMatched,
-                )
-                orderedIds.append(entry.contactId)
+                byKey[key] = contact
+                orderedKeys.append(key)
             }
         }
-        return orderedIds.compactMap { byContactId[$0] }
+        return orderedKeys.compactMap { byKey[$0] }
     }
 
     static func load(database: Database) async -> ResolvedContacts {
@@ -131,36 +149,50 @@ enum RecipientLoader {
             let region = Region.current ?? .us
             let placements = placements(snapshot: snapshot, flipcashSet: flipcashSet)
 
-            var onFlipcash: [ResolvedContact] = []
-            var invite: [ResolvedContact] = []
-            let onFlipcashCount = placements.lazy.filter(\.isOnFlipcash).count
-            onFlipcash.reserveCapacity(onFlipcashCount)
-            invite.reserveCapacity(placements.count - onFlipcashCount)
+            // Resolve every placement first; cache `unifiedContact` lookups
+            // so the same contactId across rows doesn't hit CN repeatedly.
+            var resolvedByPlacement: [ResolvedContact] = []
+            resolvedByPlacement.reserveCapacity(placements.count)
+            var cnCache: [String: CNContact] = [:]
 
             for placement in placements {
-                guard let cnContact = try? store.unifiedContact(
+                let cnContact: CNContact
+                if let cached = cnCache[placement.contactId] {
+                    cnContact = cached
+                } else if let fetched = try? store.unifiedContact(
                     withIdentifier: placement.contactId,
                     keysToFetch: keys,
-                ) else {
+                ) {
+                    cnCache[placement.contactId] = fetched
+                    cnContact = fetched
+                } else {
                     continue
                 }
 
                 let nationalPhone = Phone(placement.e164, defaultRegion: region)?.national ?? placement.e164
-                let displayName = CNContactFormatter.string(from: cnContact, style: .fullName)
+                let displayName   = CNContactFormatter.string(from: cnContact, style: .fullName)
                     ?? nationalPhone
 
-                let resolved = ResolvedContact(
-                    id: placement.contactId,
+                resolvedByPlacement.append(ResolvedContact(
+                    contactId: placement.contactId,
                     displayName: displayName,
                     phoneE164: placement.e164,
                     nationalPhone: nationalPhone,
                     imageData: cnContact.thumbnailImageData,
-                )
+                ))
+            }
 
-                if placement.isOnFlipcash {
-                    onFlipcash.append(resolved)
+            // Collapse `(displayName, nationalPhone)` collisions — Ted's
+            // invariant: don't ever show the same name + number twice.
+            let unique = deduplicatedForDisplay(resolvedByPlacement, flipcashSet: flipcashSet)
+
+            var onFlipcash: [ResolvedContact] = []
+            var invite: [ResolvedContact] = []
+            for contact in unique {
+                if flipcashSet.contains(contact.phoneE164) {
+                    onFlipcash.append(contact)
                 } else {
-                    invite.append(resolved)
+                    invite.append(contact)
                 }
             }
 

--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -1,0 +1,176 @@
+//
+//  ContactDirectory.swift
+//  Flipcash
+//
+
+import Contacts
+import Foundation
+import FlipcashCore
+
+nonisolated private let logger = Logger(label: "flipcash.contact-directory")
+
+// MARK: - Resolved data -
+
+nonisolated struct ResolvedContact: Identifiable, Hashable, Sendable {
+    let id: String          // CNContact.identifier
+    let displayName: String
+    let phoneE164: String
+    let nationalPhone: String
+    let imageData: Data?
+}
+
+nonisolated struct ResolvedContacts: Equatable, Sendable {
+    var onFlipcash: [ResolvedContact]
+    var invite: [ResolvedContact]
+
+    static let empty = Self(onFlipcash: [], invite: [])
+
+    var isEmpty: Bool { onFlipcash.isEmpty && invite.isEmpty }
+
+    /// Case-insensitive substring match on `displayName` OR `nationalPhone`.
+    /// Empty/whitespace-only query returns `self` unchanged.
+    func filtered(by query: String) -> ResolvedContacts {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return self }
+        let lowered = trimmed.lowercased()
+        return ResolvedContacts(
+            onFlipcash: onFlipcash.filter { $0.matches(lowered) },
+            invite: invite.filter { $0.matches(lowered) },
+        )
+    }
+}
+
+nonisolated private extension ResolvedContact {
+    func matches(_ loweredQuery: String) -> Bool {
+        displayName.lowercased().contains(loweredQuery)
+            || nationalPhone.lowercased().contains(loweredQuery)
+    }
+}
+
+// MARK: - Loader -
+
+/// Reads contact-sync DB tables and resolves each snapshot entry against
+/// `CNContactStore`. All work runs in a detached task so the main actor
+/// stays free while we hit SQLite and the Contacts TCC layer.
+///
+/// Called from `ContactSyncController` after each sync; the picker reads
+/// the controller's cached output rather than re-loading on every appear.
+enum RecipientLoader {
+
+    /// One row per unique address-book contact, with the e164 we should
+    /// display chosen by ``placements(snapshot:flipcashSet:)``. The
+    /// snapshot table dedupes by `e164` only, so a single contact with
+    /// multiple phone-number entries (Home / Work / iPhone) yields
+    /// multiple snapshot rows that share `contactId`.
+    nonisolated struct ContactPlacement: Equatable, Sendable {
+        let contactId: String
+        let e164: String
+        let isOnFlipcash: Bool
+    }
+
+    /// Group snapshot rows by `contactId` and pick a single e164 per
+    /// contact. Preference order:
+    /// 1. The first e164 we encounter that is in `flipcashSet` — that's
+    ///    the address the user can send to right now.
+    /// 2. Otherwise, the first e164 we encountered for that contact.
+    ///
+    /// Result order is first-seen, so callers can sort independently.
+    nonisolated static func placements(
+        snapshot: [Database.LocalContact],
+        flipcashSet: Set<String>,
+    ) -> [ContactPlacement] {
+        var byContactId: [String: ContactPlacement] = [:]
+        var orderedIds: [String] = []
+        for entry in snapshot {
+            let isMatched = flipcashSet.contains(entry.e164)
+            if let existing = byContactId[entry.contactId] {
+                // Promote to a matched e164 if we haven't seen one yet.
+                if !existing.isOnFlipcash, isMatched {
+                    byContactId[entry.contactId] = ContactPlacement(
+                        contactId: entry.contactId,
+                        e164: entry.e164,
+                        isOnFlipcash: true,
+                    )
+                }
+            } else {
+                byContactId[entry.contactId] = ContactPlacement(
+                    contactId: entry.contactId,
+                    e164: entry.e164,
+                    isOnFlipcash: isMatched,
+                )
+                orderedIds.append(entry.contactId)
+            }
+        }
+        return orderedIds.compactMap { byContactId[$0] }
+    }
+
+    static func load(database: Database) async -> ResolvedContacts {
+        await Task.detached(priority: .userInitiated) {
+            let snapshot: [Database.LocalContact]
+            let flipcashSet: Set<String>
+            do {
+                snapshot = try database.localContactsSnapshot()
+                flipcashSet = Set(try database.flipcashContacts())
+            } catch {
+                logger.error("Failed to read contact-sync tables", metadata: [
+                    "error": "\(error)",
+                ])
+                return ResolvedContacts.empty
+            }
+
+            let store = CNContactStore()
+            // `CNContactFormatter.descriptorForRequiredKeys(for:)` returns the
+            // full key set the formatter needs — including locale-specific
+            // ones like `middleName`. Fetching with a smaller list crashes
+            // with `CNPropertyNotFetchedException` the moment the formatter
+            // reaches a property that wasn't in `keysToFetch`.
+            let keys: [CNKeyDescriptor] = [
+                CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+                CNContactThumbnailImageDataKey as CNKeyDescriptor,
+            ]
+            let region = Region.current ?? .us
+            let placements = placements(snapshot: snapshot, flipcashSet: flipcashSet)
+
+            var onFlipcash: [ResolvedContact] = []
+            var invite: [ResolvedContact] = []
+            let onFlipcashCount = placements.lazy.filter(\.isOnFlipcash).count
+            onFlipcash.reserveCapacity(onFlipcashCount)
+            invite.reserveCapacity(placements.count - onFlipcashCount)
+
+            for placement in placements {
+                guard let cnContact = try? store.unifiedContact(
+                    withIdentifier: placement.contactId,
+                    keysToFetch: keys,
+                ) else {
+                    continue
+                }
+
+                let nationalPhone = Phone(placement.e164, defaultRegion: region)?.national ?? placement.e164
+                let displayName = CNContactFormatter.string(from: cnContact, style: .fullName)
+                    ?? nationalPhone
+
+                let resolved = ResolvedContact(
+                    id: placement.contactId,
+                    displayName: displayName,
+                    phoneE164: placement.e164,
+                    nationalPhone: nationalPhone,
+                    imageData: cnContact.thumbnailImageData,
+                )
+
+                if placement.isOnFlipcash {
+                    onFlipcash.append(resolved)
+                } else {
+                    invite.append(resolved)
+                }
+            }
+
+            let sorter: (ResolvedContact, ResolvedContact) -> Bool = {
+                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+            }
+            onFlipcash.sort(by: sorter)
+            invite.sort(by: sorter)
+
+            return ResolvedContacts(onFlipcash: onFlipcash, invite: invite)
+        }.value
+    }
+}

--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -104,10 +104,18 @@ enum RecipientLoader {
         _ contacts: [ResolvedContact],
         flipcashSet: Set<String>,
     ) -> [ResolvedContact] {
-        var byKey: [String: ResolvedContact] = [:]
-        var orderedKeys: [String] = []
+        // Struct key (not a separator-joined string) — display names and
+        // phone formats can legitimately contain any character, and a
+        // joined-string key would collide when the separator appears in
+        // the data itself.
+        struct Key: Hashable {
+            let displayName: String
+            let nationalPhone: String
+        }
+        var byKey: [Key: ResolvedContact] = [:]
+        var orderedKeys: [Key] = []
         for contact in contacts {
-            let key = "\(contact.displayName)|\(contact.nationalPhone)"
+            let key = Key(displayName: contact.displayName, nationalPhone: contact.nationalPhone)
             if let existing = byKey[key] {
                 let existingMatched = flipcashSet.contains(existing.phoneE164)
                 let newMatched      = flipcashSet.contains(contact.phoneE164)

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -30,6 +30,16 @@ final class ContactSyncController {
     @ObservationIgnored internal private(set) var observerTask: Task<Void, Never>?
     @ObservationIgnored private var needsResync = false
 
+    /// Resolved directory cache surfaced to the picker. Updated after every
+    /// successful sync; consumers observe it and re-render on changes.
+    private(set) var resolvedContacts: ResolvedContacts = .empty
+
+    /// Flips to `true` after the first directory resolution completes —
+    /// regardless of whether `resolvedContacts` ends up empty. The picker
+    /// gate uses this to distinguish "loading for the first time" from
+    /// "we ran a load and found nothing".
+    private(set) var hasResolvedOnce: Bool = false
+
     nonisolated private var ownerKeyPair: KeyPair {
         owner.authority.keyPair
     }
@@ -151,6 +161,7 @@ final class ContactSyncController {
             switch result {
             case .ok:
                 logger.info("Sync skipped — local unchanged, server agrees")
+                await resolveDirectory()
                 return
             case .outOfSync:
                 serverDrifted = true
@@ -203,6 +214,21 @@ final class ContactSyncController {
                 lastSyncedAt:  .now
             )
         )
+
+        await resolveDirectory()
+    }
+
+    // MARK: - Directory resolution -
+
+    /// Re-resolve the picker's display data from the freshly-persisted
+    /// snapshot. Safe to call from any actor — the load itself is detached
+    /// and the observable updates hop back to main.
+    nonisolated func resolveDirectory() async {
+        let resolved = await RecipientLoader.load(database: database)
+        await MainActor.run {
+            self.resolvedContacts = resolved
+            self.hasResolvedOnce  = true
+        }
     }
 
     nonisolated private func uploadFull(phones: [String], checksum: Data) async throws {

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -149,7 +149,13 @@ final class ContactSyncController {
     /// preserved when called through the production `runSync` path.
     internal nonisolated func performSync(contacts: [Database.LocalContact]) async throws {
         let storedState = try database.contactSyncState()
-        let phones      = contacts.map(\.e164)
+        // The snapshot stores every `(e164, contactId)` pair so the picker
+        // can show each contact with each of their phone numbers. Upload
+        // + checksum operate on the unique e164 set — the server doesn't
+        // care which addr-book contacts a phone is on. Preserve first-seen
+        // order so the upload payload is deterministic across runs.
+        var seenPhones: Set<String> = []
+        let phones      = contacts.map(\.e164).filter { seenPhones.insert($0).inserted }
         let newChecksum = Self.checksum(of: phones)
 
         var serverDrifted = false
@@ -176,8 +182,10 @@ final class ContactSyncController {
             if snapshot.isEmpty {
                 try await uploadFull(phones: phones, checksum: newChecksum)
             } else {
+                var seenSnapshot: Set<String> = []
+                let snapshotPhones = snapshot.map(\.e164).filter { seenSnapshot.insert($0).inserted }
                 let (adds, removes) = Self.delta(
-                    oldSnapshot: snapshot.map(\.e164),
+                    oldSnapshot: snapshotPhones,
                     newContacts: phones
                 )
                 let result = try await client.uploadContactDelta(
@@ -273,18 +281,23 @@ final class ContactSyncController {
         return Self.normalizeContacts(rawNumbers: rawNumbers, region: Region.current ?? .us)
     }
 
-    /// Parses each raw number against `region`, normalizes to E.164, dedupes
-    /// keeping the first occurrence's `contactId`.
+    /// Parses each raw number against `region`, normalizes to E.164, and
+    /// keeps every `(e164, contactId)` pair so the picker can show each
+    /// contact with each of their phone numbers, and a phone shared
+    /// across contacts shows once per contact name. Dedupe is on the
+    /// tuple — same pair seen twice (e.g. a label-duplicated entry on
+    /// one card) collapses to a single row.
     nonisolated static func normalizeContacts(
         rawNumbers: [(raw: String, contactId: String)],
         region: Region
     ) -> [Database.LocalContact] {
-        var seen:   Set<String> = []
+        var seen:   Set<Database.LocalContact> = []
         var locals: [Database.LocalContact] = []
         for entry in rawNumbers {
             guard let phone = Phone(entry.raw, defaultRegion: region) else { continue }
-            if seen.insert(phone.e164).inserted {
-                locals.append(.init(e164: phone.e164, contactId: entry.contactId))
+            let local = Database.LocalContact(e164: phone.e164, contactId: entry.contactId)
+            if seen.insert(local).inserted {
+                locals.append(local)
             }
         }
         return locals

--- a/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
+++ b/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
@@ -95,13 +95,14 @@ nonisolated extension Database {
     }
 
     /// Replace the snapshot with the latest uploaded set.
-    /// Linked iOS contacts commonly share a normalized phone number; the
-    /// snapshot's purpose is delta computation against the unique e164 set,
-    /// so we dedupe by `e164` keeping the first occurrence's `contactId`.
+    /// Composite PK `(e164, contactId)` lets the same phone show up under
+    /// multiple address-book contacts (the picker shows each name with
+    /// that number). Dedupe defensively on the tuple in case the source
+    /// ever emits the same pair twice.
     func replaceLocalContactsSnapshot(_ contacts: [LocalContact]) throws {
         let table = LocalContactsSnapshotTable()
-        var seen: Set<String> = []
-        let deduped = contacts.filter { seen.insert($0.e164).inserted }
+        var seen: Set<LocalContact> = []
+        let deduped = contacts.filter { seen.insert($0).inserted }
         try writer.transaction {
             try writer.run(table.table.delete())
             for contact in deduped {

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -288,9 +288,15 @@ nonisolated extension Database {
         let localContactsSnapshotTable = LocalContactsSnapshotTable()
 
         try writer.transaction {
+            // Composite PK (e164, contactId): the same phone number may
+            // appear on multiple address-book contacts (a household
+            // landline, a shop number on several cards). The picker shows
+            // every (name, number) pair, so the snapshot has to preserve
+            // them all.
             try writer.run(localContactsSnapshotTable.table.create(ifNotExists: true, withoutRowid: true) { t in
-                t.column(localContactsSnapshotTable.e164, primaryKey: true)
+                t.column(localContactsSnapshotTable.e164)
                 t.column(localContactsSnapshotTable.contactId)
+                t.primaryKey(localContactsSnapshotTable.e164, localContactsSnapshotTable.contactId)
             })
         }
 

--- a/Flipcash/Core/Screens/ContactsPermission/ContactsPermissionScreen.swift
+++ b/Flipcash/Core/Screens/ContactsPermission/ContactsPermissionScreen.swift
@@ -9,12 +9,28 @@ import FlipcashUI
 
 /// Priming view for the system contacts authorization prompt. The parent
 /// owns the ``ContactsAuthorizer`` so grants propagate via `@Observable`.
-/// Pass `onSkipped: nil` to hide the secondary "Not Now" button.
+/// Pass `onSkipped: nil` to hide the secondary "Not Now" button. Set
+/// `isAllowing` to `true` to swap the primary button label for a spinner
+/// — used by parents that need to keep the priming screen visible while
+/// an in-flight grant + downstream load resolves.
 struct ContactsPermissionScreen: View {
 
     let authorizer: ContactsAuthorizer
     let onAllowed: () -> Void
     let onSkipped: (() -> Void)?
+    let isAllowing: Bool
+
+    init(
+        authorizer: ContactsAuthorizer,
+        onAllowed: @escaping () -> Void,
+        onSkipped: (() -> Void)?,
+        isAllowing: Bool = false
+    ) {
+        self.authorizer = authorizer
+        self.onAllowed = onAllowed
+        self.onSkipped = onSkipped
+        self.isAllowing = isAllowing
+    }
 
     // MARK: - Body -
 
@@ -42,12 +58,18 @@ struct ContactsPermissionScreen: View {
 
                 Spacer()
 
-                Button(primaryTitle, action: primaryAction)
-                    .buttonStyle(.filled)
+                Button(action: primaryAction) {
+                    Loadable(isLoading: isAllowing, color: .textAction) {
+                        Text(primaryTitle)
+                    }
+                }
+                .buttonStyle(.filled)
+                .disabled(isAllowing)
 
                 if let onSkipped {
                     Button("Not Now", action: onSkipped)
                         .buttonStyle(.subtle)
+                        .disabled(isAllowing)
                 }
             }
             .padding(20)

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -405,10 +405,7 @@ private struct RoutedSheet: View {
             }
         case .send:
             NavigationStack(path: $router[.send]) {
-                SendRootScreen(
-                    container: container,
-                    sessionContainer: sessionContainer
-                )
+                SendRootScreen(container: container)
                 .appRouterDestinations(container: container, sessionContainer: sessionContainer)
                 .navigationTitle("Send")
                 .toolbarTitleDisplayMode(.inline)

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -11,31 +11,27 @@ import FlipcashUI
 nonisolated private let logger = Logger(label: "flipcash.recipient-picker")
 
 /// The Send section's primary view. Shown after the `SendRootScreen` gate
-/// confirms a verified phone and authorized contacts.
+/// confirms a verified phone, authorized contacts, AND that
+/// `ContactSyncController` has resolved the directory at least once.
 ///
-/// Reads the contact-sync tables (`flipcash_contacts`,
-/// `local_contacts_snapshot`) populated by `ContactSyncController`, joins
-/// each snapshot entry against `CNContactStore` for the display name and
-/// thumbnail, and renders two sections: contacts already on Flipcash and
-/// contacts the user can invite. Reload triggers on appear and on
-/// `CNContactStoreDidChange` so the picker tracks address-book edits.
+/// Reads the controller's `resolvedContacts` cache directly — no internal
+/// loading state. Refreshes happen invisibly on the controller side; the
+/// picker observes the updated value and re-renders without ever flipping
+/// to a spinner.
 ///
 /// Row tap actions are stubbed pending Phase 6 (invite sheet) and Phase 7
 /// (resolve-and-send wire-up).
 struct RecipientPickerScreen: View {
 
-    let sessionContainer: SessionContainer
+    @Environment(ContactSyncController.self) private var contactSyncController
 
-    @State private var contacts: ResolvedContacts = .empty
     @State private var filtered: ResolvedContacts = .empty
-    @State private var isLoading: Bool = true
     @State private var searchText: String = ""
 
     var body: some View {
-        Group {
-            if isLoading {
-                RecipientPickerLoadingState()
-            } else if contacts.isEmpty {
+        let contacts = contactSyncController.resolvedContacts
+        return Group {
+            if contacts.isEmpty {
                 RecipientPickerEmptyState()
             } else {
                 VStack(spacing: 0) {
@@ -58,38 +54,17 @@ struct RecipientPickerScreen: View {
                 }
             }
         }
-        .task {
-            await reload()
-        }
-        .task {
-            for await _ in NotificationCenter.default.notifications(named: .CNContactStoreDidChange) {
-                await reload()
-            }
-        }
+        .onAppear { refilter() }
         .onChange(of: searchText) { refilter() }
         .onChange(of: contacts) { refilter() }
     }
 
-    // MARK: - Reload -
-
-    private func reload() async {
-        contacts = await RecipientLoader.load(database: sessionContainer.database)
-        isLoading = false
-    }
-
     private func refilter() {
-        filtered = contacts.filtered(by: searchText)
+        filtered = contactSyncController.resolvedContacts.filtered(by: searchText)
     }
 }
 
-// MARK: - States -
-
-private struct RecipientPickerLoadingState: View {
-    var body: some View {
-        ProgressView()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
+// MARK: - Empty state -
 
 private struct RecipientPickerEmptyState: View {
     var body: some View {
@@ -171,169 +146,6 @@ private struct RecipientPickerList: View {
                 ContentUnavailableView.search(text: searchText)
             }
         }
-    }
-}
-
-// MARK: - Resolved data -
-
-nonisolated struct ResolvedContact: Identifiable, Hashable, Sendable {
-    let id: String          // CNContact.identifier
-    let displayName: String
-    let phoneE164: String
-    let nationalPhone: String
-    let imageData: Data?
-}
-
-nonisolated struct ResolvedContacts: Equatable, Sendable {
-    var onFlipcash: [ResolvedContact]
-    var invite: [ResolvedContact]
-
-    static let empty = Self(onFlipcash: [], invite: [])
-
-    var isEmpty: Bool { onFlipcash.isEmpty && invite.isEmpty }
-
-    /// Case-insensitive substring match on `displayName` OR `nationalPhone`.
-    /// Empty/whitespace-only query returns `self` unchanged.
-    func filtered(by query: String) -> ResolvedContacts {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return self }
-        let lowered = trimmed.lowercased()
-        return ResolvedContacts(
-            onFlipcash: onFlipcash.filter { $0.matches(lowered) },
-            invite: invite.filter { $0.matches(lowered) },
-        )
-    }
-}
-
-nonisolated private extension ResolvedContact {
-    func matches(_ loweredQuery: String) -> Bool {
-        displayName.lowercased().contains(loweredQuery)
-            || nationalPhone.lowercased().contains(loweredQuery)
-    }
-}
-
-// MARK: - Loader -
-
-/// Reads contact-sync DB tables and resolves each snapshot entry against
-/// `CNContactStore`. All work runs in a detached task so the main actor
-/// stays free while we hit SQLite and the Contacts TCC layer.
-enum RecipientLoader {
-
-    /// One row per unique address-book contact, with the e164 we should
-    /// display chosen by ``placements(snapshot:flipcashSet:)``. The
-    /// snapshot table dedupes by `e164` only, so a single contact with
-    /// multiple phone-number entries (Home / Work / iPhone) yields
-    /// multiple snapshot rows that share `contactId`.
-    nonisolated struct ContactPlacement: Equatable, Sendable {
-        let contactId: String
-        let e164: String
-        let isOnFlipcash: Bool
-    }
-
-    /// Group snapshot rows by `contactId` and pick a single e164 per
-    /// contact. Preference order:
-    /// 1. The first e164 we encounter that is in `flipcashSet` — that's
-    ///    the address the user can send to right now.
-    /// 2. Otherwise, the first e164 we encountered for that contact.
-    ///
-    /// Result order is first-seen, so callers can sort independently.
-    nonisolated static func placements(
-        snapshot: [Database.LocalContact],
-        flipcashSet: Set<String>,
-    ) -> [ContactPlacement] {
-        var byContactId: [String: ContactPlacement] = [:]
-        var orderedIds: [String] = []
-        for entry in snapshot {
-            let isMatched = flipcashSet.contains(entry.e164)
-            if let existing = byContactId[entry.contactId] {
-                // Promote to a matched e164 if we haven't seen one yet.
-                if !existing.isOnFlipcash, isMatched {
-                    byContactId[entry.contactId] = ContactPlacement(
-                        contactId: entry.contactId,
-                        e164: entry.e164,
-                        isOnFlipcash: true,
-                    )
-                }
-            } else {
-                byContactId[entry.contactId] = ContactPlacement(
-                    contactId: entry.contactId,
-                    e164: entry.e164,
-                    isOnFlipcash: isMatched,
-                )
-                orderedIds.append(entry.contactId)
-            }
-        }
-        return orderedIds.compactMap { byContactId[$0] }
-    }
-
-    static func load(database: Database) async -> ResolvedContacts {
-        await Task.detached(priority: .userInitiated) {
-            let snapshot: [Database.LocalContact]
-            let flipcashSet: Set<String>
-            do {
-                snapshot = try database.localContactsSnapshot()
-                flipcashSet = Set(try database.flipcashContacts())
-            } catch {
-                logger.error("Failed to read contact-sync tables", metadata: [
-                    "error": "\(error)",
-                ])
-                return ResolvedContacts.empty
-            }
-
-            let store = CNContactStore()
-            // `CNContactFormatter.descriptorForRequiredKeys(for:)` returns the
-            // full key set the formatter needs — including locale-specific
-            // ones like `middleName`. Fetching with a smaller list crashes
-            // with `CNPropertyNotFetchedException` the moment the formatter
-            // reaches a property that wasn't in `keysToFetch`.
-            let keys: [CNKeyDescriptor] = [
-                CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
-                CNContactThumbnailImageDataKey as CNKeyDescriptor,
-            ]
-            let region = Region.current ?? .us
-            let placements = placements(snapshot: snapshot, flipcashSet: flipcashSet)
-
-            var onFlipcash: [ResolvedContact] = []
-            var invite: [ResolvedContact] = []
-            let onFlipcashCount = placements.lazy.filter(\.isOnFlipcash).count
-            onFlipcash.reserveCapacity(onFlipcashCount)
-            invite.reserveCapacity(placements.count - onFlipcashCount)
-
-            for placement in placements {
-                guard let cnContact = try? store.unifiedContact(
-                    withIdentifier: placement.contactId,
-                    keysToFetch: keys,
-                ) else {
-                    continue
-                }
-
-                let nationalPhone = Phone(placement.e164, defaultRegion: region)?.national ?? placement.e164
-                let displayName = CNContactFormatter.string(from: cnContact, style: .fullName)
-                    ?? nationalPhone
-
-                let resolved = ResolvedContact(
-                    id: placement.contactId,
-                    displayName: displayName,
-                    phoneE164: placement.e164,
-                    nationalPhone: nationalPhone,
-                    imageData: cnContact.thumbnailImageData,
-                )
-
-                if placement.isOnFlipcash {
-                    onFlipcash.append(resolved)
-                } else {
-                    invite.append(resolved)
-                }
-            }
-
-            let sorter: (ResolvedContact, ResolvedContact) -> Bool = {
-                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
-            }
-            onFlipcash.sort(by: sorter)
-            invite.sort(by: sorter)
-
-            return ResolvedContacts(onFlipcash: onFlipcash, invite: invite)
-        }.value
     }
 }
 

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -1,0 +1,440 @@
+//
+//  RecipientPickerScreen.swift
+//  Flipcash
+//
+
+import Contacts
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+nonisolated private let logger = Logger(label: "flipcash.recipient-picker")
+
+/// The Send section's primary view. Shown after the `SendRootScreen` gate
+/// confirms a verified phone and authorized contacts.
+///
+/// Reads the contact-sync tables (`flipcash_contacts`,
+/// `local_contacts_snapshot`) populated by `ContactSyncController`, joins
+/// each snapshot entry against `CNContactStore` for the display name and
+/// thumbnail, and renders two sections: contacts already on Flipcash and
+/// contacts the user can invite. Reload triggers on appear and on
+/// `CNContactStoreDidChange` so the picker tracks address-book edits.
+///
+/// Row tap actions are stubbed pending Phase 6 (invite sheet) and Phase 7
+/// (resolve-and-send wire-up).
+struct RecipientPickerScreen: View {
+
+    let sessionContainer: SessionContainer
+
+    @State private var contacts: ResolvedContacts = .empty
+    @State private var filtered: ResolvedContacts = .empty
+    @State private var isLoading: Bool = true
+    @State private var searchText: String = ""
+
+    var body: some View {
+        Group {
+            if isLoading {
+                RecipientPickerLoadingState()
+            } else if contacts.isEmpty {
+                RecipientPickerEmptyState()
+            } else {
+                VStack(spacing: 0) {
+                    InlineSearchField(text: $searchText)
+                        .padding(.top, 8)
+                        .padding(.bottom, 12)
+                    RecipientPickerList(
+                        filtered: filtered,
+                        searchText: searchText,
+                        onFlipcashTap: { _ in
+                            // Phase 7 wires this to `session.send` once
+                            // `PaymentDestinationService.resolve(phone:)` is in.
+                            logger.info("Tapped On Flipcash row (send wire-up pending)")
+                        },
+                        onInviteTap: { _ in
+                            // Phase 6 wires this to `MessageComposerSheet`.
+                            logger.info("Tapped Invite row (composer sheet pending)")
+                        }
+                    )
+                }
+            }
+        }
+        .task {
+            await reload()
+        }
+        .task {
+            for await _ in NotificationCenter.default.notifications(named: .CNContactStoreDidChange) {
+                await reload()
+            }
+        }
+        .onChange(of: searchText) { refilter() }
+        .onChange(of: contacts) { refilter() }
+    }
+
+    // MARK: - Reload -
+
+    private func reload() async {
+        contacts = await RecipientLoader.load(database: sessionContainer.database)
+        isLoading = false
+    }
+
+    private func refilter() {
+        filtered = contacts.filtered(by: searchText)
+    }
+}
+
+// MARK: - States -
+
+private struct RecipientPickerLoadingState: View {
+    var body: some View {
+        ProgressView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct RecipientPickerEmptyState: View {
+    var body: some View {
+        ContentUnavailableView(
+            "No Contacts Found",
+            systemImage: "person.crop.circle.badge.questionmark",
+            description: Text("None of the people in your address book have a phone number we can match.")
+        )
+    }
+}
+
+// MARK: - Search field -
+
+private struct InlineSearchField: View {
+
+    @Binding var text: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Color.textSecondary)
+            TextField("Search", text: $text)
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .foregroundStyle(Color.textMain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color.backgroundRow)
+        .clipShape(Capsule())
+        .padding(.horizontal, 20)
+    }
+}
+
+// MARK: - List -
+
+private struct RecipientPickerList: View {
+
+    let filtered: ResolvedContacts
+    let searchText: String
+    let onFlipcashTap: (ResolvedContact) -> Void
+    let onInviteTap: (ResolvedContact) -> Void
+
+    var body: some View {
+        List {
+            if !filtered.onFlipcash.isEmpty {
+                Section {
+                    ForEach(filtered.onFlipcash) { contact in
+                        RecipientRow(
+                            contact: contact,
+                            trailing: .chevron,
+                            onTap: { onFlipcashTap(contact) }
+                        )
+                    }
+                } header: {
+                    RecipientSectionHeader(title: "On Flipcash")
+                }
+            }
+            if !filtered.invite.isEmpty {
+                Section {
+                    ForEach(filtered.invite) { contact in
+                        RecipientRow(
+                            contact: contact,
+                            trailing: .invite { onInviteTap(contact) },
+                            onTap: { onInviteTap(contact) }
+                        )
+                    }
+                } header: {
+                    RecipientSectionHeader(title: "Not on Flipcash Yet")
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .scrollDismissesKeyboard(.interactively)
+        .overlay {
+            if !searchText.isEmpty && filtered.isEmpty {
+                ContentUnavailableView.search(text: searchText)
+            }
+        }
+    }
+}
+
+// MARK: - Resolved data -
+
+nonisolated struct ResolvedContact: Identifiable, Hashable, Sendable {
+    let id: String          // CNContact.identifier
+    let displayName: String
+    let phoneE164: String
+    let nationalPhone: String
+    let imageData: Data?
+}
+
+nonisolated struct ResolvedContacts: Equatable, Sendable {
+    var onFlipcash: [ResolvedContact]
+    var invite: [ResolvedContact]
+
+    static let empty = Self(onFlipcash: [], invite: [])
+
+    var isEmpty: Bool { onFlipcash.isEmpty && invite.isEmpty }
+
+    /// Case-insensitive substring match on `displayName` OR `nationalPhone`.
+    /// Empty/whitespace-only query returns `self` unchanged.
+    func filtered(by query: String) -> ResolvedContacts {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return self }
+        let lowered = trimmed.lowercased()
+        return ResolvedContacts(
+            onFlipcash: onFlipcash.filter { $0.matches(lowered) },
+            invite: invite.filter { $0.matches(lowered) },
+        )
+    }
+}
+
+nonisolated private extension ResolvedContact {
+    func matches(_ loweredQuery: String) -> Bool {
+        displayName.lowercased().contains(loweredQuery)
+            || nationalPhone.lowercased().contains(loweredQuery)
+    }
+}
+
+// MARK: - Loader -
+
+/// Reads contact-sync DB tables and resolves each snapshot entry against
+/// `CNContactStore`. All work runs in a detached task so the main actor
+/// stays free while we hit SQLite and the Contacts TCC layer.
+enum RecipientLoader {
+
+    /// One row per unique address-book contact, with the e164 we should
+    /// display chosen by ``placements(snapshot:flipcashSet:)``. The
+    /// snapshot table dedupes by `e164` only, so a single contact with
+    /// multiple phone-number entries (Home / Work / iPhone) yields
+    /// multiple snapshot rows that share `contactId`.
+    nonisolated struct ContactPlacement: Equatable, Sendable {
+        let contactId: String
+        let e164: String
+        let isOnFlipcash: Bool
+    }
+
+    /// Group snapshot rows by `contactId` and pick a single e164 per
+    /// contact. Preference order:
+    /// 1. The first e164 we encounter that is in `flipcashSet` — that's
+    ///    the address the user can send to right now.
+    /// 2. Otherwise, the first e164 we encountered for that contact.
+    ///
+    /// Result order is first-seen, so callers can sort independently.
+    nonisolated static func placements(
+        snapshot: [Database.LocalContact],
+        flipcashSet: Set<String>,
+    ) -> [ContactPlacement] {
+        var byContactId: [String: ContactPlacement] = [:]
+        var orderedIds: [String] = []
+        for entry in snapshot {
+            let isMatched = flipcashSet.contains(entry.e164)
+            if let existing = byContactId[entry.contactId] {
+                // Promote to a matched e164 if we haven't seen one yet.
+                if !existing.isOnFlipcash, isMatched {
+                    byContactId[entry.contactId] = ContactPlacement(
+                        contactId: entry.contactId,
+                        e164: entry.e164,
+                        isOnFlipcash: true,
+                    )
+                }
+            } else {
+                byContactId[entry.contactId] = ContactPlacement(
+                    contactId: entry.contactId,
+                    e164: entry.e164,
+                    isOnFlipcash: isMatched,
+                )
+                orderedIds.append(entry.contactId)
+            }
+        }
+        return orderedIds.compactMap { byContactId[$0] }
+    }
+
+    static func load(database: Database) async -> ResolvedContacts {
+        await Task.detached(priority: .userInitiated) {
+            let snapshot: [Database.LocalContact]
+            let flipcashSet: Set<String>
+            do {
+                snapshot = try database.localContactsSnapshot()
+                flipcashSet = Set(try database.flipcashContacts())
+            } catch {
+                logger.error("Failed to read contact-sync tables", metadata: [
+                    "error": "\(error)",
+                ])
+                return ResolvedContacts.empty
+            }
+
+            let store = CNContactStore()
+            // `CNContactFormatter.descriptorForRequiredKeys(for:)` returns the
+            // full key set the formatter needs — including locale-specific
+            // ones like `middleName`. Fetching with a smaller list crashes
+            // with `CNPropertyNotFetchedException` the moment the formatter
+            // reaches a property that wasn't in `keysToFetch`.
+            let keys: [CNKeyDescriptor] = [
+                CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+                CNContactThumbnailImageDataKey as CNKeyDescriptor,
+            ]
+            let region = Region.current ?? .us
+            let placements = placements(snapshot: snapshot, flipcashSet: flipcashSet)
+
+            var onFlipcash: [ResolvedContact] = []
+            var invite: [ResolvedContact] = []
+            let onFlipcashCount = placements.lazy.filter(\.isOnFlipcash).count
+            onFlipcash.reserveCapacity(onFlipcashCount)
+            invite.reserveCapacity(placements.count - onFlipcashCount)
+
+            for placement in placements {
+                guard let cnContact = try? store.unifiedContact(
+                    withIdentifier: placement.contactId,
+                    keysToFetch: keys,
+                ) else {
+                    continue
+                }
+
+                let nationalPhone = Phone(placement.e164, defaultRegion: region)?.national ?? placement.e164
+                let displayName = CNContactFormatter.string(from: cnContact, style: .fullName)
+                    ?? nationalPhone
+
+                let resolved = ResolvedContact(
+                    id: placement.contactId,
+                    displayName: displayName,
+                    phoneE164: placement.e164,
+                    nationalPhone: nationalPhone,
+                    imageData: cnContact.thumbnailImageData,
+                )
+
+                if placement.isOnFlipcash {
+                    onFlipcash.append(resolved)
+                } else {
+                    invite.append(resolved)
+                }
+            }
+
+            let sorter: (ResolvedContact, ResolvedContact) -> Bool = {
+                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+            }
+            onFlipcash.sort(by: sorter)
+            invite.sort(by: sorter)
+
+            return ResolvedContacts(onFlipcash: onFlipcash, invite: invite)
+        }.value
+    }
+}
+
+// MARK: - Row -
+
+private enum RecipientRowTrailing {
+    case chevron
+    case invite(() -> Void)
+}
+
+private struct RecipientRow: View {
+
+    let contact: ResolvedContact
+    let trailing: RecipientRowTrailing
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                ContactAvatarView(
+                    id: contact.id,
+                    displayName: contact.displayName,
+                    imageData: contact.imageData,
+                    size: 44
+                )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(contact.displayName)
+                        .font(.appTextMedium)
+                        .foregroundStyle(Color.textMain)
+                        .lineLimit(1)
+                    Text(contact.nationalPhone)
+                        .font(.appTextSmall)
+                        .foregroundStyle(Color.textSecondary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 12)
+                RecipientRowTrailingAccessory(trailing: trailing)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .listRowInsets(EdgeInsets(top: 14, leading: 20, bottom: 14, trailing: 20))
+        .listRowBackground(Color.clear)
+        .listRowSeparatorTint(.rowSeparator)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("\(contact.displayName), \(contact.nationalPhone)"))
+        .accessibilityAddTraits(.isButton)
+        .accessibilityActions {
+            if case .invite(let action) = trailing {
+                Button("Invite", action: action)
+            }
+        }
+    }
+}
+
+private struct RecipientRowTrailingAccessory: View {
+
+    let trailing: RecipientRowTrailing
+
+    var body: some View {
+        switch trailing {
+        case .chevron:
+            Image(systemName: "chevron.right")
+                .font(.appTextSmall)
+                .foregroundStyle(Color.textSecondary)
+        case .invite(let action):
+            Button(action: action) {
+                Text("Invite")
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textMain)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background {
+                        RoundedRectangle(cornerRadius: Metrics.buttonRadius)
+                            .fill(Color.backgroundRow)
+                    }
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+
+// MARK: - Section header -
+
+/// Opaque section header. List's `.plain` style sticky-pins headers as the
+/// user scrolls; without a background, the row content underneath shows
+/// through the floating header. `Color.backgroundMain` matches the sheet
+/// backdrop so the header reads as a solid bar.
+private struct RecipientSectionHeader: View {
+
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .textCase(.none)
+            .font(.appTextSmall)
+            .foregroundStyle(Color.textSecondary)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.backgroundMain)
+            .listRowInsets(EdgeInsets())
+    }
+}

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -166,7 +166,7 @@ private struct RecipientRow: View {
         Button(action: onTap) {
             HStack(spacing: 12) {
                 ContactAvatarView(
-                    id: contact.id,
+                    id: contact.contactId,
                     displayName: contact.displayName,
                     imageData: contact.imageData,
                     size: 44

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -8,8 +8,7 @@ import FlipcashCore
 import FlipcashUI
 
 /// Root view for the Send sheet. Gates entry on a verified phone and
-/// authorized contacts; the satisfied state renders a placeholder for the
-/// recipient picker.
+/// authorized contacts; the satisfied state renders the recipient picker.
 struct SendRootScreen: View {
 
     @Environment(Session.self) private var session
@@ -43,7 +42,7 @@ struct SendRootScreen: View {
                     onSkipped: nil
                 )
             case .ready:
-                RecipientPickerPlaceholder()
+                RecipientPickerScreen(sessionContainer: sessionContainer)
             }
         }
         .sheet(item: $phoneVerificationViewModel.cancellingOnDismiss()) { viewModel in
@@ -84,17 +83,3 @@ struct SendRootScreen: View {
     }
 }
 
-// MARK: - Picker placeholder -
-
-private struct RecipientPickerPlaceholder: View {
-    var body: some View {
-        // TODO: replace with `RecipientPickerScreen`.
-        VStack(spacing: 12) {
-            ProgressView()
-            Text("Recipient picker arrives in Phase 5")
-                .font(.appTextMedium)
-                .foregroundStyle(Color.textSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -19,13 +19,11 @@ struct SendRootScreen: View {
     @State private var contactsAuthorizer = ContactsAuthorizer()
 
     private let container: Container
-    private let sessionContainer: SessionContainer
 
     // MARK: - Init -
 
-    init(container: Container, sessionContainer: SessionContainer) {
-        self.container        = container
-        self.sessionContainer = sessionContainer
+    init(container: Container) {
+        self.container = container
     }
 
     // MARK: - Body -
@@ -41,8 +39,20 @@ struct SendRootScreen: View {
                     onAllowed: { contactSyncController.activate() },
                     onSkipped: nil
                 )
+            case .loadingContacts:
+                // Already authorized; controller is resolving the directory
+                // for the first time this session. Keep the priming screen
+                // visible with a spinner on the primary button so the user
+                // sees clear in-progress feedback instead of a flash to a
+                // half-populated picker.
+                ContactsPermissionScreen(
+                    authorizer: contactsAuthorizer,
+                    onAllowed: { contactSyncController.activate() },
+                    onSkipped: nil,
+                    isAllowing: true
+                )
             case .ready:
-                RecipientPickerScreen(sessionContainer: sessionContainer)
+                RecipientPickerScreen()
             }
         }
         .sheet(item: $phoneVerificationViewModel.cancellingOnDismiss()) { viewModel in
@@ -55,6 +65,7 @@ struct SendRootScreen: View {
     private enum Step {
         case needsPhone
         case needsContacts
+        case loadingContacts
         case ready
     }
 
@@ -62,7 +73,10 @@ struct SendRootScreen: View {
         guard session.profile?.isPhoneVerified ?? false else {
             return .needsPhone
         }
-        return contactsAuthorizer.status == .authorized ? .ready : .needsContacts
+        guard contactsAuthorizer.status == .authorized else {
+            return .needsContacts
+        }
+        return contactSyncController.hasResolvedOnce ? .ready : .loadingContacts
     }
 
     // MARK: - Phone verification handoff -

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -16,7 +16,7 @@
 		</dict>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>12</integer>
+	<integer>13</integer>
 	<key>UIApplicationShortcutItems</key>
 	<array>
 		<dict>

--- a/FlipcashTests/ContactAvatarViewInitialsTests.swift
+++ b/FlipcashTests/ContactAvatarViewInitialsTests.swift
@@ -1,0 +1,56 @@
+//
+//  ContactAvatarViewInitialsTests.swift
+//  FlipcashTests
+//
+
+import Testing
+import FlipcashUI
+
+@Suite("ContactAvatarView.initials(for:)")
+struct ContactAvatarViewInitialsTests {
+
+    @Test("Two-word name yields first letter of first + last word")
+    func twoWords() {
+        #expect(ContactAvatarView.initials(for: "Jane Doe") == "JD")
+    }
+
+    @Test("Three-word name still takes first and LAST word")
+    func threeWords() {
+        #expect(ContactAvatarView.initials(for: "Mary Jane Doe") == "MD")
+    }
+
+    @Test("Single-word name yields first two letters")
+    func singleWord() {
+        #expect(ContactAvatarView.initials(for: "Madonna") == "MA")
+    }
+
+    @Test("Single short word yields just that character")
+    func singleLetter() {
+        #expect(ContactAvatarView.initials(for: "A") == "A")
+    }
+
+    @Test("Lowercase input is uppercased")
+    func lowercased() {
+        #expect(ContactAvatarView.initials(for: "jane doe") == "JD")
+    }
+
+    @Test("Empty string yields fallback")
+    func empty() {
+        #expect(ContactAvatarView.initials(for: "") == "?")
+    }
+
+    @Test("Whitespace-only yields fallback")
+    func whitespaceOnly() {
+        #expect(ContactAvatarView.initials(for: "   \n  ") == "?")
+    }
+
+    @Test("Leading/trailing whitespace is trimmed before split")
+    func surroundingWhitespace() {
+        #expect(ContactAvatarView.initials(for: "  Jane Doe  ") == "JD")
+    }
+
+    @Test("Repeated inner whitespace collapses")
+    func collapsedWhitespace() {
+        #expect(ContactAvatarView.initials(for: "Jane   Doe") == "JD")
+    }
+}

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -236,20 +236,32 @@ struct ContactSyncControllerTests {
             #expect(result.first?.contactId == "bob")
         }
 
-        @Test("Dedupe by E.164 keeps the first occurrence's contactId")
-        func dedupeKeepsFirst() {
+        @Test("Same e164 under distinct contactIds keeps every (e164, contactId) pair")
+        func sharedPhoneAcrossContactsAllSurvive() {
             let result = ContactSyncController.normalizeContacts(
                 rawNumbers: [
                     ("415-555-0100", "alice"),
-                    ("(415) 555-0100", "alice-work"),
-                    ("+14155550100", "alice-home"),
+                    ("(415) 555-0100", "bob"),
+                    ("+14155550100", "carol"),
                 ],
                 region: .us
             )
-            #expect(result.count == 1)
-            let first = result.first!
-            #expect(first.e164 == "+14155550100")
-            #expect(first.contactId == "alice")
+            #expect(result.count == 3)
+            #expect(result.allSatisfy { $0.e164 == "+14155550100" })
+            #expect(result.map(\.contactId) == ["alice", "bob", "carol"])
+        }
+
+        @Test("Same (e164, contactId) tuple seen twice collapses to one")
+        func dedupeOnTuple() {
+            let result = ContactSyncController.normalizeContacts(
+                rawNumbers: [
+                    ("415-555-0100", "alice"),
+                    ("(415) 555-0100", "alice"),
+                    ("+14155550100", "alice"),
+                ],
+                region: .us
+            )
+            #expect(result == [.init(e164: "+14155550100", contactId: "alice")])
         }
 
         @Test("Empty input returns empty result")

--- a/FlipcashTests/Database/Database+ContactSyncTests.swift
+++ b/FlipcashTests/Database/Database+ContactSyncTests.swift
@@ -153,8 +153,8 @@ struct DatabaseContactSyncTests {
         #expect(try db.localContactsSnapshot().isEmpty)
     }
 
-    @Test("replaceLocalContactsSnapshot dedupes linked iOS contacts by e164, keeping first contactId")
-    func snapshot_dedupesByE164KeepingFirst() throws {
+    @Test("replaceLocalContactsSnapshot keeps every (e164, contactId) pair")
+    func snapshot_keepsEveryPairAcrossContacts() throws {
         let db = Database.mock
         try db.replaceLocalContactsSnapshot([
             Database.LocalContact(e164: "+15551234567", contactId: "work-card"),
@@ -162,13 +162,27 @@ struct DatabaseContactSyncTests {
             Database.LocalContact(e164: "+447700900000", contactId: "abroad"),
         ])
 
-        // Asserts as a set — the read query has no ORDER BY, so the
-        // dedup-keep-first invariant lives in the (e164, contactId) pair,
-        // not in row ordering. The "work-card" id is what proves "first wins"
-        // (vs. "personal-card" if the dedup picked the last occurrence).
+        // Composite PK (e164, contactId): the same phone number under two
+        // different address-book contacts produces two rows so the picker
+        // can show each name with that number.
         #expect(Set(try db.localContactsSnapshot()) == [
             Database.LocalContact(e164: "+15551234567", contactId: "work-card"),
+            Database.LocalContact(e164: "+15551234567", contactId: "personal-card"),
             Database.LocalContact(e164: "+447700900000", contactId: "abroad"),
+        ])
+    }
+
+    @Test("replaceLocalContactsSnapshot dedupes a repeated (e164, contactId) pair")
+    func snapshot_dedupesIdenticalPair() throws {
+        let db = Database.mock
+        try db.replaceLocalContactsSnapshot([
+            Database.LocalContact(e164: "+15551234567", contactId: "alice"),
+            Database.LocalContact(e164: "+15551234567", contactId: "alice"),
+            Database.LocalContact(e164: "+15551234567", contactId: "alice"),
+        ])
+
+        #expect(try db.localContactsSnapshot() == [
+            Database.LocalContact(e164: "+15551234567", contactId: "alice"),
         ])
     }
 }

--- a/FlipcashTests/RecipientLoaderPlacementsTests.swift
+++ b/FlipcashTests/RecipientLoaderPlacementsTests.swift
@@ -180,4 +180,18 @@ struct RecipientLoaderDeduplicatedForDisplayTests {
     func emptyInput() {
         #expect(RecipientLoader.deduplicatedForDisplay([], flipcashSet: ["+1..."]).isEmpty)
     }
+
+    /// Regression: a joined-string key like `"\(displayName)|\(nationalPhone)"`
+    /// would collide for these two contacts on the boundary character.
+    /// The struct-key implementation keeps them distinct.
+    @Test("Display strings containing a literal pipe do NOT collide")
+    func pipeCharacterDoesNotCollide() {
+        let contacts = [
+            makeContact(contactId: "A", name: "Alice|Smith", e164: "+14085551111", national: "(408) 555-1111"),
+            makeContact(contactId: "B", name: "Alice",       e164: "+14085552222", national: "Smith|(408) 555-1111"),
+        ]
+        let unique = RecipientLoader.deduplicatedForDisplay(contacts, flipcashSet: [])
+        #expect(unique.count == 2)
+        #expect(Set(unique.map(\.displayName)) == ["Alice|Smith", "Alice"])
+    }
 }

--- a/FlipcashTests/RecipientLoaderPlacementsTests.swift
+++ b/FlipcashTests/RecipientLoaderPlacementsTests.swift
@@ -1,0 +1,107 @@
+//
+//  RecipientLoaderPlacementsTests.swift
+//  FlipcashTests
+//
+
+import Testing
+@testable import Flipcash
+
+@Suite("RecipientLoader.placements(snapshot:flipcashSet:)")
+struct RecipientLoaderPlacementsTests {
+
+    private typealias Placement = RecipientLoader.ContactPlacement
+    private typealias LocalContact = Database.LocalContact
+
+    @Test("Single phone — single placement")
+    func singlePhoneSinglePlacement() {
+        let snapshot = [
+            LocalContact(e164: "+14085551111", contactId: "A"),
+        ]
+        let placements = RecipientLoader.placements(snapshot: snapshot, flipcashSet: [])
+
+        #expect(placements == [
+            Placement(contactId: "A", e164: "+14085551111", isOnFlipcash: false),
+        ])
+    }
+
+    @Test("Multiple phones on the same contact yield ONE placement")
+    func dedupesByContactId() {
+        let snapshot = [
+            LocalContact(e164: "+14085551111;ext=100", contactId: "A"),
+            LocalContact(e164: "+14085551111;ext=200", contactId: "A"),
+            LocalContact(e164: "+14085551111;ext=300", contactId: "A"),
+        ]
+        let placements = RecipientLoader.placements(snapshot: snapshot, flipcashSet: [])
+
+        #expect(placements.count == 1)
+        #expect(placements[0].contactId == "A")
+        #expect(placements[0].e164 == "+14085551111;ext=100")  // first-seen wins
+    }
+
+    @Test("Matched phone wins over earlier unmatched phone on the same contact")
+    func matchedPhonePromotes() {
+        let snapshot = [
+            LocalContact(e164: "+14085551111", contactId: "A"),     // home, not on Flipcash
+            LocalContact(e164: "+14085552222", contactId: "A"),     // cell, on Flipcash
+        ]
+        let placements = RecipientLoader.placements(
+            snapshot: snapshot,
+            flipcashSet: ["+14085552222"],
+        )
+
+        #expect(placements == [
+            Placement(contactId: "A", e164: "+14085552222", isOnFlipcash: true),
+        ])
+    }
+
+    @Test("First matched phone is kept; later matched phones do not overwrite")
+    func firstMatchedWins() {
+        let snapshot = [
+            LocalContact(e164: "+14085551111", contactId: "A"),     // on Flipcash
+            LocalContact(e164: "+14085552222", contactId: "A"),     // also on Flipcash
+        ]
+        let placements = RecipientLoader.placements(
+            snapshot: snapshot,
+            flipcashSet: ["+14085551111", "+14085552222"],
+        )
+
+        #expect(placements == [
+            Placement(contactId: "A", e164: "+14085551111", isOnFlipcash: true),
+        ])
+    }
+
+    @Test("Distinct contacts produce distinct placements in first-seen order")
+    func ordersByFirstSeen() {
+        let snapshot = [
+            LocalContact(e164: "+14085551111", contactId: "C"),
+            LocalContact(e164: "+14085552222", contactId: "A"),
+            LocalContact(e164: "+14085553333", contactId: "B"),
+        ]
+        let placements = RecipientLoader.placements(snapshot: snapshot, flipcashSet: [])
+
+        #expect(placements.map(\.contactId) == ["C", "A", "B"])
+    }
+
+    @Test("Empty snapshot yields no placements")
+    func emptySnapshot() {
+        let placements = RecipientLoader.placements(snapshot: [], flipcashSet: ["+14085551111"])
+        #expect(placements.isEmpty)
+    }
+
+    @Test("isOnFlipcash reflects flipcashSet membership for the chosen e164")
+    func isOnFlipcashReflectsChosenE164() {
+        let snapshot = [
+            LocalContact(e164: "+14085551111", contactId: "A"),
+            LocalContact(e164: "+14085552222", contactId: "B"),
+            LocalContact(e164: "+14085553333", contactId: "C"),
+        ]
+        let placements = RecipientLoader.placements(
+            snapshot: snapshot,
+            flipcashSet: ["+14085552222"],
+        )
+
+        #expect(placements.first { $0.contactId == "A" }?.isOnFlipcash == false)
+        #expect(placements.first { $0.contactId == "B" }?.isOnFlipcash == true)
+        #expect(placements.first { $0.contactId == "C" }?.isOnFlipcash == false)
+    }
+}

--- a/FlipcashTests/RecipientLoaderPlacementsTests.swift
+++ b/FlipcashTests/RecipientLoaderPlacementsTests.swift
@@ -12,74 +12,61 @@ struct RecipientLoaderPlacementsTests {
     private typealias Placement = RecipientLoader.ContactPlacement
     private typealias LocalContact = Database.LocalContact
 
-    @Test("Single phone — single placement")
-    func singlePhoneSinglePlacement() {
+    @Test("One placement per snapshot row, preserving order")
+    func directMap() {
         let snapshot = [
             LocalContact(e164: "+14085551111", contactId: "A"),
+            LocalContact(e164: "+14085552222", contactId: "B"),
         ]
         let placements = RecipientLoader.placements(snapshot: snapshot, flipcashSet: [])
 
         #expect(placements == [
             Placement(contactId: "A", e164: "+14085551111", isOnFlipcash: false),
+            Placement(contactId: "B", e164: "+14085552222", isOnFlipcash: false),
         ])
     }
 
-    @Test("Multiple phones on the same contact yield ONE placement")
-    func dedupesByContactId() {
+    @Test("Multiple phones on one contact each get a placement")
+    func multiplePhonesPerContact() {
         let snapshot = [
-            LocalContact(e164: "+14085551111;ext=100", contactId: "A"),
-            LocalContact(e164: "+14085551111;ext=200", contactId: "A"),
-            LocalContact(e164: "+14085551111;ext=300", contactId: "A"),
-        ]
-        let placements = RecipientLoader.placements(snapshot: snapshot, flipcashSet: [])
-
-        #expect(placements.count == 1)
-        #expect(placements[0].contactId == "A")
-        #expect(placements[0].e164 == "+14085551111;ext=100")  // first-seen wins
-    }
-
-    @Test("Matched phone wins over earlier unmatched phone on the same contact")
-    func matchedPhonePromotes() {
-        let snapshot = [
-            LocalContact(e164: "+14085551111", contactId: "A"),     // home, not on Flipcash
-            LocalContact(e164: "+14085552222", contactId: "A"),     // cell, on Flipcash
-        ]
-        let placements = RecipientLoader.placements(
-            snapshot: snapshot,
-            flipcashSet: ["+14085552222"],
-        )
-
-        #expect(placements == [
-            Placement(contactId: "A", e164: "+14085552222", isOnFlipcash: true),
-        ])
-    }
-
-    @Test("First matched phone is kept; later matched phones do not overwrite")
-    func firstMatchedWins() {
-        let snapshot = [
-            LocalContact(e164: "+14085551111", contactId: "A"),     // on Flipcash
-            LocalContact(e164: "+14085552222", contactId: "A"),     // also on Flipcash
-        ]
-        let placements = RecipientLoader.placements(
-            snapshot: snapshot,
-            flipcashSet: ["+14085551111", "+14085552222"],
-        )
-
-        #expect(placements == [
-            Placement(contactId: "A", e164: "+14085551111", isOnFlipcash: true),
-        ])
-    }
-
-    @Test("Distinct contacts produce distinct placements in first-seen order")
-    func ordersByFirstSeen() {
-        let snapshot = [
-            LocalContact(e164: "+14085551111", contactId: "C"),
+            LocalContact(e164: "+14085551111", contactId: "A"),
             LocalContact(e164: "+14085552222", contactId: "A"),
-            LocalContact(e164: "+14085553333", contactId: "B"),
+            LocalContact(e164: "+14085553333", contactId: "A"),
         ]
         let placements = RecipientLoader.placements(snapshot: snapshot, flipcashSet: [])
 
-        #expect(placements.map(\.contactId) == ["C", "A", "B"])
+        #expect(placements.count == 3)
+        #expect(placements.allSatisfy { $0.contactId == "A" })
+        #expect(placements.map(\.e164) == ["+14085551111", "+14085552222", "+14085553333"])
+    }
+
+    @Test("One phone shared across contacts each get a placement")
+    func sharedPhoneAcrossContacts() {
+        let snapshot = [
+            LocalContact(e164: "+14085551234", contactId: "A"),
+            LocalContact(e164: "+14085551234", contactId: "B"),
+        ]
+        let placements = RecipientLoader.placements(snapshot: snapshot, flipcashSet: [])
+
+        #expect(placements == [
+            Placement(contactId: "A", e164: "+14085551234", isOnFlipcash: false),
+            Placement(contactId: "B", e164: "+14085551234", isOnFlipcash: false),
+        ])
+    }
+
+    @Test("isOnFlipcash reflects flipcashSet membership for that exact e164")
+    func isOnFlipcashPerE164() {
+        let snapshot = [
+            LocalContact(e164: "+14085551111", contactId: "A"),   // matched
+            LocalContact(e164: "+14085552222", contactId: "A"),   // not
+        ]
+        let placements = RecipientLoader.placements(
+            snapshot: snapshot,
+            flipcashSet: ["+14085551111"],
+        )
+
+        #expect(placements[0].isOnFlipcash == true)
+        #expect(placements[1].isOnFlipcash == false)
     }
 
     @Test("Empty snapshot yields no placements")
@@ -87,21 +74,110 @@ struct RecipientLoaderPlacementsTests {
         let placements = RecipientLoader.placements(snapshot: [], flipcashSet: ["+14085551111"])
         #expect(placements.isEmpty)
     }
+}
 
-    @Test("isOnFlipcash reflects flipcashSet membership for the chosen e164")
-    func isOnFlipcashReflectsChosenE164() {
-        let snapshot = [
-            LocalContact(e164: "+14085551111", contactId: "A"),
-            LocalContact(e164: "+14085552222", contactId: "B"),
-            LocalContact(e164: "+14085553333", contactId: "C"),
-        ]
-        let placements = RecipientLoader.placements(
-            snapshot: snapshot,
-            flipcashSet: ["+14085552222"],
+@Suite("RecipientLoader.deduplicatedForDisplay(_:flipcashSet:)")
+struct RecipientLoaderDeduplicatedForDisplayTests {
+
+    private func makeContact(
+        contactId: String,
+        name: String,
+        e164: String,
+        national: String,
+    ) -> ResolvedContact {
+        ResolvedContact(
+            contactId: contactId,
+            displayName: name,
+            phoneE164: e164,
+            nationalPhone: national,
+            imageData: nil,
         )
+    }
 
-        #expect(placements.first { $0.contactId == "A" }?.isOnFlipcash == false)
-        #expect(placements.first { $0.contactId == "B" }?.isOnFlipcash == true)
-        #expect(placements.first { $0.contactId == "C" }?.isOnFlipcash == false)
+    @Test("Distinct (name, nationalPhone) tuples all survive")
+    func distinctTuples() {
+        let contacts = [
+            makeContact(contactId: "A", name: "Alice", e164: "+14085551111", national: "(408) 555-1111"),
+            makeContact(contactId: "B", name: "Bob",   e164: "+14085552222", national: "(408) 555-2222"),
+        ]
+        let unique = RecipientLoader.deduplicatedForDisplay(contacts, flipcashSet: [])
+        #expect(unique.count == 2)
+    }
+
+    @Test("Same name with multiple different numbers shows once per number")
+    func sameNameMultipleNumbers() {
+        let contacts = [
+            makeContact(contactId: "A", name: "Alice", e164: "+14085551111", national: "(408) 555-1111"),
+            makeContact(contactId: "A", name: "Alice", e164: "+14085552222", national: "(408) 555-2222"),
+        ]
+        let unique = RecipientLoader.deduplicatedForDisplay(contacts, flipcashSet: [])
+        #expect(unique.count == 2)
+        #expect(unique.map(\.nationalPhone) == ["(408) 555-1111", "(408) 555-2222"])
+    }
+
+    @Test("Same number under multiple names shows once per name")
+    func sameNumberMultipleNames() {
+        let contacts = [
+            makeContact(contactId: "A", name: "Alice", e164: "+14085551234", national: "(408) 555-1234"),
+            makeContact(contactId: "B", name: "Bob",   e164: "+14085551234", national: "(408) 555-1234"),
+        ]
+        let unique = RecipientLoader.deduplicatedForDisplay(contacts, flipcashSet: [])
+        #expect(unique.count == 2)
+        #expect(Set(unique.map(\.displayName)) == ["Alice", "Bob"])
+    }
+
+    @Test("Same (name, nationalPhone) collapses to ONE row")
+    func sameNameAndNumber() {
+        let contacts = [
+            makeContact(contactId: "A", name: "Daniel", e164: "+14085553514",          national: "(408) 555-3514"),
+            makeContact(contactId: "A", name: "Daniel", e164: "+14085553514;ext=100",  national: "(408) 555-3514"),
+            makeContact(contactId: "A", name: "Daniel", e164: "+14085553514;ext=200",  national: "(408) 555-3514"),
+        ]
+        let unique = RecipientLoader.deduplicatedForDisplay(contacts, flipcashSet: [])
+        #expect(unique.count == 1)
+    }
+
+    @Test("Matched e164 wins over an earlier unmatched collision")
+    func matchedWinsOverEarlierUnmatched() {
+        let contacts = [
+            makeContact(contactId: "A", name: "Daniel", e164: "+14085553514;ext=100",  national: "(408) 555-3514"),
+            makeContact(contactId: "A", name: "Daniel", e164: "+14085553514",          national: "(408) 555-3514"),
+        ]
+        let unique = RecipientLoader.deduplicatedForDisplay(
+            contacts,
+            flipcashSet: ["+14085553514"],
+        )
+        #expect(unique.count == 1)
+        #expect(unique[0].phoneE164 == "+14085553514")
+    }
+
+    @Test("First matched e164 stays when a later matched arrives")
+    func firstMatchedStays() {
+        let contacts = [
+            makeContact(contactId: "A", name: "Daniel", e164: "+14085553514",          national: "(408) 555-3514"),
+            makeContact(contactId: "A", name: "Daniel", e164: "+14085553514;ext=100",  national: "(408) 555-3514"),
+        ]
+        let unique = RecipientLoader.deduplicatedForDisplay(
+            contacts,
+            flipcashSet: ["+14085553514", "+14085553514;ext=100"],
+        )
+        #expect(unique.count == 1)
+        #expect(unique[0].phoneE164 == "+14085553514")
+    }
+
+    @Test("Result preserves first-seen order")
+    func preservesOrder() {
+        let contacts = [
+            makeContact(contactId: "C", name: "Carla", e164: "+1...3", national: "n3"),
+            makeContact(contactId: "A", name: "Alice", e164: "+1...1", national: "n1"),
+            makeContact(contactId: "B", name: "Bob",   e164: "+1...2", national: "n2"),
+        ]
+        let unique = RecipientLoader.deduplicatedForDisplay(contacts, flipcashSet: [])
+        #expect(unique.map(\.displayName) == ["Carla", "Alice", "Bob"])
+    }
+
+    @Test("Empty input yields empty output")
+    func emptyInput() {
+        #expect(RecipientLoader.deduplicatedForDisplay([], flipcashSet: ["+1..."]).isEmpty)
     }
 }

--- a/FlipcashTests/RecipientPickerFilterTests.swift
+++ b/FlipcashTests/RecipientPickerFilterTests.swift
@@ -1,0 +1,86 @@
+//
+//  RecipientPickerFilterTests.swift
+//  FlipcashTests
+//
+
+import Testing
+@testable import Flipcash
+
+@Suite("ResolvedContacts.filtered(by:)")
+struct ResolvedContactsFilterTests {
+
+    private let directory = ResolvedContacts(
+        onFlipcash: [
+            ResolvedContact(
+                id: "1",
+                displayName: "Alice Anderson",
+                phoneE164: "+15551110001",
+                nationalPhone: "(555) 111-0001",
+                imageData: nil
+            ),
+            ResolvedContact(
+                id: "2",
+                displayName: "Bob Brown",
+                phoneE164: "+15552220002",
+                nationalPhone: "(555) 222-0002",
+                imageData: nil
+            ),
+        ],
+        invite: [
+            ResolvedContact(
+                id: "3",
+                displayName: "Carla Costa",
+                phoneE164: "+15553330003",
+                nationalPhone: "(555) 333-0003",
+                imageData: nil
+            ),
+        ]
+    )
+
+    @Test("Empty query returns everything unchanged")
+    func emptyQuery() {
+        let filtered = directory.filtered(by: "")
+        #expect(filtered.onFlipcash.count == 2)
+        #expect(filtered.invite.count == 1)
+    }
+
+    @Test("Whitespace-only query returns everything unchanged")
+    func whitespaceQuery() {
+        let filtered = directory.filtered(by: "   ")
+        #expect(filtered.onFlipcash.count == 2)
+        #expect(filtered.invite.count == 1)
+    }
+
+    @Test("Name match is case-insensitive substring")
+    func nameMatch() {
+        let filtered = directory.filtered(by: "ali")
+        #expect(filtered.onFlipcash.map(\.id) == ["1"])
+        #expect(filtered.invite.isEmpty)
+    }
+
+    @Test("Phone match uses national format")
+    func phoneMatch() {
+        let filtered = directory.filtered(by: "222")
+        #expect(filtered.onFlipcash.map(\.id) == ["2"])
+        #expect(filtered.invite.isEmpty)
+    }
+
+    @Test("Query that matches across sections returns both")
+    func crossSectionMatch() {
+        let filtered = directory.filtered(by: "555")
+        #expect(filtered.onFlipcash.count == 2)
+        #expect(filtered.invite.count == 1)
+    }
+
+    @Test("Non-matching query yields empty sections")
+    func noMatch() {
+        let filtered = directory.filtered(by: "xyz")
+        #expect(filtered.isEmpty)
+    }
+
+    @Test("isEmpty reflects both sections empty")
+    func isEmptyAggregates() {
+        #expect(ResolvedContacts.empty.isEmpty)
+        #expect(!directory.isEmpty)
+    }
+}

--- a/FlipcashTests/RecipientPickerFilterTests.swift
+++ b/FlipcashTests/RecipientPickerFilterTests.swift
@@ -12,14 +12,14 @@ struct ResolvedContactsFilterTests {
     private let directory = ResolvedContacts(
         onFlipcash: [
             ResolvedContact(
-                id: "1",
+                contactId: "1",
                 displayName: "Alice Anderson",
                 phoneE164: "+15551110001",
                 nationalPhone: "(555) 111-0001",
                 imageData: nil
             ),
             ResolvedContact(
-                id: "2",
+                contactId: "2",
                 displayName: "Bob Brown",
                 phoneE164: "+15552220002",
                 nationalPhone: "(555) 222-0002",
@@ -28,7 +28,7 @@ struct ResolvedContactsFilterTests {
         ],
         invite: [
             ResolvedContact(
-                id: "3",
+                contactId: "3",
                 displayName: "Carla Costa",
                 phoneE164: "+15553330003",
                 nationalPhone: "(555) 333-0003",
@@ -54,14 +54,14 @@ struct ResolvedContactsFilterTests {
     @Test("Name match is case-insensitive substring")
     func nameMatch() {
         let filtered = directory.filtered(by: "ali")
-        #expect(filtered.onFlipcash.map(\.id) == ["1"])
+        #expect(filtered.onFlipcash.map(\.contactId) == ["1"])
         #expect(filtered.invite.isEmpty)
     }
 
     @Test("Phone match uses national format")
     func phoneMatch() {
         let filtered = directory.filtered(by: "222")
-        #expect(filtered.onFlipcash.map(\.id) == ["2"])
+        #expect(filtered.onFlipcash.map(\.contactId) == ["2"])
         #expect(filtered.invite.isEmpty)
     }
 

--- a/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactAvatarView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactAvatarView.swift
@@ -1,0 +1,118 @@
+//
+//  ContactAvatarView.swift
+//  FlipcashUI
+//
+
+import SwiftUI
+import UIKit
+
+/// Circular avatar for a contact. Renders a cached image when supplied;
+/// otherwise falls back to a monogram chip built from the display name's
+/// initials. Decoded `UIImage`s live in a process-wide `NSCache` keyed by
+/// `id`, so scrolling a list of avatars decodes each contact's blob at
+/// most once.
+public struct ContactAvatarView: View {
+
+    public let id: String
+    public let displayName: String
+    public let imageData: Data?
+    public let size: CGFloat
+
+    public init(id: String, displayName: String, imageData: Data? = nil, size: CGFloat = 44) {
+        self.id = id
+        self.displayName = displayName
+        self.imageData = imageData
+        self.size = size
+    }
+
+    public var body: some View {
+        Group {
+            if let imageData,
+               let uiImage = ContactAvatarCache.shared.image(forKey: id, data: imageData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                LinearGradient(
+                    stops: [
+                        Gradient.Stop(color: Color(red: 0.25, green: 0.25, blue: 0.25), location: 0.00),
+                        Gradient.Stop(color: Color(red: 0.13, green: 0.13, blue: 0.13), location: 1.00),
+                    ],
+                    startPoint: UnitPoint(x: 0.5, y: 0),
+                    endPoint: UnitPoint(x: 0.5, y: 1)
+                )
+                .overlay {
+                    Text(Self.initials(for: displayName))
+                        .font(.appTextMedium)
+                        .foregroundStyle(Color.textMain)
+                }
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(displayName.isEmpty ? "Contact" : displayName))
+        .accessibilityAddTraits(.isImage)
+    }
+
+    /// Two-letter monogram for a display name. Two-word names yield the first
+    /// letter of the first and last words; single-word names yield the first
+    /// two characters; an empty or whitespace-only name yields `"?"`.
+    nonisolated public static func initials(for displayName: String) -> String {
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "?" }
+
+        let words = trimmed.split(separator: " ", omittingEmptySubsequences: true)
+        if words.count >= 2 {
+            let first = words.first?.first.map(String.init) ?? ""
+            let last = words.last?.first.map(String.init) ?? ""
+            return (first + last).uppercased()
+        }
+        return String(words[0].prefix(2)).uppercased()
+    }
+}
+
+/// Process-wide cache of decoded contact thumbnails. `NSCache` is thread-safe
+/// so the same instance is read from main and background callers without
+/// additional synchronization. `countLimit` caps memory growth on devices
+/// with very large address books.
+nonisolated public final class ContactAvatarCache: @unchecked Sendable {
+
+    public static let shared = ContactAvatarCache()
+
+    private let cache = NSCache<NSString, UIImage>()
+
+    public init(countLimit: Int = 200) {
+        cache.countLimit = countLimit
+    }
+
+    /// Returns the cached `UIImage` for `key`. Decodes `data` and caches the
+    /// result on a miss; returns `nil` when `data` doesn't yield a valid
+    /// image.
+    public func image(forKey key: String, data: Data) -> UIImage? {
+        if let cached = cache.object(forKey: key as NSString) {
+            return cached
+        }
+        guard let image = UIImage(data: data) else { return nil }
+        cache.setObject(image, forKey: key as NSString)
+        return image
+    }
+}
+
+#Preview("Initials — two names") {
+    ContactAvatarView(id: "p1", displayName: "Jane Doe")
+        .padding()
+        .background(Color.backgroundMain)
+}
+
+#Preview("Initials — single name") {
+    ContactAvatarView(id: "p2", displayName: "Madonna")
+        .padding()
+        .background(Color.backgroundMain)
+}
+
+#Preview("Initials — empty") {
+    ContactAvatarView(id: "p3", displayName: "   ")
+        .padding()
+        .background(Color.backgroundMain)
+}

--- a/FlipcashUITests/Support/BaseUITestCase.swift
+++ b/FlipcashUITests/Support/BaseUITestCase.swift
@@ -119,29 +119,47 @@ class BaseUITestCase: XCTestCase {
         waitUntilHittableAndTap(springboard.buttons["Allow"])
     }
 
-    /// Handles the contacts permission screen if it appears. Resilient to the
-    /// determined-status case where the screen is skipped entirely, and to
-    /// the differences in iOS's system permission flow across versions:
-    ///   - iOS 18:  jumps straight to the "How do you want to share
-    ///              contacts?" picker — no Continue prompt.
-    ///   - iOS 26+: shows a "Continue" prompt first, then the share picker.
-    /// Both steps are optional so this helper works on any supported iOS.
+    /// Handles the contacts permission screen if it appears. Resilient to:
+    ///   - the determined-status case where the screen is skipped entirely
+    ///   - iOS 18 jumping straight to the share picker (no Continue prompt)
+    ///   - iOS 26+ showing a Continue prompt before the share picker
+    /// iOS 18+ hosts the share picker in a dedicated XPC process,
+    /// `com.apple.ContactsUI.LimitedAccessPromptView`. The process must be
+    /// activated explicitly — queries against the non-frontmost process
+    /// return empty hierarchies even when the picker is on screen. Older
+    /// iOS variants present the same picker from springboard, so springboard
+    /// is the fallback.
     func allowContactsIfNeeded() {
         let giveAccessButton = app.buttons["Give Access To Contacts"]
         guard giveAccessButton.waitForExistence(timeout: 2) else { return }
         giveAccessButton.tap()
 
-        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let springboard   = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let limitedAccess = XCUIApplication(bundleIdentifier: "com.apple.ContactsUI.LimitedAccessPromptView")
 
+        // iOS 26+ Continue prompt — absent on earlier iOS.
         let continueButton = springboard.buttons["Continue"]
         if continueButton.waitForExistence(timeout: 2) {
             waitUntilHittableAndTap(continueButton)
         }
 
-        let shareAllPredicate = NSPredicate(format: "label BEGINSWITH 'Share All'")
-        let shareAllButton = springboard.buttons.matching(shareAllPredicate).firstMatch
-        if shareAllButton.waitForExistence(timeout: 2) {
-            waitUntilHittableAndTap(shareAllButton)
+        // Share picker. iOS 18+ hosts this in a dedicated XPC process
+        // (com.apple.ContactsUI.LimitedAccessPromptView); some iOS variants
+        // host it from springboard. Poll both — naming the bundle scopes
+        // the query without taking focus from the picker (`.activate()`
+        // would launch the process fresh and steal foreground).
+        let predicate    = NSPredicate(format: "label BEGINSWITH[c] 'Share All'")
+        let candidates: [XCUIApplication] = [limitedAccess, springboard]
+        let deadline     = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            for candidate in candidates {
+                let button = candidate.buttons.matching(predicate).firstMatch
+                if button.exists {
+                    waitUntilHittableAndTap(button)
+                    return
+                }
+            }
+            Thread.sleep(forTimeInterval: 0.25)
         }
     }
 

--- a/FlipcashUITests/Support/BaseUITestCase.swift
+++ b/FlipcashUITests/Support/BaseUITestCase.swift
@@ -120,17 +120,24 @@ class BaseUITestCase: XCTestCase {
     }
 
     /// Handles the contacts permission screen if it appears. Resilient to the
-    /// determined-status case where the screen is skipped entirely.
+    /// determined-status case where the screen is skipped entirely, and to
+    /// the differences in iOS's system permission flow across versions:
+    ///   - iOS 18:  jumps straight to the "How do you want to share
+    ///              contacts?" picker — no Continue prompt.
+    ///   - iOS 26+: shows a "Continue" prompt first, then the share picker.
+    /// Both steps are optional so this helper works on any supported iOS.
     func allowContactsIfNeeded() {
         let giveAccessButton = app.buttons["Give Access To Contacts"]
         guard giveAccessButton.waitForExistence(timeout: 2) else { return }
         giveAccessButton.tap()
 
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        waitUntilHittableAndTap(springboard.buttons["Continue"])
 
-        // iOS 26+ inserts a "Share All N Contacts" follow-up sheet; absent on
-        // earlier iOS.
+        let continueButton = springboard.buttons["Continue"]
+        if continueButton.waitForExistence(timeout: 2) {
+            waitUntilHittableAndTap(continueButton)
+        }
+
         let shareAllPredicate = NSPredicate(format: "label BEGINSWITH 'Share All'")
         let shareAllButton = springboard.buttons.matching(shareAllPredicate).firstMatch
         if shareAllButton.waitForExistence(timeout: 2) {


### PR DESCRIPTION
The Send sheet's primary view. Two sections — On Flipcash and Not on Flipcash Yet — with inline search, per-contact avatars, and dedup so a contact with multiple phone-number entries shows up once. Row taps stub through to Phase 6 (invite sheet) and Phase 7 (resolve-and-send wire-up).

## Test plan
- [x] Grant contacts permission and open the Send sheet — picker renders with both sections
- [x] Search filters both sections by name and by national phone format
- [x] A contact with multiple phone-number labels appears exactly once, with the matched number when one exists
- [x] Tap an On Flipcash row — info log, no crash (real send arrives in Phase 7)
- [x] Tap an Invite button — info log, no crash (real composer arrives in Phase 6)
- [x] Add or remove a contact in the system Contacts app — picker refreshes automatically
- [x] Tap X to dismiss the sheet — closes cleanly
- [x] VoiceOver reads each row as "Name, Phone" with an Invite action where applicable