### PR TITLE
fix: show wallet toast when collecting a created currency

### DIFF
--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -920,12 +920,6 @@ class Session {
 
                 updatePostTransaction()
 
-                // Toast: user grabbed cash by scanning a bill (+amount)
-                enqueue(toast: .init(
-                    amount: metadata.exchangedFiat.nativeAmount,
-                    isDeposit: true
-                ))
-
                 showCashBill(.init(
                     kind: .cash,
                     exchangedFiat: metadata.exchangedFiat,
@@ -990,6 +984,14 @@ class Session {
     }
     
     func showCashBill(_ billDescription: BillDescription) {
+        // Only inbound bills enqueue a "+$" deposit toast; sent bills don't.
+        if billDescription.received {
+            enqueue(toast: .init(
+                amount: billDescription.exchangedFiat.nativeAmount,
+                isDeposit: true
+            ))
+        }
+
         let operation = SendCashOperation(
             client: client,
             database: database,
@@ -1443,12 +1445,6 @@ class Session {
                 )
 
                 updatePostTransaction()
-
-                // Toast: user redeemed a cash link (+amount)
-                enqueue(toast: .init(
-                    amount: exchangedFiat.nativeAmount,
-                    isDeposit: true
-                ))
 
                 showCashBill(
                     .init(


### PR DESCRIPTION
When you create a new currency, the app shows a bill to collect your new balance — but unlike every other collected bill, it was missing the little toast that pops over the wallet icon afterward. This wires that toast into the shared bill-display path so the currency-creation bill behaves like the rest, and receiving cash by scan or by link still shows its toast exactly once.

## Test plan
- [x] Create a currency and confirm the toast appears over the wallet after dismissing the bill.
- [x] Grab cash by scanning and confirm the toast still shows once.
- [x] Receive a cash link and confirm the toast still shows once.
- [x] Give cash and confirm no deposit toast appears.
