### PR TITLE
feat: invite sheet, onboarding phone verification, and smoke coverage

### DIFF
--- a/Flipcash/Core/Screens/Onboarding/IntroScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/IntroScreen.swift
@@ -185,7 +185,6 @@ private struct OnboardingPhoneVerificationStep: View {
             EnterPhoneScreen(viewModel: phoneVM)
                 .interactiveDismissDisabled()
                 .navigationTitle("Connect Phone Number")
-                .toolbarTitleDisplayMode(.inline)
                 .navigationBarBackButtonHidden(true)
         }
     }

--- a/Flipcash/Core/Screens/Onboarding/IntroScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/IntroScreen.swift
@@ -124,7 +124,8 @@ struct IntroScreen: View {
                 case .confirmPhoneNumberCode:
                     if let phoneVM = viewModel.phoneVerificationViewModel {
                         ConfirmPhoneScreen(viewModel: phoneVM)
-                            .interactiveDismissDisabled()
+                            .navigationTitle("Connect Phone Number")
+                            .navigationBarBackButtonHidden(true)
                     }
                 }
             }
@@ -183,7 +184,6 @@ private struct OnboardingPhoneVerificationStep: View {
     var body: some View {
         if let phoneVM = viewModel.phoneVerificationViewModel {
             EnterPhoneScreen(viewModel: phoneVM)
-                .interactiveDismissDisabled()
                 .navigationTitle("Connect Phone Number")
                 .navigationBarBackButtonHidden(true)
         }

--- a/Flipcash/Core/Screens/Onboarding/IntroScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/IntroScreen.swift
@@ -119,6 +119,13 @@ struct IntroScreen: View {
                     NotificationPermissionDeniedScreen(viewModel: viewModel)
                 case .contactsPermissions:
                     OnboardingContactsPermissionStep(viewModel: viewModel)
+                case .phoneVerification:
+                    OnboardingPhoneVerificationStep(viewModel: viewModel)
+                case .confirmPhoneNumberCode:
+                    if let phoneVM = viewModel.phoneVerificationViewModel {
+                        ConfirmPhoneScreen(viewModel: phoneVM)
+                            .interactiveDismissDisabled()
+                    }
                 }
             }
         }
@@ -160,6 +167,26 @@ private struct OnboardingContactsPermissionStep: View {
             .subtle("I'm Sure") {
                 viewModel.skipContactsAction()
             }
+        }
+    }
+}
+
+// MARK: - Phone verification step -
+
+/// Wrapper for the onboarding phone entry screen. Reads the shared
+/// `PhoneVerificationViewModel` from `OnboardingViewModel` so the
+/// follow-up `ConfirmPhoneScreen` destination binds the same instance.
+private struct OnboardingPhoneVerificationStep: View {
+
+    let viewModel: OnboardingViewModel
+
+    var body: some View {
+        if let phoneVM = viewModel.phoneVerificationViewModel {
+            EnterPhoneScreen(viewModel: phoneVM)
+                .interactiveDismissDisabled()
+                .navigationTitle("Connect Phone Number")
+                .toolbarTitleDisplayMode(.inline)
+                .navigationBarBackButtonHidden(true)
         }
     }
 }

--- a/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
@@ -22,9 +22,14 @@ class OnboardingViewModel {
 
     private(set) var inflightMnemonic: MnemonicPhrase = .generate(.words12)
 
-    @ObservationIgnored private let container: Container
+    @ObservationIgnored let container: Container
     @ObservationIgnored private let sessionAuthenticator: SessionAuthenticator
     @ObservationIgnored private var initializedAccount: InitializedAccount?
+
+    /// Built on first call to ``navigateToPhoneVerification``; shared
+    /// between the `EnterPhoneScreen` and `ConfirmPhoneScreen`
+    /// destinations so input state survives the push.
+    var phoneVerificationViewModel: PhoneVerificationViewModel?
 
     // MARK: - Init -
 
@@ -118,14 +123,9 @@ class OnboardingViewModel {
         accessKeyButtonState = .success
         try await Task.delay(milliseconds: 500)
 
-        let contactsStatus = await Task.detached {
-            CNContactStore.authorizationStatus(for: .contacts)
-        }.value
-        if contactsStatus == .notDetermined {
-            navigateToContactsPermissions()
-        } else {
-            await advanceFromContactsStep()
-        }
+        // No Session yet (completeLogin runs after the permission gates),
+        // and a fresh registration has no verified phone. Always show.
+        navigateToPhoneVerification()
 
         try await Task.delay(milliseconds: 500) // Delay deferred state change
     }
@@ -282,15 +282,61 @@ class OnboardingViewModel {
         path.append(.contactsPermissions)
     }
 
+    func navigateToPhoneVerification() {
+        if phoneVerificationViewModel == nil {
+            let vm = PhoneVerificationViewModel(
+                owner: inflightMnemonic.solanaKeyPair(),
+                flipClient: container.flipClient,
+                enterPhoneEvent: Analytics.OnboardingEvent.showEnterPhone,
+                confirmPhoneEvent: Analytics.OnboardingEvent.showConfirmPhone,
+            )
+            vm.onCodeRequested = { [weak self] in
+                self?.navigateToConfirmPhoneCode()
+            }
+            vm.onVerified = { [weak self] in
+                Task { await self?.advanceFromPhoneVerificationStep() }
+            }
+            phoneVerificationViewModel = vm
+        }
+        path.append(.phoneVerification)
+    }
+
+    func navigateToConfirmPhoneCode() {
+        path.append(.confirmPhoneNumberCode)
+    }
+
+    /// Phone-step success handler. Routes to contacts priming when
+    /// unprompted, otherwise to push + completeLogin.
+    func advanceFromPhoneVerificationStep() async {
+        let contactsStatus = await Task.detached {
+            CNContactStore.authorizationStatus(for: .contacts)
+        }.value
+        if let next = Self.destinationAfterPhoneStep(contactsStatus: contactsStatus) {
+            path.append(next)
+        } else {
+            await advanceFromContactsStep()
+        }
+    }
+
+    /// `.notDetermined` → `.contactsPermissions`; any other status → nil
+    /// (post-contacts flow takes over).
+    nonisolated static func destinationAfterPhoneStep(
+        contactsStatus: CNAuthorizationStatus
+    ) -> OnboardingPath? {
+        contactsStatus == .notDetermined ? .contactsPermissions : nil
+    }
+
 }
 
 // MARK: - Path -
 
-enum OnboardingPath {
+nonisolated enum OnboardingPath {
     case accountSelection
     case login
     case accessKey
     case accessKeyHelp
+    case phoneVerification
+    case confirmPhoneNumberCode
     case pushNotifications
     case pushNotificationsDenied
     case contactsPermissions

--- a/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
@@ -54,6 +54,7 @@ class OnboardingViewModel {
 
     func createAccountAction() {
         inflightMnemonic = MnemonicPhrase.generate(.words12)
+        phoneVerificationViewModel = nil
 
         navigateToAccessKey()
 

--- a/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
@@ -173,7 +173,12 @@ extension OnrampVerificationViewModel
     convenience init(session: Session, flipClient: FlipClient) {
         self.init(
             session: session,
-            phoneVerifier: PhoneVerificationViewModel(session: session, flipClient: flipClient),
+            phoneVerifier: PhoneVerificationViewModel(
+                owner: session.ownerKeyPair,
+                flipClient: flipClient,
+                isAlreadyVerified: { [weak session] in session?.profile?.isPhoneVerified ?? false },
+                onShouldRefreshProfile: { [weak session] in try? await session?.updateProfile() },
+            ),
             emailVerifier: EmailVerificationViewModel(session: session, flipClient: flipClient)
         )
     }

--- a/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
@@ -70,6 +70,7 @@ struct VerifyInfoScreen<P: PhoneVerifying, E: EmailVerifying>: View {
                 case .confirmPhoneNumberCode:
                     ConfirmPhoneScreen(viewModel: viewModel.phoneVerifier)
                         .interactiveDismissDisabled()
+                        .navigationTitle("Verify Phone Number")
                 case .enterEmail:
                     EnterEmailScreen(viewModel: viewModel.emailVerifier)
                         .interactiveDismissDisabled()

--- a/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
@@ -66,6 +66,7 @@ struct VerifyInfoScreen<P: PhoneVerifying, E: EmailVerifying>: View {
                 case .enterPhoneNumber:
                     EnterPhoneScreen(viewModel: viewModel.phoneVerifier)
                         .interactiveDismissDisabled()
+                        .navigationTitle("Verify Phone Number")
                 case .confirmPhoneNumberCode:
                     ConfirmPhoneScreen(viewModel: viewModel.phoneVerifier)
                         .interactiveDismissDisabled()

--- a/Flipcash/Core/Screens/PhoneVerification/ConfirmPhoneScreen.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/ConfirmPhoneScreen.swift
@@ -94,7 +94,6 @@ struct ConfirmPhoneScreen<VM: PhoneVerifying>: View {
             .foregroundStyle(.textMain)
         }
         .dialog(item: $viewModel.dialogItem)
-        .navigationTitle("Verify Phone Number")
         .toolbarTitleDisplayMode(.inline)
         .onAppear {
             countdownEnd = Date.now.addingTimeInterval(60)

--- a/Flipcash/Core/Screens/PhoneVerification/EnterPhoneScreen.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/EnterPhoneScreen.swift
@@ -85,7 +85,6 @@ struct EnterPhoneScreen<VM: PhoneVerifying>: View {
             .foregroundStyle(.textMain)
         }
         .dialog(item: $viewModel.dialogItem)
-        .navigationTitle("Verify Phone Number")
         .toolbarTitleDisplayMode(.inline)
         .task {
             try? await Task.sleep(for: .milliseconds(100))

--- a/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationFlowScreen.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationFlowScreen.swift
@@ -40,6 +40,7 @@ struct PhoneVerificationFlowScreen<VM: PhoneVerifying>: View {
                     case .confirmPhoneNumberCode:
                         ConfirmPhoneScreen(viewModel: viewModel)
                             .interactiveDismissDisabled()
+                            .navigationTitle("Connect Phone Number")
                     }
                 }
                 .ignoresSafeArea(.keyboard)

--- a/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationViewModel.swift
@@ -41,7 +41,6 @@ final class PhoneVerificationViewModel: PhoneVerifying {
 
     // MARK: - Dependencies -
 
-    @ObservationIgnored private let session: Session
     @ObservationIgnored private let flipClient: FlipClient
     @ObservationIgnored private let owner: KeyPair
 
@@ -59,6 +58,15 @@ final class PhoneVerificationViewModel: PhoneVerifying {
     /// its own flavored event there.
     @ObservationIgnored private let confirmPhoneEvent: (any AnalyticsEvent)?
 
+    // MARK: - Profile hooks -
+
+    /// Short-circuit for `Verifying.run()`. Defaults to `false`.
+    @ObservationIgnored private let isAlreadyVerifiedProvider: @MainActor () -> Bool
+
+    /// Post-success refresh, awaited before `onVerified` fires. Defaults
+    /// to a no-op.
+    @ObservationIgnored private let onShouldRefreshProfile: @MainActor () async -> Void
+
     // MARK: - Verifying lifecycle hooks -
 
     @ObservationIgnored var onCodeRequested: (@MainActor () -> Void)?
@@ -71,17 +79,20 @@ final class PhoneVerificationViewModel: PhoneVerifying {
     // MARK: - Init -
 
     init(
-        session: Session,
+        owner: KeyPair,
         flipClient: FlipClient,
         enterPhoneEvent: (any AnalyticsEvent)? = nil,
-        confirmPhoneEvent: (any AnalyticsEvent)? = nil
+        confirmPhoneEvent: (any AnalyticsEvent)? = nil,
+        isAlreadyVerified: @MainActor @escaping () -> Bool = { false },
+        onShouldRefreshProfile: @MainActor @escaping () async -> Void = { },
     ) {
-        self.session = session
         self.flipClient = flipClient
-        self.owner = session.ownerKeyPair
+        self.owner = owner
         self.region = phoneFormatter.currentRegion
         self.enterPhoneEvent = enterPhoneEvent
         self.confirmPhoneEvent = confirmPhoneEvent
+        self.isAlreadyVerifiedProvider = isAlreadyVerified
+        self.onShouldRefreshProfile = onShouldRefreshProfile
     }
 
     isolated deinit {
@@ -119,7 +130,7 @@ final class PhoneVerificationViewModel: PhoneVerifying {
     }
 
     var isAlreadyVerified: Bool {
-        session.profile?.isPhoneVerified ?? false
+        isAlreadyVerifiedProvider()
     }
 
     // MARK: - Setters & bindings -
@@ -286,7 +297,7 @@ final class PhoneVerificationViewModel: PhoneVerifying {
                     owner: owner
                 )
 
-                try? await session.updateProfile()
+                await onShouldRefreshProfile()
 
                 try await Task.delay(milliseconds: 500)
                 confirmCodeButtonState = .success

--- a/Flipcash/Core/Screens/Send/MessageComposerSheet.swift
+++ b/Flipcash/Core/Screens/Send/MessageComposerSheet.swift
@@ -1,0 +1,64 @@
+//
+//  MessageComposerSheet.swift
+//  Flipcash
+//
+
+import MessageUI
+import SwiftUI
+
+/// SwiftUI wrapper around `MFMessageComposeViewController` for prefilled
+/// iMessage invites. Present from a `.sheet(item:)` and clear the bound
+/// item from `onFinish` so SwiftUI tears the sheet down once the user
+/// taps Send, Cancel, or hits a failure.
+///
+/// Gate presentation with ``isAvailable`` — the composer is absent on
+/// devices that aren't configured for iMessage (iPad without SIM, etc.).
+struct MessageComposerSheet: UIViewControllerRepresentable {
+
+    /// Placeholder invite body. Marketing-final copy lands before ship.
+    // TODO: Finalize invite copy with product/marketing before App Store ship.
+    static let placeholderBody = """
+    Download Flipcash so I can send you money
+
+    \(URL.downloadApp.absoluteString)
+    """
+
+    /// Whether `MFMessageComposeViewController` can be presented on this
+    /// device. Mirrors `MFMessageComposeViewController.canSendText()` so
+    /// callers don't need to import `MessageUI` themselves.
+    static var isAvailable: Bool { MFMessageComposeViewController.canSendText() }
+
+    let recipient: String
+    let body: String
+    let onFinish: (MessageComposeResult) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onFinish: onFinish)
+    }
+
+    func makeUIViewController(context: Context) -> MFMessageComposeViewController {
+        let controller = MFMessageComposeViewController()
+        controller.recipients = [recipient]
+        controller.body = body
+        controller.messageComposeDelegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: MFMessageComposeViewController, context: Context) {}
+
+    final class Coordinator: NSObject, MFMessageComposeViewControllerDelegate {
+
+        let onFinish: (MessageComposeResult) -> Void
+
+        init(onFinish: @escaping (MessageComposeResult) -> Void) {
+            self.onFinish = onFinish
+        }
+
+        func messageComposeViewController(
+            _ controller: MFMessageComposeViewController,
+            didFinishWith result: MessageComposeResult,
+        ) {
+            onFinish(result)
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Send/MessageComposerSheet.swift
+++ b/Flipcash/Core/Screens/Send/MessageComposerSheet.swift
@@ -58,7 +58,9 @@ struct MessageComposerSheet: UIViewControllerRepresentable {
             _ controller: MFMessageComposeViewController,
             didFinishWith result: MessageComposeResult,
         ) {
-            onFinish(result)
+            controller.dismiss(animated: true) { [onFinish] in
+                onFinish(result)
+            }
         }
     }
 }

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -83,10 +83,10 @@ struct RecipientPickerScreen: View {
 
     private func outcomeName(_ result: MessageComposeResult) -> String {
         switch result {
-        case .sent:      "sent"
-        case .cancelled: "cancelled"
-        case .failed:    "failed"
-        @unknown default: "unknown"
+        case .sent:       return "sent"
+        case .cancelled:  return "cancelled"
+        case .failed:     return "failed"
+        @unknown default: return "unknown"
         }
     }
 

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -4,6 +4,7 @@
 //
 
 import Contacts
+import MessageUI
 import SwiftUI
 import FlipcashCore
 import FlipcashUI
@@ -27,6 +28,7 @@ struct RecipientPickerScreen: View {
 
     @State private var filtered: ResolvedContacts = .empty
     @State private var searchText: String = ""
+    @State private var inviteTarget: ResolvedContact?
 
     var body: some View {
         let contacts = contactSyncController.resolvedContacts
@@ -46,10 +48,7 @@ struct RecipientPickerScreen: View {
                             // `PaymentDestinationService.resolve(phone:)` is in.
                             logger.info("Tapped On Flipcash row (send wire-up pending)")
                         },
-                        onInviteTap: { _ in
-                            // Phase 6 wires this to `MessageComposerSheet`.
-                            logger.info("Tapped Invite row (composer sheet pending)")
-                        }
+                        onInviteTap: presentInvite,
                     )
                 }
             }
@@ -57,6 +56,38 @@ struct RecipientPickerScreen: View {
         .onAppear { refilter() }
         .onChange(of: searchText) { refilter() }
         .onChange(of: contacts) { refilter() }
+        .sheet(item: $inviteTarget) { contact in
+            MessageComposerSheet(
+                recipient: contact.phoneE164,
+                body: MessageComposerSheet.placeholderBody,
+                onFinish: { result in
+                    logger.info("Invite composer finished", metadata: [
+                        "outcome": "\(outcomeName(result))",
+                    ])
+                    inviteTarget = nil
+                },
+            )
+        }
+    }
+
+    private func presentInvite(for contact: ResolvedContact) {
+        if MessageComposerSheet.isAvailable {
+            inviteTarget = contact
+        } else {
+            // iMessage isn't configured on this device (iPad without SIM, etc.).
+            // Fall back to the system share sheet with the download URL only.
+            logger.info("Presenting share fallback (iMessage unavailable)")
+            ShareSheet.present(url: URL.downloadApp)
+        }
+    }
+
+    private func outcomeName(_ result: MessageComposeResult) -> String {
+        switch result {
+        case .sent:      "sent"
+        case .cancelled: "cancelled"
+        case .failed:    "failed"
+        @unknown default: "unknown"
+        }
     }
 
     private func refilter() {

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -70,7 +70,12 @@ struct SendRootScreen: View {
     }
 
     private var step: Step {
-        guard session.profile?.isPhoneVerified ?? false else {
+        // The dev-backend mock phone (`+10000000000`) used in UI tests
+        // does not link to a real user, so `profile.phone` stays nil
+        // even after the verification screen completes. Bypass the gate
+        // under `--ui-testing` so the smoke test can reach the picker.
+        let phoneVerified = session.profile?.isPhoneVerified ?? false
+        guard phoneVerified || Container.isRunningUITests else {
             return .needsPhone
         }
         guard contactsAuthorizer.status == .authorized else {
@@ -83,10 +88,12 @@ struct SendRootScreen: View {
 
     private func startPhoneVerification() {
         let viewModel = PhoneVerificationViewModel(
-            session: session,
+            owner: session.ownerKeyPair,
             flipClient: container.flipClient,
             enterPhoneEvent: Analytics.SendEvent.showEnterPhone,
-            confirmPhoneEvent: Analytics.SendEvent.showConfirmPhone
+            confirmPhoneEvent: Analytics.SendEvent.showConfirmPhone,
+            isAlreadyVerified: { [weak session] in session?.profile?.isPhoneVerified ?? false },
+            onShouldRefreshProfile: { [weak session] in try? await session?.updateProfile() },
         )
         phoneVerificationViewModel = viewModel
 

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -70,12 +70,7 @@ struct SendRootScreen: View {
     }
 
     private var step: Step {
-        // The dev-backend mock phone (`+10000000000`) used in UI tests
-        // does not link to a real user, so `profile.phone` stays nil
-        // even after the verification screen completes. Bypass the gate
-        // under `--ui-testing` so the smoke test can reach the picker.
-        let phoneVerified = session.profile?.isPhoneVerified ?? false
-        guard phoneVerified || Container.isRunningUITests else {
+        guard session.profile?.isPhoneVerified ?? false else {
             return .needsPhone
         }
         guard contactsAuthorizer.status == .authorized else {

--- a/Flipcash/Utilities/Events.swift
+++ b/Flipcash/Utilities/Events.swift
@@ -61,6 +61,11 @@ extension Analytics {
         case showConfirmPhone = "Send: Show Confirm Phone"
     }
 
+    enum OnboardingEvent: String, AnalyticsEvent {
+        case showEnterPhone   = "Onboarding: Show Enter Phone"
+        case showConfirmPhone = "Onboarding: Show Confirm Phone"
+    }
+
     enum WalletEvent: String, AnalyticsEvent {
         case connect               = "Wallet: Connect"
         case requestAmount         = "Wallet: Request Amount"

--- a/FlipcashTests/OnboardingViewModelTests.swift
+++ b/FlipcashTests/OnboardingViewModelTests.swift
@@ -10,28 +10,19 @@ import Testing
 @Suite("OnboardingViewModel.destinationAfterPhoneStep(contactsStatus:)")
 struct OnboardingViewModelDestinationAfterPhoneStepTests {
 
-    @Test(".notDetermined routes to the contacts permission step")
-    func notDeterminedRoutesToContactsPermissions() {
-        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .notDetermined) == .contactsPermissions)
-    }
+    private static let cases: [(CNAuthorizationStatus, OnboardingPath?)] = [
+        (.notDetermined, .contactsPermissions),
+        (.authorized,    nil),
+        (.denied,        nil),
+        (.restricted,    nil),
+        (.limited,       nil),
+    ]
 
-    @Test(".authorized falls through (nil) so the post-contacts flow runs")
-    func authorizedFallsThrough() {
-        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .authorized) == nil)
-    }
-
-    @Test(".denied falls through")
-    func deniedFallsThrough() {
-        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .denied) == nil)
-    }
-
-    @Test(".restricted falls through")
-    func restrictedFallsThrough() {
-        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .restricted) == nil)
-    }
-
-    @Test(".limited falls through (treated as denied for v1)")
-    func limitedFallsThrough() {
-        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .limited) == nil)
+    @Test(
+        "Only .notDetermined routes to .contactsPermissions; every other status falls through",
+        arguments: cases,
+    )
+    func routes(status: CNAuthorizationStatus, expected: OnboardingPath?) {
+        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: status) == expected)
     }
 }

--- a/FlipcashTests/OnboardingViewModelTests.swift
+++ b/FlipcashTests/OnboardingViewModelTests.swift
@@ -1,0 +1,37 @@
+//
+//  OnboardingViewModelTests.swift
+//  FlipcashTests
+//
+
+import Contacts
+import Testing
+@testable import Flipcash
+
+@Suite("OnboardingViewModel.destinationAfterPhoneStep(contactsStatus:)")
+struct OnboardingViewModelDestinationAfterPhoneStepTests {
+
+    @Test(".notDetermined routes to the contacts permission step")
+    func notDeterminedRoutesToContactsPermissions() {
+        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .notDetermined) == .contactsPermissions)
+    }
+
+    @Test(".authorized falls through (nil) so the post-contacts flow runs")
+    func authorizedFallsThrough() {
+        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .authorized) == nil)
+    }
+
+    @Test(".denied falls through")
+    func deniedFallsThrough() {
+        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .denied) == nil)
+    }
+
+    @Test(".restricted falls through")
+    func restrictedFallsThrough() {
+        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .restricted) == nil)
+    }
+
+    @Test(".limited falls through (treated as denied for v1)")
+    func limitedFallsThrough() {
+        #expect(OnboardingViewModel.destinationAfterPhoneStep(contactsStatus: .limited) == nil)
+    }
+}

--- a/FlipcashTests/PhoneVerificationViewModelTests.swift
+++ b/FlipcashTests/PhoneVerificationViewModelTests.swift
@@ -13,11 +13,33 @@ struct PhoneVerificationViewModelTests {
 
     @Test("Formatted input parses to E.164 via the Phone derived property")
     func enteredPhone_parsesToE164() {
-        let viewModel = PhoneVerificationViewModel(session: .unverifiedMock, flipClient: .mock)
+        let viewModel = PhoneVerificationViewModel(owner: .mock, flipClient: .mock)
         viewModel.setRegion(.us)
         viewModel.enteredPhone = "+1 415 555 0100"
 
         #expect(viewModel.canSendVerificationCode)
         #expect(viewModel.phone?.e164 == "+14155550100")
+    }
+
+    @Test("Default isAlreadyVerified is false — onboarding never short-circuits the phone step")
+    func isAlreadyVerified_defaultsFalse() {
+        let viewModel = PhoneVerificationViewModel(owner: .mock, flipClient: .mock)
+        #expect(viewModel.isAlreadyVerified == false)
+    }
+
+    @Test("Caller-supplied isAlreadyVerified closure is consulted")
+    func isAlreadyVerified_usesProvider() {
+        let verifiedVM = PhoneVerificationViewModel(
+            owner: .mock,
+            flipClient: .mock,
+            isAlreadyVerified: { true },
+        )
+        let unverifiedVM = PhoneVerificationViewModel(
+            owner: .mock,
+            flipClient: .mock,
+            isAlreadyVerified: { false },
+        )
+        #expect(verifiedVM.isAlreadyVerified == true)
+        #expect(unverifiedVM.isAlreadyVerified == false)
     }
 }

--- a/FlipcashUITests/Smoke/CreateAccountSmokeTests.swift
+++ b/FlipcashUITests/Smoke/CreateAccountSmokeTests.swift
@@ -23,6 +23,9 @@ final class CreateAccountSmokeTests: BaseUITestCase {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         waitUntilHittableAndTap(springboard.buttons["Allow"])
 
+        // Onboarding phone verification — forced for new registrations.
+        allowPhoneVerificationIfNeeded()
+
         // Contacts permission screen (may be skipped if already prompted)
         allowContactsIfNeeded()
 
@@ -42,6 +45,9 @@ final class CreateAccountSmokeTests: BaseUITestCase {
 
         // Confirmation dialog: "Are You Sure?"
         waitAndTap(app.buttons["Yes, I Wrote Them Down"])
+
+        // Onboarding phone verification — forced for new registrations.
+        allowPhoneVerificationIfNeeded()
 
         // Contacts permission screen (may be skipped if already prompted)
         allowContactsIfNeeded()

--- a/FlipcashUITests/Smoke/SendSmokeTests.swift
+++ b/FlipcashUITests/Smoke/SendSmokeTests.swift
@@ -1,0 +1,77 @@
+//
+//  SendSmokeTests.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+final class SendSmokeTests: BaseUITestCase {
+
+    override var requiresAuthentication: Bool { true }
+    override var resetPermissions: [XCUIProtectedResource] { [.contacts] }
+
+    func testSendFlow_picker_inviteFallback() {
+        assertMainScreenReached()
+
+        // Send is the 4th LargeButton on ScanBottomBar.
+        waitAndTap(app.buttons["Send"])
+
+        // The helpers are idempotent — they no-op when the gate is already
+        // satisfied for the test account.
+        allowPhoneVerificationIfNeeded()
+        allowContactsIfNeeded()
+
+        // RecipientPickerScreen renders one of three states. Wait for any of
+        // them so the test is resilient to whether the test account has any
+        // matched/invitable contacts at run time.
+        let onFlipcashHeader = app.staticTexts["On Flipcash"]
+        let inviteHeader     = app.staticTexts["Not on Flipcash Yet"]
+        let emptyState       = app.staticTexts["No Contacts Found"]
+
+        let deadline = Date().addingTimeInterval(30)
+        while Date() < deadline {
+            if onFlipcashHeader.exists || inviteHeader.exists || emptyState.exists { break }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        XCTAssertTrue(
+            onFlipcashHeader.exists || inviteHeader.exists || emptyState.exists,
+            "Expected `RecipientPickerScreen` to render an On-Flipcash header, an Invite header, or the empty state"
+        )
+
+        // The invite-fallback path requires at least one row in the Invite
+        // section. If the picker is empty (simulator without contacts), the
+        // header assertions above stand on their own — skip the rest.
+        guard inviteHeader.exists else { return }
+
+        waitAndTap(app.buttons["Invite"].firstMatch)
+
+        // `MFMessageComposeViewController.canSendText()` returns `false`
+        // on the simulator, so `RecipientPickerScreen.presentInvite(for:)`
+        // takes the fallback path and calls `ShareSheet.present(url:)`.
+        // `UIActivityViewController` hosts its actions as cells, not buttons,
+        // since iOS 13.
+        let copyCell = app.cells["Copy"]
+        XCTAssertTrue(
+            copyCell.waitForExistence(timeout: 10),
+            "Expected the share-sheet fallback (UIActivityViewController) after tapping Invite"
+        )
+
+        // Dismiss. The share sheet exposes either a "Close" button (iOS 16+)
+        // or a "Cancel" button (older iOS) — fall back to a downward swipe
+        // when neither is present.
+        let close  = app.buttons["Close"]
+        let cancel = app.buttons["Cancel"]
+        if close.exists {
+            close.tap()
+        } else if cancel.exists {
+            cancel.tap()
+        } else {
+            app.swipeDown(velocity: .fast)
+        }
+
+        XCTAssertTrue(
+            inviteHeader.waitForExistence(timeout: 10),
+            "Expected `RecipientPickerScreen` to remain visible after dismissing the share sheet"
+        )
+    }
+}

--- a/FlipcashUITests/Support/BaseUITestCase.swift
+++ b/FlipcashUITests/Support/BaseUITestCase.swift
@@ -107,6 +107,44 @@ class BaseUITestCase: XCTestCase {
         return amountEntry
     }
 
+    /// Drives the phone-verification flow using the backend mock phone
+    /// (`+15005550000`), which auto-succeeds `SendVerificationCode` and
+    /// `CheckVerificationCode` regardless of the typed code. Resilient to
+    /// the case where the flow isn't presented (re-auth, prior verify).
+    /// Detection uses per-screen elements rather than the navigation title
+    /// because both EnterPhoneScreen and ConfirmPhoneScreen render under
+    /// the same nav title.
+    func allowPhoneVerificationIfNeeded() {
+        // EnterPhoneScreen signature: the "Phone Number" text field.
+        let phoneField = app.textFields["Phone Number"]
+        guard phoneField.waitForExistence(timeout: 2) else { return }
+        phoneField.tap()
+        // US-default region, so only the 10 digits get typed; the formatter
+        // prepends "+1".
+        phoneField.typeText("5005550000")
+
+        waitAndTap(app.buttons["Next"])
+
+        // ConfirmPhoneScreen signature: the Confirm CodeButton. The hidden
+        // code field auto-focuses ~100ms after appear; six typed digits
+        // trigger `confirmPhoneNumberCodeAction()` via the onChange hook.
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(
+            confirmButton.waitForExistence(timeout: 10),
+            "Expected `ConfirmPhoneScreen` after submitting the mock phone number"
+        )
+        app.typeText("123456")
+
+        // Success signal: the Confirm button has gone away.
+        let dismissed = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: dismissed, object: confirmButton)
+        let result = XCTWaiter().wait(for: [expectation], timeout: 15)
+        XCTAssertEqual(
+            result, .completed,
+            "Phone verification did not advance past `ConfirmPhoneScreen` within 15s"
+        )
+    }
+
     /// Handles the push notification permission screen if it appears.
     /// The screen is skipped when notification permissions are already determined,
     /// so this helper is resilient to both states.


### PR DESCRIPTION
Bundles three Send-section landings: the iMessage invite sheet for "Not on Flipcash Yet" rows in the recipient picker; a forced phone verification step at onboarding (slotted before the contacts permission step) so every new account lands with a verified phone; and a smoke-test helper that drives the verification screens with the backend mock phone, slotted into the existing CreateAccount tests.

Touches the per-caller navigation title for the phone-entry screen so onboarding can read "Connect Phone Number" while the Onramp flow keeps its existing "Verify Phone Number" copy.

### Test plan

- [x] Onboarding via Save to Photos → phone step appears titled "Connect Phone Number" before the contacts permission screen
- [x] Onboarding via Wrote Down → same
- [x] Existing Coinbase onramp phone verification still shows the original "Verify Phone Number" title
- [x] Tap a contact in the picker's "Not on Flipcash Yet" section on a real device → iMessage composer opens with the recipient and body prefilled
- [x] Same flow in the simulator → ShareSheet fallback opens with the download URL (iMessage unavailable)
- [x] AllTargets unit suite passes