### PR TITLE
feat: clear server contact set on contacts revoke and account deletion

### DIFF
--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -24,8 +24,6 @@ final class ContactSyncController {
     @ObservationIgnored nonisolated private let database: Database
     @ObservationIgnored nonisolated private let owner: AccountCluster
     @ObservationIgnored nonisolated private let authorizationStatusProvider: @Sendable () -> CNAuthorizationStatus
-    @ObservationIgnored nonisolated private let lastAuthorizationStatusProvider: @Sendable () -> CNAuthorizationStatus
-    @ObservationIgnored nonisolated private let persistAuthorizationStatus: @Sendable (CNAuthorizationStatus) -> Void
 
     @ObservationIgnored internal private(set) var isSyncing = false
     @ObservationIgnored internal private(set) var syncTask: Task<Void, Never>?
@@ -54,22 +52,12 @@ final class ContactSyncController {
         owner: AccountCluster,
         authorizationStatusProvider: @escaping @Sendable () -> CNAuthorizationStatus = {
             CNContactStore.authorizationStatus(for: .contacts)
-        },
-        lastAuthorizationStatusProvider: @escaping @Sendable () -> CNAuthorizationStatus = {
-            CNAuthorizationStatus(
-                rawValue: UserDefaults.standard.integer(forKey: DefaultsKey.lastContactAuthStatus.rawValue)
-            ) ?? .notDetermined
-        },
-        persistAuthorizationStatus: @escaping @Sendable (CNAuthorizationStatus) -> Void = {
-            UserDefaults.standard.set($0.rawValue, forKey: DefaultsKey.lastContactAuthStatus.rawValue)
         }
     ) {
-        self.client                          = client
-        self.database                        = database
-        self.owner                           = owner
-        self.authorizationStatusProvider     = authorizationStatusProvider
-        self.lastAuthorizationStatusProvider = lastAuthorizationStatusProvider
-        self.persistAuthorizationStatus      = persistAuthorizationStatus
+        self.client                      = client
+        self.database                    = database
+        self.owner                       = owner
+        self.authorizationStatusProvider = authorizationStatusProvider
     }
 
     deinit {
@@ -153,10 +141,6 @@ final class ContactSyncController {
             ])
             return
         }
-
-        // Record that we hold access so a later revoke (authorized → denied)
-        // is detectable on the next foreground, even across a cold launch.
-        persistAuthorizationStatus(status)
 
         do {
             let contacts = try readContacts()
@@ -292,37 +276,14 @@ final class ContactSyncController {
 
     // MARK: - Permission revoke -
 
-    /// Wipes the server's stored contact set when contacts access transitions
-    /// from authorized to denied/restricted. `internal` + `nonisolated` so
-    /// tests can drive it directly and it runs off-main in production.
+    /// Wipes the server's stored contact set when contacts access is now
+    /// denied/restricted for a user who had previously uploaded one.
     ///
-    /// Idempotent and safe to call on every foreground: it short-circuits
-    /// unless we previously held access AND access is now revoked AND a set was
-    /// actually uploaded. On upload failure the stored status is left armed so
-    /// the next foreground retries.
+    /// A non-nil checksum only exists after a sync, which only runs while
+    /// authorized, so it doubles as the "we previously had access" marker.
+    /// Idempotent: a successful wipe nulls the checksum; a failure leaves it
+    /// intact so the next foreground retries.
     internal nonisolated func clearServerContactSetIfRevoked() async {
-        // Only a previously-accessible state can be revoked. Arming persists
-        // `.authorized` today; `.limited` becomes armable in Phase 11. Switched
-        // exhaustively so a new `CNAuthorizationStatus` case forces a decision.
-        let previous = lastAuthorizationStatusProvider()
-        let wasAccessible = switch previous {
-        case .authorized, .limited: true
-        case .notDetermined, .denied, .restricted: false
-        @unknown default: false
-        }
-        guard wasAccessible else { return }
-
-        // A revoke is a transition into denied/restricted. `.limited` is a
-        // narrower grant (Phase 11), not a revoke; `.notDetermined` is an
-        // OS-level reset we don't wipe on.
-        let current = authorizationStatusProvider()
-        let isRevoked = switch current {
-        case .denied, .restricted: true
-        case .notDetermined, .authorized, .limited: false
-        @unknown default: false
-        }
-        guard isRevoked else { return }
-
         let hadServerSet: Bool
         do {
             hadServerSet = try database.contactSyncState().checksum != nil
@@ -330,22 +291,24 @@ final class ContactSyncController {
             logger.error("Clear-on-revoke aborted — could not read sync state", metadata: [
                 "error": "\(error)",
             ])
-            return  // leave the stored status armed so the next foreground retries
-        }
-
-        guard hadServerSet else {
-            // Nothing was ever uploaded; record the revoked status so we stop
-            // re-checking on every foreground.
-            persistAuthorizationStatus(current)
             return
         }
+        guard hadServerSet else { return }
+
+        // `.limited` is a narrower grant, not a revoke; `.notDetermined` is an
+        // OS-level reset we don't wipe on. Switched exhaustively so a new
+        // `CNAuthorizationStatus` case forces a decision.
+        let isRevoked = switch authorizationStatusProvider() {
+        case .denied, .restricted: true
+        case .notDetermined, .authorized, .limited: false
+        @unknown default: false
+        }
+        guard isRevoked else { return }
 
         do {
             try await clearServerContactSet()
-            persistAuthorizationStatus(current)  // disarm only after a successful wipe
             logger.info("Cleared server contact set after permission revoke")
         } catch {
-            // Keep the stored status armed so the next foreground retries.
             logger.info("Clear-on-revoke deferred — will retry next foreground", metadata: [
                 "error": "\(error)",
             ])
@@ -355,7 +318,10 @@ final class ContactSyncController {
     /// Wipes the server's stored contact set as part of account deletion.
     /// Best-effort: deletion proceeds even if the wipe fails — there's no
     /// retry once the session tears down. No-ops when nothing was uploaded.
-    internal nonisolated func clearServerContactSetForAccountDeletion() async {
+    ///
+    /// `@concurrent` keeps it off-main when awaited from the `@MainActor`
+    /// delete-account flow, which SE-0461 would otherwise inherit.
+    @concurrent internal func clearServerContactSetForAccountDeletion() async {
         let hadServerSet: Bool
         do {
             hadServerSet = try database.contactSyncState().checksum != nil

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -24,6 +24,8 @@ final class ContactSyncController {
     @ObservationIgnored nonisolated private let database: Database
     @ObservationIgnored nonisolated private let owner: AccountCluster
     @ObservationIgnored nonisolated private let authorizationStatusProvider: @Sendable () -> CNAuthorizationStatus
+    @ObservationIgnored nonisolated private let lastAuthorizationStatusProvider: @Sendable () -> CNAuthorizationStatus
+    @ObservationIgnored nonisolated private let persistAuthorizationStatus: @Sendable (CNAuthorizationStatus) -> Void
 
     @ObservationIgnored internal private(set) var isSyncing = false
     @ObservationIgnored internal private(set) var syncTask: Task<Void, Never>?
@@ -52,12 +54,22 @@ final class ContactSyncController {
         owner: AccountCluster,
         authorizationStatusProvider: @escaping @Sendable () -> CNAuthorizationStatus = {
             CNContactStore.authorizationStatus(for: .contacts)
+        },
+        lastAuthorizationStatusProvider: @escaping @Sendable () -> CNAuthorizationStatus = {
+            CNAuthorizationStatus(
+                rawValue: UserDefaults.standard.integer(forKey: DefaultsKey.lastContactAuthStatus.rawValue)
+            ) ?? .notDetermined
+        },
+        persistAuthorizationStatus: @escaping @Sendable (CNAuthorizationStatus) -> Void = {
+            UserDefaults.standard.set($0.rawValue, forKey: DefaultsKey.lastContactAuthStatus.rawValue)
         }
     ) {
-        self.client                       = client
-        self.database                     = database
-        self.owner                        = owner
-        self.authorizationStatusProvider  = authorizationStatusProvider
+        self.client                          = client
+        self.database                        = database
+        self.owner                           = owner
+        self.authorizationStatusProvider     = authorizationStatusProvider
+        self.lastAuthorizationStatusProvider = lastAuthorizationStatusProvider
+        self.persistAuthorizationStatus      = persistAuthorizationStatus
     }
 
     deinit {
@@ -84,11 +96,22 @@ final class ContactSyncController {
         sync()
     }
 
-    /// No-op until ``activate()`` has been called this session.
+    /// Detects a contacts-permission revoke and, independently, triggers a sync
+    /// when activated.
+    ///
+    /// The revoke check runs even before ``activate()`` — a set uploaded in a
+    /// prior session must still be wiped after a cold launch while access is
+    /// denied. It is cheap when nothing was ever uploaded: it reads the stored
+    /// status and short-circuits without touching the Contacts store. The sync
+    /// remains a no-op until ``activate()`` has registered the observer.
     nonisolated func didBecomeActive() {
-        Task { @MainActor [weak self] in
-            guard let self, self.observerTask != nil else { return }
-            self.sync()
+        // Detached so the nonisolated revoke check stays off-main under SE-0461.
+        Task.detached { [weak self] in
+            await self?.clearServerContactSetIfRevoked()
+            await MainActor.run { [weak self] in
+                guard let self, self.observerTask != nil else { return }
+                self.sync()
+            }
         }
     }
 
@@ -130,6 +153,11 @@ final class ContactSyncController {
             ])
             return
         }
+
+        // Record that we hold access so a later revoke (authorized → denied)
+        // is detectable on the next foreground, even across a cold launch.
+        persistAuthorizationStatus(status)
+
         do {
             let contacts = try readContacts()
             try await performSync(contacts: contacts)
@@ -260,6 +288,111 @@ final class ContactSyncController {
         }
         try database.replaceFlipcashContacts(matched, matchedAt: .now)
         logger.info("Refreshed flipcash contacts", metadata: ["matched": "\(matched.count)"])
+    }
+
+    // MARK: - Permission revoke -
+
+    /// Wipes the server's stored contact set when contacts access transitions
+    /// from authorized to denied/restricted. `internal` + `nonisolated` so
+    /// tests can drive it directly and it runs off-main in production.
+    ///
+    /// Idempotent and safe to call on every foreground: it short-circuits
+    /// unless we previously held access AND access is now revoked AND a set was
+    /// actually uploaded. On upload failure the stored status is left armed so
+    /// the next foreground retries.
+    internal nonisolated func clearServerContactSetIfRevoked() async {
+        // Only a previously-accessible state can be revoked. Arming persists
+        // `.authorized` today; `.limited` becomes armable in Phase 11. Switched
+        // exhaustively so a new `CNAuthorizationStatus` case forces a decision.
+        let previous = lastAuthorizationStatusProvider()
+        let wasAccessible = switch previous {
+        case .authorized, .limited: true
+        case .notDetermined, .denied, .restricted: false
+        @unknown default: false
+        }
+        guard wasAccessible else { return }
+
+        // A revoke is a transition into denied/restricted. `.limited` is a
+        // narrower grant (Phase 11), not a revoke; `.notDetermined` is an
+        // OS-level reset we don't wipe on.
+        let current = authorizationStatusProvider()
+        let isRevoked = switch current {
+        case .denied, .restricted: true
+        case .notDetermined, .authorized, .limited: false
+        @unknown default: false
+        }
+        guard isRevoked else { return }
+
+        let hadServerSet: Bool
+        do {
+            hadServerSet = try database.contactSyncState().checksum != nil
+        } catch {
+            logger.error("Clear-on-revoke aborted — could not read sync state", metadata: [
+                "error": "\(error)",
+            ])
+            return  // leave the stored status armed so the next foreground retries
+        }
+
+        guard hadServerSet else {
+            // Nothing was ever uploaded; record the revoked status so we stop
+            // re-checking on every foreground.
+            persistAuthorizationStatus(current)
+            return
+        }
+
+        do {
+            try await clearServerContactSet()
+            persistAuthorizationStatus(current)  // disarm only after a successful wipe
+            logger.info("Cleared server contact set after permission revoke")
+        } catch {
+            // Keep the stored status armed so the next foreground retries.
+            logger.info("Clear-on-revoke deferred — will retry next foreground", metadata: [
+                "error": "\(error)",
+            ])
+        }
+    }
+
+    /// Wipes the server's stored contact set as part of account deletion.
+    /// Best-effort: deletion proceeds even if the wipe fails — there's no
+    /// retry once the session tears down. No-ops when nothing was uploaded.
+    internal nonisolated func clearServerContactSetForAccountDeletion() async {
+        let hadServerSet: Bool
+        do {
+            hadServerSet = try database.contactSyncState().checksum != nil
+        } catch {
+            logger.error("Account-deletion contact wipe aborted — could not read sync state", metadata: [
+                "error": "\(error)",
+            ])
+            return
+        }
+        guard hadServerSet else { return }
+
+        do {
+            try await clearServerContactSet()
+            logger.info("Cleared server contact set for account deletion")
+        } catch {
+            logger.info("Account-deletion contact wipe failed — best effort", metadata: [
+                "error": "\(error)",
+            ])
+        }
+    }
+
+    /// Empties the server's stored set via a `phones: []` full upload (no
+    /// dedicated RPC) and drains the local contact tables + picker cache.
+    /// Writes the checksum-bearing sync state last so a mid-drain failure
+    /// leaves `checksum != nil` and the next foreground re-runs the full wipe.
+    private nonisolated func clearServerContactSet() async throws {
+        try await client.uploadAllContacts(
+            phones:   [],
+            checksum: Self.checksum(of: []),
+            owner:    ownerKeyPair
+        )
+        try database.replaceLocalContactsSnapshot([])
+        try database.replaceFlipcashContacts([], matchedAt: .now)
+        try database.setContactSyncState(.empty)
+        await MainActor.run {
+            self.resolvedContacts = .empty
+        }
     }
 
     // MARK: - Address book -

--- a/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
@@ -81,6 +81,11 @@ struct SettingsMyAccountScreen: View {
         Task {
             router.dismissSheet()
             try await Task.delay(milliseconds: 250)
+            // No server-side account deletion exists; logout only tears down
+            // locally. Wipe the server's stored contact set first so it isn't
+            // retained after the account is "deleted". Best-effort — must run
+            // before logout while the session can still authenticate the call.
+            await sessionContainer.contactSyncController.clearServerContactSetForAccountDeletion()
             sessionAuthenticator.logout()
         }
     }

--- a/Flipcash/Keychain/Defaults.swift
+++ b/Flipcash/Keychain/Defaults.swift
@@ -21,8 +21,6 @@ enum DefaultsKey: String {
     case storedTokenMint = "com.flipcash.token.storedTokenMint"
 
     case betaFlags = "com.flipcash.betaFlags"
-
-    case lastContactAuthStatus = "com.flipcash.contactSync.lastAuthStatus"
 }
 
 private let defaultsEncoder = JSONEncoder()

--- a/Flipcash/Keychain/Defaults.swift
+++ b/Flipcash/Keychain/Defaults.swift
@@ -21,6 +21,8 @@ enum DefaultsKey: String {
     case storedTokenMint = "com.flipcash.token.storedTokenMint"
 
     case betaFlags = "com.flipcash.betaFlags"
+
+    case lastContactAuthStatus = "com.flipcash.contactSync.lastAuthStatus"
 }
 
 private let defaultsEncoder = JSONEncoder()

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -286,12 +286,10 @@ struct ContactSyncControllerTests {
             status: CNAuthorizationStatus = .notDetermined
         ) -> ContactSyncController {
             ContactSyncController(
-                client:                          mock,
-                database:                        database,
-                owner:                           .mock,
-                authorizationStatusProvider:     { status },
-                lastAuthorizationStatusProvider: { .notDetermined },
-                persistAuthorizationStatus:      { _ in }
+                client:                      mock,
+                database:                    database,
+                owner:                       .mock,
+                authorizationStatusProvider: { status }
             )
         }
 
@@ -341,12 +339,10 @@ struct ContactSyncControllerTests {
         func didBecomeActiveNoOpBeforeActivate() async {
             let counter = AuthCounter()
             let controller = ContactSyncController(
-                client:                          MockContactSync(),
-                database:                        .mock,
-                owner:                           .mock,
-                authorizationStatusProvider:     counter.bumpAndReturnNotDetermined,
-                lastAuthorizationStatusProvider: { .notDetermined },
-                persistAuthorizationStatus:      { _ in }
+                client:                      MockContactSync(),
+                database:                    .mock,
+                owner:                       .mock,
+                authorizationStatusProvider: counter.bumpAndReturnNotDetermined
             )
             controller.didBecomeActive()
             await Task.yield()
@@ -361,12 +357,10 @@ struct ContactSyncControllerTests {
         func didBecomeActiveTriggersSyncAfterActivate() async throws {
             let counter = AuthCounter()
             let controller = ContactSyncController(
-                client:                          MockContactSync(),
-                database:                        .mock,
-                owner:                           .mock,
-                authorizationStatusProvider:     counter.bumpAndReturnNotDetermined,
-                lastAuthorizationStatusProvider: { .notDetermined },
-                persistAuthorizationStatus:      { _ in }
+                client:                      MockContactSync(),
+                database:                    .mock,
+                owner:                       .mock,
+                authorizationStatusProvider: counter.bumpAndReturnNotDetermined
             )
 
             controller.activate()
@@ -383,12 +377,10 @@ struct ContactSyncControllerTests {
         func syncCoalescesInFlightTriggerAndRerunsAfterCompletion() async throws {
             let counter = AuthCounter()
             let controller = ContactSyncController(
-                client:                          MockContactSync(),
-                database:                        .mock,
-                owner:                           .mock,
-                authorizationStatusProvider:     counter.bumpAndReturnNotDetermined,
-                lastAuthorizationStatusProvider: { .notDetermined },
-                persistAuthorizationStatus:      { _ in }
+                client:                      MockContactSync(),
+                database:                    .mock,
+                owner:                       .mock,
+                authorizationStatusProvider: counter.bumpAndReturnNotDetermined
             )
 
             controller.sync()
@@ -659,31 +651,16 @@ struct ContactSyncControllerTests {
     @MainActor
     struct ClearOnRevokeTests {
 
-        /// Lock-guarded in-memory `lastAuthStatus` store so the suite is
-        /// hermetic (no real `UserDefaults`) and deterministic under parallel
-        /// execution.
-        private final class AuthStatusStore: @unchecked Sendable {
-            private let lock = NSLock()
-            private var status: CNAuthorizationStatus
-            init(_ initial: CNAuthorizationStatus) { status = initial }
-            var current: CNAuthorizationStatus { lock.withLock { status } }
-            func load() -> CNAuthorizationStatus { lock.withLock { status } }
-            func save(_ newValue: CNAuthorizationStatus) { lock.withLock { status = newValue } }
-        }
-
         private static func makeController(
             mock: MockContactSync,
             database: Database,
-            current: CNAuthorizationStatus,
-            store: AuthStatusStore
+            status: CNAuthorizationStatus
         ) -> ContactSyncController {
             ContactSyncController(
-                client:                          mock,
-                database:                        database,
-                owner:                           .mock,
-                authorizationStatusProvider:     { current },
-                lastAuthorizationStatusProvider: { store.load() },
-                persistAuthorizationStatus:      { store.save($0) }
+                client:                      mock,
+                database:                    database,
+                owner:                       .mock,
+                authorizationStatusProvider: { status }
             )
         }
 
@@ -706,12 +683,14 @@ struct ContactSyncControllerTests {
         private static let aliceContact = Database.LocalContact(e164: "+14155550100", contactId: "alice")
         private static let bobContact   = Database.LocalContact(e164: "+14155550101", contactId: "bob")
 
-        @Test("authorized → denied with an uploaded set fires an empty full upload and drains the local tables")
-        func revoke_firesEmptyUploadAndDrainsTables() async throws {
+        @Test(
+            "Revoked access wipes the server set and drains the local tables",
+            arguments: [CNAuthorizationStatus.denied, .restricted]
+        )
+        func revoke_wipesAndDrains(_ status: CNAuthorizationStatus) async throws {
             let mock = MockContactSync()
             let database = Database.mock
-            let store = AuthStatusStore(.authorized)
-            let controller = Self.makeController(mock: mock, database: database, current: .denied, store: store)
+            let controller = Self.makeController(mock: mock, database: database, status: status)
 
             try Self.seedUploadedSet(database, contacts: [Self.aliceContact, Self.bobContact], matched: [Self.bobContact.e164])
 
@@ -727,54 +706,49 @@ struct ContactSyncControllerTests {
             #expect(try database.contactSyncState() == .empty)
             #expect(try database.localContactsSnapshot().isEmpty)
             #expect(try database.flipcashContacts().isEmpty)
-            #expect(store.current == .denied)  // disarmed after a successful wipe
         }
 
-        @Test("authorized → restricted is treated as a revoke")
-        func revoke_restrictedAlsoClears() async throws {
+        @Test("Revoked but nothing was ever uploaded → no upload")
+        func revoke_nothingUploaded_noOp() async throws {
             let mock = MockContactSync()
-            let database = Database.mock
-            let store = AuthStatusStore(.authorized)
-            let controller = Self.makeController(mock: mock, database: database, current: .restricted, store: store)
-
-            try Self.seedUploadedSet(database, contacts: [Self.aliceContact])
-
-            await controller.clearServerContactSetIfRevoked()
-
-            #expect(mock.fullCalls.count == 1)
-            #expect(mock.fullCalls.first?.phones.isEmpty == true)
-            #expect(try database.localContactsSnapshot().isEmpty)
-            #expect(store.current == .restricted)
-        }
-
-        @Test("Revoke with nothing previously uploaded records the status without an upload")
-        func revoke_noServerSet_recordsStatusWithoutUpload() async throws {
-            let mock = MockContactSync()
-            let database = Database.mock  // empty — checksum is nil
-            let store = AuthStatusStore(.authorized)
-            let controller = Self.makeController(mock: mock, database: database, current: .denied, store: store)
+            let database = Database.mock  // checksum is nil
+            let controller = Self.makeController(mock: mock, database: database, status: .denied)
 
             await controller.clearServerContactSetIfRevoked()
 
             #expect(mock.fullCalls.isEmpty)
-            #expect(store.current == .denied)  // recorded so we stop re-checking
         }
 
-        @Test("Upload failure keeps the status armed and the local set intact; the next call retries")
-        func revoke_uploadFailure_keepsArmedAndRetries() async throws {
+        @Test(
+            "Non-revoked access leaves an uploaded set untouched",
+            arguments: [CNAuthorizationStatus.authorized, .notDetermined]
+        )
+        func nonRevoked_leavesSetIntact(_ status: CNAuthorizationStatus) async throws {
             let mock = MockContactSync()
-            mock.fullUploadResult = .failure(ErrorContactSync.networkError)
             let database = Database.mock
-            let store = AuthStatusStore(.authorized)
-            let controller = Self.makeController(mock: mock, database: database, current: .denied, store: store)
+            let controller = Self.makeController(mock: mock, database: database, status: status)
 
             try Self.seedUploadedSet(database, contacts: [Self.aliceContact])
 
             await controller.clearServerContactSetIfRevoked()
 
-            // Attempted, but the failure leaves everything armed for a retry.
+            #expect(mock.fullCalls.isEmpty)
+            #expect(try database.contactSyncState().checksum != nil)
+        }
+
+        @Test("Upload failure leaves the set intact, and the next foreground retries")
+        func revoke_uploadFailure_retriesNextForeground() async throws {
+            let mock = MockContactSync()
+            mock.fullUploadResult = .failure(ErrorContactSync.networkError)
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database, status: .denied)
+
+            try Self.seedUploadedSet(database, contacts: [Self.aliceContact])
+
+            await controller.clearServerContactSetIfRevoked()
+
+            // Attempted, but the failure leaves the checksum + snapshot for a retry.
             #expect(mock.fullCalls.count == 1)
-            #expect(store.current == .authorized)
             #expect(try database.contactSyncState().checksum != nil)
             #expect(try database.localContactsSnapshot().isEmpty == false)
 
@@ -783,38 +757,8 @@ struct ContactSyncControllerTests {
             await controller.clearServerContactSetIfRevoked()
 
             #expect(mock.fullCalls.count == 2)
-            #expect(store.current == .denied)
             #expect(try database.contactSyncState() == .empty)
             #expect(try database.localContactsSnapshot().isEmpty)
-        }
-
-        @Test("Still authorized → no upload, status unchanged")
-        func stillAuthorized_noOp() async throws {
-            let mock = MockContactSync()
-            let database = Database.mock
-            let store = AuthStatusStore(.authorized)
-            let controller = Self.makeController(mock: mock, database: database, current: .authorized, store: store)
-
-            try Self.seedUploadedSet(database, contacts: [Self.aliceContact])
-
-            await controller.clearServerContactSetIfRevoked()
-
-            #expect(mock.fullCalls.isEmpty)
-            #expect(store.current == .authorized)
-            #expect(try database.contactSyncState().checksum != nil)
-        }
-
-        @Test("Never authorized (notDetermined → denied) short-circuits without touching the server or store")
-        func neverAuthorized_shortCircuits() async throws {
-            let mock = MockContactSync()
-            let database = Database.mock
-            let store = AuthStatusStore(.notDetermined)
-            let controller = Self.makeController(mock: mock, database: database, current: .denied, store: store)
-
-            await controller.clearServerContactSetIfRevoked()
-
-            #expect(mock.fullCalls.isEmpty)
-            #expect(store.current == .notDetermined)  // not even recorded
         }
     }
 

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -286,10 +286,12 @@ struct ContactSyncControllerTests {
             status: CNAuthorizationStatus = .notDetermined
         ) -> ContactSyncController {
             ContactSyncController(
-                client:                      mock,
-                database:                    database,
-                owner:                       .mock,
-                authorizationStatusProvider: { status }
+                client:                          mock,
+                database:                        database,
+                owner:                           .mock,
+                authorizationStatusProvider:     { status },
+                lastAuthorizationStatusProvider: { .notDetermined },
+                persistAuthorizationStatus:      { _ in }
             )
         }
 
@@ -339,10 +341,12 @@ struct ContactSyncControllerTests {
         func didBecomeActiveNoOpBeforeActivate() async {
             let counter = AuthCounter()
             let controller = ContactSyncController(
-                client:                      MockContactSync(),
-                database:                    .mock,
-                owner:                       .mock,
-                authorizationStatusProvider: counter.bumpAndReturnNotDetermined
+                client:                          MockContactSync(),
+                database:                        .mock,
+                owner:                           .mock,
+                authorizationStatusProvider:     counter.bumpAndReturnNotDetermined,
+                lastAuthorizationStatusProvider: { .notDetermined },
+                persistAuthorizationStatus:      { _ in }
             )
             controller.didBecomeActive()
             await Task.yield()
@@ -357,10 +361,12 @@ struct ContactSyncControllerTests {
         func didBecomeActiveTriggersSyncAfterActivate() async throws {
             let counter = AuthCounter()
             let controller = ContactSyncController(
-                client:                      MockContactSync(),
-                database:                    .mock,
-                owner:                       .mock,
-                authorizationStatusProvider: counter.bumpAndReturnNotDetermined
+                client:                          MockContactSync(),
+                database:                        .mock,
+                owner:                           .mock,
+                authorizationStatusProvider:     counter.bumpAndReturnNotDetermined,
+                lastAuthorizationStatusProvider: { .notDetermined },
+                persistAuthorizationStatus:      { _ in }
             )
 
             controller.activate()
@@ -377,10 +383,12 @@ struct ContactSyncControllerTests {
         func syncCoalescesInFlightTriggerAndRerunsAfterCompletion() async throws {
             let counter = AuthCounter()
             let controller = ContactSyncController(
-                client:                      MockContactSync(),
-                database:                    .mock,
-                owner:                       .mock,
-                authorizationStatusProvider: counter.bumpAndReturnNotDetermined
+                client:                          MockContactSync(),
+                database:                        .mock,
+                owner:                           .mock,
+                authorizationStatusProvider:     counter.bumpAndReturnNotDetermined,
+                lastAuthorizationStatusProvider: { .notDetermined },
+                persistAuthorizationStatus:      { _ in }
             )
 
             controller.sync()
@@ -641,6 +649,220 @@ struct ContactSyncControllerTests {
                 try await controller.performSync(contacts: contacts)
             }
             #expect(mock.deltaCalls.isEmpty)
+            #expect(mock.fullCalls.isEmpty)
+        }
+    }
+
+    // MARK: - Clear on revoke
+
+    @Suite("ClearOnRevoke", .serialized)
+    @MainActor
+    struct ClearOnRevokeTests {
+
+        /// Lock-guarded in-memory `lastAuthStatus` store so the suite is
+        /// hermetic (no real `UserDefaults`) and deterministic under parallel
+        /// execution.
+        private final class AuthStatusStore: @unchecked Sendable {
+            private let lock = NSLock()
+            private var status: CNAuthorizationStatus
+            init(_ initial: CNAuthorizationStatus) { status = initial }
+            var current: CNAuthorizationStatus { lock.withLock { status } }
+            func load() -> CNAuthorizationStatus { lock.withLock { status } }
+            func save(_ newValue: CNAuthorizationStatus) { lock.withLock { status = newValue } }
+        }
+
+        private static func makeController(
+            mock: MockContactSync,
+            database: Database,
+            current: CNAuthorizationStatus,
+            store: AuthStatusStore
+        ) -> ContactSyncController {
+            ContactSyncController(
+                client:                          mock,
+                database:                        database,
+                owner:                           .mock,
+                authorizationStatusProvider:     { current },
+                lastAuthorizationStatusProvider: { store.load() },
+                persistAuthorizationStatus:      { store.save($0) }
+            )
+        }
+
+        private static func seedUploadedSet(
+            _ database: Database,
+            contacts: [Database.LocalContact],
+            matched: [String] = []
+        ) throws {
+            try database.setContactSyncState(.init(
+                checksum:      ContactSyncController.checksum(of: contacts.map(\.e164)),
+                changeHistory: nil,
+                lastSyncedAt:  Date(timeIntervalSince1970: 1_716_000_000)
+            ))
+            try database.replaceLocalContactsSnapshot(contacts)
+            if !matched.isEmpty {
+                try database.replaceFlipcashContacts(matched, matchedAt: Date(timeIntervalSince1970: 1_716_000_000))
+            }
+        }
+
+        private static let aliceContact = Database.LocalContact(e164: "+14155550100", contactId: "alice")
+        private static let bobContact   = Database.LocalContact(e164: "+14155550101", contactId: "bob")
+
+        @Test("authorized → denied with an uploaded set fires an empty full upload and drains the local tables")
+        func revoke_firesEmptyUploadAndDrainsTables() async throws {
+            let mock = MockContactSync()
+            let database = Database.mock
+            let store = AuthStatusStore(.authorized)
+            let controller = Self.makeController(mock: mock, database: database, current: .denied, store: store)
+
+            try Self.seedUploadedSet(database, contacts: [Self.aliceContact, Self.bobContact], matched: [Self.bobContact.e164])
+
+            await controller.clearServerContactSetIfRevoked()
+
+            let fullCall = try #require(mock.fullCalls.first)
+            #expect(mock.fullCalls.count == 1)
+            #expect(fullCall.phones.isEmpty)
+            #expect(fullCall.checksum == ContactSyncController.checksum(of: []))
+            #expect(mock.deltaCalls.isEmpty)
+            #expect(mock.streamCalls.isEmpty)
+
+            #expect(try database.contactSyncState() == .empty)
+            #expect(try database.localContactsSnapshot().isEmpty)
+            #expect(try database.flipcashContacts().isEmpty)
+            #expect(store.current == .denied)  // disarmed after a successful wipe
+        }
+
+        @Test("authorized → restricted is treated as a revoke")
+        func revoke_restrictedAlsoClears() async throws {
+            let mock = MockContactSync()
+            let database = Database.mock
+            let store = AuthStatusStore(.authorized)
+            let controller = Self.makeController(mock: mock, database: database, current: .restricted, store: store)
+
+            try Self.seedUploadedSet(database, contacts: [Self.aliceContact])
+
+            await controller.clearServerContactSetIfRevoked()
+
+            #expect(mock.fullCalls.count == 1)
+            #expect(mock.fullCalls.first?.phones.isEmpty == true)
+            #expect(try database.localContactsSnapshot().isEmpty)
+            #expect(store.current == .restricted)
+        }
+
+        @Test("Revoke with nothing previously uploaded records the status without an upload")
+        func revoke_noServerSet_recordsStatusWithoutUpload() async throws {
+            let mock = MockContactSync()
+            let database = Database.mock  // empty — checksum is nil
+            let store = AuthStatusStore(.authorized)
+            let controller = Self.makeController(mock: mock, database: database, current: .denied, store: store)
+
+            await controller.clearServerContactSetIfRevoked()
+
+            #expect(mock.fullCalls.isEmpty)
+            #expect(store.current == .denied)  // recorded so we stop re-checking
+        }
+
+        @Test("Upload failure keeps the status armed and the local set intact; the next call retries")
+        func revoke_uploadFailure_keepsArmedAndRetries() async throws {
+            let mock = MockContactSync()
+            mock.fullUploadResult = .failure(ErrorContactSync.networkError)
+            let database = Database.mock
+            let store = AuthStatusStore(.authorized)
+            let controller = Self.makeController(mock: mock, database: database, current: .denied, store: store)
+
+            try Self.seedUploadedSet(database, contacts: [Self.aliceContact])
+
+            await controller.clearServerContactSetIfRevoked()
+
+            // Attempted, but the failure leaves everything armed for a retry.
+            #expect(mock.fullCalls.count == 1)
+            #expect(store.current == .authorized)
+            #expect(try database.contactSyncState().checksum != nil)
+            #expect(try database.localContactsSnapshot().isEmpty == false)
+
+            // Next foreground: the upload now succeeds → the wipe completes.
+            mock.fullUploadResult = .success(())
+            await controller.clearServerContactSetIfRevoked()
+
+            #expect(mock.fullCalls.count == 2)
+            #expect(store.current == .denied)
+            #expect(try database.contactSyncState() == .empty)
+            #expect(try database.localContactsSnapshot().isEmpty)
+        }
+
+        @Test("Still authorized → no upload, status unchanged")
+        func stillAuthorized_noOp() async throws {
+            let mock = MockContactSync()
+            let database = Database.mock
+            let store = AuthStatusStore(.authorized)
+            let controller = Self.makeController(mock: mock, database: database, current: .authorized, store: store)
+
+            try Self.seedUploadedSet(database, contacts: [Self.aliceContact])
+
+            await controller.clearServerContactSetIfRevoked()
+
+            #expect(mock.fullCalls.isEmpty)
+            #expect(store.current == .authorized)
+            #expect(try database.contactSyncState().checksum != nil)
+        }
+
+        @Test("Never authorized (notDetermined → denied) short-circuits without touching the server or store")
+        func neverAuthorized_shortCircuits() async throws {
+            let mock = MockContactSync()
+            let database = Database.mock
+            let store = AuthStatusStore(.notDetermined)
+            let controller = Self.makeController(mock: mock, database: database, current: .denied, store: store)
+
+            await controller.clearServerContactSetIfRevoked()
+
+            #expect(mock.fullCalls.isEmpty)
+            #expect(store.current == .notDetermined)  // not even recorded
+        }
+    }
+
+    // MARK: - Clear on account deletion
+
+    @Suite("AccountDeletionClear", .serialized)
+    @MainActor
+    struct AccountDeletionClearTests {
+
+        private static func makeController(mock: MockContactSync, database: Database) -> ContactSyncController {
+            ContactSyncController(client: mock, database: database, owner: .mock)
+        }
+
+        private static let aliceContact = Database.LocalContact(e164: "+14155550100", contactId: "alice")
+
+        @Test("Account deletion with an uploaded set fires an empty full upload and drains the local tables")
+        func accountDeletion_withUploadedSet_firesEmptyUploadAndDrains() async throws {
+            let mock = MockContactSync()
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            try database.setContactSyncState(.init(
+                checksum:      ContactSyncController.checksum(of: [Self.aliceContact.e164]),
+                changeHistory: nil,
+                lastSyncedAt:  Date(timeIntervalSince1970: 1_716_000_000)
+            ))
+            try database.replaceLocalContactsSnapshot([Self.aliceContact])
+            try database.replaceFlipcashContacts([Self.aliceContact.e164], matchedAt: Date(timeIntervalSince1970: 1_716_000_000))
+
+            await controller.clearServerContactSetForAccountDeletion()
+
+            let fullCall = try #require(mock.fullCalls.first)
+            #expect(mock.fullCalls.count == 1)
+            #expect(fullCall.phones.isEmpty)
+            #expect(fullCall.checksum == ContactSyncController.checksum(of: []))
+            #expect(try database.contactSyncState() == .empty)
+            #expect(try database.localContactsSnapshot().isEmpty)
+            #expect(try database.flipcashContacts().isEmpty)
+        }
+
+        @Test("Account deletion with nothing previously uploaded does not call the server")
+        func accountDeletion_nothingUploaded_noOp() async throws {
+            let mock = MockContactSync()
+            let database = Database.mock  // checksum is nil
+            let controller = Self.makeController(mock: mock, database: database)
+
+            await controller.clearServerContactSetForAccountDeletion()
+
             #expect(mock.fullCalls.isEmpty)
         }
     }


### PR DESCRIPTION
## Summary

- When someone turns off Contacts access after we've uploaded their address book, the next time the app comes to the foreground we wipe the copy the server is holding.
- The same wipe now runs when they choose "Delete Account" in Settings, which previously only logged out and left the uploaded contacts on the server.
- Both reuse an empty contact upload, so no new server API was needed.

## Test plan

- [x] Sync contacts, revoke Contacts access in iOS Settings, reopen the app, and confirm the server no longer has the contact set
- [x] Re-grant Contacts access and confirm contacts sync and match again
- [x] With contacts never granted, confirm nothing happens on foreground
- [x] Choose "Delete Account" in Settings and confirm the stored contact set is cleared