### PR TITLE
feat: swipe-to-send control on the Send amount screen

### DIFF
--- a/Flipcash/Core/Screens/Send/SendAmountScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountScreen.swift
@@ -20,6 +20,7 @@ struct SendAmountScreen: View {
     @State private var viewModel: SendAmountViewModel
     @State private var isShowingCurrencySelection: Bool = false
     @State private var isShowingTokenSelection: Bool = false
+    @State private var didSucceed: Bool = false
 
     private var maxLimit: ExchangedFiat {
         let rate = ratesController.rateForBalanceCurrency()
@@ -60,16 +61,13 @@ struct SendAmountScreen: View {
                 SwipeControl(text: "Swipe to Send") {
                     switch await viewModel.sendAction() {
                     case .success:
-                        break
+                        didSucceed = true
                     case .recipientNotFound:
                         router.popTopmost()
                         throw SendDismissed()
                     case .failed:
                         throw SendDismissed()
                     }
-                } completion: {
-                    try await Task.delay(seconds: 1)
-                    router.popTopmost()
                 }
             }
             .foregroundStyle(.textMain)
@@ -95,6 +93,15 @@ struct SendAmountScreen: View {
             guard let mint else { return }
             viewModel.depositMint = nil
             router.push(.currencyInfoForDeposit(mint))
+        }
+        // Hold the success checkmark briefly, then return to the contact list.
+        // Tied to the view via `.task` so a dismissal during the hold cancels
+        // the pop instead of firing it on a screen that's already gone.
+        .task(id: didSucceed) {
+            guard didSucceed else { return }
+            try? await Task.delay(seconds: 1)
+            guard !Task.isCancelled else { return }
+            router.popTopmost()
         }
         .sheet(isPresented: $isShowingTokenSelection) {
             SelectCurrencyScreen(isPresented: $isShowingTokenSelection) { balance in

--- a/Flipcash/Core/Screens/Send/SendAmountScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountScreen.swift
@@ -7,6 +7,10 @@ import SwiftUI
 import FlipcashUI
 import FlipcashCore
 
+/// Thrown to reset the SwipeControl knob without its success checkmark when a
+/// send doesn't complete (errors stay put; not-found has already popped).
+private struct SendDismissed: Error {}
+
 struct SendAmountScreen: View {
 
     @Environment(Session.self) private var session
@@ -46,38 +50,34 @@ struct SendAmountScreen: View {
 
     var body: some View {
         Background(color: .backgroundMain) {
-            switch viewModel.state {
-            case .ready, .submitting:
-                EnterAmountView(
-                    mode: .currency,
-                    enteredAmount: $viewModel.enteredAmount,
-                    subtitle: .balanceWithLimit(maxLimit),
-                    actionState: $viewModel.actionState,
-                    actionEnabled: { _ in viewModel.canSend },
-                    action: {
-                        Task {
-                            switch await viewModel.sendAction() {
-                            case .stay:
-                                break
-                            case .recipientNotFound:
-                                router.popTopmost()
-                            }
-                        }
-                    },
-                    currencySelectionAction: { isShowingCurrencySelection.toggle() }
-                )
-                .foregroundStyle(.textMain)
-                .padding(.horizontal, 20)
-                .padding(.bottom, 20)
-                .padding(.top, -40)
-                .sheet(isPresented: $isShowingCurrencySelection) {
-                    CurrencySelectionScreen(ratesController: ratesController)
+            EnterAmountView(
+                mode: .currency,
+                enteredAmount: $viewModel.enteredAmount,
+                subtitle: .balanceWithLimit(maxLimit),
+                actionEnabled: { _ in viewModel.canSend },
+                currencySelectionAction: { isShowingCurrencySelection.toggle() }
+            ) {
+                SwipeControl(text: "Swipe to Send") {
+                    switch await viewModel.sendAction() {
+                    case .success:
+                        break
+                    case .recipientNotFound:
+                        router.popTopmost()
+                        throw SendDismissed()
+                    case .failed:
+                        throw SendDismissed()
+                    }
+                } completion: {
+                    try await Task.delay(seconds: 1)
+                    router.popTopmost()
                 }
-            case .succeeded(let amount):
-                SendSuccessView(
-                    amount: amount,
-                    recipientDisplayName: viewModel.recipientDisplayName
-                )
+            }
+            .foregroundStyle(.textMain)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 20)
+            .padding(.top, -40)
+            .sheet(isPresented: $isShowingCurrencySelection) {
+                CurrencySelectionScreen(ratesController: ratesController)
             }
         }
         .ignoresSafeArea(.keyboard)
@@ -95,12 +95,6 @@ struct SendAmountScreen: View {
             guard let mint else { return }
             viewModel.depositMint = nil
             router.push(.currencyInfoForDeposit(mint))
-        }
-        .task(id: viewModel.state) {
-            guard case .succeeded = viewModel.state else { return }
-            try? await Task.sleep(for: .seconds(2.5))
-            guard !Task.isCancelled else { return }
-            router.dismissSheet()
         }
         .sheet(isPresented: $isShowingTokenSelection) {
             SelectCurrencyScreen(isPresented: $isShowingTokenSelection) { balance in
@@ -131,35 +125,5 @@ private struct TokenSelectorButton: View {
                     .foregroundStyle(.textMain)
             }
         }
-    }
-}
-
-// MARK: - Success view -
-
-private struct SendSuccessView: View {
-
-    let amount: ExchangedFiat
-    let recipientDisplayName: String?
-
-    var body: some View {
-        VStack(spacing: 16) {
-            Image.system(.circleCheck)
-                .font(.default(size: 64, weight: .regular))
-                .foregroundStyle(.textMain)
-
-            VStack(spacing: 8) {
-                Text("Sent \(amount.nativeAmount.formatted())")
-                    .font(.appDisplaySmall)
-                    .foregroundStyle(.textMain)
-                    .multilineTextAlignment(.center)
-
-                if let recipientDisplayName {
-                    Text("to \(recipientDisplayName)")
-                        .font(.appTextMedium)
-                        .foregroundStyle(.textSecondary)
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -12,23 +12,16 @@ private let logger = Logger(label: "flipcash.send-amount")
 @Observable
 final class SendAmountViewModel {
 
-    enum State: Equatable {
-        case ready
-        case submitting
-        case succeeded(amount: ExchangedFiat)
-    }
-
-    /// What the screen should do after a send attempt. Success (auto-dismisses
-    /// via `state`) and errors (`session.dialogItem`) are surfaced internally;
-    /// only `.recipientNotFound` requires the screen to navigate.
+    /// Result of a send attempt. `.success` and `.recipientNotFound` both return
+    /// the screen to the contact list; `.failed` keeps it on amount entry. Error
+    /// copy is surfaced internally via `session.dialogItem`.
     enum SendOutcome: Equatable {
-        case stay
+        case success
         case recipientNotFound
+        case failed
     }
 
     var enteredAmount: String = ""
-    var actionState: ButtonState = .normal
-    var state: State = .ready
 
     var depositMint: PublicKey?
 
@@ -43,8 +36,6 @@ final class SendAmountViewModel {
     /// Cached after the first successful resolve so a retried send (e.g. after a
     /// transient send failure) skips the round-trip.
     private var resolvedRecipient: PublicKey?
-
-    var recipientDisplayName: String? { contact.displayName }
 
     /// Amount validity only — never gated on the recipient. A red subtitle in
     /// `EnterAmountView` (driven by `!canSend`) therefore means over-limit, not
@@ -142,12 +133,11 @@ final class SendAmountViewModel {
     // MARK: - Action -
 
     /// Validates the amount locally, resolves the recipient on the Send tap
-    /// (retrying a transient network failure), then submits. Returns what the
-    /// screen should do next — only `.recipientNotFound` requires navigation.
+    /// (retrying a transient network failure), then submits. The control owns
+    /// the loading/checkmark state; this returns only where to go next.
     @discardableResult
     func sendAction() async -> SendOutcome {
-        guard case .ready = state else { return .stay }
-        guard let exchangedFiat = enteredFiat else { return .stay }
+        guard let exchangedFiat = enteredFiat else { return .failed }
 
         switch session.hasSufficientFunds(for: exchangedFiat) {
         case .insufficient(let shortfall):
@@ -156,36 +146,27 @@ final class SendAmountViewModel {
             } else {
                 showInsufficientBalanceError()
             }
-            return .stay
+            return .failed
 
         case .sufficient:
-            state = .submitting
-            actionState = .loading
-
             let recipient: PublicKey
             switch await resolveRecipient() {
             case .resolved(let owner):
                 recipient = owner
             case .notFound:
-                state = .ready
-                actionState = .normal
                 showRecipientNotFoundError()
                 return .recipientNotFound
             case .failed:
-                state = .ready
-                actionState = .normal
                 showResolveFailedError()
-                return .stay
+                return .failed
             }
 
             guard let (amountToSend, pinnedState) = await prepareSubmission() else {
-                state = .ready
-                actionState = .normal
                 session.dialogItem = .error(
                     title: "Rate Unavailable",
                     subtitle: "Couldn't get a fresh rate. Please try again."
                 )
-                return .stay
+                return .failed
             }
 
             let sendLimit = session.sendLimitFor(currency: amountToSend.nativeAmount.currency) ?? .zero
@@ -195,10 +176,8 @@ final class SendAmountViewModel {
                     "next_tx": "\(sendLimit.nextTransaction.value)",
                     "currency": "\(amountToSend.nativeAmount.currency)",
                 ])
-                state = .ready
-                actionState = .normal
                 showLimitsError()
-                return .stay
+                return .failed
             }
 
             do {
@@ -208,14 +187,12 @@ final class SendAmountViewModel {
                     to: recipient
                 )
                 Analytics.track(event: Analytics.SendEvent.sendSuccess)
-                state = .succeeded(amount: amountToSend)
+                return .success
             } catch {
                 Analytics.track(event: Analytics.SendEvent.sendFailure)
-                state = .ready
-                actionState = .normal
                 showSendError()
+                return .failed
             }
-            return .stay
         }
     }
 

--- a/Flipcash/UI/EnterAmountView.swift
+++ b/Flipcash/UI/EnterAmountView.swift
@@ -22,6 +22,7 @@ public struct EnterAmountView: View {
     private let actionEnabled: (String) -> Bool
     private let action: () -> Void
     private let currencySelectionAction: (() -> Void)?
+    private let actionOverride: AnyView?
     
     // MARK: - Calculator -
     
@@ -51,6 +52,28 @@ public struct EnterAmountView: View {
         self.actionEnabled           = actionEnabled
         self.action                  = action
         self.currencySelectionAction = currencySelectionAction
+        self.actionOverride          = nil
+    }
+
+    /// Variant where the caller supplies the bottom action control (e.g.
+    /// `SwipeControl`) instead of the default `CodeButton`. The control inherits
+    /// the same disabled gating via `actionEnabled`.
+    init<ActionContent: View>(
+        mode: Mode,
+        enteredAmount: Binding<String>,
+        subtitle: Subtitle,
+        actionEnabled: @escaping (String) -> Bool,
+        currencySelectionAction: (() -> Void)? = nil,
+        @ViewBuilder actionContent: () -> ActionContent
+    ) {
+        self.mode                    = mode
+        self.subtitle                = subtitle
+        self._enteredAmount          = enteredAmount
+        self._actionState            = .constant(.normal)
+        self.actionEnabled           = actionEnabled
+        self.action                  = {}
+        self.currencySelectionAction = currencySelectionAction
+        self.actionOverride          = AnyView(actionContent())
     }
     
     // MARK: - Computed -
@@ -126,14 +149,20 @@ public struct EnterAmountView: View {
             )
             .padding([.leading, .trailing], -20)
             
-            CodeButton(
-                state: actionState,
-                style: mode.buttonStyle,
-                title: mode.actionName,
-                disabled: !actionEnabled(enteredAmount),
-                action: action
-            )
-            .padding(.top, 10)
+            if let actionOverride {
+                actionOverride
+                    .disabled(!actionEnabled(enteredAmount))
+                    .padding(.top, 10)
+            } else {
+                CodeButton(
+                    state: actionState,
+                    style: mode.buttonStyle,
+                    title: mode.actionName,
+                    disabled: !actionEnabled(enteredAmount),
+                    action: action
+                )
+                .padding(.top, 10)
+            }
         }
     }
 }

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -85,14 +85,6 @@ struct SendAmountViewModelTests {
         return container
     }
 
-    // MARK: - Display
-
-    @Test("Display name is taken from the contact")
-    func init_exposesContactDisplayName() {
-        let viewModel = Self.createViewModel(displayName: "Alice Anderson")
-        #expect(viewModel.recipientDisplayName == "Alice Anderson")
-    }
-
     // MARK: - canSend
 
     @Test("canSend is false when no amount is entered")
@@ -175,9 +167,8 @@ struct SendAmountViewModelTests {
 
         let outcome = await viewModel.sendAction()
 
-        #expect(outcome == .stay)
+        #expect(outcome == .failed)
         #expect(sender.sendCalls.isEmpty)
-        #expect(viewModel.state == .ready)
     }
 
     @Test("sendAction with insufficient funds surfaces a dialog and resolves nothing")
@@ -196,7 +187,7 @@ struct SendAmountViewModelTests {
 
         let outcome = await viewModel.sendAction()
 
-        #expect(outcome == .stay)
+        #expect(outcome == .failed)
         // Sufficiency is checked first, so a short balance never hits the network.
         #expect(mock.resolveContactCalls.isEmpty)
         #expect(mock.sendCalls.isEmpty)
@@ -222,7 +213,6 @@ struct SendAmountViewModelTests {
         #expect(outcome == .recipientNotFound)
         #expect(mock.sendCalls.isEmpty)
         #expect(container.session.dialogItem?.title == "Not on Flipcash")
-        #expect(viewModel.state == .ready)
     }
 
     @Test("sendAction with a resolve network failure stays put, retries once, surfaces a dialog, does not send")
@@ -241,11 +231,10 @@ struct SendAmountViewModelTests {
 
         let outcome = await viewModel.sendAction()
 
-        #expect(outcome == .stay)
+        #expect(outcome == .failed)
         #expect(mock.resolveContactCalls.count == 2)  // initial attempt + one retry
         #expect(mock.sendCalls.isEmpty)
         #expect(container.session.dialogItem?.title == "Couldn't Send")
-        #expect(viewModel.state == .ready)
     }
 
     @Test("sendAction retries a transient resolve failure once, then proceeds past the resolve")
@@ -272,11 +261,10 @@ struct SendAmountViewModelTests {
         // Resolved on the retry, then prepareSubmission finds no pinned state in
         // tests → the "Rate Unavailable" dialog (not "Couldn't Send") proves the
         // resolve cleared and the flow proceeded past it.
-        #expect(outcome == .stay)
+        #expect(outcome == .failed)
         #expect(mock.resolveContactCalls.count == 2)
         #expect(mock.sendCalls.isEmpty)
         #expect(container.session.dialogItem?.title == "Rate Unavailable")
-        #expect(viewModel.state == .ready)
     }
 
     @Test("sendAction caches the resolved recipient so a retried send doesn't re-resolve")
@@ -296,11 +284,9 @@ struct SendAmountViewModelTests {
         await viewModel.sendAction()               // resolves (call #1), then rate-unavailable
         let second = await viewModel.sendAction()  // re-enters; reuses the cached recipient
 
-        // The second call ran the full flow (re-entered past the .ready guard,
-        // .stay outcome) yet the resolve count stayed at 1 — the cache, not an
-        // early bail, suppressed re-resolution.
-        #expect(second == .stay)
-        #expect(viewModel.state == .ready)
+        // The second call ran the full flow yet the resolve count stayed at 1 —
+        // the cache, not an early bail, suppressed re-resolution.
+        #expect(second == .failed)
         #expect(mock.resolveContactCalls.count == 1)
     }
 
@@ -321,9 +307,8 @@ struct SendAmountViewModelTests {
         let outcome = await viewModel.sendAction()
 
         // Pinned VerifiedState is absent in tests → rate-unavailable branch.
-        #expect(outcome == .stay)
+        #expect(outcome == .failed)
         #expect(mock.sendCalls.isEmpty)
         #expect(container.session.dialogItem?.title == "Rate Unavailable")
-        #expect(viewModel.state == .ready)
     }
 }

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -5,11 +5,11 @@
 
 import Foundation
 import Testing
-import FlipcashCore
+@testable import FlipcashCore
 @testable import Flipcash
 
 @MainActor
-@Suite
+@Suite("SendAmountViewModel")
 struct SendAmountViewModelTests {
 
     // MARK: - Helpers
@@ -82,6 +82,34 @@ struct SendAmountViewModelTests {
             .init(mint: .usdf, quarks: 100_000_000), // $100 USDF
         ])
         container.ratesController.configureTestRates(rates: [.oneToOne])
+        return container
+    }
+
+    /// Funded USDF container with a pinned fresh USD verified state and send
+    /// limits — everything `sendAction` needs to clear the pin and limit gates
+    /// and reach an actual `sender.send`. (`makeFundedContainer` omits the pin
+    /// so its tests exercise the rate-unavailable branch.)
+    static func makeReadyToSendContainer(sendLimitUSD: Decimal = 1000) async throws -> SessionContainer {
+        let limit = FiatAmount(value: sendLimitUSD, currency: .usd)
+        let container = try SessionContainer.makeTest(
+            holdings: [.init(mint: .usdf, quarks: 100_000_000)], // $100 USDF
+            limits: Limits(
+                sinceDate: .now,
+                fetchDate: .now,
+                sendLimits: [.usd: SendLimit(
+                    nextTransaction: limit,
+                    maxPerTransaction: limit,
+                    maxPerDay: limit
+                )]
+            )
+        )
+        container.ratesController.configureTestRates(
+            balanceCurrency: .usd,
+            rates: [Rate(fx: 1.0, currency: .usd)]
+        )
+        await container.ratesController.verifiedProtoService.saveRates([
+            .freshRate(currencyCode: "USD", rate: 1.0)
+        ])
         return container
     }
 
@@ -169,6 +197,7 @@ struct SendAmountViewModelTests {
 
         #expect(outcome == .failed)
         #expect(sender.sendCalls.isEmpty)
+        #expect(viewModel.session.dialogItem == nil)  // silent no-op: no dialog
     }
 
     @Test("sendAction with insufficient funds surfaces a dialog and resolves nothing")
@@ -191,7 +220,8 @@ struct SendAmountViewModelTests {
         // Sufficiency is checked first, so a short balance never hits the network.
         #expect(mock.resolveContactCalls.isEmpty)
         #expect(mock.sendCalls.isEmpty)
-        #expect(viewModel.session.dialogItem != nil)
+        let title = viewModel.session.dialogItem?.title
+        #expect(title == "You Need More Cash" || title?.contains("Short") == true)
     }
 
     @Test("sendAction with a NOT_FOUND recipient returns .recipientNotFound, surfaces a dialog, does not send")
@@ -237,9 +267,9 @@ struct SendAmountViewModelTests {
         #expect(container.session.dialogItem?.title == "Couldn't Send")
     }
 
-    @Test("sendAction retries a transient resolve failure once, then proceeds past the resolve")
-    func sendAction_resolveRetriesThenSucceeds_proceedsPastResolve() async throws {
-        let container = try Self.makeFundedContainer()
+    @Test("sendAction retries a transient resolve failure once, then sends successfully")
+    func sendAction_resolveRetriesThenSucceeds_sends() async throws {
+        let container = try await Self.makeReadyToSendContainer()
         let mock = MockSession()
         var attempts = 0
         mock.resolveContactHandler = { _ in
@@ -247,6 +277,7 @@ struct SendAmountViewModelTests {
             if attempts == 1 { throw ErrorResolve.networkError }
             return Self.recipient
         }
+        mock.sendHandler = { _, _, _ in }
         let viewModel = SendAmountViewModel(
             sessionContainer: container,
             contact: Self.makeContact(),
@@ -258,13 +289,11 @@ struct SendAmountViewModelTests {
 
         let outcome = await viewModel.sendAction()
 
-        // Resolved on the retry, then prepareSubmission finds no pinned state in
-        // tests → the "Rate Unavailable" dialog (not "Couldn't Send") proves the
-        // resolve cleared and the flow proceeded past it.
-        #expect(outcome == .failed)
+        // First resolve attempt throws networkError; the retry resolves and the
+        // send completes end-to-end — proving the flow proceeds past the resolve.
+        #expect(outcome == .success)
         #expect(mock.resolveContactCalls.count == 2)
-        #expect(mock.sendCalls.isEmpty)
-        #expect(container.session.dialogItem?.title == "Rate Unavailable")
+        #expect(mock.sendCalls.count == 1)
     }
 
     @Test("sendAction caches the resolved recipient so a retried send doesn't re-resolve")
@@ -310,5 +339,72 @@ struct SendAmountViewModelTests {
         #expect(outcome == .failed)
         #expect(mock.sendCalls.isEmpty)
         #expect(container.session.dialogItem?.title == "Rate Unavailable")
+    }
+
+    @Test("sendAction with a pinned rate, funds, and a resolved recipient sends and returns .success")
+    func sendAction_success_sendsAndReturnsSuccess() async throws {
+        let container = try await Self.makeReadyToSendContainer()
+        let mock = MockSession()
+        mock.resolveContactHandler = { _ in Self.recipient }
+        mock.sendHandler = { _, _, _ in }  // succeeds
+        let viewModel = SendAmountViewModel(
+            sessionContainer: container,
+            contact: Self.makeContact(),
+            mint: .usdf,
+            sender: mock,
+            resolver: mock
+        )
+        viewModel.enteredAmount = "5"
+
+        let outcome = await viewModel.sendAction()
+
+        #expect(outcome == .success)
+        #expect(mock.sendCalls.count == 1)
+        #expect(mock.sendCalls.first?.destination == Self.recipient)
+        #expect(container.session.dialogItem == nil)
+    }
+
+    @Test("sendAction returns .failed with a dialog when the send itself throws")
+    func sendAction_sendThrows_returnsFailed() async throws {
+        let container = try await Self.makeReadyToSendContainer()
+        let mock = MockSession()
+        mock.resolveContactHandler = { _ in Self.recipient }
+        mock.sendHandler = { _, _, _ in throw URLError(.timedOut) }
+        let viewModel = SendAmountViewModel(
+            sessionContainer: container,
+            contact: Self.makeContact(),
+            mint: .usdf,
+            sender: mock,
+            resolver: mock
+        )
+        viewModel.enteredAmount = "5"
+
+        let outcome = await viewModel.sendAction()
+
+        #expect(outcome == .failed)
+        #expect(mock.sendCalls.count == 1)  // the send was attempted
+        #expect(container.session.dialogItem?.title == "Couldn't Send")
+    }
+
+    @Test("sendAction over the send limit returns .failed with the limit dialog and never sends")
+    func sendAction_overSendLimit_returnsFailed() async throws {
+        let container = try await Self.makeReadyToSendContainer(sendLimitUSD: 1)
+        let mock = MockSession()
+        mock.resolveContactHandler = { _ in Self.recipient }
+        mock.sendHandler = { _, _, _ in }
+        let viewModel = SendAmountViewModel(
+            sessionContainer: container,
+            contact: Self.makeContact(),
+            mint: .usdf,
+            sender: mock,
+            resolver: mock
+        )
+        viewModel.enteredAmount = "5"  // exceeds the $1 limit
+
+        let outcome = await viewModel.sendAction()
+
+        #expect(outcome == .failed)
+        #expect(mock.sendCalls.isEmpty)  // the limit gate blocks before sending
+        #expect(container.session.dialogItem?.title == "Transaction Limit Reached")
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Views/Controls/SwipeControl.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Controls/SwipeControl.swift
@@ -1,0 +1,209 @@
+//
+//  SwipeControl.swift
+//  FlipcashUI
+//
+//  Created by Raul Riera.
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import SwiftUI
+import FlipcashCore
+
+/// A slide-to-confirm control. The user drags the knob along the track; once it
+/// passes the commit threshold the `action` runs, showing a loading indicator
+/// and then a success checkmark before the knob resets.
+///
+/// The knob commits when dragged past 70% of the track, or past 50% with a fast
+/// release velocity.
+///
+/// ```swift
+/// SwipeControl(text: "Swipe to Send") {
+///     try await session.send(amount)
+/// }
+/// ```
+public struct SwipeControl: View {
+
+    @Environment(\.displayScale) private var displayScale
+    @Environment(\.isEnabled) private var isEnabled
+
+    @State private var knobX: CGFloat = 0
+    @State private var state: KnobState = .normal
+
+    private let text: String
+    private let action: ThrowingAction
+    private let completion: ThrowingAction?
+
+    public init(text: String, action: @escaping ThrowingAction, completion: ThrowingAction? = nil) {
+        self.text = text
+        self.action = action
+        self.completion = completion
+    }
+
+    public var body: some View {
+        ZStack {
+            Text(text)
+                .lineLimit(1)
+                .font(.appTextMedium)
+                .foregroundStyle(.textMain)
+                .padding(.horizontal, Layout.knobSize.width)
+                .opacity(state == .normal ? 1 : 0)
+
+            GeometryReader { geometry in
+                let maxX = geometry.size.width - Layout.knobSize.width
+
+                Knob(maxX: maxX, knobX: knobX, isIdle: state == .normal) {
+                    Task {
+                        state = .loading
+                        knobX = maxX + Layout.knobSize.width * 2
+                        do {
+                            try await action()
+                            state = .success
+                            try await completion?()
+                            try await Task.delay(seconds: 2)
+                        } catch {}
+                        state = .normal
+                        knobX = 0
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal, 4)
+        .frame(height: Layout.height)
+        .background(.action.opacity(0.1), in: RoundedRectangle(cornerRadius: Metrics.buttonRadius))
+        .compositingGroup()
+        .clipShape(.rect(cornerRadius: Metrics.buttonRadius))
+        .overlay {
+            ZStack {
+                RoundedRectangle(cornerRadius: Metrics.buttonRadius)
+                    .stroke(.textSecondary.opacity(0.3), lineWidth: 1 / displayScale)
+
+                switch state {
+                case .normal:
+                    EmptyView()
+                case .loading:
+                    LoadingView(color: .gray, style: .medium)
+                case .success:
+                    Image.asset(.checkmarkLarge)
+                        .renderingMode(.template)
+                        .foregroundStyle(.textSuccess)
+                }
+            }
+            .animation(nil, value: state)
+        }
+        .opacity(isEnabled ? 1 : Layout.disabledOpacity)
+        .accessibilityRepresentation {
+            Button(text) {
+                Task {
+                    do {
+                        try await action()
+                        try await completion?()
+                    } catch {}
+                }
+            }
+        }
+    }
+}
+
+/// The draggable knob. Owns the high-frequency drag and idle-nudge state so a
+/// drag or nudge re-renders only the knob, not the whole control.
+private struct Knob: View {
+
+    let maxX: CGFloat
+    let knobX: CGFloat
+    let isIdle: Bool
+    let onCommit: () -> Void
+
+    @Environment(\.isEnabled) private var isEnabled
+
+    @GestureState private var dragOffset: CGFloat? = nil
+    @State private var isNudging = false
+
+    var body: some View {
+        let nudgeX: CGFloat = (isIdle && isEnabled && dragOffset == nil && isNudging) ? Layout.nudgeOffset : 0
+
+        RoundedRectangle(cornerRadius: Layout.knobCornerRadius)
+            .fill(.action)
+            .frame(width: Layout.knobSize.width, height: Layout.knobSize.height)
+            .overlay {
+                Image.system(.arrowRight)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: Layout.arrowSize, height: Layout.arrowSize)
+                    .foregroundStyle(.textAction)
+            }
+            .offset(x: knobX + (dragOffset ?? 0) + nudgeX)
+            .animation(.springFastestDamped, value: dragOffset)
+            .animation(.springFastestDamped, value: knobX)
+            .animation(.springFastestDamped, value: isNudging)
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .updating($dragOffset) { value, dragState, transaction in
+                        transaction.disablesAnimations = true
+                        dragState = min(max(value.translation.width, 0), maxX)
+                    }
+                    .onEnded { value in
+                        let offset = min(max(value.translation.width, 0), maxX)
+                        let velocity = value.predictedEndLocation.x - value.location.x
+                        let percent = maxX > 0 ? offset / maxX : 0
+                        guard percent > Layout.commitFraction
+                            || (percent > Layout.velocityAssistFraction && velocity > Layout.velocityAssistMinimum)
+                        else { return }
+                        onCommit()
+                    }
+            )
+            .disabled(!isIdle)
+            .task {
+                do {
+                    try await Task.delay(seconds: 3)
+                    while true {
+                        isNudging = true
+                        try await Task.delay(milliseconds: 150)
+                        isNudging = false
+                        try await Task.delay(seconds: 4)
+                    }
+                } catch {
+                    isNudging = false
+                }
+            }
+    }
+}
+
+private enum Layout {
+    static let height: CGFloat = Metrics.buttonHeight
+    static let knobSize = CGSize(width: 60, height: 52)
+    static let knobCornerRadius: CGFloat = 4
+    static let arrowSize: CGFloat = 18
+    static let nudgeOffset: CGFloat = 20
+    static let disabledOpacity: CGFloat = 0.4
+
+    static let commitFraction: CGFloat = 0.7
+    static let velocityAssistFraction: CGFloat = 0.5
+    static let velocityAssistMinimum: CGFloat = 200
+}
+
+private enum KnobState {
+    case normal
+    case loading
+    case success
+}
+
+#Preview {
+    Background(color: .backgroundMain) {
+        VStack(spacing: 40) {
+            SwipeControl(text: "Swipe to Send") {
+                try await Task.delay(seconds: 2)
+            }
+
+            SwipeControl(text: "Swipe to Pay") {
+                try await Task.delay(seconds: 1)
+            }
+
+            SwipeControl(text: "Swipe to Send") {
+                try await Task.delay(seconds: 1)
+            }
+            .disabled(true)
+        }
+        .padding(20)
+    }
+}


### PR DESCRIPTION
Restores the slide-to-confirm "Swipe to Send" control and uses it as the action on the Send amount screen in place of the tap button. The temporary success screen is removed — the control's loading and checkmark states are now the feedback, and after a successful send (or when the recipient isn't on Flipcash) the screen returns to the contact list, while failures keep you on the amount screen with the existing error message. The control is disabled and greyed out until a valid amount is entered.

## Test plan
- [x] Swiping with a valid amount sends, shows the checkmark, then returns to the contact list
- [x] A failed send keeps you on the amount screen with the knob reset and an error message
- [x] Sending to someone not on Flipcash returns to the contact list with an explanation
- [x] An empty or invalid amount leaves the control greyed out and unswipeable