### PR TITLE
fix: stop "No Contacts Found" flash on first contacts grant

### DIFF
--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -35,11 +35,17 @@ final class ContactSyncController {
     /// successful sync; consumers observe it and re-render on changes.
     private(set) var resolvedContacts: ResolvedContacts = .empty
 
-    /// Flips to `true` after the first directory resolution completes —
-    /// regardless of whether `resolvedContacts` ends up empty. The picker
-    /// gate uses this to distinguish "loading for the first time" from
-    /// "we ran a load and found nothing".
+    /// `true` once the first sync attempt has settled the directory — success
+    /// or failure — and never resets. Distinguishes "the first sync is still
+    /// in flight" from "a sync settled and found nothing".
     private(set) var hasResolvedOnce: Bool = false
+
+    /// `true` when the picker has something definitive to show: contacts are
+    /// present, or the first sync has settled so an empty result is
+    /// authoritative (not merely "not loaded yet").
+    var isDirectoryReady: Bool {
+        hasResolvedOnce || !resolvedContacts.isEmpty
+    }
 
     /// Set once, during the user's first contact scan, to the number of the
     /// user's contacts the server matched. `SendRootScreen` forwards it to
@@ -100,8 +106,8 @@ final class ContactSyncController {
                 }
             }
         }
-        // Render the picker from the persisted directory before the network
-        // sync; an offline launch would otherwise spin until a sync succeeds.
+        // Surface cached contacts before the network sync so an offline relaunch
+        // renders immediately instead of spinning.
         if !hasResolvedOnce {
             Task { [weak self] in await self?.resolveDirectory() }
         }
@@ -147,6 +153,11 @@ final class ContactSyncController {
                 guard let self else { return }
                 self.isSyncing = false
                 self.syncTask = nil
+                // A finished attempt — success or failure — is a definitive
+                // result. Mark resolved so the picker leaves its loading state
+                // even when nothing matched or the sync failed, rather than
+                // spinning forever.
+                self.hasResolvedOnce = true
                 if self.needsResync {
                     self.needsResync = false
                     self.sync()
@@ -296,7 +307,6 @@ final class ContactSyncController {
         let resolved = await RecipientLoader.load(database: database)
         await MainActor.run {
             self.resolvedContacts = resolved
-            self.hasResolvedOnce  = true
         }
     }
 

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -94,7 +94,7 @@ struct SendRootScreen: View {
         guard contactsAuthorizer.status.allowsContactAccess else {
             return .needsContacts
         }
-        return contactSyncController.hasResolvedOnce ? .ready : .loading
+        return contactSyncController.isDirectoryReady ? .ready : .loading
     }
 
     // MARK: - Phone verification handoff -

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -355,6 +355,16 @@ struct ContactSyncControllerTests {
             #expect(controller.hasResolvedOnce)
         }
 
+        @Test("Pre-network resolve on an empty DB leaves the picker not-ready — first grant keeps loading instead of flashing the empty state")
+        func emptyCacheResolve_leavesPickerNotReady() async {
+            let controller = Self.makeController()
+
+            await controller.resolveDirectory()
+
+            #expect(!controller.hasResolvedOnce)
+            #expect(!controller.isDirectoryReady)
+        }
+
         @Test("didBecomeActive() is a no-op before activate()")
         func didBecomeActiveNoOpBeforeActivate() async {
             let counter = AuthCounter()
@@ -523,7 +533,6 @@ struct ContactSyncControllerTests {
             #expect(mock.fullCalls.isEmpty)
             #expect(mock.deltaCalls.isEmpty)
             #expect(Set(try database.flipcashContacts()) == [Self.bobContact.e164])
-            #expect(controller.hasResolvedOnce)
         }
 
         @Test("refreshMatchedSet is a no-op without a prior sync")


### PR DESCRIPTION
After granting contacts access for the first time, the Send recipient picker briefly flashed "No Contacts Found" for about a second before the matched list appeared. The picker was advancing as soon as the empty local cache was read, rather than waiting for the first sync to finish. It now stays on the loading spinner until the first sync completes — so the empty state only shows when there genuinely are no contacts — while still rendering cached contacts instantly on relaunch.

## Test plan
- [ ] Grant contacts access for the first time and confirm a spinner shows (no brief "No Contacts Found") before your contacts appear.
- [ ] With no matchable contacts, confirm "No Contacts Found" still appears once the sync finishes.
- [ ] Relaunch the app and confirm previously-synced contacts appear immediately.