### PR TITLE
feat: cache profile and user flags for offline launch

### DIFF
--- a/Flipcash/Core/Controllers/Database/Database+Profile.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Profile.swift
@@ -1,0 +1,83 @@
+//
+//  Database+Profile.swift
+//  Flipcash
+//
+
+import Foundation
+import FlipcashCore
+import SQLite
+
+nonisolated extension Database {
+
+    // MARK: - Get -
+
+    func getProfile() throws -> Profile? {
+        let t = ProfileTable()
+
+        let statement = try reader.prepareRowIterator("""
+        SELECT
+            t.data
+        FROM
+            profile t
+        WHERE
+            t.id = 1
+        LIMIT 1;
+        """)
+
+        guard let row = try statement.map({ $0 }).first else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(Profile.self, from: row[t.data])
+    }
+
+    func getUserFlags() throws -> UserFlags? {
+        let t = UserFlagsTable()
+
+        let statement = try reader.prepareRowIterator("""
+        SELECT
+            t.data
+        FROM
+            userFlags t
+        WHERE
+            t.id = 1
+        LIMIT 1;
+        """)
+
+        guard let row = try statement.map({ $0 }).first else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(UserFlags.self, from: row[t.data])
+    }
+
+    // MARK: - Insert -
+
+    func insertProfile(_ profile: Profile) throws {
+        let table = ProfileTable()
+        let data = try JSONEncoder().encode(profile)
+
+        try writer.run(
+            table.table.upsert(
+                table.id   <- 1,
+                table.data <- data,
+
+                onConflictOf: table.id
+            )
+        )
+    }
+
+    func insertUserFlags(_ userFlags: UserFlags) throws {
+        let table = UserFlagsTable()
+        let data = try JSONEncoder().encode(userFlags)
+
+        try writer.run(
+            table.table.upsert(
+                table.id   <- 1,
+                table.data <- data,
+
+                onConflictOf: table.id
+            )
+        )
+    }
+}

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -104,6 +104,22 @@ nonisolated struct VerifiedRateTable: Sendable {
     let rateProto  = Expression <Data>   ("rateProto")
 }
 
+nonisolated struct ProfileTable: Sendable {
+    static let name = "profile"
+
+    let table = Table(Self.name)
+    let id    = Expression <Int>  ("id")
+    let data  = Expression <Data> ("data")
+}
+
+nonisolated struct UserFlagsTable: Sendable {
+    static let name = "userFlags"
+
+    let table = Table(Self.name)
+    let id    = Expression <Int>  ("id")
+    let data  = Expression <Data> ("data")
+}
+
 // Verified reserve-state proofs, one per mint.
 nonisolated struct VerifiedReserveTable: Sendable {
     static let name = "verified_reserve"
@@ -231,6 +247,24 @@ nonisolated extension Database {
             try writer.run(verifiedReserveTable.table.create(ifNotExists: true, withoutRowid: true) { t in
                 t.column(verifiedReserveTable.mint, primaryKey: true)
                 t.column(verifiedReserveTable.reserveProto)
+            })
+        }
+
+        let profileTable = ProfileTable()
+
+        try writer.transaction {
+            try writer.run(profileTable.table.create(ifNotExists: true, withoutRowid: true) { t in
+                t.column(profileTable.id, primaryKey: true)
+                t.column(profileTable.data)
+            })
+        }
+
+        let userFlagsTable = UserFlagsTable()
+
+        try writer.transaction {
+            try writer.run(userFlagsTable.table.create(ifNotExists: true, withoutRowid: true) { t in
+                t.column(userFlagsTable.id, primaryKey: true)
+                t.column(userFlagsTable.data)
             })
         }
 

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -225,6 +225,9 @@ class Session {
         registerPoller()
         startStreaming()
 
+        profile   = try? database.getProfile()
+        userFlags = try? database.getUserFlags()
+
         // Independent so a profile failure doesn't starve the user-flags fetch.
         // userFlags carries server-pinned withdrawal/launch fees; without it,
         // those flows submit fee=0 and the server denies the intent.
@@ -293,13 +296,16 @@ class Session {
     // MARK: - Info -
     
     func updateProfile() async throws {
-        profile = try await Task.retry(
+        let fetched = try await Task.retry(
             maxAttempts: 3,
             delay: .milliseconds(500),
             shouldRetry: { (error: any Swift.Error) in (error as? ErrorFetchProfile) == .unknown }
         ) {
             try await flipClient.fetchProfile(userID: userID, owner: ownerKeyPair)
         }
+
+        profile = fetched
+        try? database.insertProfile(fetched)
     }
     
     func unlinkProfile() async throws {
@@ -323,13 +329,16 @@ class Session {
     }
     
     func updateUserFlags() async throws {
-        userFlags = try await Task.retry(
+        let fetched = try await Task.retry(
             maxAttempts: 3,
             delay: .milliseconds(500),
             shouldRetry: { (error: any Swift.Error) in (error as? ErrorFetchUserFlags) == .unknown }
         ) {
             try await flipClient.fetchUserFlags(userID: userID, owner: ownerKeyPair)
         }
+
+        userFlags = fetched
+        try? database.insertUserFlags(fetched)
     }
 
     // MARK: - Settings Sync -

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -16,7 +16,7 @@
 		</dict>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>11</integer>
+	<integer>12</integer>
 	<key>UIApplicationShortcutItems</key>
 	<array>
 		<dict>

--- a/FlipcashCore/Sources/FlipcashCore/Models/Profile.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Profile.swift
@@ -8,7 +8,7 @@
 import Foundation
 import FlipcashAPI
 
-public struct Profile: Equatable, Sendable {
+public struct Profile: Codable, Equatable, Sendable {
     
     public static let empty = Profile(
         displayName: nil,

--- a/FlipcashCore/Sources/FlipcashCore/Models/UserFlags.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/UserFlags.swift
@@ -9,7 +9,7 @@
 import Foundation
 import FlipcashAPI
 
-public struct UserFlags: Sendable {
+public struct UserFlags: Codable, Sendable {
     public let isRegistered: Bool
     public let isStaff: Bool
     public let onrampProviders: [OnRampProvider]
@@ -45,7 +45,7 @@ public struct UserFlags: Sendable {
 }
 
 extension UserFlags {
-    public enum OnRampProvider: Int, Sendable {
+    public enum OnRampProvider: Int, Codable, Sendable {
         case unknown
         case coinbaseVirtual
         case coinbasePhysicalDebit

--- a/FlipcashTests/DatabaseProfileTests.swift
+++ b/FlipcashTests/DatabaseProfileTests.swift
@@ -1,0 +1,106 @@
+//
+//  DatabaseProfileTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+@testable import Flipcash
+
+@Suite("Profile + UserFlags offline cache round-trip")
+struct DatabaseProfileTests {
+
+    private static func makeDatabase() throws -> Database {
+        try Database.makeTemp()
+    }
+
+    private static let richUserFlags = UserFlags(
+        isRegistered: true,
+        isStaff: false,
+        onrampProviders: [.coinbaseVirtual, .phantom],
+        preferredOnrampProvider: .coinbaseVirtual,
+        minBuildNumber: 42,
+        billExchangeDataTimeout: 90,
+        newCurrencyPurchaseAmount: TokenAmount(quarks: 5_000_000, mint: .usdf),
+        newCurrencyFeeAmount: TokenAmount(quarks: 1_000_000, mint: .usdf),
+        withdrawalFeeAmount: TokenAmount(quarks: 50_000, mint: .usdf),
+        minimumHolderValue: TokenAmount(quarks: 100_000, mint: .usdf)
+    )
+
+    /// Restricted account: no onramp providers, unset timeout, zero fees.
+    private static let minimalUserFlags = UserFlags(
+        isRegistered: false,
+        isStaff: false,
+        onrampProviders: [],
+        preferredOnrampProvider: .unknown,
+        minBuildNumber: 0,
+        billExchangeDataTimeout: nil,
+        newCurrencyPurchaseAmount: .zero(mint: .usdf),
+        newCurrencyFeeAmount: .zero(mint: .usdf),
+        withdrawalFeeAmount: .zero(mint: .usdf),
+        minimumHolderValue: .zero(mint: .usdf)
+    )
+
+    // MARK: - Empty (fresh install) -
+
+    @Test("Empty database returns nil for profile and userFlags")
+    func emptyDatabase_returnsNil() throws {
+        let db = try Self.makeDatabase()
+        #expect(try db.getProfile() == nil)
+        #expect(try db.getUserFlags() == nil)
+    }
+
+    // MARK: - Profile -
+
+    @Test("Profile survives an insert/read round-trip with verification flags intact")
+    func profile_roundTrip_preservesFields() throws {
+        let db = try Self.makeDatabase()
+        let original = Profile.verifiedFixture
+
+        try db.insertProfile(original)
+        let restored = try #require(try db.getProfile())
+
+        #expect(restored == original)
+        #expect(restored.isPhoneVerified)
+        #expect(restored.isEmailVerified)
+    }
+
+    @Test("Re-inserting a profile replaces the single cached row")
+    func profile_insert_upsertsSingleRow() throws {
+        let db = try Self.makeDatabase()
+
+        try db.insertProfile(Profile.verifiedFixture)
+        try db.insertProfile(Profile(displayName: "Updated", phone: Optional<Phone>.none, email: nil))
+
+        let restored = try #require(try db.getProfile())
+        #expect(restored.displayName == "Updated")
+        #expect(!restored.isPhoneVerified)
+        #expect(!restored.isEmailVerified)
+    }
+
+    // MARK: - UserFlags -
+
+    @Test(
+        "UserFlags round-trips every field",
+        arguments: [DatabaseProfileTests.richUserFlags, DatabaseProfileTests.minimalUserFlags]
+    )
+    func userFlags_roundTrip(original: UserFlags) throws {
+        let db = try Self.makeDatabase()
+
+        try db.insertUserFlags(original)
+        let restored = try #require(try db.getUserFlags())
+
+        #expect(restored.isRegistered == original.isRegistered)
+        #expect(restored.isStaff == original.isStaff)
+        #expect(restored.onrampProviders == original.onrampProviders)
+        #expect(restored.preferredOnrampProvider == original.preferredOnrampProvider)
+        #expect(restored.hasCoinbase == original.hasCoinbase)
+        #expect(restored.minBuildNumber == original.minBuildNumber)
+        #expect(restored.billExchangeDataTimeout == original.billExchangeDataTimeout)
+        #expect(restored.newCurrencyPurchaseAmount == original.newCurrencyPurchaseAmount)
+        #expect(restored.newCurrencyFeeAmount == original.newCurrencyFeeAmount)
+        #expect(restored.withdrawalFeeAmount == original.withdrawalFeeAmount)
+        #expect(restored.minimumHolderValue == original.minimumHolderValue)
+    }
+}

--- a/FlipcashTests/SessionTests.swift
+++ b/FlipcashTests/SessionTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Testing
-import FlipcashCore
+@testable import FlipcashCore
 @testable import Flipcash
 
 @MainActor
@@ -606,5 +606,64 @@ struct SessionWithdrawVerifiedStateTests {
         } catch {
             Issue.record("Unexpected error thrown: \(error)")
         }
+    }
+}
+
+// MARK: -
+
+@MainActor
+@Suite("Session restores profile + userFlags from cache on init")
+struct SessionOfflineCacheTests {
+
+    private static func cachedUserFlags() -> UserFlags {
+        UserFlags(
+            isRegistered: true,
+            isStaff: false,
+            onrampProviders: [.coinbaseVirtual],
+            preferredOnrampProvider: .coinbaseVirtual,
+            minBuildNumber: 0,
+            billExchangeDataTimeout: nil,
+            newCurrencyPurchaseAmount: .zero(mint: .usdf),
+            newCurrencyFeeAmount: .zero(mint: .usdf),
+            withdrawalFeeAmount: TokenAmount(quarks: 50_000, mint: .usdf),
+            minimumHolderValue: .zero(mint: .usdf)
+        )
+    }
+
+    // Tests stay synchronous: the restore runs in `init`, while `updateProfile()`
+    // runs in a main-actor Task that can't execute until the test yields. An
+    // `async` test would race the network fetch against the cache.
+
+    @Test("A cached verified profile is restored before any network fetch")
+    func restoresProfileOnInit() throws {
+        let database = Database.mock
+        try database.insertProfile(.verifiedFixture)
+
+        let session = Session.makeMock(database: database)
+        let restored = try #require(session.profile)
+
+        #expect(restored == .verifiedFixture)
+        #expect(restored.isPhoneVerified)
+    }
+
+    @Test("Cached userFlags are restored, so fee and Coinbase gates read real values")
+    func restoresUserFlagsOnInit() throws {
+        let database = Database.mock
+        let flags = Self.cachedUserFlags()
+        try database.insertUserFlags(flags)
+
+        let session = Session.makeMock(database: database)
+        let restored = try #require(session.userFlags)
+
+        #expect(restored.hasCoinbase)
+        #expect(restored.withdrawalFeeAmount == flags.withdrawalFeeAmount)
+    }
+
+    @Test("Empty cache leaves profile nil — fresh install still shows connect-phone")
+    func emptyCacheLeavesProfileNil() {
+        let session = Session.makeMock(database: .mock)
+
+        #expect(session.profile == nil)
+        #expect(session.userFlags == nil)
     }
 }


### PR DESCRIPTION
## Summary

A returning user who relaunched the app without internet was shown the connect-phone prompt and $0 fees, because the profile and feature flags were fetched fresh from the server every launch and never cached. This persists both to the local database and restores them on launch, so an offline relaunch behaves normally. Transactions still require a connection, as before.

## Test plan

- [x] Confirm the automated tests covering offline restore-on-launch and cache persistence pass in CI.
- [x] As a final smoke, verify a phone, relaunch once with no internet, and confirm the Send flow shows the picker.