### PR TITLE
fix: show cached contacts in Send when offline

### DIFF
--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -93,6 +93,11 @@ final class ContactSyncController {
                 }
             }
         }
+        // Render the picker from the persisted directory before the network
+        // sync; an offline launch would otherwise spin until a sync succeeds.
+        if !hasResolvedOnce {
+            Task { [weak self] in await self?.resolveDirectory() }
+        }
         sync()
     }
 

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -335,6 +335,26 @@ struct ContactSyncControllerTests {
             #expect(controller.observerTask == firstObserver)
         }
 
+        @Test("activate() surfaces the cached directory even when the contact sync fails")
+        func activateResolvesCachedDirectoryWhenSyncFails() async throws {
+            let mock = MockContactSync()
+            mock.fullUploadResult = .failure(ErrorContactSync.networkError)
+            let database = Database.mock
+            try database.replaceLocalContactsSnapshot([
+                Database.LocalContact(e164: "+14155550100", contactId: "alice"),
+            ])
+            try database.replaceFlipcashContacts(["+14155550100"], matchedAt: .now)
+            let controller = Self.makeController(mock: mock, database: database, status: .authorized)
+
+            controller.activate()
+            await controller.syncTask?.value
+            try await Self.awaitResolved(controller)
+
+            // The flag, not the contents: name resolution reads the real
+            // CNContactStore, which a unit test can't seed.
+            #expect(controller.hasResolvedOnce)
+        }
+
         @Test("didBecomeActive() is a no-op before activate()")
         func didBecomeActiveNoOpBeforeActivate() async {
             let counter = AuthCounter()
@@ -420,6 +440,13 @@ struct ContactSyncControllerTests {
                 } else {
                     await Task.yield()
                 }
+            }
+        }
+
+        private static func awaitResolved(_ controller: ContactSyncController) async throws {
+            let deadline = Date.now.addingTimeInterval(1.0)
+            while !controller.hasResolvedOnce, Date.now < deadline {
+                await Task.yield()
             }
         }
     }


### PR DESCRIPTION
The Send tab showed a spinner forever when opened offline, even when contacts were already cached, because the recipient picker only revealed its contents after a successful contact sync. Now the cached contacts load from the local store as soon as Send opens, before any network call, so they appear instantly whether online or offline. The background sync still runs and refreshes the list once a connection is available.

## Test plan
- [x] Offline with cached contacts: open Send and the contacts appear immediately, no spinner.
- [x] Offline with nothing cached yet: open Send and the empty picker shows, not a spinner.
- [x] Online: open Send and the list still refreshes from the server.
