### PR TITLE
fix: open the amount screen instantly when sending to a contact

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter+Destination.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Destination.swift
@@ -61,7 +61,7 @@ extension AppRouter {
         case withdraw
 
         // Send flow
-        case sendAmount(recipient: PublicKey, recipientDisplayName: String?)
+        case sendAmount(contact: ResolvedContact)
 
         /// The stack this destination naturally belongs in. Cross-stack
         /// navigation uses this to know which sheet to present.
@@ -128,8 +128,8 @@ extension AppRouter {
                  .withdrawCurrency(let mint),
                  .depositAddress(let mint):
                 return mint.base58
-            case .sendAmount(let recipient, _):
-                return recipient.base58
+            case .sendAmount(let contact):
+                return contact.contactId
             case .phantomFlow:
                 return nil
             case .discoverCurrencies, .currencyCreationSummary, .currencyCreationWizard,

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -180,13 +180,12 @@ struct DestinationView: View {
 
         // MARK: - Send flow
 
-        case .sendAmount(let recipient, let recipientDisplayName):
+        case .sendAmount(let contact):
             SendAmountScreen(
                 sessionContainer: sessionContainer,
-                recipient: recipient,
-                recipientDisplayName: recipientDisplayName
+                contact: contact
             )
-            .id(recipient)
+            .id(contact)
         }
     }
 }

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -15,13 +15,11 @@ nonisolated private let logger = Logger(label: "flipcash.recipient-picker")
 struct RecipientPickerScreen: View {
 
     @Environment(ContactSyncController.self) private var contactSyncController
-    @Environment(Session.self) private var session
     @Environment(AppRouter.self) private var router
 
     @State private var filtered: ResolvedContacts = .empty
     @State private var searchText: String = ""
     @State private var inviteTarget: ResolvedContact?
-    @State private var resolvingContactId: String?
 
     var body: some View {
         let contacts = contactSyncController.resolvedContacts
@@ -36,7 +34,7 @@ struct RecipientPickerScreen: View {
                     RecipientPickerList(
                         filtered: filtered,
                         searchText: searchText,
-                        onFlipcashTap: resolveAndPush,
+                        onFlipcashTap: selectRecipient,
                         onInviteTap: presentInvite,
                     )
                 }
@@ -59,52 +57,11 @@ struct RecipientPickerScreen: View {
         }
     }
 
-    // MARK: - Resolve + push -
+    // MARK: - Tap -
 
-    /// Coalesces re-taps via `resolvingContactId` so a double-tap can't fire two resolves.
-    private func resolveAndPush(contact: ResolvedContact) {
-        guard resolvingContactId == nil else { return }
-        resolvingContactId = contact.id
+    private func selectRecipient(_ contact: ResolvedContact) {
         Analytics.track(event: Analytics.SendEvent.tapRecipient)
-
-        Task {
-            defer { resolvingContactId = nil }
-            do {
-                let resolved = try await session.resolveContact(e164: contact.phoneE164)
-                guard let resolved else {
-                    Analytics.track(event: Analytics.SendEvent.resolveNotFound)
-                    logger.info("Resolve returned NOT_FOUND", metadata: ["contactId": "\(contact.contactId)"])
-                    showUnreachableError()
-                    return
-                }
-                Analytics.track(event: Analytics.SendEvent.resolveSuccess)
-                router.push(.sendAmount(
-                    recipient: resolved,
-                    recipientDisplayName: contact.displayName
-                ))
-            } catch ErrorResolve.denied {
-                Analytics.track(event: Analytics.SendEvent.resolveError)
-                logger.warning("Resolve denied", metadata: ["contactId": "\(contact.contactId)"])
-                showUnreachableError()
-            } catch {
-                Analytics.track(event: Analytics.SendEvent.resolveError)
-                logger.error("Resolve failed", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error, reason: "Contact resolve failed")
-                session.dialogItem = .error(
-                    title: "Something Went Wrong",
-                    subtitle: "We couldn't reach the network. Please try again."
-                )
-            }
-        }
-    }
-
-    /// Soft transient error — the next contact sync reconciles authoritatively,
-    /// so we don't drop anything locally.
-    private func showUnreachableError() {
-        session.dialogItem = .error(
-            title: "Couldn't Send",
-            subtitle: "We can't reach this contact right now. Please try again."
-        )
+        router.push(.sendAmount(contact: contact))
     }
 
     private func presentInvite(for contact: ResolvedContact) {

--- a/Flipcash/Core/Screens/Send/SendAmountScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountScreen.swift
@@ -34,13 +34,11 @@ struct SendAmountScreen: View {
 
     init(
         sessionContainer: SessionContainer,
-        recipient: PublicKey,
-        recipientDisplayName: String?
+        contact: ResolvedContact
     ) {
         _viewModel = State(initialValue: SendAmountViewModel(
             sessionContainer: sessionContainer,
-            recipient: recipient,
-            recipientDisplayName: recipientDisplayName
+            contact: contact
         ))
     }
 
@@ -94,6 +92,11 @@ struct SendAmountScreen: View {
             try? await Task.sleep(for: .seconds(2.5))
             guard !Task.isCancelled else { return }
             router.dismissSheet()
+        }
+        .task {
+            await viewModel.resolveRecipient()
+            guard !Task.isCancelled else { return }
+            if case .failed = viewModel.recipientState { router.popTopmost() }
         }
         .sheet(isPresented: $isShowingTokenSelection) {
             SelectCurrencyScreen(isPresented: $isShowingTokenSelection) { balance in

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -18,21 +18,30 @@ final class SendAmountViewModel {
         case succeeded(amount: ExchangedFiat)
     }
 
+    enum RecipientState: Equatable {
+        case resolving
+        case resolved(PublicKey)
+        case failed
+    }
+
     var enteredAmount: String = ""
     var actionState: ButtonState = .normal
     var state: State = .ready
+    var recipientState: RecipientState = .resolving
 
     var depositMint: PublicKey?
 
     @ObservationIgnored let session: Session
     @ObservationIgnored let ratesController: RatesController
     @ObservationIgnored let sender: any DirectSending
-    @ObservationIgnored let recipient: PublicKey
-    @ObservationIgnored let recipientDisplayName: String?
+    @ObservationIgnored let contact: ResolvedContact
 
     private(set) var selectedBalance: ExchangedBalance?
 
+    var recipientDisplayName: String? { contact.displayName }
+
     var canSend: Bool {
+        guard case .resolved = recipientState else { return false }
         guard let enteredFiat else { return false }
         return enteredFiat.onChainAmount.quarks > 0
     }
@@ -76,8 +85,7 @@ final class SendAmountViewModel {
 
     init(
         sessionContainer: SessionContainer,
-        recipient: PublicKey,
-        recipientDisplayName: String?,
+        contact: ResolvedContact,
         mint: PublicKey? = nil,
         sender: (any DirectSending)? = nil
     ) {
@@ -89,12 +97,11 @@ final class SendAmountViewModel {
             ratesController: ratesController
         )
 
-        self.session              = session
-        self.ratesController      = ratesController
-        self.sender               = sender ?? session
-        self.recipient            = recipient
-        self.recipientDisplayName = recipientDisplayName
-        self.selectedBalance      = resolved
+        self.session         = session
+        self.ratesController = ratesController
+        self.sender          = sender ?? session
+        self.contact         = contact
+        self.selectedBalance = resolved
 
         if let resolved, ratesController.selectedTokenMint != resolved.stored.mint {
             ratesController.selectToken(resolved.stored.mint)
@@ -126,6 +133,7 @@ final class SendAmountViewModel {
 
     func sendAction() async {
         guard case .ready = state else { return }
+        guard case .resolved(let recipient) = recipientState else { return }
         guard let exchangedFiat = enteredFiat else { return }
 
         let result = session.hasSufficientFunds(for: exchangedFiat)
@@ -179,6 +187,60 @@ final class SendAmountViewModel {
                 showInsufficientBalanceError()
             }
         }
+    }
+
+    // MARK: - Recipient resolution -
+
+    /// `resolveContact` isn't cancellation-aware — the guard drops a stale commit after dismissal.
+    func resolveRecipient() async {
+        let resolution = await fetchRecipient()
+        guard !Task.isCancelled else { return }
+        switch resolution {
+        case .resolved(let recipient):
+            Analytics.track(event: Analytics.SendEvent.resolveSuccess)
+            recipientState = .resolved(recipient)
+        case .notFound:
+            Analytics.track(event: Analytics.SendEvent.resolveNotFound)
+            logger.info("Resolve returned NOT_FOUND", metadata: ["contactId": "\(contact.contactId)"])
+            recipientState = .failed
+            showUnreachableRecipientError()
+        case .failed(let error):
+            Analytics.track(event: Analytics.SendEvent.resolveError)
+            logger.error("Resolve failed", metadata: ["contactId": "\(contact.contactId)", "error": "\(error)"])
+            ErrorReporting.captureError(error, reason: "Contact resolve failed")
+            recipientState = .failed
+            showUnreachableRecipientError()
+        }
+    }
+
+    private enum RecipientResolution {
+        case resolved(PublicKey)
+        case notFound
+        case failed(Error)
+    }
+
+    /// UI-free so the caller commits behind a single cancellation check.
+    private func fetchRecipient() async -> RecipientResolution {
+        for attempt in 0..<2 {
+            do {
+                if let recipient = try await session.resolveContact(e164: contact.phoneE164) {
+                    return .resolved(recipient)
+                }
+                return .notFound
+            } catch ErrorResolve.networkError where attempt == 0 {
+                continue
+            } catch {
+                return .failed(error)
+            }
+        }
+        return .failed(ErrorResolve.networkError)
+    }
+
+    private func showUnreachableRecipientError() {
+        session.dialogItem = .error(
+            title: "Couldn't Send",
+            subtitle: "We can't reach this contact right now. Please try again."
+        )
     }
 
     /// Returns nil when no fresh pin is cached; otherwise the amount + pin

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -16,16 +16,31 @@ struct SendAmountViewModelTests {
 
     private static let recipient: PublicKey = .generate()!
 
+    static func makeContact(displayName: String = "Alice") -> ResolvedContact {
+        ResolvedContact(
+            contactId: "test-contact",
+            displayName: displayName,
+            phoneE164: "+15551234567",
+            nationalPhone: "(555) 123-4567",
+            imageData: nil
+        )
+    }
+
+    /// Marks the recipient resolved by default so amount/send tests aren't
+    /// gated by the background resolve. Pass `resolved: false` to exercise the
+    /// resolving state.
     static func createViewModel(
         recipient: PublicKey = SendAmountViewModelTests.recipient,
-        recipientDisplayName: String? = "Alice"
+        displayName: String = "Alice",
+        resolved: Bool = true
     ) -> SendAmountViewModel {
-        SendAmountViewModel(
+        let viewModel = SendAmountViewModel(
             sessionContainer: .mock,
-            recipient: recipient,
-            recipientDisplayName: recipientDisplayName,
+            contact: makeContact(displayName: displayName),
             mint: nil
         )
+        if resolved { viewModel.recipientState = .resolved(recipient) }
+        return viewModel
     }
 
     static func createExchangedBalance(
@@ -66,23 +81,29 @@ struct SendAmountViewModelTests {
         )
     }
 
-    // MARK: - Recipient storage
+    // MARK: - Recipient
 
-    @Test("Init stores recipient pubkey and display name as provided")
-    func init_storesRecipientFields() {
-        let pubkey = PublicKey.generate()!
-        let viewModel = Self.createViewModel(recipient: pubkey, recipientDisplayName: "Alice Anderson")
-        #expect(viewModel.recipient == pubkey)
+    @Test("Display name is taken from the contact")
+    func init_exposesContactDisplayName() {
+        let viewModel = Self.createViewModel(displayName: "Alice Anderson", resolved: false)
         #expect(viewModel.recipientDisplayName == "Alice Anderson")
     }
 
-    @Test("Init keeps a nil display name (fallback handled at the view layer)")
-    func init_keepsNilDisplayName() {
-        let viewModel = Self.createViewModel(recipientDisplayName: nil)
-        #expect(viewModel.recipientDisplayName == nil)
+    @Test("Recipient starts in the resolving state")
+    func init_startsResolving() {
+        let viewModel = Self.createViewModel(resolved: false)
+        #expect(viewModel.recipientState == .resolving)
     }
 
     // MARK: - canSend
+
+    @Test("canSend is false while the recipient is still resolving")
+    func canSend_whileResolving_isFalse() {
+        let viewModel = Self.createViewModel(resolved: false)
+        viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance())
+        viewModel.enteredAmount = "5"
+        #expect(viewModel.canSend == false)
+    }
 
     @Test("canSend is false when no amount is entered")
     func canSend_emptyAmount_isFalse() {
@@ -112,10 +133,10 @@ struct SendAmountViewModelTests {
     func canSend_noSelectedBalance_isFalse() {
         let viewModel = SendAmountViewModel(
             sessionContainer: .mock,
-            recipient: .generate()!,
-            recipientDisplayName: "Alice",
+            contact: Self.makeContact(),
             mint: .generate()!  // unknown mint forces selectedBalance to nil
         )
+        viewModel.recipientState = .resolved(Self.recipient)
         viewModel.enteredAmount = "10"
         #expect(viewModel.canSend == false)
     }
@@ -154,11 +175,11 @@ struct SendAmountViewModelTests {
         let sender = MockSession()
         let viewModel = SendAmountViewModel(
             sessionContainer: .mock,
-            recipient: Self.recipient,
-            recipientDisplayName: "Alice",
+            contact: Self.makeContact(),
             mint: nil,
             sender: sender
         )
+        viewModel.recipientState = .resolved(Self.recipient)
         viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance())
         viewModel.enteredAmount = ""
 
@@ -173,11 +194,11 @@ struct SendAmountViewModelTests {
         let sender = MockSession()
         let viewModel = SendAmountViewModel(
             sessionContainer: .mock,
-            recipient: Self.recipient,
-            recipientDisplayName: "Alice",
+            contact: Self.makeContact(),
             mint: nil,
             sender: sender
         )
+        viewModel.recipientState = .resolved(Self.recipient)
         // Empty balance + non-zero entered amount → hasSufficientFunds == .insufficient.
         viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance(quarks: 0))
         viewModel.enteredAmount = "5"
@@ -197,11 +218,11 @@ struct SendAmountViewModelTests {
         let sender = MockSession()
         let viewModel = SendAmountViewModel(
             sessionContainer: container,
-            recipient: Self.recipient,
-            recipientDisplayName: "Alice",
+            contact: Self.makeContact(),
             mint: .usdf,
             sender: sender
         )
+        viewModel.recipientState = .resolved(Self.recipient)
         viewModel.enteredAmount = "5"
 
         await viewModel.sendAction()


### PR DESCRIPTION
## Summary

Picking a recipient used to pause on a network lookup before the amount screen opened. Now the amount screen opens immediately and the lookup runs in the background while the user enters an amount, so the tap feels instant. Send stays disabled until the recipient is confirmed, and an unreachable contact shows a message and returns to the list.

## Test plan

- [x] Pick a contact who's on Flipcash — the amount screen opens with no delay.
- [x] Enter a valid amount — Send enables once the recipient is confirmed.
- [x] Dismiss the sheet right after tapping — no stray error appears afterward.