### PR TITLE
feat: support limited contacts access

### DIFF
--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -68,8 +68,9 @@ final class ContactSyncController {
     // MARK: - Lifecycle -
 
     /// Idempotent. Registers the CN-change observer and triggers a sync.
-    /// Caller must verify `CNContactStore.authorizationStatus(for: .contacts)
-    /// == .authorized` before calling — this method does not prompt.
+    /// Caller must verify the contacts authorization status allows access
+    /// (`.authorized` or `.limited`) before calling — this method does not
+    /// prompt.
     func activate() {
         if observerTask == nil {
             // Detached: subscribing to `CNContactStoreDidChange` on the main
@@ -135,8 +136,8 @@ final class ContactSyncController {
     /// `nonisolated` annotation alone is not enough to keep it off-main.
     nonisolated private func runSync() async {
         let status = authorizationStatusProvider()
-        guard status == .authorized else {
-            logger.debug("Skipping sync — contacts not authorized", metadata: [
+        guard status.allowsContactAccess else {
+            logger.debug("Skipping sync — contacts not accessible", metadata: [
                 "status": "\(status.rawValue)",
             ])
             return

--- a/Flipcash/Core/Screens/ContactsPermission/ContactsPermissionScreen.swift
+++ b/Flipcash/Core/Screens/ContactsPermission/ContactsPermissionScreen.swift
@@ -77,7 +77,7 @@ struct ContactsPermissionScreen: View {
         .navigationBarBackButtonHidden(true)
         .task {
             await authorizer.refresh()
-            if authorizer.status == .authorized {
+            if authorizer.status.allowsContactAccess {
                 onAllowed()
             }
         }
@@ -87,9 +87,9 @@ struct ContactsPermissionScreen: View {
 
     private var title: String {
         switch authorizer.status {
-        case .denied, .restricted, .limited:
+        case .denied, .restricted:
             return "Contact Access Required"
-        case .notDetermined, .authorized:
+        case .notDetermined, .authorized, .limited:
             return "Find Your Friends"
         @unknown default:
             return "Find Your Friends"
@@ -98,9 +98,9 @@ struct ContactsPermissionScreen: View {
 
     private var subtitle: String {
         switch authorizer.status {
-        case .denied, .restricted, .limited:
+        case .denied, .restricted:
             return "Go to Settings and give Full Access"
-        case .notDetermined, .authorized:
+        case .notDetermined, .authorized, .limited:
             return "Sync your contacts to find, invite,\n and pay friends"
         @unknown default:
             return "Sync your contacts to find, invite,\n and pay friends"
@@ -109,9 +109,9 @@ struct ContactsPermissionScreen: View {
 
     private var primaryTitle: String {
         switch authorizer.status {
-        case .denied, .restricted, .limited:
+        case .denied, .restricted:
             return "Go To Settings to Give Contacts Full Access"
-        case .notDetermined, .authorized:
+        case .notDetermined, .authorized, .limited:
             return "Give Access To Contacts"
         @unknown default:
             return "Give Access To Contacts"
@@ -120,11 +120,11 @@ struct ContactsPermissionScreen: View {
 
     private func primaryAction() {
         switch authorizer.status {
-        case .denied, .restricted, .limited:
+        case .denied, .restricted:
             URL.openSettings()
         case .notDetermined:
             Task { await requestAuthorization() }
-        case .authorized:
+        case .authorized, .limited:
             onAllowed()
         @unknown default:
             Task { await requestAuthorization() }
@@ -133,7 +133,7 @@ struct ContactsPermissionScreen: View {
 
     private func requestAuthorization() async {
         let resolved = await authorizer.authorize()
-        if resolved == .authorized {
+        if resolved.allowsContactAccess {
             onAllowed()
         }
     }

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -4,7 +4,6 @@
 //
 
 import Contacts
-import ContactsUI
 import MessageUI
 import SwiftUI
 import FlipcashCore
@@ -15,9 +14,8 @@ nonisolated private let logger = Logger(label: "flipcash.recipient-picker")
 /// Send section's primary view. Renders `contactSyncController.resolvedContacts`.
 struct RecipientPickerScreen: View {
 
-    /// `true` when contacts are shared under iOS 18 limited access. Surfaces
-    /// the `ContactAccessButton` affordance so the user can add more people to
-    /// the shared set without granting full access.
+    /// `true` when contacts are shared under iOS 18 limited access. Drives the
+    /// limited-access empty state shown when nothing has been shared yet.
     let isLimitedAccess: Bool
 
     @Environment(ContactSyncController.self) private var contactSyncController
@@ -30,8 +28,12 @@ struct RecipientPickerScreen: View {
     var body: some View {
         let contacts = contactSyncController.resolvedContacts
         return Group {
-            if contacts.isEmpty && !isLimitedAccess {
-                RecipientPickerEmptyState()
+            if contacts.isEmpty {
+                if isLimitedAccess {
+                    LimitedAccessEmptyState()
+                } else {
+                    RecipientPickerEmptyState()
+                }
             } else {
                 VStack(spacing: 0) {
                     InlineSearchField(text: $searchText)
@@ -40,15 +42,6 @@ struct RecipientPickerScreen: View {
                     RecipientPickerList(
                         filtered: filtered,
                         searchText: searchText,
-                        isLimitedAccess: isLimitedAccess,
-                        onAddApproved: {
-                            // Clear the query so the add affordance can't flip
-                            // to its "No matches" state once the only result is
-                            // added; the new contact lands in the list after
-                            // the re-sync.
-                            searchText = ""
-                            contactSyncController.sync()
-                        },
                         onFlipcashTap: selectRecipient,
                         onInviteTap: presentInvite,
                     )
@@ -104,42 +97,71 @@ struct RecipientPickerScreen: View {
     }
 }
 
-// MARK: - Empty state -
+// MARK: - Empty states -
 
 private struct RecipientPickerEmptyState: View {
     var body: some View {
-        ContentUnavailableView(
-            "No Contacts Found",
-            systemImage: "person.crop.circle.badge.questionmark",
-            description: Text("None of the people in your address book have a phone number we can match.")
-        )
+        VStack(spacing: 10) {
+            Text("No Contacts Found")
+                .font(.appTextLarge)
+
+            Text("None of the people in your address book have a phone number we can match.")
+                .font(.appTextMedium)
+                .foregroundStyle(Color.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 
-// MARK: - Limited access -
+/// Shown under iOS 18 limited access when no contacts have been shared. Routes
+/// to Settings to pick contacts — adding them in-app is unavailable on iOS 26
+/// (FB14821786).
+private struct LimitedAccessEmptyState: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            Text("No Contacts Shared")
+                .font(.appTextLarge)
 
-/// iOS 18 limited-access affordance: surfaces contacts matching `queryString`
-/// that aren't in the shared set yet; tapping one shares it without a
-/// full-access prompt, and the approval callback re-syncs so it appears here.
-///
-/// Sized to mirror `RecipientRow` — 44pt avatar, 12pt gap, phone caption — so
-/// the system control reads as part of the list. Its remaining system styling
-/// is intentional: it signals the distinct "grant access" action.
-@available(iOS 18, *)
-private struct AddLimitedContactsButton: View {
+            Text("Choose which contacts to share with Flipcash, then you can send them cash.")
+                .font(.appTextMedium)
+                .foregroundStyle(Color.textSecondary)
+                .multilineTextAlignment(.center)
 
-    let queryString: String
-    let onApproved: () -> Void
+            BubbleButton(text: "Choose in Settings") {
+                URL.openSettings()
+            }
+            .padding(.top, 8)
+        }
+        .padding(.horizontal, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Shown over the list when a search matches no contacts.
+private struct RecipientSearchEmptyState: View {
+
+    let searchText: String
 
     var body: some View {
-        ContactAccessButton(queryString: queryString) { _ in
-            onApproved()
+        VStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.textSecondary)
+                .padding(.bottom, 8)
+
+            Text("No Results for “\(searchText)”")
+                .font(.appTextLarge)
+                .multilineTextAlignment(.center)
+
+            Text("Check the spelling or try a new search.")
+                .font(.appTextMedium)
+                .foregroundStyle(Color.textSecondary)
+                .multilineTextAlignment(.center)
         }
-        .backgroundStyle(Color.background)
-        .contactAccessButtonCaption(.phone)
-        .contactAccessButtonStyle(
-            .init(imageTrailingEdgePadding: 12, imageWidth: 44, imageColor: nil)
-        )
+        .padding(.horizontal, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 
@@ -173,25 +195,11 @@ private struct RecipientPickerList: View {
 
     let filtered: ResolvedContacts
     let searchText: String
-    let isLimitedAccess: Bool
-    let onAddApproved: () -> Void
     let onFlipcashTap: (ResolvedContact) -> Void
     let onInviteTap: (ResolvedContact) -> Void
 
     var body: some View {
         List {
-            if isLimitedAccess, !searchText.isEmpty {
-                if #available(iOS 18, *) {
-                    Section {
-                        AddLimitedContactsButton(queryString: searchText, onApproved: onAddApproved)
-                            .listRowInsets(EdgeInsets(top: 14, leading: 20, bottom: 14, trailing: 20))
-                            .listRowBackground(Color.clear)
-                            .listRowSeparatorTint(.rowSeparator)
-                    } header: {
-                        RecipientSectionHeader(title: "Add from Contacts")
-                    }
-                }
-            }
             if !filtered.onFlipcash.isEmpty {
                 Section {
                     ForEach(filtered.onFlipcash) { contact in
@@ -223,8 +231,8 @@ private struct RecipientPickerList: View {
         .scrollContentBackground(.hidden)
         .scrollDismissesKeyboard(.interactively)
         .overlay {
-            if !searchText.isEmpty && filtered.isEmpty && !isLimitedAccess {
-                ContentUnavailableView.search(text: searchText)
+            if !searchText.isEmpty && filtered.isEmpty {
+                RecipientSearchEmptyState(searchText: searchText)
             }
         }
     }

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -4,6 +4,7 @@
 //
 
 import Contacts
+import ContactsUI
 import MessageUI
 import SwiftUI
 import FlipcashCore
@@ -13,6 +14,11 @@ nonisolated private let logger = Logger(label: "flipcash.recipient-picker")
 
 /// Send section's primary view. Renders `contactSyncController.resolvedContacts`.
 struct RecipientPickerScreen: View {
+
+    /// `true` when contacts are shared under iOS 18 limited access. Surfaces
+    /// the `ContactAccessButton` affordance so the user can add more people to
+    /// the shared set without granting full access.
+    let isLimitedAccess: Bool
 
     @Environment(ContactSyncController.self) private var contactSyncController
     @Environment(AppRouter.self) private var router
@@ -24,7 +30,7 @@ struct RecipientPickerScreen: View {
     var body: some View {
         let contacts = contactSyncController.resolvedContacts
         return Group {
-            if contacts.isEmpty {
+            if contacts.isEmpty && !isLimitedAccess {
                 RecipientPickerEmptyState()
             } else {
                 VStack(spacing: 0) {
@@ -34,6 +40,15 @@ struct RecipientPickerScreen: View {
                     RecipientPickerList(
                         filtered: filtered,
                         searchText: searchText,
+                        isLimitedAccess: isLimitedAccess,
+                        onAddApproved: {
+                            // Clear the query so the add affordance can't flip
+                            // to its "No matches" state once the only result is
+                            // added; the new contact lands in the list after
+                            // the re-sync.
+                            searchText = ""
+                            contactSyncController.sync()
+                        },
                         onFlipcashTap: selectRecipient,
                         onInviteTap: presentInvite,
                     )
@@ -101,6 +116,33 @@ private struct RecipientPickerEmptyState: View {
     }
 }
 
+// MARK: - Limited access -
+
+/// iOS 18 limited-access affordance: surfaces contacts matching `queryString`
+/// that aren't in the shared set yet; tapping one shares it without a
+/// full-access prompt, and the approval callback re-syncs so it appears here.
+///
+/// Sized to mirror `RecipientRow` — 44pt avatar, 12pt gap, phone caption — so
+/// the system control reads as part of the list. Its remaining system styling
+/// is intentional: it signals the distinct "grant access" action.
+@available(iOS 18, *)
+private struct AddLimitedContactsButton: View {
+
+    let queryString: String
+    let onApproved: () -> Void
+
+    var body: some View {
+        ContactAccessButton(queryString: queryString) { _ in
+            onApproved()
+        }
+        .backgroundStyle(Color.background)
+        .contactAccessButtonCaption(.phone)
+        .contactAccessButtonStyle(
+            .init(imageTrailingEdgePadding: 12, imageWidth: 44, imageColor: nil)
+        )
+    }
+}
+
 // MARK: - Search field -
 
 private struct InlineSearchField: View {
@@ -131,11 +173,25 @@ private struct RecipientPickerList: View {
 
     let filtered: ResolvedContacts
     let searchText: String
+    let isLimitedAccess: Bool
+    let onAddApproved: () -> Void
     let onFlipcashTap: (ResolvedContact) -> Void
     let onInviteTap: (ResolvedContact) -> Void
 
     var body: some View {
         List {
+            if isLimitedAccess, !searchText.isEmpty {
+                if #available(iOS 18, *) {
+                    Section {
+                        AddLimitedContactsButton(queryString: searchText, onApproved: onAddApproved)
+                            .listRowInsets(EdgeInsets(top: 14, leading: 20, bottom: 14, trailing: 20))
+                            .listRowBackground(Color.clear)
+                            .listRowSeparatorTint(.rowSeparator)
+                    } header: {
+                        RecipientSectionHeader(title: "Add from Contacts")
+                    }
+                }
+            }
             if !filtered.onFlipcash.isEmpty {
                 Section {
                     ForEach(filtered.onFlipcash) { contact in
@@ -167,7 +223,7 @@ private struct RecipientPickerList: View {
         .scrollContentBackground(.hidden)
         .scrollDismissesKeyboard(.interactively)
         .overlay {
-            if !searchText.isEmpty && filtered.isEmpty {
+            if !searchText.isEmpty && filtered.isEmpty && !isLimitedAccess {
                 ContentUnavailableView.search(text: searchText)
             }
         }

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -8,7 +8,7 @@ import FlipcashCore
 import FlipcashUI
 
 /// Root view for the Send sheet. Gates entry on a verified phone and
-/// authorized contacts; the satisfied state renders the recipient picker.
+/// accessible contacts; the satisfied state renders the recipient picker.
 struct SendRootScreen: View {
 
     @Environment(Session.self) private var session
@@ -17,7 +17,6 @@ struct SendRootScreen: View {
 
     @State private var phoneVerificationViewModel: PhoneVerificationViewModel?
     @State private var contactsAuthorizer = ContactsAuthorizer()
-    @State private var didResolveContactsStatus = false
 
     private let container: Container
 
@@ -34,23 +33,28 @@ struct SendRootScreen: View {
             switch step {
             case .needsPhone:
                 ConnectPhoneEmptyState(onConnect: startPhoneVerification)
-            case .loading:
-                // Contacts status not yet resolved, or the matched set is still
-                // syncing. A neutral spinner avoids flashing the permission
-                // priming screen at a user who already granted access.
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .needsContacts:
                 ContactsPermissionScreen(
                     authorizer: contactsAuthorizer,
                     onAllowed: { contactSyncController.activate() },
                     onSkipped: nil
                 )
+            case .loadingContacts:
+                // Access is in place (full or limited); the controller is
+                // resolving the directory for the first time this session. Keep
+                // the priming screen visible with a spinner on the primary
+                // button so the user sees clear in-progress feedback instead of
+                // a flash to a half-populated picker.
+                ContactsPermissionScreen(
+                    authorizer: contactsAuthorizer,
+                    onAllowed: { contactSyncController.activate() },
+                    onSkipped: nil,
+                    isAllowing: true
+                )
             case .ready:
                 RecipientPickerScreen(isLimitedAccess: contactsAuthorizer.status.isLimited)
             }
         }
-        .task { await resolveContactsAccess() }
         .sheet(item: $phoneVerificationViewModel.cancellingOnDismiss()) { viewModel in
             PhoneVerificationFlowScreen(viewModel: viewModel)
         }
@@ -60,8 +64,8 @@ struct SendRootScreen: View {
 
     private enum Step {
         case needsPhone
-        case loading
         case needsContacts
+        case loadingContacts
         case ready
     }
 
@@ -69,26 +73,10 @@ struct SendRootScreen: View {
         guard session.profile?.isPhoneVerified ?? false else {
             return .needsPhone
         }
-        guard didResolveContactsStatus else {
-            return .loading
-        }
         guard contactsAuthorizer.status.allowsContactAccess else {
             return .needsContacts
         }
-        return contactSyncController.hasResolvedOnce ? .ready : .loading
-    }
-
-    // MARK: - Contacts access -
-
-    /// Resolves the live contacts status before the gate runs so the priming
-    /// screen never flashes for a user who already granted full or limited
-    /// access, and activates the sync controller when access is in place.
-    private func resolveContactsAccess() async {
-        await contactsAuthorizer.refresh()
-        didResolveContactsStatus = true
-        if contactsAuthorizer.status.allowsContactAccess {
-            contactSyncController.activate()
-        }
+        return contactSyncController.hasResolvedOnce ? .ready : .loadingContacts
     }
 
     // MARK: - Phone verification handoff -
@@ -110,4 +98,3 @@ struct SendRootScreen: View {
         }
     }
 }
-

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -17,6 +17,7 @@ struct SendRootScreen: View {
 
     @State private var phoneVerificationViewModel: PhoneVerificationViewModel?
     @State private var contactsAuthorizer = ContactsAuthorizer()
+    @State private var didResolveContactsStatus = false
 
     private let container: Container
 
@@ -33,26 +34,31 @@ struct SendRootScreen: View {
             switch step {
             case .needsPhone:
                 ConnectPhoneEmptyState(onConnect: startPhoneVerification)
+            case .loading:
+                // Resolving the contacts status, or the matched set is still
+                // syncing. A neutral spinner avoids flashing the permission
+                // priming screen at someone who already granted access.
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .needsContacts:
                 ContactsPermissionScreen(
                     authorizer: contactsAuthorizer,
                     onAllowed: { contactSyncController.activate() },
                     onSkipped: nil
                 )
-            case .loadingContacts:
-                // Access is in place (full or limited); the controller is
-                // resolving the directory for the first time this session. Keep
-                // the priming screen visible with a spinner on the primary
-                // button so the user sees clear in-progress feedback instead of
-                // a flash to a half-populated picker.
-                ContactsPermissionScreen(
-                    authorizer: contactsAuthorizer,
-                    onAllowed: { contactSyncController.activate() },
-                    onSkipped: nil,
-                    isAllowing: true
-                )
             case .ready:
                 RecipientPickerScreen(isLimitedAccess: contactsAuthorizer.status.isLimited)
+            }
+        }
+        // Resolve the contacts status only once the phone gate is satisfied.
+        // Reading a Contacts API before the permission screen trips the iOS 26
+        // prompt-on-`authorizationStatus` behavior and stalls the phone step.
+        .task(id: session.profile?.isPhoneVerified) {
+            guard session.profile?.isPhoneVerified == true else { return }
+            await contactsAuthorizer.refresh()
+            didResolveContactsStatus = true
+            if contactsAuthorizer.status.allowsContactAccess {
+                contactSyncController.activate()
             }
         }
         .sheet(item: $phoneVerificationViewModel.cancellingOnDismiss()) { viewModel in
@@ -64,8 +70,8 @@ struct SendRootScreen: View {
 
     private enum Step {
         case needsPhone
+        case loading
         case needsContacts
-        case loadingContacts
         case ready
     }
 
@@ -73,10 +79,13 @@ struct SendRootScreen: View {
         guard session.profile?.isPhoneVerified ?? false else {
             return .needsPhone
         }
+        guard didResolveContactsStatus else {
+            return .loading
+        }
         guard contactsAuthorizer.status.allowsContactAccess else {
             return .needsContacts
         }
-        return contactSyncController.hasResolvedOnce ? .ready : .loadingContacts
+        return contactSyncController.hasResolvedOnce ? .ready : .loading
     }
 
     // MARK: - Phone verification handoff -

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -17,6 +17,7 @@ struct SendRootScreen: View {
 
     @State private var phoneVerificationViewModel: PhoneVerificationViewModel?
     @State private var contactsAuthorizer = ContactsAuthorizer()
+    @State private var didResolveContactsStatus = false
 
     private let container: Container
 
@@ -33,28 +34,23 @@ struct SendRootScreen: View {
             switch step {
             case .needsPhone:
                 ConnectPhoneEmptyState(onConnect: startPhoneVerification)
+            case .loading:
+                // Contacts status not yet resolved, or the matched set is still
+                // syncing. A neutral spinner avoids flashing the permission
+                // priming screen at a user who already granted access.
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .needsContacts:
                 ContactsPermissionScreen(
                     authorizer: contactsAuthorizer,
                     onAllowed: { contactSyncController.activate() },
                     onSkipped: nil
                 )
-            case .loadingContacts:
-                // Already authorized; controller is resolving the directory
-                // for the first time this session. Keep the priming screen
-                // visible with a spinner on the primary button so the user
-                // sees clear in-progress feedback instead of a flash to a
-                // half-populated picker.
-                ContactsPermissionScreen(
-                    authorizer: contactsAuthorizer,
-                    onAllowed: { contactSyncController.activate() },
-                    onSkipped: nil,
-                    isAllowing: true
-                )
             case .ready:
-                RecipientPickerScreen()
+                RecipientPickerScreen(isLimitedAccess: contactsAuthorizer.status.isLimited)
             }
         }
+        .task { await resolveContactsAccess() }
         .sheet(item: $phoneVerificationViewModel.cancellingOnDismiss()) { viewModel in
             PhoneVerificationFlowScreen(viewModel: viewModel)
         }
@@ -64,8 +60,8 @@ struct SendRootScreen: View {
 
     private enum Step {
         case needsPhone
+        case loading
         case needsContacts
-        case loadingContacts
         case ready
     }
 
@@ -73,10 +69,26 @@ struct SendRootScreen: View {
         guard session.profile?.isPhoneVerified ?? false else {
             return .needsPhone
         }
-        guard contactsAuthorizer.status == .authorized else {
+        guard didResolveContactsStatus else {
+            return .loading
+        }
+        guard contactsAuthorizer.status.allowsContactAccess else {
             return .needsContacts
         }
-        return contactSyncController.hasResolvedOnce ? .ready : .loadingContacts
+        return contactSyncController.hasResolvedOnce ? .ready : .loading
+    }
+
+    // MARK: - Contacts access -
+
+    /// Resolves the live contacts status before the gate runs so the priming
+    /// screen never flashes for a user who already granted full or limited
+    /// access, and activates the sync controller when access is in place.
+    private func resolveContactsAccess() async {
+        await contactsAuthorizer.refresh()
+        didResolveContactsStatus = true
+        if contactsAuthorizer.status.allowsContactAccess {
+            contactSyncController.activate()
+        }
     }
 
     // MARK: - Phone verification handoff -

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -243,10 +243,11 @@ final class SessionAuthenticator {
             owner: owner
         )
 
-        // Activate at bootstrap when contacts are already authorized.
+        // Activate at bootstrap when contacts are already accessible
+        // (full or limited).
         Task.detached { [contactSyncController] in
             let status = CNContactStore.authorizationStatus(for: .contacts)
-            guard status == .authorized else { return }
+            guard status.allowsContactAccess else { return }
             await MainActor.run {
                 contactSyncController.activate()
             }

--- a/Flipcash/Extensions/CNAuthorizationStatus+ContactAccess.swift
+++ b/Flipcash/Extensions/CNAuthorizationStatus+ContactAccess.swift
@@ -1,0 +1,42 @@
+//
+//  CNAuthorizationStatus+ContactAccess.swift
+//  Flipcash
+//
+
+import Contacts
+
+extension CNAuthorizationStatus {
+
+    /// `true` when the app may read contacts — full (`.authorized`) or partial
+    /// (`.limited`, iOS 18+). `.limited` is matched only as a `switch` pattern,
+    /// never used as a value, so this compiles on the iOS 17 deployment target
+    /// where `.limited` is unavailable as an expression.
+    ///
+    /// `nonisolated` so the off-main sync gate (`ContactSyncController.runSync`)
+    /// and bootstrap `Task.detached` can read it under main-actor-by-default
+    /// isolation.
+    nonisolated var allowsContactAccess: Bool {
+        switch self {
+        case .authorized, .limited:
+            true
+        case .notDetermined, .denied, .restricted:
+            false
+        @unknown default:
+            false
+        }
+    }
+
+    /// `true` only for `.limited` (iOS 18+ partial access). Pattern-matched for
+    /// the same iOS 17 compile-safety reason as ``allowsContactAccess``, and
+    /// `nonisolated` for the same off-main-access reason.
+    nonisolated var isLimited: Bool {
+        switch self {
+        case .limited:
+            true
+        case .notDetermined, .denied, .restricted, .authorized:
+            false
+        @unknown default:
+            false
+        }
+    }
+}

--- a/FlipcashTests/CNAuthorizationStatusTests.swift
+++ b/FlipcashTests/CNAuthorizationStatusTests.swift
@@ -1,0 +1,48 @@
+//
+//  CNAuthorizationStatusTests.swift
+//  FlipcashTests
+//
+
+import Contacts
+import Testing
+@testable import Flipcash
+
+@Suite("CNAuthorizationStatus.allowsContactAccess")
+struct CNAuthorizationStatusAllowsContactAccessTests {
+
+    private static let cases: [(CNAuthorizationStatus, Bool)] = [
+        (.authorized,    true),
+        (.limited,       true),
+        (.notDetermined, false),
+        (.denied,        false),
+        (.restricted,    false),
+    ]
+
+    @Test(
+        "Only .authorized and .limited allow contact access",
+        arguments: cases,
+    )
+    func allowsContactAccess(status: CNAuthorizationStatus, expected: Bool) {
+        #expect(status.allowsContactAccess == expected)
+    }
+}
+
+@Suite("CNAuthorizationStatus.isLimited")
+struct CNAuthorizationStatusIsLimitedTests {
+
+    private static let cases: [(CNAuthorizationStatus, Bool)] = [
+        (.limited,       true),
+        (.authorized,    false),
+        (.notDetermined, false),
+        (.denied,        false),
+        (.restricted,    false),
+    ]
+
+    @Test(
+        "isLimited is true only for .limited",
+        arguments: cases,
+    )
+    func isLimited(status: CNAuthorizationStatus, expected: Bool) {
+        #expect(status.isLimited == expected)
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Contacts/ContactsAuthorizer.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Contacts/ContactsAuthorizer.swift
@@ -28,8 +28,10 @@ public final class ContactsAuthorizer {
     }
 
     /// Prompts the user once when the status is `.notDetermined`, then returns
-    /// the resolved authorization status. iOS suppresses repeat prompts; for
-    /// `.denied` / `.restricted` / `.limited` callers should route to Settings.
+    /// the resolved authorization status. iOS suppresses repeat prompts.
+    /// `.limited` (iOS 18+) grants partial access and is usable like
+    /// `.authorized`; only `.denied` / `.restricted` callers should route to
+    /// Settings.
     public func authorize() async -> CNAuthorizationStatus {
         let current = await Task.detached {
             CNContactStore.authorizationStatus(for: .contacts)

--- a/FlipcashUITests/Smoke/SendSmokeTests.swift
+++ b/FlipcashUITests/Smoke/SendSmokeTests.swift
@@ -27,15 +27,22 @@ final class SendSmokeTests: BaseUITestCase {
         let onFlipcashHeader = app.staticTexts["On Flipcash"]
         let inviteHeader     = app.staticTexts["Not on Flipcash Yet"]
         let emptyState       = app.staticTexts["No Contacts Found"]
+        // Limited access (iOS 18+) with nothing shared renders its own state.
+        let limitedEmptyState = app.staticTexts["No Contacts Shared"]
+
+        func pickerRendered() -> Bool {
+            onFlipcashHeader.exists || inviteHeader.exists
+                || emptyState.exists || limitedEmptyState.exists
+        }
 
         let deadline = Date().addingTimeInterval(30)
         while Date() < deadline {
-            if onFlipcashHeader.exists || inviteHeader.exists || emptyState.exists { break }
+            if pickerRendered() { break }
             Thread.sleep(forTimeInterval: 0.25)
         }
         XCTAssertTrue(
-            onFlipcashHeader.exists || inviteHeader.exists || emptyState.exists,
-            "Expected `RecipientPickerScreen` to render an On-Flipcash header, an Invite header, or the empty state"
+            pickerRendered(),
+            "Expected `RecipientPickerScreen` to render an On-Flipcash header, an Invite header, or an empty state"
         )
 
         // The invite-fallback path requires at least one row in the Invite

--- a/FlipcashUITests/Smoke/SendSmokeTests.swift
+++ b/FlipcashUITests/Smoke/SendSmokeTests.swift
@@ -16,6 +16,15 @@ final class SendSmokeTests: BaseUITestCase {
         // Send is the 4th LargeButton on ScanBottomBar.
         waitAndTap(app.buttons["Send"])
 
+        // Send gates phone entry behind a "Connect Your Phone Number" CTA;
+        // onboarding drops you on the entry screen directly, so `allowPhone…`
+        // alone can't reach the flow here. Tap through the CTA when the gate
+        // is shown (skipped when the test account already has a verified phone).
+        let connectPhone = app.buttons["Connect Your Phone Number"]
+        if connectPhone.waitForExistence(timeout: 5) {
+            connectPhone.tap()
+        }
+
         // The helpers are idempotent — they no-op when the gate is already
         // satisfied for the test account.
         allowPhoneVerificationIfNeeded()


### PR DESCRIPTION
Treats iOS 18 limited contacts access as a first-class state. The app previously treated limited access like denied and pushed users to Settings; now it syncs whatever subset of contacts the user shared, shows them in the Send recipient picker, and lets you send to them. A limited user who has shared no contacts gets an empty state pointing them to Settings to pick some.

An in-app button to add more contacts was prototyped and dropped because iOS 18's contact pickers render a blank sheet on iOS 26 (a confirmed Apple bug, FB14821786, with no workaround); adding contacts goes through Settings until Apple fixes it.

Test plan:
- [x] With limited access and a few contacts shared, open Send and confirm they appear and you can send to one.
- [x] With limited access and no contacts shared, open Send and confirm the empty state with a "Choose in Settings" button.
- [x] Revoke contacts access entirely and confirm the synced set clears as before.
- [ ] On an iOS 17 device, confirm contact sync still works as before.
