### PR TITLE
feat: dynamic Home Screen quick actions with flag-gated Send

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -103,6 +103,9 @@ final class DeepLinkController {
         case .discover:
             return actionForOpenSheet(.discover)
 
+        case .send:
+            return actionForOpenSheet(.send)
+
         case .unknown:
             break
         }
@@ -240,6 +243,9 @@ struct DeepLinkAction {
                         }
                         return
                     }
+                }
+                if sheet == .send {
+                    guard container.session.userFlags?.enablePhoneNumberSend == true else { return }
                 }
                 container.appRouter.present(sheet)
             }

--- a/Flipcash/Core/Controllers/Deep Links/Route.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Route.swift
@@ -88,6 +88,7 @@ nonisolated extension Route {
         case give
         case balance
         case discover
+        case send
         case unknown(String)
         
         static func parse(path: String) -> Path? {
@@ -125,6 +126,8 @@ nonisolated extension Route {
                 return .unknown(url.lastPathComponent)
             case "discover":
                 return .discover
+            case "send":
+                return .send
             default:
                 return .unknown(url.lastPathComponent)
             }

--- a/Flipcash/Core/Controllers/QuickActionsController.swift
+++ b/Flipcash/Core/Controllers/QuickActionsController.swift
@@ -1,0 +1,54 @@
+//
+//  QuickActionsController.swift
+//  Flipcash
+//
+
+import UIKit
+import FlipcashCore
+
+/// Owns the Home Screen quick actions (long-press the app icon).
+///
+/// Actions are installed on login and cleared on logout. The Send action is
+/// included only for users with `enablePhoneNumberSend`. Taps reuse the existing
+/// deep-link pipeline via each action's `url` userInfo (see ``SceneDelegate``).
+@MainActor
+final class QuickActionsController {
+
+    private let session: Session
+
+    init(session: Session) {
+        self.session = session
+    }
+
+    func configure() {
+        UIApplication.shared.shortcutItems = Self.shortcutItems(
+            includeSend: session.userFlags?.enablePhoneNumberSend == true
+        )
+    }
+
+    static func clear() {
+        UIApplication.shared.shortcutItems = []
+    }
+
+    nonisolated static func shortcutItems(includeSend: Bool) -> [UIApplicationShortcutItem] {
+        var items = [
+            item(type: "discover", title: "Discover", symbol: "binoculars", url: "flipcash://discover"),
+            item(type: "give", title: "Cash", symbol: "banknote", url: "flipcash://give"),
+        ]
+        if includeSend {
+            items.append(item(type: "send", title: "Send", symbol: "paperplane", url: "flipcash://send"))
+        }
+        items.append(item(type: "wallet", title: "Wallet", symbol: "wallet.bifold", url: "flipcash://balance"))
+        return items
+    }
+
+    nonisolated private static func item(type: String, title: String, symbol: String, url: String) -> UIApplicationShortcutItem {
+        UIApplicationShortcutItem(
+            type: "com.flipcash.shortcut.\(type)",
+            localizedTitle: title,
+            localizedSubtitle: nil,
+            icon: UIApplicationShortcutIcon(systemImageName: symbol),
+            userInfo: ["url": url as NSString]
+        )
+    }
+}

--- a/Flipcash/Core/Screens/Main/ScanViewModel.swift
+++ b/Flipcash/Core/Screens/Main/ScanViewModel.swift
@@ -116,7 +116,7 @@ class ScanViewModel {
         switch route.path {
         case .cash, .token:
             return true
-        case .login, .verifyEmail, .give, .balance, .discover, .unknown:
+        case .login, .verifyEmail, .give, .balance, .discover, .send, .unknown:
             return false
         }
     }

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -385,6 +385,7 @@ final class SessionAuthenticator {
         )
         
         state = .loggedIn(session)
+        session.quickActionsController.configure()
         UserDefaults.wasLoggedIn = true
 
         Analytics.setIdentity(initializedAccount.userID)
@@ -425,6 +426,7 @@ final class SessionAuthenticator {
             container.session.prepareForLogout()
             container.pushController.prepareForLogout()
             container.usdcSweepOperation.cancel()
+            QuickActionsController.clear()
         }
 
         accountManager.resetForLogout()
@@ -454,6 +456,7 @@ struct SessionContainer {
     let coinbaseService: CoinbaseService
     let appRouter: AppRouter
     let usdcSweepOperation: UsdcSweepOperation
+    let quickActionsController: QuickActionsController
 
     init(
         session: Session,
@@ -513,6 +516,8 @@ struct SessionContainer {
                 await session?.updatePostTransaction()
             }
         )
+
+        self.quickActionsController = QuickActionsController(session: session)
     }
 
     fileprivate func injectingEnvironment<SomeView>(into view: SomeView) -> some View where SomeView: View {

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -21,48 +21,6 @@
 	</array>
 	<key>SQLiteVersion</key>
 	<integer>14</integer>
-	<key>UIApplicationShortcutItems</key>
-	<array>
-		<dict>
-			<key>UIApplicationShortcutItemType</key>
-			<string>com.flipcash.shortcut.discover</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>Discover</string>
-			<key>UIApplicationShortcutItemIconSymbolName</key>
-			<string>binoculars</string>
-			<key>UIApplicationShortcutItemUserInfo</key>
-			<dict>
-				<key>url</key>
-				<string>flipcash://discover</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>UIApplicationShortcutItemType</key>
-			<string>com.flipcash.shortcut.give</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>Cash</string>
-			<key>UIApplicationShortcutItemIconSymbolName</key>
-			<string>banknote</string>
-			<key>UIApplicationShortcutItemUserInfo</key>
-			<dict>
-				<key>url</key>
-				<string>flipcash://give</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>UIApplicationShortcutItemType</key>
-			<string>com.flipcash.shortcut.wallet</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>Wallet</string>
-			<key>UIApplicationShortcutItemIconSymbolName</key>
-			<string>wallet.bifold</string>
-			<key>UIApplicationShortcutItemUserInfo</key>
-			<dict>
-				<key>url</key>
-				<string>flipcash://balance</string>
-			</dict>
-		</dict>
-	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FlipcashTests/QuickActionsControllerTests.swift
+++ b/FlipcashTests/QuickActionsControllerTests.swift
@@ -1,0 +1,43 @@
+//
+//  QuickActionsControllerTests.swift
+//  FlipcashTests
+//
+
+import Testing
+import UIKit
+@testable import Flipcash
+
+@Suite("QuickActionsController")
+struct QuickActionsControllerTests {
+
+    @Test("With Send enabled, actions follow tab-bar order: discover, cash, send, wallet")
+    func orderWithSend() {
+        let types = QuickActionsController.shortcutItems(includeSend: true).map(\.type)
+        #expect(types == [
+            "com.flipcash.shortcut.discover",
+            "com.flipcash.shortcut.give",
+            "com.flipcash.shortcut.send",
+            "com.flipcash.shortcut.wallet",
+        ])
+    }
+
+    @Test("With Send disabled, the order is discover, cash, wallet")
+    func orderWithoutSend() {
+        let types = QuickActionsController.shortcutItems(includeSend: false).map(\.type)
+        #expect(types == [
+            "com.flipcash.shortcut.discover",
+            "com.flipcash.shortcut.give",
+            "com.flipcash.shortcut.wallet",
+        ])
+    }
+
+    @Test("Send action carries the flipcash://send deep link")
+    func sendActionContents() throws {
+        let send = try #require(
+            QuickActionsController.shortcutItems(includeSend: true)
+                .first { $0.type == "com.flipcash.shortcut.send" }
+        )
+        #expect(send.localizedTitle == "Send")
+        #expect(send.userInfo?["url"] as? String == "flipcash://send")
+    }
+}

--- a/FlipcashTests/RouteTests.swift
+++ b/FlipcashTests/RouteTests.swift
@@ -122,9 +122,8 @@ struct RouteTests {
 
     // MARK: - Sheet Routes -
     //
-    // The three home-screen quick actions defined in Info.plist (Give,
-    // Wallet, Discover) all open sheets via these routes. Universal links
-    // and `flipcash://` deep links must both parse to the same case.
+    // The home-screen quick actions open sheets via these routes. The
+    // `flipcash://` deep link and the universal link must parse to the same case.
 
     @Test(
         "Give route parses from both URL formats",
@@ -156,6 +155,17 @@ struct RouteTests {
         let path = try #require(Route(url: URL(string: urlString)!)?.path)
         if case .discover = path {} else {
             Issue.record("\(urlString) should parse as .discover")
+        }
+    }
+
+    @Test(
+        "Send route parses from both URL formats",
+        arguments: ["flipcash://send", "https://app.flipcash.com/send"]
+    )
+    func sendRoute(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        if case .send = path {} else {
+            Issue.record("\(urlString) should parse as .send")
         }
     }
 


### PR DESCRIPTION
Home Screen quick actions (long-press the app icon) are now built dynamically when you log in and cleared when you log out, instead of being a fixed list. This lets us show a new Send action only to people who have the unreleased phone-number send feature turned on, while everyone keeps Discover, Cash, and Wallet. Logged-out users get no quick actions, since a tap would only land them on the login screen.

## Test plan
- [x] Log in, long-press the app icon, and confirm Discover, Cash, and Wallet appear.
- [ ] With the Send feature enabled for the account, confirm Send also appears in third position.
- [ ] Tap Send and confirm the Send screen opens.
- [ ] With the Send feature off, confirm Send is absent.
- [x] Log out and confirm the quick actions are cleared.
