### PR TITLE
refactor: lean out contact-sync and fix shared-number picker

### DIFF
--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -67,7 +67,7 @@ nonisolated private extension ResolvedContact {
 /// the controller's cached output rather than re-loading on every appear.
 enum RecipientLoader {
 
-    /// One placement per snapshot row. The snapshot now uses a composite
+    /// One placement per snapshot row. The snapshot uses a composite
     /// `(e164, contactId)` PK, so each pair survives — multiple phones on
     /// one contact, or one phone shared across multiple contacts, all
     /// come through here.
@@ -99,7 +99,7 @@ enum RecipientLoader {
     /// same row. On a collision, prefer the variant whose e164 is on
     /// Flipcash so the resulting row is the actionable one.
     ///
-    /// Result preserves first-seen order, mirroring ``placements``.
+    /// Result preserves first-seen order.
     nonisolated static func deduplicatedForDisplay(
         _ contacts: [ResolvedContact],
         flipcashSet: Set<String>,
@@ -190,8 +190,8 @@ enum RecipientLoader {
                 ))
             }
 
-            // Collapse `(displayName, nationalPhone)` collisions — Ted's
-            // invariant: don't ever show the same name + number twice.
+            // Collapse `(displayName, nationalPhone)` collisions so the same
+            // display name + national number is never shown twice.
             let unique = deduplicatedForDisplay(resolvedByPlacement, flipcashSet: flipcashSet)
 
             var onFlipcash: [ResolvedContact] = []

--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -92,42 +92,53 @@ enum RecipientLoader {
         }
     }
 
-    /// Collapse contacts that look identical to the user — same display
-    /// name and same nationally-formatted phone number — to a single
-    /// row. Different underlying e164s that format to the same national
-    /// string (extension trailers, formatting variants) count as the
-    /// same row. On a collision, prefer the variant whose e164 is on
-    /// Flipcash so the resulting row is the actionable one.
-    ///
-    /// Result preserves first-seen order.
+    /// One row per displayed phone number. A payment to a number reaches the
+    /// same recipient regardless of which contact it came from, so contacts
+    /// that share a nationally-formatted number — including extension/format
+    /// variants of one e164 — collapse to a single row. On a collision the
+    /// most useful label wins, in order: a real name beats a bare-number
+    /// fallback; then an on-Flipcash (sendable) e164 beats one that isn't;
+    /// then, between two different named contacts, the last-seen one wins;
+    /// otherwise the first-seen row stays.
     nonisolated static func deduplicatedForDisplay(
         _ contacts: [ResolvedContact],
         flipcashSet: Set<String>,
     ) -> [ResolvedContact] {
-        // Struct key (not a separator-joined string) — display names and
-        // phone formats can legitimately contain any character, and a
-        // joined-string key would collide when the separator appears in
-        // the data itself.
-        struct Key: Hashable {
-            let displayName: String
-            let nationalPhone: String
-        }
-        var byKey: [Key: ResolvedContact] = [:]
-        var orderedKeys: [Key] = []
+        var byNumber: [String: ResolvedContact] = [:]
+        var order: [String] = []
         for contact in contacts {
-            let key = Key(displayName: contact.displayName, nationalPhone: contact.nationalPhone)
-            if let existing = byKey[key] {
-                let existingMatched = flipcashSet.contains(existing.phoneE164)
-                let newMatched      = flipcashSet.contains(contact.phoneE164)
-                if !existingMatched, newMatched {
-                    byKey[key] = contact
-                }
-            } else {
-                byKey[key] = contact
-                orderedKeys.append(key)
+            let key = contact.nationalPhone
+            guard let existing = byNumber[key] else {
+                byNumber[key] = contact
+                order.append(key)
+                continue
+            }
+            if prefers(contact, over: existing, flipcashSet: flipcashSet) {
+                byNumber[key] = contact
             }
         }
-        return orderedKeys.compactMap { byKey[$0] }
+        return order.compactMap { byNumber[$0] }
+    }
+
+    /// Whether `candidate` is a better row than `existing` for the same number.
+    private nonisolated static func prefers(
+        _ candidate: ResolvedContact,
+        over existing: ResolvedContact,
+        flipcashSet: Set<String>,
+    ) -> Bool {
+        // A resolved contact with no name falls back to its own number as the
+        // display name; a real name is more useful than that bare number.
+        let candidateNamed = candidate.displayName != candidate.nationalPhone
+        let existingNamed   = existing.displayName != existing.nationalPhone
+        if candidateNamed != existingNamed { return candidateNamed }
+
+        let candidateMatched = flipcashSet.contains(candidate.phoneE164)
+        let existingMatched   = flipcashSet.contains(existing.phoneE164)
+        if candidateMatched != existingMatched { return candidateMatched }
+
+        // Two different named contacts on one number: the last-seen wins.
+        // Variants of the same contact keep the first/base e164.
+        return candidateNamed && candidate.contactId != existing.contactId
     }
 
     static func load(database: Database) async -> ResolvedContacts {

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -219,6 +219,11 @@ final class ContactSyncController {
                 // A contact may have joined without changing our checksum.
                 logger.info("Local set unchanged, server agrees — refreshing matched set")
                 try await refreshFlipcashContacts(checksum: storedChecksum)
+                // The checksum only covers unique phone numbers, so a contact
+                // added/renamed on a number we already had doesn't change it.
+                // Refresh the local snapshot from the current address book so
+                // the picker reflects the best name per number.
+                try database.replaceLocalContactsSnapshot(contacts)
                 await resolveDirectory()
                 return
             case .outOfSync:

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -268,11 +268,7 @@ final class ContactSyncController {
 
         try database.updateContactSyncSnapshotAndState(
             snapshot: contacts,
-            state: .init(
-                checksum:      newChecksum,
-                changeHistory: nil,
-                lastSyncedAt:  .now
-            )
+            state: .init(checksum: newChecksum)
         )
 
         await resolveDirectory()

--- a/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
+++ b/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
@@ -12,13 +12,11 @@ nonisolated extension Database {
     // MARK: - Sync State -
 
     /// The contact-sync state machine's persisted cursor.
-    /// `nil` fields indicate first-run state.
+    /// A `nil` checksum indicates first-run state.
     struct ContactSyncState: Equatable, Sendable {
         let checksum: Data?
-        let changeHistory: Data?
-        let lastSyncedAt: Date?
 
-        static let empty = ContactSyncState(checksum: nil, changeHistory: nil, lastSyncedAt: nil)
+        static let empty = ContactSyncState(checksum: nil)
     }
 
     func contactSyncState() throws -> ContactSyncState {
@@ -26,11 +24,7 @@ nonisolated extension Database {
         guard let row = try reader.pluck(table.table.filter(table.id == 1)) else {
             return .empty
         }
-        return ContactSyncState(
-            checksum: row[table.checksum],
-            changeHistory: row[table.changeHistory],
-            lastSyncedAt: row[table.lastSyncedAt]
-        )
+        return ContactSyncState(checksum: row[table.checksum])
     }
 
     func setContactSyncState(_ state: ContactSyncState) throws {
@@ -40,8 +34,6 @@ nonisolated extension Database {
                 table.table.upsert(
                     table.id <- 1,
                     table.checksum <- state.checksum,
-                    table.changeHistory <- state.changeHistory,
-                    table.lastSyncedAt <- state.lastSyncedAt,
                     onConflictOf: table.id
                 )
             )
@@ -95,24 +87,28 @@ nonisolated extension Database {
     }
 
     /// Replace the snapshot with the latest uploaded set.
-    /// Composite PK `(e164, contactId)` lets the same phone show up under
-    /// multiple address-book contacts (the picker shows each name with
-    /// that number). Dedupe defensively on the tuple in case the source
-    /// ever emits the same pair twice.
     func replaceLocalContactsSnapshot(_ contacts: [LocalContact]) throws {
+        try writer.transaction {
+            try rewriteLocalContactsSnapshot(contacts)
+        }
+    }
+
+    /// Dedupes on the full `(e164, contactId)` tuple — the composite PK that lets the
+    /// same phone appear under multiple address-book contacts (the picker shows each
+    /// name with that number) — then rewrites the snapshot table. Must be called
+    /// inside a `writer.transaction`.
+    private func rewriteLocalContactsSnapshot(_ contacts: [LocalContact]) throws {
         let table = LocalContactsSnapshotTable()
         var seen: Set<LocalContact> = []
         let deduped = contacts.filter { seen.insert($0).inserted }
-        try writer.transaction {
-            try writer.run(table.table.delete())
-            for contact in deduped {
-                try writer.run(
-                    table.table.insert(
-                        table.e164 <- contact.e164,
-                        table.contactId <- contact.contactId
-                    )
+        try writer.run(table.table.delete())
+        for contact in deduped {
+            try writer.run(
+                table.table.insert(
+                    table.e164 <- contact.e164,
+                    table.contactId <- contact.contactId
                 )
-            }
+            )
         }
     }
 
@@ -123,29 +119,13 @@ nonisolated extension Database {
         snapshot contacts: [LocalContact],
         state: ContactSyncState
     ) throws {
-        let snapshotTable = LocalContactsSnapshotTable()
-        let stateTable    = ContactSyncStateTable()
-
-        var seen: Set<String> = []
-        let dedupedSnapshot = contacts.filter { seen.insert($0.e164).inserted }
-
+        let stateTable = ContactSyncStateTable()
         try writer.transaction {
-            try writer.run(snapshotTable.table.delete())
-            for contact in dedupedSnapshot {
-                try writer.run(
-                    snapshotTable.table.insert(
-                        snapshotTable.e164 <- contact.e164,
-                        snapshotTable.contactId <- contact.contactId
-                    )
-                )
-            }
-
+            try rewriteLocalContactsSnapshot(contacts)
             try writer.run(
                 stateTable.table.upsert(
                     stateTable.id <- 1,
                     stateTable.checksum <- state.checksum,
-                    stateTable.changeHistory <- state.changeHistory,
-                    stateTable.lastSyncedAt <- state.lastSyncedAt,
                     onConflictOf: stateTable.id
                 )
             )

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -137,8 +137,6 @@ nonisolated struct ContactSyncStateTable: Sendable {
     let table         = Table(Self.name)
     let id            = Expression <Int>   ("id")
     let checksum      = Expression <Data?> ("checksum")
-    let changeHistory = Expression <Data?> ("changeHistory")
-    let lastSyncedAt  = Expression <Date?> ("lastSyncedAt")
 }
 
 // E.164 phones the server has confirmed are on Flipcash.
@@ -305,8 +303,6 @@ nonisolated extension Database {
             try writer.run(contactSyncStateTable.table.create(ifNotExists: true, withoutRowid: true) { t in
                 t.column(contactSyncStateTable.id, primaryKey: true)
                 t.column(contactSyncStateTable.checksum)
-                t.column(contactSyncStateTable.changeHistory)
-                t.column(contactSyncStateTable.lastSyncedAt)
             })
         }
 

--- a/Flipcash/Core/Screens/ContactsPermission/ContactsPermissionScreen.swift
+++ b/Flipcash/Core/Screens/ContactsPermission/ContactsPermissionScreen.swift
@@ -9,28 +9,12 @@ import FlipcashUI
 
 /// Priming view for the system contacts authorization prompt. The parent
 /// owns the ``ContactsAuthorizer`` so grants propagate via `@Observable`.
-/// Pass `onSkipped: nil` to hide the secondary "Not Now" button. Set
-/// `isAllowing` to `true` to swap the primary button label for a spinner
-/// — used by parents that need to keep the priming screen visible while
-/// an in-flight grant + downstream load resolves.
+/// Pass `onSkipped: nil` to hide the secondary "Not Now" button.
 struct ContactsPermissionScreen: View {
 
     let authorizer: ContactsAuthorizer
     let onAllowed: () -> Void
     let onSkipped: (() -> Void)?
-    let isAllowing: Bool
-
-    init(
-        authorizer: ContactsAuthorizer,
-        onAllowed: @escaping () -> Void,
-        onSkipped: (() -> Void)?,
-        isAllowing: Bool = false
-    ) {
-        self.authorizer = authorizer
-        self.onAllowed = onAllowed
-        self.onSkipped = onSkipped
-        self.isAllowing = isAllowing
-    }
 
     // MARK: - Body -
 
@@ -58,18 +42,12 @@ struct ContactsPermissionScreen: View {
 
                 Spacer()
 
-                Button(action: primaryAction) {
-                    Loadable(isLoading: isAllowing, color: .textAction) {
-                        Text(primaryTitle)
-                    }
-                }
-                .buttonStyle(.filled)
-                .disabled(isAllowing)
+                Button(primaryTitle, action: primaryAction)
+                    .buttonStyle(.filled)
 
                 if let onSkipped {
                     Button("Not Now", action: onSkipped)
                         .buttonStyle(.subtle)
-                        .disabled(isAllowing)
                 }
             }
             .padding(20)

--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -32,59 +32,12 @@ final class GiveViewModel {
     private(set) var selectedBalance: ExchangedBalance?
 
     private var enteredFiat: ExchangedFiat? {
-        guard !enteredAmount.isEmpty else {
-            return nil
-        }
-
-        guard let amount = Decimal(string: enteredAmount), amount > 0 else {
-            return nil
-        }
-
-        guard let selectedBalance else {
-            return nil
-        }
-
-        let mint = selectedBalance.stored.mint
-
-        // Only applies for bonded tokens
-        if mint != .usdf {
-            guard let supplyQuarks = selectedBalance.stored.supplyFromBonding else {
-                return nil
-            }
-
-            let rate = ratesController.rateForBalanceCurrency()
-            let entered = FiatAmount(value: amount, currency: rate.currency)
-
-            if let viaCurve = ExchangedFiat.compute(
-                fromEntered: entered,
-                rate: rate,
-                mint: mint,
-                supplyQuarks: supplyQuarks
-            ) {
-                return viaCurve
-            }
-
-            // Curve could not price the entered amount (requested > TVL).
-            // Build a synthetic ExchangedFiat so `hasSufficientFunds` sees an
-            // over-balance request and returns `.insufficient` with a shortfall
-            // derived from `nativeAmount`. The onChainAmount is a sentinel —
-            // this ExchangedFiat is never transported.
-            return ExchangedFiat(
-                onChainAmount: TokenAmount(
-                    quarks: selectedBalance.stored.quarks + 1,
-                    mint: mint
-                ),
-                nativeAmount: entered,
-                currencyRate: rate
-            )
-
-        } else {
-            let rate = ratesController.rateForBalanceCurrency()
-            return ExchangedFiat(
-                nativeAmount: FiatAmount(value: amount, currency: rate.currency),
-                rate: rate
-            )
-        }
+        guard let amount = Decimal(string: enteredAmount),
+              let selectedBalance else { return nil }
+        return selectedBalance.enteredFiat(
+            for: amount,
+            rate: ratesController.rateForBalanceCurrency()
+        )
     }
 
     // MARK: - Init -

--- a/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
@@ -22,7 +22,7 @@ class OnboardingViewModel {
 
     private(set) var inflightMnemonic: MnemonicPhrase = .generate(.words12)
 
-    @ObservationIgnored let container: Container
+    @ObservationIgnored private let container: Container
     @ObservationIgnored private let sessionAuthenticator: SessionAuthenticator
     @ObservationIgnored private var initializedAccount: InitializedAccount?
 

--- a/Flipcash/Core/Screens/Send/MessageComposerSheet.swift
+++ b/Flipcash/Core/Screens/Send/MessageComposerSheet.swift
@@ -28,7 +28,6 @@ struct MessageComposerSheet: UIViewControllerRepresentable {
     static var isAvailable: Bool { MFMessageComposeViewController.canSendText() }
 
     let recipient: String
-    let body: String
     let onFinish: (MessageComposeResult) -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -38,7 +37,7 @@ struct MessageComposerSheet: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> MFMessageComposeViewController {
         let controller = MFMessageComposeViewController()
         controller.recipients = [recipient]
-        controller.body = body
+        controller.body = Self.placeholderBody
         controller.messageComposeDelegate = context.coordinator
         return controller
     }

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -55,7 +55,6 @@ struct RecipientPickerScreen: View {
         .sheet(item: $inviteTarget) { contact in
             MessageComposerSheet(
                 recipient: contact.phoneE164,
-                body: MessageComposerSheet.placeholderBody,
                 onFinish: { result in
                     logger.info("Invite composer finished", metadata: [
                         "outcome": "\(outcomeName(result))",

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -46,37 +46,11 @@ final class SendAmountViewModel {
     }
 
     private var enteredFiat: ExchangedFiat? {
-        guard !enteredAmount.isEmpty,
-              let amount = Decimal(string: enteredAmount), amount > 0,
+        guard let amount = Decimal(string: enteredAmount),
               let selectedBalance else { return nil }
-
-        let mint = selectedBalance.stored.mint
-        let rate = ratesController.rateForBalanceCurrency()
-        let entered = FiatAmount(value: amount, currency: rate.currency)
-
-        if mint == .usdf {
-            return ExchangedFiat(nativeAmount: entered, rate: rate)
-        }
-
-        guard let supplyQuarks = selectedBalance.stored.supplyFromBonding else { return nil }
-
-        if let viaCurve = ExchangedFiat.compute(
-            fromEntered: entered,
-            rate: rate,
-            mint: mint,
-            supplyQuarks: supplyQuarks
-        ) {
-            return viaCurve
-        }
-
-        // Curve cannot price requested > TVL — surface as over-balance.
-        return ExchangedFiat(
-            onChainAmount: TokenAmount(
-                quarks: selectedBalance.stored.quarks + 1,
-                mint: mint
-            ),
-            nativeAmount: entered,
-            currencyRate: rate
+        return selectedBalance.enteredFiat(
+            for: amount,
+            rate: ratesController.rateForBalanceCurrency()
         )
     }
 

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -347,9 +347,8 @@ class Session {
 
     /// Links an already-verified phone for payment once per session. Best-effort; server-idempotent.
     private func linkPhoneForPaymentIfNeeded() async {
-        // The server's enablePhoneNumberSend flag is off for everyone, so this runs
-        // unconditionally for now rather than gating on dead state.
-        // TODO: re-gate behind a local override (BetaFlags || userFlags?.enablePhoneNumberSend).
+        // TODO: gate on (BetaFlags || userFlags?.enablePhoneNumberSend) once
+        // enablePhoneNumberSend ships; runs unconditionally until then.
         guard let phone = profile?.phone,
               !hasLinkedPhoneForPayment else { return }
         // Claim before the await so two concurrent callers can't double-fire; released on failure below.

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -354,7 +354,9 @@ class Session {
         // Claim before the await so two concurrent callers can't double-fire; released on failure below.
         hasLinkedPhoneForPayment = true
         do {
-            try await flipClient.linkForPayment(phone: phone.e164, owner: ownerKeyPair)
+            try await Task.retry(maxAttempts: 3, delay: .milliseconds(500)) {
+                try await flipClient.linkForPayment(phone: phone.e164, owner: ownerKeyPair)
+            }
         } catch is CancellationError {
             hasLinkedPhoneForPayment = false
         } catch {

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -243,11 +243,16 @@ final class SessionAuthenticator {
             owner: owner
         )
 
-        // Activate at bootstrap when contacts are already accessible
-        // (full or limited).
-        Task.detached { [contactSyncController] in
+        // Activate at bootstrap only when contacts are accessible (full or
+        // limited) AND a phone is already verified. A new user who granted
+        // contacts during onboarding but hasn't verified a phone yet must not
+        // sync — or fire the "already on Flipcash" dialog — before completing
+        // the Send phone step. In-screen activation handles the post-verify case.
+        Task.detached { [contactSyncController, database] in
             let status = CNContactStore.authorizationStatus(for: .contacts)
             guard status.allowsContactAccess else { return }
+            let storedProfile = (try? database.getProfile()) ?? nil
+            guard storedProfile?.isPhoneVerified == true else { return }
             await MainActor.run {
                 contactSyncController.activate()
             }

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -20,7 +20,7 @@
 		<string>INSendMessageIntent</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>13</integer>
+	<integer>14</integer>
 	<key>UIApplicationShortcutItems</key>
 	<array>
 		<dict>

--- a/Flipcash/UI/ExchangedBalance+EnteredFiat.swift
+++ b/Flipcash/UI/ExchangedBalance+EnteredFiat.swift
@@ -1,0 +1,45 @@
+//
+//  ExchangedBalance+EnteredFiat.swift
+//  Flipcash
+//
+
+import Foundation
+import FlipcashCore
+
+extension ExchangedBalance {
+
+    /// Prices a user-entered fiat `amount` against this balance for amount-entry
+    /// screens. USDF maps straight through; a bonded mint resolves via the bonding
+    /// curve. When the curve cannot price the request (entered value exceeds the
+    /// curve's TVL), returns a synthetic over-balance value whose `onChainAmount`
+    /// is a sentinel (`quarks + 1`) so `Session.hasSufficientFunds` reports
+    /// `.insufficient` with a real shortfall — this value is never transported.
+    /// Returns nil for a non-positive amount or a bonded mint with no supply.
+    func enteredFiat(for amount: Decimal, rate: Rate) -> ExchangedFiat? {
+        guard amount > 0 else { return nil }
+
+        let mint = stored.mint
+        let entered = FiatAmount(value: amount, currency: rate.currency)
+
+        if mint == .usdf {
+            return ExchangedFiat(nativeAmount: entered, rate: rate)
+        }
+
+        guard let supplyQuarks = stored.supplyFromBonding else { return nil }
+
+        if let priced = ExchangedFiat.compute(
+            fromEntered: entered,
+            rate: rate,
+            mint: mint,
+            supplyQuarks: supplyQuarks
+        ) {
+            return priced
+        }
+
+        return ExchangedFiat(
+            onChainAmount: TokenAmount(quarks: stored.quarks + 1, mint: mint),
+            nativeAmount: entered,
+            currencyRate: rate
+        )
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Extensions/Task+Retry.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Extensions/Task+Retry.swift
@@ -11,14 +11,17 @@ extension Task where Success == Never, Failure == Never {
 
     /// Runs `body`, retrying up to `maxAttempts - 1` times if the thrown
     /// error satisfies `shouldRetry`. Sleeps `delay` between attempts.
-    /// The error from the final attempt is rethrown.
+    /// The error from the final attempt is rethrown. `CancellationError` is
+    /// never retried — it rethrows immediately so cancellation propagates
+    /// promptly, regardless of `shouldRetry`.
     ///
     /// - Parameters:
     ///   - maxAttempts: Total number of tries, including the first.
     ///     Must be at least 1.
     ///   - delay: Time to sleep between attempts.
-    ///   - shouldRetry: Predicate over the thrown error. Defaults to
-    ///     retrying every error. Return `false` to short-circuit.
+    ///   - shouldRetry: Predicate over the thrown error (never consulted for
+    ///     `CancellationError`). Defaults to retrying every other error.
+    ///     Return `false` to short-circuit.
     ///   - body: The async operation to attempt.
     public static func retry<T>(
         maxAttempts: Int,
@@ -33,6 +36,7 @@ extension Task where Success == Never, Failure == Never {
             do {
                 return try await body()
             } catch {
+                if error is CancellationError { throw error }
                 if attempt >= maxAttempts || !shouldRetry(error) {
                     throw error
                 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/TaskRetryTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TaskRetryTests.swift
@@ -94,4 +94,22 @@ struct TaskRetryTests {
         }
         #expect(attempts == 1)
     }
+
+    @Test("Never retries on cancellation — rethrows immediately without consulting shouldRetry")
+    func doesNotRetryCancellation() async {
+        var attempts = 0
+        var shouldRetryCalled = false
+        await #expect(throws: CancellationError.self) {
+            try await Task.retry(
+                maxAttempts: 5,
+                delay: .nanoseconds(1),
+                shouldRetry: { _ in shouldRetryCalled = true; return true }
+            ) {
+                attempts += 1
+                throw CancellationError()
+            }
+        }
+        #expect(attempts == 1)
+        #expect(shouldRetryCalled == false)
+    }
 }

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -72,20 +72,6 @@ struct ContactSyncControllerTests {
             let expandedSum = ContactSyncController.checksum(of: expanded)
             #expect(baseSum != expandedSum)
         }
-
-        @Test("Removing a phone reverts the checksum (XOR inverse)")
-        func removingPhoneIsReverseOfAdding() {
-            let base    = ["+14155550100", "+442071234567"]
-            let added   = base + ["+819012345678"]
-            let baseSum  = ContactSyncController.checksum(of: base)
-            let addedSum = ContactSyncController.checksum(of: added)
-            let extraHash = SHA256.digest("+819012345678")
-            var restored = [UInt8](addedSum)
-            for (i, byte) in extraHash.enumerated() {
-                restored[i] ^= byte
-            }
-            #expect(Data(restored) == baseSum)
-        }
     }
 
     // MARK: - Delta
@@ -479,11 +465,7 @@ struct ContactSyncControllerTests {
             checksum: Data,
             snapshot: [Database.LocalContact] = []
         ) throws {
-            try database.setContactSyncState(.init(
-                checksum:      checksum,
-                changeHistory: nil,
-                lastSyncedAt:  Date(timeIntervalSince1970: 1_716_000_000)
-            ))
+            try database.setContactSyncState(.init(checksum: checksum))
             if !snapshot.isEmpty {
                 try database.replaceLocalContactsSnapshot(snapshot)
             }
@@ -512,7 +494,6 @@ struct ContactSyncControllerTests {
 
             let storedState = try database.contactSyncState()
             #expect(storedState.checksum == ContactSyncController.checksum(of: contacts.map(\.e164)))
-            try #require(storedState.lastSyncedAt != nil)
 
             #expect(Set(try database.localContactsSnapshot().map(\.e164)) == Set(contacts.map(\.e164)))
             #expect(Set(try database.flipcashContacts()) == ["+14155550101"])
@@ -785,9 +766,7 @@ struct ContactSyncControllerTests {
             matched: [String] = []
         ) throws {
             try database.setContactSyncState(.init(
-                checksum:      ContactSyncController.checksum(of: contacts.map(\.e164)),
-                changeHistory: nil,
-                lastSyncedAt:  Date(timeIntervalSince1970: 1_716_000_000)
+                checksum: ContactSyncController.checksum(of: contacts.map(\.e164))
             ))
             try database.replaceLocalContactsSnapshot(contacts)
             if !matched.isEmpty {
@@ -896,9 +875,7 @@ struct ContactSyncControllerTests {
             let controller = Self.makeController(mock: mock, database: database)
 
             try database.setContactSyncState(.init(
-                checksum:      ContactSyncController.checksum(of: [Self.aliceContact.e164]),
-                changeHistory: nil,
-                lastSyncedAt:  Date(timeIntervalSince1970: 1_716_000_000)
+                checksum: ContactSyncController.checksum(of: [Self.aliceContact.e164])
             ))
             try database.replaceLocalContactsSnapshot([Self.aliceContact])
             try database.replaceFlipcashContacts([Self.aliceContact.e164], matchedAt: Date(timeIntervalSince1970: 1_716_000_000))

--- a/FlipcashTests/Database/Database+ContactSyncTests.swift
+++ b/FlipcashTests/Database/Database+ContactSyncTests.swift
@@ -22,9 +22,7 @@ struct DatabaseContactSyncTests {
     func state_roundTrip() throws {
         let db = Database.mock
         let state = Database.ContactSyncState(
-            checksum: Data(repeating: 0xab, count: 32),
-            changeHistory: Data([0x01, 0x02, 0x03]),
-            lastSyncedAt: Date(timeIntervalSince1970: 1_716_000_000)
+            checksum: Data(repeating: 0xab, count: 32)
         )
 
         try db.setContactSyncState(state)
@@ -36,19 +34,12 @@ struct DatabaseContactSyncTests {
     func state_upsert() throws {
         let db = Database.mock
         let first = Database.ContactSyncState(
-            checksum: Data(repeating: 0x01, count: 32),
-            changeHistory: nil,
-            lastSyncedAt: nil
+            checksum: Data(repeating: 0x01, count: 32)
         )
-        // Integer-second epoch round-trips losslessly through SQLite's Date
-        // column; `.now` carries sub-second precision the storage truncates,
-        // which made the `==` flake. Different epoch from `state_roundTrip`
-        // so the upsert is still meaningful (the second value must overwrite
-        // the first).
+        // Different checksum so the upsert is meaningful — the second value
+        // must overwrite the first on the singleton row.
         let second = Database.ContactSyncState(
-            checksum: Data(repeating: 0x02, count: 32),
-            changeHistory: Data([0xff]),
-            lastSyncedAt: Date(timeIntervalSince1970: 1_716_000_001)
+            checksum: Data(repeating: 0x02, count: 32)
         )
 
         try db.setContactSyncState(first)
@@ -184,6 +175,33 @@ struct DatabaseContactSyncTests {
         #expect(try db.localContactsSnapshot() == [
             Database.LocalContact(e164: "+15551234567", contactId: "alice"),
         ])
+    }
+
+    // MARK: - Combined writes -
+
+    @Test("updateContactSyncSnapshotAndState keeps every (e164, contactId) pair for a shared number")
+    func combinedWrite_keepsEveryPairForSharedNumber() throws {
+        let db = Database.mock
+
+        try db.updateContactSyncSnapshotAndState(
+            snapshot: [
+                Database.LocalContact(e164: "+15551234567", contactId: "work-card"),
+                Database.LocalContact(e164: "+15551234567", contactId: "personal-card"),
+                Database.LocalContact(e164: "+447700900000", contactId: "abroad"),
+            ],
+            state: .init(checksum: Data(repeating: 0xab, count: 32))
+        )
+
+        // Regression: the combined write previously deduped on e164 only,
+        // collapsing a phone shared across two contacts to a single row and
+        // dropping the second name from the picker. It must preserve every
+        // (e164, contactId) pair, matching replaceLocalContactsSnapshot.
+        #expect(Set(try db.localContactsSnapshot()) == [
+            Database.LocalContact(e164: "+15551234567", contactId: "work-card"),
+            Database.LocalContact(e164: "+15551234567", contactId: "personal-card"),
+            Database.LocalContact(e164: "+447700900000", contactId: "abroad"),
+        ])
+        #expect(try db.contactSyncState().checksum == Data(repeating: 0xab, count: 32))
     }
 
 }

--- a/FlipcashTests/ExchangedBalanceEnteredFiatTests.swift
+++ b/FlipcashTests/ExchangedBalanceEnteredFiatTests.swift
@@ -1,0 +1,54 @@
+//
+//  ExchangedBalanceEnteredFiatTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("ExchangedBalance.enteredFiat")
+struct ExchangedBalanceEnteredFiatTests {
+
+    @Test("Non-positive amount returns nil")
+    func nonPositiveAmount_returnsNil() {
+        let balance = ExchangedBalance.makeTest(mint: .usdf, quarks: 100_000_000)
+        #expect(balance.enteredFiat(for: 0, rate: .oneToOne) == nil)
+        #expect(balance.enteredFiat(for: -5, rate: .oneToOne) == nil)
+    }
+
+    @Test("USDF entry maps straight through to a USDF amount")
+    func usdf_mapsThrough() throws {
+        let balance = ExchangedBalance.makeTest(mint: .usdf, quarks: 100_000_000)
+        let fiat = try #require(balance.enteredFiat(for: 10.50, rate: .oneToOne))
+        #expect(fiat.mint == .usdf)
+        #expect(fiat.nativeAmount.value == 10.50)
+    }
+
+    @Test("Bonded entry within TVL prices via the curve, not the sentinel")
+    func bonded_withinTVL_pricesViaCurve() throws {
+        let balance = ExchangedBalance.makeTest(
+            mint: .jeffy,
+            quarks: 1_000_000_000_000,
+            supplyQuarks: 10_000 * 10_000_000_000
+        )
+        let fiat = try #require(balance.enteredFiat(for: 1.00, rate: .oneToOne))
+        #expect(fiat.mint == .jeffy)
+        #expect(fiat.onChainAmount.quarks > 0)
+        #expect(fiat.onChainAmount.quarks != balance.stored.quarks + 1)
+    }
+
+    @Test("Bonded entry beyond curve TVL returns the over-balance sentinel")
+    func bonded_beyondTVL_returnsSentinel() throws {
+        let balance = ExchangedBalance.makeTest(
+            mint: .jeffy,
+            quarks: 10 * 10_000_000_000,
+            supplyQuarks: 10_000 * 10_000_000_000
+        )
+        // Far beyond what a 10,000-token curve can price — forces the sentinel.
+        let fiat = try #require(balance.enteredFiat(for: 1_000_000_000_000_000, rate: .oneToOne))
+        #expect(fiat.onChainAmount.quarks == balance.stored.quarks + 1)
+    }
+}

--- a/FlipcashTests/GiveViewModelTests.swift
+++ b/FlipcashTests/GiveViewModelTests.swift
@@ -32,49 +32,6 @@ struct GiveViewModelTests {
         return viewModel
     }
 
-    /// Helper to create ExchangedBalance
-    static func createExchangedBalance(
-        mint: PublicKey = .usdf,
-        quarks: UInt64 = 1_000_000,
-        supplyQuarks: UInt64? = nil
-    ) -> ExchangedBalance {
-        // For non-USDF tokens, supplyQuarks is required by StoredBalance
-        // For USDF, supplyQuarks should be nil
-        let effectiveSupplyQuarks: UInt64?
-        let effectiveSellFeeBps: Int?
-
-        if mint == .usdf {
-            effectiveSupplyQuarks = nil
-            effectiveSellFeeBps = nil
-        } else {
-            // Non-USDF tokens must have supply
-            // Use 10,000 tokens default (10,000 * 10^10 quarks)
-            effectiveSupplyQuarks = supplyQuarks ?? 10_000 * 10_000_000_000
-            effectiveSellFeeBps = 0
-        }
-
-        let stored = try! StoredBalance(
-            quarks: quarks,
-            symbol: mint == .usdf ? "USDF" : "TOKEN",
-            name: mint == .usdf ? "USDF Coin" : "Test Token",
-            supplyFromBonding: effectiveSupplyQuarks,
-            sellFeeBps: effectiveSellFeeBps,
-            mint: mint,
-            vmAuthority: mint == .usdf ? nil : .usdcAuthority,
-            updatedAt: Date(),
-            imageURL: nil,
-            costBasis: 0
-        )
-        return ExchangedBalance(
-            stored: stored,
-            exchangedFiat: ExchangedFiat.compute(
-                onChainAmount: TokenAmount(quarks: quarks, mint: mint),
-                rate: .oneToOne,
-                supplyQuarks: effectiveSupplyQuarks
-            )
-        )
-    }
-
     // MARK: - Initialization Tests
 
     @Test
@@ -95,7 +52,7 @@ struct GiveViewModelTests {
     @Test("Selecting a currency syncs selectedBalance and ratesController")
     func testSelectCurrency_SyncsBalanceAndRatesController() {
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance(
+        let balance = ExchangedBalance.makeTest(
             mint: .jeffy,
             quarks: 1_000_000_000_000,
             supplyQuarks: 10_000 * 10_000_000_000
@@ -111,12 +68,12 @@ struct GiveViewModelTests {
     @Test("Switching currency updates both selectedBalance and ratesController")
     func testSelectCurrency_SwitchingUpdatesSync() {
         let viewModel = Self.createViewModel()
-        let firstBalance = Self.createExchangedBalance(
+        let firstBalance = ExchangedBalance.makeTest(
             mint: .jeffy,
             quarks: 1_000_000_000_000,
             supplyQuarks: 10_000 * 10_000_000_000
         )
-        let secondBalance = Self.createExchangedBalance(
+        let secondBalance = ExchangedBalance.makeTest(
             mint: .usdf,
             quarks: 5_000_000
         )
@@ -136,7 +93,7 @@ struct GiveViewModelTests {
     @Test("Selecting a currency clears entered amount")
     func testSelectCurrency_ClearsEnteredAmount() {
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance()
+        let balance = ExchangedBalance.makeTest()
         viewModel.enteredAmount = "42.00"
 
         viewModel.selectCurrencyAction(exchangedBalance: balance)
@@ -150,7 +107,7 @@ struct GiveViewModelTests {
     func testCanGive_EmptyAmount_ReturnsFalse() {
         // Given: View model with no amount entered
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance()
+        let balance = ExchangedBalance.makeTest()
         viewModel.selectCurrencyAction(exchangedBalance: balance)
         viewModel.enteredAmount = ""
 
@@ -162,7 +119,7 @@ struct GiveViewModelTests {
     func testCanGive_InvalidAmount_ReturnsFalse() {
         // Given: View model with invalid amount
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance()
+        let balance = ExchangedBalance.makeTest()
         viewModel.selectCurrencyAction(exchangedBalance: balance)
         viewModel.enteredAmount = "invalid"
 
@@ -174,7 +131,7 @@ struct GiveViewModelTests {
     func testCanGive_ZeroAmount_ReturnsFalse() {
         // Given: View model with zero amount
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance()
+        let balance = ExchangedBalance.makeTest()
         viewModel.selectCurrencyAction(exchangedBalance: balance)
         viewModel.enteredAmount = "0"
 
@@ -197,7 +154,7 @@ struct GiveViewModelTests {
     func testCanGive_ValidAmountAndBalance_ReturnsTrue() {
         // Given: View model with valid amount and balance
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance()
+        let balance = ExchangedBalance.makeTest()
         viewModel.selectCurrencyAction(exchangedBalance: balance)
         viewModel.enteredAmount = "10"
 
@@ -212,7 +169,7 @@ struct GiveViewModelTests {
         // Given: View model with some entered amount
         let viewModel = Self.createViewModel()
         viewModel.enteredAmount = "100"
-        let balance = Self.createExchangedBalance()
+        let balance = ExchangedBalance.makeTest()
 
         // When: Selecting a currency
         viewModel.selectCurrencyAction(exchangedBalance: balance)
@@ -228,7 +185,7 @@ struct GiveViewModelTests {
     func testEnteredFiat_USDC_CalculatesCorrectly() {
         // Given: View model with USDC balance
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance(
+        let balance = ExchangedBalance.makeTest(
             mint: .usdf,
             quarks: 100_000_000
         )
@@ -250,7 +207,7 @@ struct GiveViewModelTests {
         // Given: View model with bonded token
         // 10,000 tokens supply supports reasonable exchange amounts
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance(
+        let balance = ExchangedBalance.makeTest(
             mint: .jeffy,
             quarks: 1_000_000_000_000, // 100 tokens (10 decimals)
             supplyQuarks: 10_000 * 10_000_000_000 // 10,000 tokens supply
@@ -269,7 +226,7 @@ struct GiveViewModelTests {
     func testEnteredFiat_BondedToken_AmountAtMaxBalance() {
         // Given: View model with bonded token where user has significant balance
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance(
+        let balance = ExchangedBalance.makeTest(
             mint: .jeffy,
             quarks: 5_000_000_000_000, // 500 tokens (10 decimals)
             supplyQuarks: 50_000 * 10_000_000_000 // 50,000 tokens supply
@@ -288,7 +245,7 @@ struct GiveViewModelTests {
     func testEnteredFiat_BondedToken_LargeSupply() {
         // Given: View model with large supply (100,000 tokens)
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance(
+        let balance = ExchangedBalance.makeTest(
             mint: .jeffy,
             quarks: 10_000_000_000_000, // 1,000 tokens
             supplyQuarks: 100_000 * 10_000_000_000 // 100,000 tokens supply
@@ -309,7 +266,7 @@ struct GiveViewModelTests {
     func testEnteredAmount_NegativeValue_CanGiveFalse() {
         // Given: View model with negative amount
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance()
+        let balance = ExchangedBalance.makeTest()
         viewModel.selectCurrencyAction(exchangedBalance: balance)
         viewModel.enteredAmount = "-10"
 
@@ -321,7 +278,7 @@ struct GiveViewModelTests {
     func testEnteredAmount_VeryLargeValue_HandledCorrectly() {
         // Given: View model with very large amount
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance(quarks: UInt64.max)
+        let balance = ExchangedBalance.makeTest(quarks: UInt64.max)
         viewModel.selectCurrencyAction(exchangedBalance: balance)
         viewModel.enteredAmount = "999999999.99"
 
@@ -336,7 +293,7 @@ struct GiveViewModelTests {
     func testEnteredAmount_DecimalPlaces_HandledCorrectly() {
         // Given: View model with many decimal places
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance()
+        let balance = ExchangedBalance.makeTest()
         viewModel.selectCurrencyAction(exchangedBalance: balance)
         viewModel.enteredAmount = "10.123456789"
 
@@ -355,7 +312,7 @@ struct GiveViewModelTests {
         // Given: View model with bonded token and modest supply
         // 1,000 tokens supply, user tries to exchange $100 (valid)
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance(
+        let balance = ExchangedBalance.makeTest(
             mint: .jeffy,
             quarks: 10_000_000_000_000, // 1,000 tokens
             supplyQuarks: 1_000 * 10_000_000_000 // 1,000 tokens supply
@@ -374,7 +331,7 @@ struct GiveViewModelTests {
     func testEnteredFiat_BondedToken_AmountWellUnderMaxSupply_Succeeds() {
         // Given: View model where entered amount is well under max supply value
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance(
+        let balance = ExchangedBalance.makeTest(
             mint: .jeffy,
             quarks: 100_000_000_000_000, // 10,000 tokens
             supplyQuarks: 50_000 * 10_000_000_000 // 50,000 tokens supply

--- a/FlipcashTests/RecipientLoaderPlacementsTests.swift
+++ b/FlipcashTests/RecipientLoaderPlacementsTests.swift
@@ -115,15 +115,28 @@ struct RecipientLoaderDeduplicatedForDisplayTests {
         #expect(unique.map(\.nationalPhone) == ["(408) 555-1111", "(408) 555-2222"])
     }
 
-    @Test("Same number under multiple names shows once per name")
+    @Test("Same number under multiple names collapses to one — the last-seen named wins")
     func sameNumberMultipleNames() {
         let contacts = [
             makeContact(contactId: "A", name: "Alice", e164: "+14085551234", national: "(408) 555-1234"),
             makeContact(contactId: "B", name: "Bob",   e164: "+14085551234", national: "(408) 555-1234"),
         ]
         let unique = RecipientLoader.deduplicatedForDisplay(contacts, flipcashSet: [])
-        #expect(unique.count == 2)
-        #expect(Set(unique.map(\.displayName)) == ["Alice", "Bob"])
+        #expect(unique.count == 1)
+        #expect(unique[0].displayName == "Bob")
+    }
+
+    @Test("A named contact wins over a no-name duplicate on the same number")
+    func namedWinsOverNoName() {
+        let national = "(408) 555-1234"
+        let contacts = [
+            // No-name contact: its label falls back to the bare number.
+            makeContact(contactId: "A", name: national, e164: "+14085551234", national: national),
+            makeContact(contactId: "B", name: "Ted",    e164: "+14085551234", national: national),
+        ]
+        let unique = RecipientLoader.deduplicatedForDisplay(contacts, flipcashSet: [])
+        #expect(unique.count == 1)
+        #expect(unique[0].displayName == "Ted")
     }
 
     @Test("Same (name, nationalPhone) collapses to ONE row")

--- a/FlipcashTests/Regressions/Regression_give_max_precision.swift
+++ b/FlipcashTests/Regressions/Regression_give_max_precision.swift
@@ -25,7 +25,7 @@ struct Regression_give_max_precision {
         let supply = UInt64(tokens) * UInt64(DiscreteBondingCurve.quarksPerToken)
 
         let viewModel = GiveViewModelTests.createViewModel()
-        let balance = GiveViewModelTests.createExchangedBalance(
+        let balance = ExchangedBalance.makeTest(
             mint: .jeffy,
             quarks: supply,
             supplyQuarks: supply

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -36,44 +36,6 @@ struct SendAmountViewModelTests {
         )
     }
 
-    static func createExchangedBalance(
-        mint: PublicKey = .usdf,
-        quarks: UInt64 = 1_000_000,
-        supplyQuarks: UInt64? = nil
-    ) -> ExchangedBalance {
-        let effectiveSupplyQuarks: UInt64?
-        let effectiveSellFeeBps: Int?
-
-        if mint == .usdf {
-            effectiveSupplyQuarks = nil
-            effectiveSellFeeBps = nil
-        } else {
-            effectiveSupplyQuarks = supplyQuarks ?? 10_000 * 10_000_000_000
-            effectiveSellFeeBps = 0
-        }
-
-        let stored = try! StoredBalance(
-            quarks: quarks,
-            symbol: mint == .usdf ? "USDF" : "TOKEN",
-            name: mint == .usdf ? "USDF Coin" : "Test Token",
-            supplyFromBonding: effectiveSupplyQuarks,
-            sellFeeBps: effectiveSellFeeBps,
-            mint: mint,
-            vmAuthority: mint == .usdf ? nil : .usdcAuthority,
-            updatedAt: Date(),
-            imageURL: nil,
-            costBasis: 0
-        )
-        return ExchangedBalance(
-            stored: stored,
-            exchangedFiat: ExchangedFiat.compute(
-                onChainAmount: TokenAmount(quarks: quarks, mint: mint),
-                rate: .oneToOne,
-                supplyQuarks: effectiveSupplyQuarks
-            )
-        )
-    }
-
     /// Funded USDF container + test rates, mirroring the production amount-entry
     /// path so `sendAction` clears the local sufficiency gate and reaches the
     /// recipient resolve.
@@ -156,7 +118,7 @@ struct SendAmountViewModelTests {
     @Test("canSend is false when no amount is entered")
     func canSend_emptyAmount_isFalse() {
         let viewModel = Self.createViewModel()
-        viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance())
+        viewModel.selectCurrencyAction(exchangedBalance: ExchangedBalance.makeTest())
         viewModel.enteredAmount = ""
         #expect(viewModel.canSend == false)
     }
@@ -164,7 +126,7 @@ struct SendAmountViewModelTests {
     @Test("canSend is false when the entered amount can't parse as a positive decimal")
     func canSend_invalidAmount_isFalse() {
         let viewModel = Self.createViewModel()
-        viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance())
+        viewModel.selectCurrencyAction(exchangedBalance: ExchangedBalance.makeTest())
         viewModel.enteredAmount = "not-a-number"
         #expect(viewModel.canSend == false)
     }
@@ -172,7 +134,7 @@ struct SendAmountViewModelTests {
     @Test("canSend is false for a zero amount")
     func canSend_zero_isFalse() {
         let viewModel = Self.createViewModel()
-        viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance())
+        viewModel.selectCurrencyAction(exchangedBalance: ExchangedBalance.makeTest())
         viewModel.enteredAmount = "0"
         #expect(viewModel.canSend == false)
     }
@@ -191,7 +153,7 @@ struct SendAmountViewModelTests {
     @Test("canSend is true for a positive amount, never gated on recipient resolution")
     func canSend_positiveAmount_isTrueWithoutResolution() {
         let viewModel = Self.createViewModel()
-        viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance())
+        viewModel.selectCurrencyAction(exchangedBalance: ExchangedBalance.makeTest())
         viewModel.enteredAmount = "5"
         // No resolve has happened — canSend reflects amount validity only, so a
         // red subtitle in EnterAmountView would mean over-limit, not unresolved.
@@ -203,7 +165,7 @@ struct SendAmountViewModelTests {
     @Test("selectCurrencyAction syncs selectedBalance and ratesController")
     func selectCurrency_syncsBalanceAndRates() {
         let viewModel = Self.createViewModel()
-        let balance = Self.createExchangedBalance(mint: .jeffy, quarks: 1_000_000_000_000, supplyQuarks: 10_000 * 10_000_000_000)
+        let balance = ExchangedBalance.makeTest(mint: .jeffy, quarks: 1_000_000_000_000, supplyQuarks: 10_000 * 10_000_000_000)
         viewModel.selectCurrencyAction(exchangedBalance: balance)
         #expect(viewModel.selectedBalance?.stored.mint == .jeffy)
         #expect(viewModel.ratesController.selectedTokenMint == .jeffy)
@@ -213,7 +175,7 @@ struct SendAmountViewModelTests {
     func selectCurrency_clearsEnteredAmount() {
         let viewModel = Self.createViewModel()
         viewModel.enteredAmount = "42.00"
-        viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance())
+        viewModel.selectCurrencyAction(exchangedBalance: ExchangedBalance.makeTest())
         #expect(viewModel.enteredAmount == "")
     }
 
@@ -228,7 +190,7 @@ struct SendAmountViewModelTests {
             mint: nil,
             sender: sender
         )
-        viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance())
+        viewModel.selectCurrencyAction(exchangedBalance: ExchangedBalance.makeTest())
         viewModel.enteredAmount = ""
 
         let outcome = await viewModel.sendAction()
@@ -249,7 +211,7 @@ struct SendAmountViewModelTests {
             resolver: mock
         )
         // Empty balance + non-zero entered amount → hasSufficientFunds == .insufficient.
-        viewModel.selectCurrencyAction(exchangedBalance: Self.createExchangedBalance(quarks: 0))
+        viewModel.selectCurrencyAction(exchangedBalance: ExchangedBalance.makeTest(quarks: 0))
         viewModel.enteredAmount = "5"
 
         let outcome = await viewModel.sendAction()

--- a/FlipcashTests/TestSupport/ExchangedBalance+TestSupport.swift
+++ b/FlipcashTests/TestSupport/ExchangedBalance+TestSupport.swift
@@ -1,0 +1,51 @@
+//
+//  ExchangedBalance+TestSupport.swift
+//  FlipcashTests
+//
+
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+extension ExchangedBalance {
+
+    /// Builds an `ExchangedBalance` for amount-entry tests. USDF carries no
+    /// bonding supply; a non-USDF mint defaults to a 10,000-token supply.
+    static func makeTest(
+        mint: PublicKey = .usdf,
+        quarks: UInt64 = 1_000_000,
+        supplyQuarks: UInt64? = nil
+    ) -> ExchangedBalance {
+        let effectiveSupplyQuarks: UInt64?
+        let effectiveSellFeeBps: Int?
+
+        if mint == .usdf {
+            effectiveSupplyQuarks = nil
+            effectiveSellFeeBps = nil
+        } else {
+            effectiveSupplyQuarks = supplyQuarks ?? 10_000 * 10_000_000_000
+            effectiveSellFeeBps = 0
+        }
+
+        let stored = try! StoredBalance(
+            quarks: quarks,
+            symbol: mint == .usdf ? "USDF" : "TOKEN",
+            name: mint == .usdf ? "USDF Coin" : "Test Token",
+            supplyFromBonding: effectiveSupplyQuarks,
+            sellFeeBps: effectiveSellFeeBps,
+            mint: mint,
+            vmAuthority: mint == .usdf ? nil : .usdcAuthority,
+            updatedAt: Date(),
+            imageURL: nil,
+            costBasis: 0
+        )
+        return ExchangedBalance(
+            stored: stored,
+            exchangedFiat: ExchangedFiat.compute(
+                onChainAmount: TokenAmount(quarks: quarks, mint: mint),
+                rate: .oneToOne,
+                supplyQuarks: effectiveSupplyQuarks
+            )
+        )
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactAvatarView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactAvatarView.swift
@@ -82,8 +82,8 @@ nonisolated public final class ContactAvatarCache: @unchecked Sendable {
 
     private let cache = NSCache<NSString, UIImage>()
 
-    public init(countLimit: Int = 200) {
-        cache.countLimit = countLimit
+    private init() {
+        cache.countLimit = 200
     }
 
     /// Returns the cached `UIImage` for `key`. Decodes `data` and caches the

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -51,6 +51,10 @@ final class NotificationService: UNNotificationServiceExtension {
             return
         }
 
+        // Only the `.contact` substitution kind ships today, resolved to a local
+        // name (or "Someone you know" when unresolved — never the raw phone). The
+        // server's per-substitution `fallback` is reserved for future kinds this
+        // client doesn't yet recognize.
         let titleResolutions = payload.titleSubstitutions.map { resolve($0.contact) }
         let bodyResolutions = payload.bodySubstitutions.map { resolve($0.contact) }
 


### PR DESCRIPTION
A review-driven cleanup of the contact-sync branch — removes dead and speculative code and de-duplicates the amount-entry logic shared between the send and give flows — plus several correctness fixes:

- A phone number saved on more than one contact now shows a single recipient row, labeled by the best name (a real name is preferred over a bare number).
- Contact sync no longer activates, or shows the "already on Flipcash" dialog, until the user has verified a phone. Granting contacts during onboarding alone no longer triggers it.
- The phone-payment link now retries on transient failures, and the shared retry helper no longer retries a cancellation.

## Test plan
- [ ] Two contacts sharing one phone number show a single picker row, labeled by the named contact.
- [ ] A new account that finishes onboarding without verifying a phone sees "Connect Phone To Send" with no contacts dialog.
- [ ] After verifying a phone with contacts granted, the contact list loads and the "already on Flipcash" dialog appears once.
- [ ] Sending and giving cash still show the correct amount, including when the entered amount is over the balance.
- [ ] A fresh login rebuilds the local database without losing anything.
- [ ] Existing contact-sync, send, give, and retry-helper tests pass.