### PR TITLE
feat: one-time dialog when first contact scan finds friends on Flipcash

### DIFF
--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -41,6 +41,13 @@ final class ContactSyncController {
     /// "we ran a load and found nothing".
     private(set) var hasResolvedOnce: Bool = false
 
+    /// Set once, during the user's first contact scan, to the number of the
+    /// user's contacts the server matched. `SendRootScreen` forwards it to
+    /// `session.dialogItem` — surfaced above the Send sheet by `DialogWindow` —
+    /// then clears it. Gated on the first sync (no prior checksum) so it never
+    /// re-fires on later syncs or screen opens.
+    var onFlipcashMatchCount: Int?
+
     nonisolated private var ownerKeyPair: KeyPair {
         owner.authority.keyPair
     }
@@ -178,6 +185,9 @@ final class ContactSyncController {
     /// preserved when called through the production `runSync` path.
     internal nonisolated func performSync(contacts: [Database.LocalContact]) async throws {
         let storedState = try database.contactSyncState()
+        // No prior checksum means this is the user's first scan — the only time
+        // the "already on Flipcash" dialog is allowed to fire.
+        let isFirstScan = storedState.checksum == nil
         // The snapshot stores every `(e164, contactId)` pair so the picker
         // can show each contact with each of their phone numbers. Upload
         // + checksum operate on the unique e164 set — the server doesn't
@@ -255,6 +265,10 @@ final class ContactSyncController {
         )
 
         await resolveDirectory()
+
+        if isFirstScan, let matched = try? database.flipcashContacts(), !matched.isEmpty {
+            await MainActor.run { self.onFlipcashMatchCount = matched.count }
+        }
     }
 
     /// Re-pulls the server's matched set and re-resolves the picker without

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -64,6 +64,15 @@ struct SendRootScreen: View {
         .sheet(item: $phoneVerificationViewModel.cancellingOnDismiss()) { viewModel in
             PhoneVerificationFlowScreen(viewModel: viewModel)
         }
+        // Surface the first-scan dialog through `session.dialogItem` so
+        // `DialogWindow` shows it above the Send sheet rather than competing
+        // with this screen's sheet stack. The controller signals once; clear it
+        // after forwarding so it never re-presents.
+        .onChange(of: contactSyncController.onFlipcashMatchCount, initial: true) { _, count in
+            guard let count else { return }
+            session.dialogItem = .contactsOnFlipcash(count: count)
+            contactSyncController.onFlipcashMatchCount = nil
+        }
     }
 
     // MARK: - Step -

--- a/Flipcash/UI/DialogItem+CashFlows.swift
+++ b/Flipcash/UI/DialogItem+CashFlows.swift
@@ -20,6 +20,16 @@ extension DialogItem {
         )
     }
 
+    /// First-scan nudge surfaced once when a user's initial contact sync finds
+    /// people they already know on Flipcash. `count` is the number of their
+    /// contacts the server matched.
+    static func contactsOnFlipcash(count: Int) -> DialogItem {
+        .info(
+            title: "\(count) \(count == 1 ? "Contact" : "Contacts") Already On Flipcash",
+            subtitle: "Send them money, or invite other contacts to sign up for Flipcash"
+        )
+    }
+
     /// Nudges the user to discover currencies when they attempt to Give
     /// with no balance.
     static func noGiveableBalance(onDiscover: @escaping () -> Void) -> DialogItem {

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -701,6 +701,54 @@ struct ContactSyncControllerTests {
             #expect(mock.deltaCalls.isEmpty)
             #expect(mock.fullCalls.isEmpty)
         }
+
+        // MARK: First-scan "already on Flipcash" signal
+
+        @Test("First scan signals how many contacts the server matched")
+        func firstScan_withMatches_signalsCount() async throws {
+            let mock = MockContactSync()
+            mock.streamYields = [Self.bobContact.e164, Self.carolContact.e164]
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            try await controller.performSync(contacts: [Self.aliceContact, Self.bobContact, Self.carolContact])
+
+            #expect(controller.onFlipcashMatchCount == 2)
+        }
+
+        @Test("First scan with no matches signals nothing")
+        func firstScan_noMatches_signalsNothing() async throws {
+            let mock = MockContactSync()
+            mock.streamYields = []
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            try await controller.performSync(contacts: [Self.aliceContact])
+
+            #expect(controller.onFlipcashMatchCount == nil)
+        }
+
+        @Test("A later sync never re-signals")
+        func laterSync_doesNotReSignal() async throws {
+            let mock = MockContactSync()
+            mock.streamYields = [Self.bobContact.e164]
+            let database = Database.mock
+            let controller = Self.makeController(mock: mock, database: database)
+
+            let contacts = [Self.aliceContact, Self.bobContact]
+            try await controller.performSync(contacts: contacts)
+            #expect(controller.onFlipcashMatchCount == 1)
+
+            // The forward consumes the signal.
+            controller.onFlipcashMatchCount = nil
+
+            // A second sync of the same set probes the server and refreshes the
+            // matched set, but the stored checksum now exists — so it must stay nil.
+            mock.checkSyncResult = .success(.ok)
+            try await controller.performSync(contacts: contacts)
+
+            #expect(controller.onFlipcashMatchCount == nil)
+        }
     }
 
     // MARK: - Clear on revoke

--- a/FlipcashTests/DialogItemFactoryTests.swift
+++ b/FlipcashTests/DialogItemFactoryTests.swift
@@ -6,6 +6,7 @@
 import Foundation
 import Testing
 import FlipcashUI
+@testable import Flipcash
 
 @MainActor
 @Suite("DialogItem factory semantics")
@@ -65,5 +66,18 @@ struct DialogItemFactoryTests {
 
         let dismissableSuccess = DialogItem.success(title: "x", subtitle: "y", dismissable: true)
         #expect(dismissableSuccess.dismissable == true)
+    }
+
+    @Test(
+        ".contactsOnFlipcash pluralizes Contact/Contacts by count",
+        arguments: [
+            (1, "1 Contact Already On Flipcash"),
+            (2, "2 Contacts Already On Flipcash"),
+        ]
+    )
+    func contactsOnFlipcash_pluralizesTitle(count: Int, expectedTitle: String) {
+        let item = DialogItem.contactsOnFlipcash(count: count)
+        #expect(item.title == expectedTitle)
+        #expect(item.style == .standard)
     }
 }


### PR DESCRIPTION
The first time someone syncs their contacts and we find people they already know on Flipcash, a one-time dialog nudges them to send cash or invite others. It shows once per account and never again on later opens or syncs. It is surfaced above the Send sheet so it can't collide with the screen's own sheets.

## Test plan
- [ ] Grant contacts access for the first time with friends already on Flipcash and confirm the dialog appears once.
- [ ] Reopen Send and confirm it does not appear again.
- [ ] Sync with no matched contacts and confirm no dialog appears.
- [ ] Confirm the title reads "1 Contact" for one match and "N Contacts" for several.