### PR TITLE
refactor: slim LargeButton and normalize bottom-bar icon sizing

### DIFF
--- a/Flipcash/Core/Screens/Main/ScanBottomBar.swift
+++ b/Flipcash/Core/Screens/Main/ScanBottomBar.swift
@@ -17,11 +17,6 @@ struct ScanBottomBar: View {
             LargeButton(
                 title: "Discover",
                 image: Image(.Icons.coins),
-                spacing: 12,
-                maxWidth: 80,
-                maxHeight: 80,
-                fullWidth: true,
-                aligment: .bottom,
                 action: onDiscover
             )
             .accessibilityIdentifier("scan-discover-button")
@@ -29,11 +24,6 @@ struct ScanBottomBar: View {
             LargeButton(
                 title: "Cash",
                 image: .asset(.cash),
-                spacing: 12,
-                maxWidth: 80,
-                maxHeight: 80,
-                fullWidth: true,
-                aligment: .bottom,
                 action: onGive
             )
             .accessibilityIdentifier("scan-cash-button")
@@ -42,11 +32,6 @@ struct ScanBottomBar: View {
                 LargeButton(
                     title: "Wallet",
                     image: .asset(.history),
-                    spacing: 12,
-                    maxWidth: 80,
-                    maxHeight: 80,
-                    fullWidth: true,
-                    aligment: .bottom,
                     action: onWallet
                 )
                 .accessibilityIdentifier("scan-wallet-button")

--- a/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
@@ -8,114 +8,41 @@
 
 import SwiftUI
 
-public struct LargeButton<Content>: View where Content: View {
-    
-    private let title: String?
-    private let content: () -> Content
-    private let spacing: CGFloat
-    private let maxWidth: CGFloat?
-    private let maxHeight: CGFloat?
-    private let fullWidth: Bool
-    private let badge: Int
-    private let badgeInsets: EdgeInsets
-    private let aligment: Alignment
+public struct LargeButton: View {
+
+    private let title: String
+    private let image: Image
     private let action: VoidAction
-    
-    public init(title: String?, content: @escaping () -> Content, spacing: CGFloat = 0, maxWidth: CGFloat? = nil, maxHeight: CGFloat? = nil, fullWidth: Bool = false, badge: Int = 0, badgeInsets: EdgeInsets = .zero, aligment: Alignment = .center, binding: Binding<Bool>) {
-        self.init(
-            title: title,
-            content: content,
-            spacing: spacing,
-            maxWidth: maxWidth,
-            maxHeight: maxHeight,
-            fullWidth: fullWidth,
-            badge: badge,
-            badgeInsets: badgeInsets,
-            aligment: aligment
-        ) {
-            binding.wrappedValue.toggle()
-        }
+
+    public init(title: String, image: Image, action: @escaping VoidAction) {
+        self.title  = title
+        self.image  = image
+        self.action = action
     }
-    
-    public init(title: String?, content: @escaping () -> Content, spacing: CGFloat = 0, maxWidth: CGFloat? = nil, maxHeight: CGFloat? = nil, fullWidth: Bool = false, badge: Int = 0, badgeInsets: EdgeInsets = .zero, aligment: Alignment = .center, action: @escaping VoidAction) {
-        self.title     = title
-        self.content   = content
-        self.spacing   = spacing
-        self.maxWidth  = maxWidth
-        self.maxHeight = maxHeight
-        self.fullWidth = fullWidth
-        self.badge     = badge
-        self.badgeInsets = badgeInsets
-        self.aligment  = aligment
-        self.action    = action
-    }
-    
+
     public var body: some View {
         Button(action: action) {
-            VStack(spacing: spacing) {
-                content()
-                    .if(badge > 0) { $0
-                        .badged(badge, insets: badgeInsets)
-                    }
-                if let title = title {
-                    Text(title)
-                        .font(.appTextSmall)
-                }
+            VStack(spacing: 12) {
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 40, height: 40)
+                Text(title)
+                    .font(.appTextSmall)
             }
-            .frame(minWidth: maxWidth, minHeight: maxHeight, alignment: aligment)
-            .if(fullWidth) { $0
-                .frame(maxWidth: .infinity)
-            }
+            .frame(maxWidth: .infinity, minHeight: 80, alignment: .bottom)
         }
         .foregroundStyle(.textMain)
     }
 }
 
-extension LargeButton where Content == Image {
-    public init(title: String?, image: Image, spacing: CGFloat = 0, maxWidth: CGFloat? = nil, maxHeight: CGFloat? = nil, fullWidth: Bool = false, badge: Int = 0, badgeInsets: EdgeInsets = .zero, aligment: Alignment = .center, binding: Binding<Bool>) {
-        self.init(
-            title: title,
-            image: image,
-            spacing: spacing,
-            maxWidth: maxWidth,
-            maxHeight: maxHeight,
-            fullWidth: fullWidth,
-            badge: badge,
-            badgeInsets: badgeInsets,
-            aligment: aligment
-        ) {
-            binding.wrappedValue.toggle()
-        }
-    }
-    
-    public init(title: String?, image: Image, spacing: CGFloat = 0, maxWidth: CGFloat? = nil, maxHeight: CGFloat? = nil, fullWidth: Bool = false, badge: Int = 0, badgeInsets: EdgeInsets = .zero, aligment: Alignment = .center, action: @escaping VoidAction) {
-        self.init(
-            title: title,
-            content: { image },
-            spacing: spacing,
-            maxWidth: maxWidth,
-            maxHeight: maxHeight,
-            fullWidth: fullWidth,
-            badge: badge,
-            badgeInsets: badgeInsets,
-            aligment: aligment,
-            action: action
-        )
-    }
-}
-
 // MARK: - Previews -
 
-struct ImageButton_Previews: PreviewProvider {
-    static var previews: some View {
-        Background(color: .backgroundMain) {
-            HStack(alignment: .bottom) {
-                LargeButton(title: "History", image: .asset(.history),   binding: .constant(true))
-                LargeButton(title: "Invites", image: .asset(.invites),   binding: .constant(true))
-//                LargeButton(title: "Give Kin", image: .asset(.kin),      binding: .constant(true))
-//                LargeButton(title: "Give Kin", image: .asset(.kinLarge), spacing: 8, binding: .constant(true))
-            }
+#Preview {
+    Background(color: .backgroundMain) {
+        HStack(alignment: .bottom) {
+            LargeButton(title: "History", image: .asset(.history)) {}
+            LargeButton(title: "Invites", image: .asset(.invites)) {}
         }
-        .accentColor(.textMain)
     }
 }


### PR DESCRIPTION
Cleans up the button component behind the scan screen's bottom bar, which had accumulated unused generics, initializers, and styling options that no longer matched how it's actually used. Also normalizes the three icons so Discover, Cash, and Wallet all sit in a consistent, centered square — previously Cash and Wallet rendered slightly larger than Discover.

## Test plan
- [x] Open the scan screen and confirm the Discover, Cash, and Wallet icons are all the same size and aligned along the bottom.
- [x] Tap each of the three buttons and confirm it triggers the correct action.