### PR TITLE
fix: dodge Swift 6.3 SIL inliner crash on Onramp deinit

### DIFF
--- a/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
@@ -87,6 +87,11 @@ final class OnrampVerificationViewModel<P: PhoneVerifying, E: EmailVerifying>: V
         }
     }
 
+    // `@_optimize(none)` skips the SIL optimizer for this deinit. Without it,
+    // Swift 6.3's `EarlyPerfInliner` crashes when checking layout-constraint
+    // compatibility through the generic parameters of this class on `-O`
+    // archive builds.
+    @_optimize(none)
     isolated deinit {
         let c = continuation
         continuation = nil


### PR DESCRIPTION
TestFlight archive (Release `-O`) of `flipcash-1.11.0` failed with a Swift compiler crash in the `EarlyPerfInliner` pass on `OnrampVerificationViewModel`'s isolated deinit (xcode-cloud build #421). Marking the deinit `@_optimize(none)` skips the SIL optimizer for just that function and works around the bug; runtime behavior is unchanged. This is cherry-picked from `fix/onramp-deinit-inliner-crash` so it can ship independently of the contact-sync stack.

Test plan:
- [ ] Local archive (Release, generic/platform=iOS) succeeds
- [ ] Re-cut flipcash-1.11.0 archives on Xcode Cloud