### PR TITLE
feat: animate recipient list row changes

### DIFF
--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -51,7 +51,7 @@ struct RecipientPickerScreen: View {
         }
         .onAppear { refilter() }
         .onChange(of: searchText) { refilter() }
-        .onChange(of: contacts) { refilter() }
+        .onChange(of: contacts) { withAnimation(.snappy) { refilter() } }
         .sheet(item: $inviteTarget) { contact in
             MessageComposerSheet(
                 recipient: contact.phoneE164,


### PR DESCRIPTION
The Send recipient list now animates when contacts change — rows ease in and out with a quick spring as people resolve or join Flipcash. Typing in search and first opening the screen stay instant, so only live updates animate rather than every refresh.

## Test plan
- [x] Open Send before contacts finish syncing and confirm rows animate in as they resolve.
- [x] Confirm a contact moving into the "On Flipcash" section animates.
- [x] Confirm typing in search filters results instantly with no animation.
- [x] Confirm opening Send with contacts already loaded shows them instantly.
