### PR TITLE
feat: nudge to deposit when sending with no balance

### DIFF
--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -26,6 +26,8 @@ struct RecipientPickerScreen: View {
 
     @Environment(ContactSyncController.self) private var contactSyncController
     @Environment(AppRouter.self) private var router
+    @Environment(Session.self) private var session
+    @Environment(RatesController.self) private var ratesController
 
     @State private var filtered: ResolvedContacts = .empty
     @State private var inviteTarget: ResolvedContact?
@@ -69,6 +71,12 @@ struct RecipientPickerScreen: View {
 
     private func selectRecipient(_ contact: ResolvedContact) {
         Analytics.track(event: Analytics.SendEvent.tapRecipient)
+        guard session.hasGiveableBalance(for: ratesController.rateForBalanceCurrency()) else {
+            session.dialogItem = .noGiveableBalance {
+                router.navigate(to: .deposit)
+            }
+            return
+        }
         router.push(.sendAmount(contact: contact))
     }
 


### PR DESCRIPTION
Tapping a recipient in Send when you have no balance to send now shows the shared "No Balance Yet" dialog — the same one the Cash tab shows — instead of opening the amount screen. Its action takes you to the deposit flow.

Heads-up: the dialog's wording and button reflect the deposit redesign (#368) once contact-sync picks up main; until then this branch shows the previous wording.

## Test plan
- [ ] On an account with no balance, open Send and tap a recipient; confirm the no-balance dialog appears instead of the amount screen.
- [ ] Tap the dialog's main button and confirm it opens the deposit flow.
- [ ] On an account with a balance, tap a recipient and confirm the amount screen still opens.