### PR TITLE
fix: don't report phone-verification RPC timeouts to Bugsnag

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PhoneService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PhoneService.swift
@@ -35,7 +35,7 @@ class PhoneService: CodeService<Flipcash_Phone_V1_PhoneVerificationNIOClient> {
             }
 
         } failure: { error in
-            completion(.failure(.unknown))
+            completion(.failure(.from(transportError: error)))
         }
     }
 
@@ -60,7 +60,7 @@ class PhoneService: CodeService<Flipcash_Phone_V1_PhoneVerificationNIOClient> {
             }
 
         } failure: { error in
-            completion(.failure(.unknown))
+            completion(.failure(.from(transportError: error)))
         }
     }
 
@@ -84,14 +84,14 @@ class PhoneService: CodeService<Flipcash_Phone_V1_PhoneVerificationNIOClient> {
             }
 
         } failure: { error in
-            completion(.failure(.unknown))
+            completion(.failure(.from(transportError: error)))
         }
     }
 }
 
 // MARK: - Errors -
 
-public enum ErrorSendVerificationCode: Int, Error {
+public enum ErrorSendVerificationCode: Int, Error, Equatable, Sendable {
     case ok
     case denied
     /// SMS is rate limited (eg. by IP, phone number, user, etc) and was not sent.
@@ -102,9 +102,10 @@ public enum ErrorSendVerificationCode: Int, Error {
     /// like a landline.
     case unsupportedPhoneType
     case unknown = -1
+    case transportFailure = -2
 }
 
-public enum ErrorCheckVerificationCode: Int, Error {
+public enum ErrorCheckVerificationCode: Int, Error, Equatable, Sendable {
     case ok
     case denied
     /// The call is rate limited (eg. by IP, phone number, etc). The code is
@@ -120,18 +121,20 @@ public enum ErrorCheckVerificationCode: Int, Error {
     /// verification using SendVerificationCode.
     case noVerification
     case unknown = -1
+    case transportFailure = -2
 }
 
-public enum ErrorUnlinkPhone: Int, Error {
+public enum ErrorUnlinkPhone: Int, Error, Equatable, Sendable {
     case ok
     case denied
     case unknown = -1
+    case transportFailure = -2
 }
 
 extension ErrorSendVerificationCode: ServerError {
     public var isReportable: Bool {
         switch self {
-        case .ok, .denied, .rateLimited, .invalidPhoneNumber, .unsupportedPhoneType: false
+        case .ok, .denied, .rateLimited, .invalidPhoneNumber, .unsupportedPhoneType, .transportFailure: false
         case .unknown: true
         }
     }
@@ -140,7 +143,7 @@ extension ErrorSendVerificationCode: ServerError {
 extension ErrorCheckVerificationCode: ServerError {
     public var isReportable: Bool {
         switch self {
-        case .ok, .denied, .rateLimited, .invalidCode, .noVerification: false
+        case .ok, .denied, .rateLimited, .invalidCode, .noVerification, .transportFailure: false
         case .unknown: true
         }
     }
@@ -149,9 +152,32 @@ extension ErrorCheckVerificationCode: ServerError {
 extension ErrorUnlinkPhone: ServerError {
     public var isReportable: Bool {
         switch self {
-        case .ok, .denied: false
+        case .ok, .denied, .transportFailure: false
         case .unknown: true
         }
+    }
+}
+
+// MARK: - Transport classification -
+
+extension ErrorSendVerificationCode {
+    /// Maps a gRPC failure status into the error type. Transient network
+    /// conditions (timeout / unavailable) become `.transportFailure`, which is
+    /// non-reportable; every other status preserves `.unknown`.
+    public static func from(transportError: GRPCStatus) -> ErrorSendVerificationCode {
+        transportError.code.isTransientNetworkError ? .transportFailure : .unknown
+    }
+}
+
+extension ErrorCheckVerificationCode {
+    public static func from(transportError: GRPCStatus) -> ErrorCheckVerificationCode {
+        transportError.code.isTransientNetworkError ? .transportFailure : .unknown
+    }
+}
+
+extension ErrorUnlinkPhone {
+    public static func from(transportError: GRPCStatus) -> ErrorUnlinkPhone {
+        transportError.code.isTransientNetworkError ? .transportFailure : .unknown
     }
 }
 

--- a/FlipcashTests/Regressions/Regression_6a1b80a.swift
+++ b/FlipcashTests/Regressions/Regression_6a1b80a.swift
@@ -1,0 +1,78 @@
+//
+//  Regression_6a1b80a.swift
+//  Flipcash
+//
+//  Symptom:  On a device with no connectivity, sendVerificationCode times out
+//            and PhoneService's failure callback collapses the gRPC deadline
+//            into ErrorSendVerificationCode.unknown, which is reportable. The
+//            PhoneVerificationViewModel catch-all then ships a Bugsnag warning
+//            per retry, misrepresenting a transport timeout as a server
+//            "unknown". checkVerificationCode and unlinkPhone share the shape.
+//
+//  Fix:      Add `.transportFailure` (isReportable: false) and a static
+//            `from(transportError:)` helper to each of the three phone error
+//            enums, classifying gRPC timeout / unavailable into it. The three
+//            PhoneService failure callbacks route through the helper.
+//            ErrorReporting already honors ServerError.isReportable, so the
+//            viewModel catch suppresses these reports automatically.
+//
+
+import Foundation
+import Testing
+import GRPC
+import FlipcashCore
+
+@Suite("Regression: 6a1b80a – Phone verification no longer reports RPC timeouts", .bug("6a1b80a33b49fe77ec7d4aec"))
+struct Regression_6a1b80a {
+
+    @Test("ErrorSendVerificationCode reportability is correct for every case", arguments: [
+        (ErrorSendVerificationCode.ok,                   false),
+        (ErrorSendVerificationCode.denied,               false),
+        (ErrorSendVerificationCode.rateLimited,          false),
+        (ErrorSendVerificationCode.invalidPhoneNumber,   false),
+        (ErrorSendVerificationCode.unsupportedPhoneType, false),
+        (ErrorSendVerificationCode.unknown,              true),
+        (ErrorSendVerificationCode.transportFailure,     false),
+    ])
+    func sendReportability(error: ErrorSendVerificationCode, expected: Bool) {
+        #expect(error.isReportable == expected)
+    }
+
+    @Test("gRPC transport errors map to the right ErrorSendVerificationCode case", arguments: [
+        (GRPCStatus.Code.deadlineExceeded, ErrorSendVerificationCode.transportFailure),
+        (GRPCStatus.Code.unavailable,      ErrorSendVerificationCode.transportFailure),
+        (GRPCStatus.Code.cancelled,        ErrorSendVerificationCode.unknown),
+        (GRPCStatus.Code.invalidArgument,  ErrorSendVerificationCode.unknown),
+        (GRPCStatus.Code.permissionDenied, ErrorSendVerificationCode.unknown),
+        (GRPCStatus.Code.internalError,    ErrorSendVerificationCode.unknown),
+    ])
+    func sendTransportMapping(code: GRPCStatus.Code, expected: ErrorSendVerificationCode) {
+        let status = GRPCStatus(code: code, message: nil)
+        #expect(ErrorSendVerificationCode.from(transportError: status) == expected)
+    }
+
+    @Test("GRPCError.RPCTimedOut routes through .transportFailure end-to-end")
+    func rpcTimedOut_routesThroughTransportFailure() {
+        let timeout = GRPCError.RPCTimedOut(.deadline(.now()))
+        let status = timeout.makeGRPCStatus()
+        let mapped = ErrorSendVerificationCode.from(transportError: status)
+
+        #expect(status.code == .deadlineExceeded)
+        #expect(mapped == .transportFailure)
+        #expect(mapped.isReportable == false)
+    }
+
+    @Test("checkVerificationCode and unlinkPhone share the transport-failure classification", arguments: [
+        GRPCStatus.Code.deadlineExceeded,
+        GRPCStatus.Code.unavailable,
+    ])
+    func siblingsClassifyTransportFailure(code: GRPCStatus.Code) {
+        let status = GRPCStatus(code: code, message: nil)
+
+        #expect(ErrorCheckVerificationCode.from(transportError: status) == .transportFailure)
+        #expect(ErrorCheckVerificationCode.transportFailure.isReportable == false)
+
+        #expect(ErrorUnlinkPhone.from(transportError: status) == .transportFailure)
+        #expect(ErrorUnlinkPhone.transportFailure.isReportable == false)
+    }
+}


### PR DESCRIPTION
On a phone or network with no connectivity, requesting a phone verification code sent a Bugsnag warning on every retry — a network timeout was being misreported as a server error. This reclassifies transient network failures as a non-reportable transport failure, matching how balance fetches already behave, so a flaky connection no longer creates noise. The behavior users see is unchanged — they still get the generic "couldn't send code" message, and the same handling covers the verify-code and unlink-phone calls.

## Test plan
- [ ] With airplane mode on, request a phone verification code and confirm the generic error still appears
- [ ] Confirm the timeout no longer creates a Bugsnag report
