### PR TITLE
refactor: render Settings screens with native List

### DIFF
--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
@@ -18,24 +18,23 @@ struct SettingsAdvancedFeaturesScreen: View {
 
     var body: some View {
         Background(color: .backgroundMain) {
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
-                    SettingsRow(systemImage: "slider.horizontal.3", title: "Bill Designer", insets: insets) {
-                        Task {
-                            router.dismissSheet()
-                            try await Task.delay(milliseconds: 250)
-                            session.isShowingBillDesigner = true
-                        }
-                    }
-
-                    SettingsRow(systemImage: "doc.text", title: "Application Logs", insets: insets) {
-                        router.push(.settingsApplicationLogs)
+            List {
+                SettingsRow(systemImage: "slider.horizontal.3", title: "Bill Designer", insets: insets) {
+                    Task {
+                        router.dismissSheet()
+                        try await Task.delay(milliseconds: 250)
+                        session.isShowingBillDesigner = true
                     }
                 }
-                .font(.appDisplayXS)
-                .foregroundStyle(.textMain)
+
+                SettingsRow(systemImage: "doc.text", title: "Application Logs", insets: insets) {
+                    router.push(.settingsApplicationLogs)
+                }
             }
-            .padding(.horizontal, 20)
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .font(.appDisplayXS)
+            .foregroundStyle(.textMain)
         }
         .navigationTitle("Advanced Features")
         .toolbarTitleDisplayMode(.inline)

--- a/Flipcash/Core/Screens/Settings/SettingsAppSettingsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAppSettingsScreen.swift
@@ -17,21 +17,23 @@ struct SettingsAppSettingsScreen: View {
 
     var body: some View {
         Background(color: .backgroundMain) {
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
-                    Row(insets: insets) {
-                        Image.asset(.camera).frame(minWidth: 45)
-                        Toggle("Auto Start Camera", isOn: cameraAutoStartDisabledBinding())
-                            .multilineTextAlignment(.leading)
-                            .truncationMode(.tail)
-                            .padding(.trailing, 2)
-                            .tint(.textSuccess)
-                    }
+            List {
+                Row(insets: insets) {
+                    Image.asset(.camera).frame(minWidth: 45)
+                    Toggle("Auto Start Camera", isOn: cameraAutoStartDisabledBinding())
+                        .multilineTextAlignment(.leading)
+                        .truncationMode(.tail)
+                        .padding(.trailing, 2)
+                        .tint(.textSuccess)
                 }
-                .font(.appDisplayXS)
-                .foregroundStyle(.textMain)
+                .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
+                .listRowBackground(Color.clear)
+                .listRowSeparatorTint(.rowSeparator)
             }
-            .padding(.horizontal, 20)
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .font(.appDisplayXS)
+            .foregroundStyle(.textMain)
         }
         .navigationTitle("App Settings")
         .toolbarTitleDisplayMode(.inline)

--- a/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
@@ -23,58 +23,51 @@ struct SettingsMyAccountScreen: View {
 
     var body: some View {
         Background(color: .backgroundMain) {
-            ScrollView(showsIndicators: false) {
-                list()
+            List {
+                SettingsRow(asset: .key, title: "Access Key", insets: insets) {
+                    dialogItem = .alert(
+                        title: "View Your Access Key?",
+                        subtitle: "Your Access Key will grant access to your Flipcash account. Keep it private and safe"
+                    ) {
+                        DialogAction.destructive("View Access Key") {
+                            router.push(.accessKey)
+                        }
+                        DialogAction.cancel()
+                    }
+                }
+
+                SettingsRow(asset: .logout, title: "Log Out", insets: insets) {
+                    dialogItem = .alert(
+                        title: "Are You Sure You Want To Log Out?",
+                        subtitle: "You can get into this account using your Access Key"
+                    ) {
+                        DialogAction.destructive("Log Out") {
+                            logout()
+                        }
+                        DialogAction.cancel()
+                    }
+                }
+
+                SettingsRow(asset: .delete, title: "Delete Account", insets: insets) {
+                    dialogItem = .alert(
+                        title: "Permanently Delete Account?",
+                        subtitle: "This will permanently delete your Flipcash account"
+                    ) {
+                        DialogAction.destructive("Permanently Delete Account") {
+                            deleteAccount()
+                        }
+                        DialogAction.cancel()
+                    }
+                }
             }
-            .padding(.horizontal, 20)
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .font(.appDisplayXS)
+            .foregroundStyle(.textMain)
         }
         .navigationTitle("My Account")
         .toolbarTitleDisplayMode(.inline)
         .dialog(item: $dialogItem)
-    }
-
-    @ViewBuilder
-    private func list() -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-
-            SettingsRow(asset: .key, title: "Access Key", insets: insets) {
-                dialogItem = .alert(
-                    title: "View Your Access Key?",
-                    subtitle: "Your Access Key will grant access to your Flipcash account. Keep it private and safe"
-                ) {
-                    DialogAction.destructive("View Access Key") {
-                        router.push(.accessKey)
-                    }
-                    DialogAction.cancel()
-                }
-            }
-
-            SettingsRow(asset: .logout, title: "Log Out", insets: insets) {
-                dialogItem = .alert(
-                    title: "Are You Sure You Want To Log Out?",
-                    subtitle: "You can get into this account using your Access Key"
-                ) {
-                    DialogAction.destructive("Log Out") {
-                        logout()
-                    }
-                    DialogAction.cancel()
-                }
-            }
-
-            SettingsRow(asset: .delete, title: "Delete Account", insets: insets) {
-                dialogItem = .alert(
-                    title: "Permanently Delete Account?",
-                    subtitle: "This will permanently delete your Flipcash account"
-                ) {
-                    DialogAction.destructive("Permanently Delete Account") {
-                        deleteAccount()
-                    }
-                    DialogAction.cancel()
-                }
-            }
-        }
-        .font(.appDisplayXS)
-        .foregroundStyle(.textMain)
     }
 
     private func deleteAccount() {

--- a/Flipcash/Core/Screens/Settings/SettingsRow.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsRow.swift
@@ -46,5 +46,8 @@ struct SettingsRow: View {
         } action: {
             action()
         }
+        .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
+        .listRowBackground(Color.clear)
+        .listRowSeparatorTint(.rowSeparator)
     }
 }

--- a/Flipcash/Core/Screens/Settings/SettingsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsScreen.swift
@@ -34,49 +34,48 @@ struct SettingsScreen: View {
         @Bindable var router = router
         NavigationStack(path: $router[.settings]) {
             Background(color: .backgroundMain) {
-                ScrollView(showsIndicators: false) {
-                    VStack(spacing: 6) {
-                        HStack(spacing: 12) {
-                            Button("Deposit") {
-                                router.push(.deposit)
-                            }
-                            .buttonStyle(.card(icon: .deposit))
-
-                            Button("Withdraw") {
-                                router.push(.withdraw)
-                            }
-                            .buttonStyle(.card(icon: .withdraw))
+                List {
+                    HStack(spacing: 12) {
+                        Button("Deposit") {
+                            router.push(.deposit)
                         }
+                        .buttonStyle(.card(icon: .deposit))
 
-                        VStack(alignment: .leading, spacing: 0) {
-                            SettingsRow(asset: .myAccount, title: "My Account", insets: insets) {
-                                router.push(.settingsMyAccount)
-                            }
-
-                            SettingsRow(asset: .settings, title: "App Settings", insets: insets) {
-                                router.push(.settingsAppSettings)
-                            }
-
-                            SettingsRow(asset: .sliders, title: "Advanced Features", insets: insets) {
-                                router.push(.settingsAdvancedFeatures)
-                            }
-
-                            if betaFlags.accessGranted {
-                                SettingsRow(asset: .debug, title: "Beta Features", badge: betaBadge, insets: insets) {
-                                    router.push(.settingsBetaFlags)
-                                }
-
-                                SettingsRow(asset: .switchAccounts, title: "Switch Accounts", badge: betaBadge, insets: insets) {
-                                    router.push(.settingsAccountSelection)
-                                }
-                            }
+                        Button("Withdraw") {
+                            router.push(.withdraw)
                         }
-                        .font(.appDisplayXS)
-                        .foregroundStyle(Color.textMain)
+                        .buttonStyle(.card(icon: .withdraw))
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.top, 10)
+                    .listRowInsets(EdgeInsets(top: 10, leading: 20, bottom: 6, trailing: 20))
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+
+                    SettingsRow(asset: .myAccount, title: "My Account", insets: insets) {
+                        router.push(.settingsMyAccount)
+                    }
+
+                    SettingsRow(asset: .settings, title: "App Settings", insets: insets) {
+                        router.push(.settingsAppSettings)
+                    }
+
+                    SettingsRow(asset: .sliders, title: "Advanced Features", insets: insets) {
+                        router.push(.settingsAdvancedFeatures)
+                    }
+
+                    if betaFlags.accessGranted {
+                        SettingsRow(asset: .debug, title: "Beta Features", badge: betaBadge, insets: insets) {
+                            router.push(.settingsBetaFlags)
+                        }
+
+                        SettingsRow(asset: .switchAccounts, title: "Switch Accounts", badge: betaBadge, insets: insets) {
+                            router.push(.settingsAccountSelection)
+                        }
+                    }
                 }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .font(.appDisplayXS)
+                .foregroundStyle(Color.textMain)
                 .safeAreaInset(edge: .bottom) {
                     Button {
                         handleVersionTap()

--- a/FlipcashUI/Sources/FlipcashUI/Views/Containers/Row.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Containers/Row.swift
@@ -27,30 +27,27 @@ public struct Row<Content>: View where Content: View {
     }
     
     public var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Button(action: action) {
-                HStack(spacing: 12) {
-                    content()
-                    if let accessory {
-                        switch accessory {
-                        case .chevron:
-                            Spacer()
-                            Image.system(.chevronRight)
-                                .renderingMode(.template)
-                        case .loader(let color):
-                            Spacer()
-                            LoadingView(color: color)
-                        }
+        Button(action: action) {
+            HStack(spacing: 12) {
+                content()
+                if let accessory {
+                    switch accessory {
+                    case .chevron:
+                        Spacer()
+                        Image.system(.chevronRight)
+                            .renderingMode(.template)
+                    case .loader(let color):
+                        Spacer()
+                        LoadingView(color: color)
                     }
                 }
-                .padding(.leading, insets.leading)
-                .padding(.bottom, insets.bottom)
-                .padding(.trailing, insets.trailing)
-                .padding(.top, insets.top)
             }
-            .disabled(disabled)
-            .vSeparator(color: .rowSeparator, position: .bottom)
+            .padding(.leading, insets.leading)
+            .padding(.bottom, insets.bottom)
+            .padding(.trailing, insets.trailing)
+            .padding(.top, insets.top)
         }
+        .disabled(disabled)
         .foregroundStyle(disabled ? .textSecondary : .textMain)
     }
 }


### PR DESCRIPTION
Converts the four Settings screens (Settings, App Settings, Advanced Features, My Account) to a native list, so separators, spacing, and scrolling come from the system instead of being hand-drawn on each row. No visual change intended. Part of the ongoing pass replacing custom UI with Apple's built-in components.

## Test plan
- [ ] Each settings screen's rows look the same as before — spacing and separators.
- [ ] The Deposit / Withdraw cards sit at the top of Settings with no separator beneath them.
- [ ] The version label stays pinned at the bottom of the main Settings screen.
- [ ] Backgrounds match the rest of the app (no stray default list background).
- [ ] The "Auto Start Camera" toggle row in App Settings reads correctly.