### PR TITLE
refactor: adopt native LabeledContent, Link, and ShareLink

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -121,13 +121,12 @@ struct CurrencyInfoScreen: View {
             }
             if !isUSDF {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        Analytics.buttonTapped(name: .shareTokenInfo)
-                        let url = URL(string: "https://app.flipcash.com/token/\(mint.base58)")!
-                        ShareSheet.present(url: url)
-                    } label: {
+                    ShareLink(item: URL(string: "https://app.flipcash.com/token/\(mint.base58)")!) {
                         Image(systemName: "square.and.arrow.up")
                     }
+                    .simultaneousGesture(TapGesture().onEnded {
+                        Analytics.buttonTapped(name: .shareTokenInfo)
+                    })
                 }
             }
         }

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoSocialLinksSection.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoSocialLinksSection.swift
@@ -18,25 +18,17 @@ struct CurrencyInfoSocialLinksSection: View {
                 ForEach(socialLinks) { socialLink in
                     switch socialLink {
                     case .website(let url):
-                        Button("Website") {
-                            UIApplication.shared.open(url)
-                        }
-                        .buttonStyle(.icon(.globus))
+                        Link("Website", destination: url)
+                            .buttonStyle(.icon(.globus))
                     case .x(let handle):
-                        Button(handle) {
-                            UIApplication.shared.open(URL(string: "https://x.com/\(handle)")!)
-                        }
-                        .buttonStyle(.icon(.twitter))
+                        Link(handle, destination: URL(string: "https://x.com/\(handle)")!)
+                            .buttonStyle(.icon(.twitter))
                     case .telegram(let username):
-                        Button("Telegram") {
-                            UIApplication.shared.open(URL(string: "https://t.me/\(username)")!)
-                        }
-                        .buttonStyle(.icon(.telegram))
+                        Link("Telegram", destination: URL(string: "https://t.me/\(username)")!)
+                            .buttonStyle(.icon(.telegram))
                     case .discord(let inviteCode):
-                        Button("Discord") {
-                            UIApplication.shared.open(URL(string: "https://discord.gg/\(inviteCode)")!)
-                        }
-                        .buttonStyle(.icon(.discord))
+                        Link("Discord", destination: URL(string: "https://discord.gg/\(inviteCode)")!)
+                            .buttonStyle(.icon(.discord))
                     }
                 }
             }

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawSummaryScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawSummaryScreen.swift
@@ -80,12 +80,12 @@ private struct SummaryLineItem: View {
     let value: String
 
     var body: some View {
-        HStack {
-            Text(title)
-                .foregroundStyle(Color.textSecondary)
-            Spacer()
+        LabeledContent {
             Text(value)
                 .foregroundStyle(Color.textMain)
+        } label: {
+            Text(title)
+                .foregroundStyle(Color.textSecondary)
         }
         .font(.appTextSmall)
     }


### PR DESCRIPTION
Replaces three hand-rolled inline elements with their native SwiftUI equivalents: the withdrawal summary rows now use LabeledContent, the currency social links use Link, and the currency-info share button uses ShareLink (its analytics event preserved). No visual change intended. Part of the ongoing pass replacing custom UI with Apple's built-in components.

Note: the withdraw address-validity rows were evaluated for Label and deliberately kept custom — a native Label changes the icon spacing and alignment for no real gain.

## Test plan
- [x] Open a currency's info screen — the share button still appears and presents the share sheet.
- [x] Open a currency that has social links — the website/X/Telegram/Discord buttons look the same and open their URLs.
- [x] Open a withdrawal summary — the amount / fee / net rows look unchanged (secondary label, primary value).