### PR TITLE
test: align currency launch success copy assertion with production

### DIFF
--- a/FlipcashTests/CurrencyLaunchProcessingViewModelTests.swift
+++ b/FlipcashTests/CurrencyLaunchProcessingViewModelTests.swift
@@ -40,7 +40,7 @@ struct CurrencyLaunchProcessingViewModelTests {
         #expect(vm.navigationTitle == "Success")
         #expect(vm.title == "Test Coin Is Live")
         #expect(vm.subtitle == "Your currency is ready to receive and use")
-        #expect(vm.actionTitle == "Get The First $1.00 of Your Currency Free")
+        #expect(vm.actionTitle == "Get The First $1 of Your Currency Free")
     }
 
     @Test("Failed state copy")


### PR DESCRIPTION
The success-state action title in CurrencyLaunchProcessingViewModel was updated in #197 to render with no trailing zeros (e.g. "$1" instead of "$1.00"), but the assertion in CurrencyLaunchProcessingViewModelTests was left at the old string. This caused successCopy() to fail on AllTargets. Aligns the assertion with the production copy.

Test plan:
- [x] AllTargets suite passes locally