### PR TITLE
feat: point the no-balance nudge at the deposit flow

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -236,7 +236,7 @@ struct DeepLinkAction {
                     let rate = container.ratesController.rateForBalanceCurrency()
                     guard container.session.hasGiveableBalance(for: rate) else {
                         container.session.dialogItem = .noGiveableBalance {
-                            container.appRouter.present(.discover)
+                            container.appRouter.navigate(to: .deposit)
                         }
                         return
                     }

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -314,7 +314,7 @@ struct ScanScreen: View {
         let rate = sessionContainer.ratesController.rateForBalanceCurrency()
         guard session.hasGiveableBalance(for: rate) else {
             session.dialogItem = .noGiveableBalance {
-                router.present(.discover)
+                router.navigate(to: .deposit)
             }
             return
         }

--- a/Flipcash/UI/DialogItem+CashFlows.swift
+++ b/Flipcash/UI/DialogItem+CashFlows.swift
@@ -20,14 +20,14 @@ extension DialogItem {
         )
     }
 
-    /// Nudges the user to discover currencies when they attempt to Give
-    /// with no balance.
-    static func noGiveableBalance(onDiscover: @escaping () -> Void) -> DialogItem {
+    /// Nudges the user to deposit funds when they attempt to give or send
+    /// with no giveable balance.
+    static func noGiveableBalance(onDeposit: @escaping () -> Void) -> DialogItem {
         .info(
             title: "No Balance Yet",
-            subtitle: "Buy a currency to get started, or get another Flipcash user to give you some cash"
+            subtitle: "Deposit funds to give cash"
         ) {
-            .standard("Discover Currencies", action: onDiscover);
+            .standard("Deposit Funds", action: onDeposit);
             .cancel()
         }
     }

--- a/FlipcashTests/DialogItemFactoryTests.swift
+++ b/FlipcashTests/DialogItemFactoryTests.swift
@@ -6,6 +6,7 @@
 import Foundation
 import Testing
 import FlipcashUI
+@testable import Flipcash
 
 @MainActor
 @Suite("DialogItem factory semantics")
@@ -65,5 +66,18 @@ struct DialogItemFactoryTests {
 
         let dismissableSuccess = DialogItem.success(title: "x", subtitle: "y", dismissable: true)
         #expect(dismissableSuccess.dismissable == true)
+    }
+
+    @Test(".noGiveableBalance uses the deposit-funds design")
+    func noGiveableBalance_depositDesign() {
+        let item = DialogItem.noGiveableBalance(onDeposit: {})
+        #expect(item.title == "No Balance Yet")
+        #expect(item.subtitle == "Deposit funds to give cash")
+        #expect(item.style == .standard)
+        #expect(item.actions.count == 2)
+        #expect(item.actions[0].title == "Deposit Funds")
+        #expect(item.actions[0].kind == .standard)
+        #expect(item.actions[1].title == "Cancel")
+        #expect(item.actions[1].kind == .subtle)
     }
 }

--- a/FlipcashTests/SessionTests.swift
+++ b/FlipcashTests/SessionTests.swift
@@ -667,3 +667,39 @@ struct SessionOfflineCacheTests {
         #expect(session.userFlags == nil)
     }
 }
+
+@MainActor
+@Suite("Session.hasGiveableBalance")
+struct SessionHasGiveableBalanceTests {
+
+    @Test("Fresh account (USDF at zero) has no giveable balance")
+    func freshAccount_hasNone() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 0),
+        ])
+        #expect(container.session.hasGiveableBalance(for: .oneToOne) == false)
+    }
+
+    @Test("USDF balance alone is not giveable — USDF is never sent peer-to-peer")
+    func usdfOnly_isNotGiveable() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 5 * 10_000_000_000),
+        ])
+        #expect(container.session.hasGiveableBalance(for: .oneToOne) == false)
+    }
+
+    @Test("A funded non-USDF balance is giveable")
+    func fundedNonUSDF_isGiveable() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 0),
+            .init(
+                mint: .makeLaunchpad(
+                    address: .jeffy,
+                    supplyFromBonding: 1_000_000 * 10_000_000_000
+                ),
+                quarks: 10 * 10_000_000_000
+            ),
+        ])
+        #expect(container.session.hasGiveableBalance(for: .oneToOne) == true)
+    }
+}


### PR DESCRIPTION
When someone with no balance tries to give cash — from the Cash tab or a give deeplink — the dialog now reads "No Balance Yet · Deposit funds to give cash" and its primary button, Deposit Funds, opens the deposit flow. Previously it pointed at Discover Currencies.

## Test plan
- [x] On an account with no balance, tap Cash and confirm the dialog reads "Deposit funds to give cash" with a Deposit Funds button.
- [x] Tap Deposit Funds and confirm it opens the deposit flow.
- [x] Tap Cancel and confirm the dialog closes.