### PR TITLE
fix: dodge Swift 6.3 SIL inliner crash on Onramp deinit

### DIFF
--- a/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
@@ -87,6 +87,11 @@ final class OnrampVerificationViewModel<P: PhoneVerifying, E: EmailVerifying>: V
         }
     }
 
+    // `@_optimize(none)` skips the SIL optimizer for this deinit. Without it,
+    // Swift 6.3's `EarlyPerfInliner` crashes when checking layout-constraint
+    // compatibility through the generic parameters of this class on `-O`
+    // archive builds.
+    @_optimize(none)
     isolated deinit {
         let c = continuation
         continuation = nil


### PR DESCRIPTION
TestFlight Build 419 archive failed with a Swift compiler crash in the SIL optimizer when archiving the generic Onramp view model. This is a Swift 6.3 compiler bug — local Debug builds dodge it because the buggy optimizer pass only runs at `-O`. Disabling the optimizer for just the one affected deinit dodges the crash with no behavior change. Local Release build now succeeds.

Test plan:
- [x] Re-trigger TestFlight archive on Xcode Cloud and confirm Build 420 succeeds
- [x] Smoke test the Coinbase onramp flow on the resulting build: phone verify, email verify, dismiss mid-flow, confirm no orphaned continuations