### PR TITLE
fix: keep phone verification continue button above the keyboard

### DIFF
--- a/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationFlowScreen.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationFlowScreen.swift
@@ -43,7 +43,6 @@ struct PhoneVerificationFlowScreen<VM: PhoneVerifying>: View {
                             .navigationTitle("Connect Phone Number")
                     }
                 }
-                .ignoresSafeArea(.keyboard)
         }
     }
 }


### PR DESCRIPTION
The continue button on the Connect Phone Number screen was hidden behind the keyboard, so it couldn't be tapped. The screen was opting out of the system's automatic keyboard avoidance, which left the button pinned to the bottom of the screen under the keypad. This removes that opt-out so the button rests just above the keyboard. The email verification screen was also checked and needs no change.

## Test plan
- [x] Open the Send flow on an account with no verified phone number.
- [x] Tap Connect to open the Connect Phone Number screen.
- [x] Confirm the continue button is fully visible above the keyboard.
- [x] Type a phone number and confirm the button stays visible and tappable.