### PR TITLE
docs: add architecture documentation and upkeep workflow

### DIFF
--- a/.claude/skills/verify-architecture-docs/SKILL.md
+++ b/.claude/skills/verify-architecture-docs/SKILL.md
@@ -20,7 +20,7 @@ allowed-tools:
 
 ultrathink
 
-You are fact-checking the architecture docs in `docs/architecture/` against the real codebase. The deliverable is **one drift report** at `.claude/plans/<YYYY-MM-DD>-doc-drift.md`. This catches **correctness drift** — a doc that is present but *wrong* — which the path-based upkeep checks (the CLAUDE.md rule + the `Stop` hook) cannot.
+You are fact-checking the architecture docs in `docs/architecture/` against the real codebase. The deliverable is **one drift report** at `.claude/plans/<YYYY-MM-DD>-doc-drift.md`. This catches **correctness drift** — a doc that is present but *wrong* — which the path-based upkeep check (the CLAUDE.md rule) cannot.
 
 ## Hard rules
 
@@ -56,4 +56,4 @@ List the fixes and ask whether to apply them. Don't edit the docs until the user
 ## Notes
 - This is the **correctness** half of doc upkeep; the CLAUDE.md "Architecture Docs" rule is the **omission** half ("you forgot to touch the doc"). Both are needed.
 - The methodology mirrors how these docs were originally verified: parallel per-doc checkers → reconcile contested claims against source → report → fix → re-verify. Two passes converge fast.
-- Expect to surface stale facts in **CLAUDE.md** too (its Key Constants / Common Pitfalls cite `file.swift:NN`). Note them in the report; don't edit CLAUDE.md without approval.
+- Expect to surface stale facts in **CLAUDE.md** too (its Key Constants / Common Pitfalls cite concrete files and symbols). Note them in the report; don't edit CLAUDE.md without approval.

--- a/.claude/skills/verify-architecture-docs/SKILL.md
+++ b/.claude/skills/verify-architecture-docs/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: verify-architecture-docs
+description: Fact-check docs/architecture/*.md against the actual code — catch correctness drift (a doc says X, the code does Y), not just untouched files. Fans out one adversarial checker per doc and writes a drift report.
+argument-hint: "[--since <ref> | --doc <path>]"
+model: opus
+effort: max
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Agent
+  - Write
+  - Bash(git diff:*)
+  - Bash(git log:*)
+  - Bash(git merge-base:*)
+  - Bash(git show:*)
+---
+
+# Verify Architecture Docs
+
+ultrathink
+
+You are fact-checking the architecture docs in `docs/architecture/` against the real codebase. The deliverable is **one drift report** at `.claude/plans/<YYYY-MM-DD>-doc-drift.md`. This catches **correctness drift** — a doc that is present but *wrong* — which the path-based upkeep checks (the CLAUDE.md rule + the `Stop` hook) cannot.
+
+## Hard rules
+
+1. **No claim without a citation.** Every finding cites a `file.swift:NN` (or command output) that contradicts the doc. If you can't cite it, it's not a finding.
+2. **The code wins.** When a doc and the code disagree, the *doc* is wrong — propose the doc fix, never "change the code to match the doc."
+3. **Verify contested claims yourself.** If a checker's finding conflicts with CLAUDE.md or another agent, open the cited file and confirm it before recording — never trust a single agent's claim. Stale CLAUDE.md facts are expected; flag them.
+4. **Read source in full, not snippets**, when confirming a behavioral assertion.
+5. **Don't fix without approval.** The report is the review artifact. Apply doc edits only after the user approves.
+
+## Steps
+
+### 1. Determine scope
+- No args → all 12 docs (`README.md`, `01`–`10`, `features/README.md`).
+- `--doc <path>` → just that doc.
+- `--since <ref>` → only docs whose watch paths changed since `<ref>`. Map changed paths (`git diff --name-only <ref>...HEAD`) to docs using the "Architecture Docs" trigger list in `CLAUDE.md` and the index in `docs/architecture/README.md`. Include `README.md` / `10-separation-of-concerns.md` only when a *structural/module* change appears (they're cross-cutting syntheses).
+
+### 2. Fan out one checker per in-scope doc (parallel)
+Dispatch an adversarial fact-check subagent per doc (read-only). Each one:
+- Reads its doc in full.
+- For **every concrete checkable claim** — file/dir paths, type & symbol names, numeric/constant values, behavioral assertions — verifies it against the source.
+- Returns ONLY evidence-backed discrepancies, each classified **ERROR** (factually wrong) or **GAP** (important omission — high bar; the docs are intentionally concise), formatted: `[ERROR|GAP] § "<quote>" — <what's wrong> — evidence: <file:NN> — fix: <correction>`. A clean doc returns `CLEAN`.
+
+### 3. Reconcile
+- For any finding that conflicts with CLAUDE.md or looks surprising, open the cited file and confirm it yourself.
+- Drop false positives; keep only findings you can stand behind with a citation. Watch for agents that *invent* symbols — verify a symbol exists before recording a fix that references it.
+
+### 4. Write the report
+`.claude/plans/<YYYY-MM-DD>-doc-drift.md`, grouped by doc, each finding as `claim → cited code (file.swift:NN) → verdict (matches | stale | wrong) → fix`. End with a per-doc count and a TOTAL. If everything is clean, say so plainly.
+
+### 5. Offer to apply
+List the fixes and ask whether to apply them. Don't edit the docs until the user says go. If asked to apply, re-verify the corrected docs (a second pass) before declaring zero errors.
+
+## Notes
+- This is the **correctness** half of doc upkeep; the CLAUDE.md "Architecture Docs" rule is the **omission** half ("you forgot to touch the doc"). Both are needed.
+- The methodology mirrors how these docs were originally verified: parallel per-doc checkers → reconcile contested claims against source → report → fix → re-verify. Two passes converge fast.
+- Expect to surface stale facts in **CLAUDE.md** too (its Key Constants / Common Pitfalls cite `file.swift:NN`). Note them in the report; don't edit CLAUDE.md without approval.

--- a/.claude/skills/verify-architecture-docs/SKILL.md
+++ b/.claude/skills/verify-architecture-docs/SKILL.md
@@ -2,7 +2,7 @@
 name: verify-architecture-docs
 description: Fact-check docs/architecture/*.md against the actual code — catch correctness drift (a doc says X, the code does Y), not just untouched files. Fans out one adversarial checker per doc and writes a drift report.
 argument-hint: "[--since <ref> | --doc <path>]"
-model: opus
+model: fable
 effort: max
 allowed-tools:
   - Read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,31 @@ When adding new information, place it in the appropriate existing section. Remov
 
 ---
 
+## Architecture Docs
+
+**`docs/architecture/` is the canonical map of how the app fits together.** Read the relevant doc before changing a subsystem, and update it in the **same change** when your work alters what it describes — treat the doc edit as part of the diff, not a follow-up.
+
+**Update the matching doc when you:**
+
+- Add/remove a package or change a module boundary → `01-modules-and-boundaries.md`
+- Change DI, state ownership, or the session/auth lifecycle → `02-state-and-dependency-injection.md`
+- Add/restructure a router sheet, stack, destination, or deeplink → `03-navigation.md`
+- Add an RPC, change `CallOptions`, or touch request signing/streaming → `04-networking.md`
+- Change the schema, a cached table, or the no-migration policy → `05-persistence.md`
+- Change intent submission, `VerifiedState`, the give/grab flow, or a funding operation → `06-payments-and-operations.md`
+- Change Quarks/fiat math, the bonding curve, a domain model, or a `Validator` → `07-currency-and-domain-model.md`
+- Add/rename a FlipcashUI component or design token → `08-design-system.md`
+- Change logging, error reporting, analytics, or crypto/scanning plumbing → `09-cross-cutting-concerns.md`
+- Add, remove, or materially change a user-facing feature → `features/README.md`
+
+The full concern→doc index and per-doc watch paths live in [`docs/architecture/README.md`](docs/architecture/README.md). `README.md` and `10-separation-of-concerns.md` are cross-cutting syntheses — revisit them when the structure they summarize shifts, not on routine edits.
+
+**Scope (mirror the docs' own style):** describe *structure and intent*, not every line — usually a one-line table row or a corrected sentence is the whole change. If a doc and the code disagree, the code wins — fix the doc. Don't add per-doc "last updated" stamps; git history is the timestamp.
+
+**Verifying correctness:** this rule catches *missing* updates only. To check whether a doc is actually *correct* against the code, run `/verify-architecture-docs` — it fact-checks each doc's claims against the source and writes a drift report. Run it after large changes or periodically.
+
+---
+
 ## Behavior & Approach
 
 ### Working Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ When adding new information, place it in the appropriate existing section. Remov
 - Add/rename a FlipcashUI component or design token → `08-design-system.md`
 - Change logging, error reporting, analytics, or crypto/scanning plumbing → `09-cross-cutting-concerns.md`
 - Add, remove, or materially change a user-facing feature → `features/README.md`
+- Change chat/conversation behavior → the doc for the layer you touched: conversation sheets/deeplinks `03-navigation.md`, chat services `04-networking.md`, conversation tables `05-persistence.md`, the user-facing flow `features/README.md`
 
 The full concern→doc index and per-doc watch paths live in [`docs/architecture/README.md`](docs/architecture/README.md). `README.md` and `10-separation-of-concerns.md` are cross-cutting syntheses — revisit them when the structure they summarize shifts, not on routine edits.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -627,14 +627,15 @@ Database:
 ### Key Constants
 
 ```swift
-// USDC
-PublicKey.usdc // Main stablecoin mint
-PublicKey.usdc.mintDecimals // 6
+// Mints
+PublicKey.usdf // Main stablecoin mint
+PublicKey.mintDecimals // .usdf → 6; every other mint INCLUDING .usdc → 10
+                       // (USDC's real 6-decimal precision comes from MintMetadata.usdc.decimals)
 
-// Bonding Curve
-BondingCurve.startPrice  // $0.01
-BondingCurve.endPrice    // $1,000,000
-BondingCurve.maxSupply   // 21,000,000 tokens
+// Bonding Curve (DiscreteBondingCurve — step-based, mirrors the on-chain program)
+DiscreteBondingCurve.maxSupply  // 21,000,000 tokens
+DiscreteBondingCurve.stepSize   // 100 tokens/step
+DiscreteBondingCurve.tableSize  // 210,001 entries (pre-computed .bin resources)
 ```
 
 ### Xcode MCP Server

--- a/docs/architecture/01-modules-and-boundaries.md
+++ b/docs/architecture/01-modules-and-boundaries.md
@@ -1,6 +1,6 @@
 # Modules & Boundaries
 
-The codebase is split into 5 SPM packages plus the app target and one app extension (NotificationService *(contact-sync)*); a share helper is embedded in the app target rather than being its own target. The split enforces a strict, acyclic dependency layering: business logic never imports UI, UI never imports the network layer, and generated code is isolated behind one package.
+The codebase is split into 5 SPM packages plus the app target and two app extensions (NotificationService, NotificationContent); a share helper is embedded in the app target rather than being its own target. The split enforces a strict, acyclic dependency layering: business logic never imports UI, UI never imports the network layer, and generated code is isolated behind one package.
 
 ## Module inventory
 
@@ -12,7 +12,8 @@ The codebase is split into 5 SPM packages plus the app target and one app extens
 | **FlipcashCore** | SPM package | Business logic, models, gRPC service wrappers, logging, validation, formatters — **no SwiftUI** |
 | **FlipcashUI** | SPM package | Reusable SwiftUI/UIKit components + design tokens — **no networking/persistence** |
 | **Flipcash** | Xcode app target | Screens, navigation, controllers (Database, Session, Rates…), 3rd-party SDKs |
-| **NotificationService** *(contact-sync)* | Xcode extension | `UNNotificationServiceExtension` — resolves contact names on-device, renders communication notifications |
+| **NotificationService** | Xcode extension | `UNNotificationServiceExtension` — resolves contact names on-device, renders communication notifications, prefetches chat transcripts into the shared cache |
+| **NotificationContent** | Xcode extension | `UNNotificationContentExtension` — expanded (long-press) chat push panel; lightweight SwiftUI transcript fed from the shared cache |
 | **Flipcash/Share** | Files in app target | System share-sheet wrapper (`UIActivityViewController`) for cash links |
 | **FlipcashTests** | Xcode test target | Unit/integration tests (Swift Testing) for app + Core |
 | **FlipcashUITests** | Xcode test target | Black-box XCUITest smoke tests |
@@ -26,12 +27,16 @@ graph TD
     App --> SQLite["SQLite fork"]
     App --> SDKs["Firebase · Bugsnag · Mixpanel · Kingfisher · tweetnacl"]
     UI --> Core["FlipcashCore"]
+    UI --> ChatLibs["ChatLayout · DifferenceKit"]
     Core --> API["FlipcashAPI"]
     Core --> Curves["CodeCurves"]
     Core --> Libs["BigDecimal · PhoneNumberKit · swift-log"]
-    API --> gRPC["grpc-swift 1.x"]
-    Ext["NotificationService extension (contact-sync)"] --> Core
-    Ext --> API
+    API --> gRPC["grpc-swift 2.x"]
+    Core --> gRPC
+    NSE["NotificationService extension"] --> Core
+    NSE --> API
+    NCE["NotificationContent extension"] --> Core
+    NCE --> UI
 ```
 *Arrows point to dependencies; the graph is acyclic.*
 
@@ -39,10 +44,13 @@ graph TD
 
 | Dependency | Pin | Used by |
 |------------|-----|---------|
-| grpc-swift | ≥1.22 (**v1, not v2**) | FlipcashAPI |
+| grpc-swift-2 | ≥2.4 (**v2**; resolved 2.4.1) | FlipcashAPI + FlipcashCore (`GRPCCore`) |
+| grpc-swift-protobuf | ≥2.0 | FlipcashAPI (`GRPCProtobuf`) |
+| grpc-swift-nio-transport (+ swift-nio) | ≥2.0 / ≥2.81 | FlipcashCore (`GRPCNIOTransportHTTP2` — Network.framework TransportServices) |
 | swift-log | ≥1.6 | FlipcashCore |
 | BigDecimal | ≥3.0.2 | FlipcashCore (quark/fiat math) |
 | PhoneNumberKit | ≥4.1.4 | FlipcashCore |
+| ChatLayout / DifferenceKit | ≥2.4.2 / ≥1.3.0 | FlipcashUI (chat transcript layout + diffing) |
 | SQLite.swift (**dbart01 fork**, `master`) | — | app only |
 | Firebase, Bugsnag, Mixpanel, Kingfisher, tweetnacl | various | app only |
 | opencv2 (bundled XCFramework) | ~4.10 | CodeScanner only |
@@ -54,14 +62,15 @@ The observability/analytics SDKs (Firebase, Bugsnag, Mixpanel) are confined to t
 - **`FlipcashAPI/**/Generated/` is never hand-edited.** Regenerate via `Scripts/run -a flipcashPayments` / `flipcashCore`. Edits are overwritten. Wrap generated stubs in hand-written service files instead.
 - **FlipcashCore is SwiftUI-free** — zero `import SwiftUI`. Models, clients, logging, validation, formatting only. Anything UI-facing crosses into FlipcashUI or the app.
 - **FlipcashUI has no business logic** — it imports FlipcashCore for *model types and formatters* only. No network calls, no session state, no persistence.
-- **SQLite belongs to the app layer only** — `import SQLite` appears exclusively under `Flipcash/Core/Controllers/Database/`. Core has no SQLite dependency.
+- **SQLite belongs to the app layer only** — `import SQLite` appears exclusively under `Flipcash/Core/Controllers/Database/` (plus its tests). Core has no SQLite dependency.
 - **CodeScanner is used at exactly two call sites** (`CodeExtractor.swift`, `CashCode.Payload+Encoding.swift`); it never reaches Core or UI.
 - **Directory placement**: screens → `Flipcash/Core/Screens/`; domain models → `FlipcashCore/.../Models/`; DB row models → `Flipcash/Core/Controllers/Database/Models/`; test support → `FlipcashTests/TestSupport/`.
 
 ## Embedded targets
 
-- **NotificationService** *(contact-sync)* — runs in a tight memory/time budget. Server pushes E.164 numbers + positional placeholders; the extension queries `CNContactStore` to resolve names, and renders "Sent You Cash" pushes as `INSendMessageIntent` communication notifications (sender avatar in the banner). Imports FlipcashCore + FlipcashAPI only.
-- **Share** — `ShareCashLinkItem` (`UIActivityItemSource` providing a cash-link URL) + `ShareSheet` (`UIViewControllerRepresentable` over `UIActivityViewController`). Embedded in the app target, not a separate bundle.
+- **NotificationService** — runs in a tight memory/time budget. Server pushes E.164 numbers + positional placeholders; the extension queries `CNContactStore` to resolve names, and renders "Sent You Cash" pushes as `INSendMessageIntent` communication notifications (sender avatar in the banner). For chat pushes it also prefetches the recent transcript over a transient gRPC connection into `NotificationPreviewCache` (App Group `group.com.flipcash.shared`). Imports FlipcashCore + FlipcashAPI only.
+- **NotificationContent** — `UNNotificationContentExtension` behind the expanded (long-press) chat push. Renders a fixed-height, bottom-anchored SwiftUI bubble transcript (`NotificationTranscriptView`) — deliberately **not** the in-app `ChatViewController`, whose footprint exceeds the extension's memory budget and gets it jetsam-killed. Reads `NotificationPreviewCache` first; on a cache miss falls back to a live fetch over a transient connection. Imports FlipcashCore + FlipcashUI only.
+- **Share** — `ShareCashLinkItem` (`UIActivityItemSource` providing a cash-link URL) + `ShareSheet` (an enum whose static `present(activityItem:completion:)` builds a `UIActivityViewController` and presents it on the root view controller). Embedded in the app target, not a separate bundle.
 
 ## Why this matters
 

--- a/docs/architecture/01-modules-and-boundaries.md
+++ b/docs/architecture/01-modules-and-boundaries.md
@@ -1,0 +1,68 @@
+# Modules & Boundaries
+
+The codebase is split into 5 SPM packages plus the app target and one app extension (NotificationService); a share helper is embedded in the app target rather than being its own target. The split enforces a strict, acyclic dependency layering: business logic never imports UI, UI never imports the network layer, and generated code is isolated behind one package.
+
+## Module inventory
+
+| Module | Type | Purpose | ~Files |
+|--------|------|---------|--------|
+| **CodeCurves** | SPM package | Ed25519 crypto — pure-C implementation (zero Swift; the `KeyPair` wrapper lives in FlipcashCore) | ~18 C/h |
+| **CodeScanner** | SPM package | C++/OpenCV "Kik Code" circular-2D encode/decode/scan; bundles OpenCV 4.10 | ~12 C++ + bridge |
+| **FlipcashAPI** | SPM package | **All** generated gRPC/protobuf Swift bindings (both backends) | ~45 (100% generated) |
+| **FlipcashCore** | SPM package | Business logic, models, gRPC service wrappers, logging, validation, formatters — **no SwiftUI** | ~216 |
+| **FlipcashUI** | SPM package | Reusable SwiftUI/UIKit components + design tokens — **no networking/persistence** | ~78 |
+| **Flipcash** | Xcode app target | Screens, navigation, controllers (Database, Session, Rates…), 3rd-party SDKs | ~205 |
+| **NotificationService** | Xcode extension | `UNNotificationServiceExtension` — resolves contact names on-device, renders communication notifications | 1 |
+| **Flipcash/Share** | Files in app target | System share-sheet wrapper (`UIActivityViewController`) for cash links | 2 |
+| **FlipcashTests** | Xcode test target | Unit/integration tests (Swift Testing) for app + Core | ~118 |
+| **FlipcashUITests** | Xcode test target | Black-box XCUITest smoke tests | ~35 |
+
+## Dependency graph
+
+```mermaid
+graph TD
+    App["Flipcash app"] --> UI["FlipcashUI"]
+    App --> Scanner["CodeScanner"]
+    App --> SQLite["SQLite fork"]
+    App --> SDKs["Firebase · Bugsnag · Mixpanel · Kingfisher · tweetnacl"]
+    UI --> Core["FlipcashCore"]
+    Core --> API["FlipcashAPI"]
+    Core --> Curves["CodeCurves"]
+    Core --> Libs["BigDecimal · PhoneNumberKit · swift-log"]
+    API --> gRPC["grpc-swift 1.x"]
+    Ext["NotificationService extension"] --> Core
+    Ext --> API
+```
+*Arrows point to dependencies; the graph is acyclic.*
+
+### Third-party dependencies (where they live)
+
+| Dependency | Pin | Used by |
+|------------|-----|---------|
+| grpc-swift | ≥1.22 (**v1, not v2**) | FlipcashAPI |
+| swift-log | ≥1.6 | FlipcashCore |
+| BigDecimal | ≥3.0.2 | FlipcashCore (quark/fiat math) |
+| PhoneNumberKit | ≥4.1.4 | FlipcashCore |
+| SQLite.swift (**dbart01 fork**, `master`) | — | app only |
+| Firebase, Bugsnag, Mixpanel, Kingfisher, tweetnacl | various | app only |
+| opencv2 (bundled XCFramework) | ~4.10 | CodeScanner only |
+
+The observability/analytics SDKs (Firebase, Bugsnag, Mixpanel) are confined to the **app target** — they never leak into Core or UI.
+
+## Boundary rules (enforced by convention)
+
+- **`FlipcashAPI/**/Generated/` is never hand-edited.** Regenerate via `Scripts/run -a flipcashPayments` / `flipcashCore`. Edits are overwritten. Wrap generated stubs in hand-written service files instead.
+- **FlipcashCore is SwiftUI-free** — zero `import SwiftUI`. Models, clients, logging, validation, formatting only. Anything UI-facing crosses into FlipcashUI or the app.
+- **FlipcashUI has no business logic** — it imports FlipcashCore for *model types and formatters* only. No network calls, no session state, no persistence.
+- **SQLite belongs to the app layer only** — `import SQLite` appears exclusively under `Flipcash/Core/Controllers/Database/`. Core has no SQLite dependency.
+- **CodeScanner is used at exactly two call sites** (`CodeExtractor.swift`, `CashCode.Payload+Encoding.swift`); it never reaches Core or UI.
+- **Directory placement**: screens → `Flipcash/Core/Screens/`; domain models → `FlipcashCore/.../Models/`; DB row models → `Flipcash/Core/Controllers/Database/Models/`; test support → `FlipcashTests/TestSupport/`.
+
+## Embedded targets
+
+- **NotificationService** — runs in a tight memory/time budget. Server pushes E.164 numbers + positional placeholders; the extension queries `CNContactStore` to resolve names, and renders "Sent You Cash" pushes as `INSendMessageIntent` communication notifications (sender avatar in the banner). Imports FlipcashCore + FlipcashAPI only.
+- **Share** — `ShareCashLinkItem` (`UIActivityItemSource` providing a cash-link URL) + `ShareSheet` (`UIViewControllerRepresentable` over `UIActivityViewController`). Embedded in the app target, not a separate bundle.
+
+## Why this matters
+
+The layering is the single biggest structural guarantee in the project: because Core can't import UI and the app can't reach into generated code, a change to a proto, a UI component, or a screen each has a bounded blast radius. Keep new code on the right layer — that's what keeps the graph acyclic.

--- a/docs/architecture/01-modules-and-boundaries.md
+++ b/docs/architecture/01-modules-and-boundaries.md
@@ -1,21 +1,21 @@
 # Modules & Boundaries
 
-The codebase is split into 5 SPM packages plus the app target and one app extension (NotificationService); a share helper is embedded in the app target rather than being its own target. The split enforces a strict, acyclic dependency layering: business logic never imports UI, UI never imports the network layer, and generated code is isolated behind one package.
+The codebase is split into 5 SPM packages plus the app target and one app extension (NotificationService *(contact-sync)*); a share helper is embedded in the app target rather than being its own target. The split enforces a strict, acyclic dependency layering: business logic never imports UI, UI never imports the network layer, and generated code is isolated behind one package.
 
 ## Module inventory
 
-| Module | Type | Purpose | ~Files |
-|--------|------|---------|--------|
-| **CodeCurves** | SPM package | Ed25519 crypto — pure-C implementation (zero Swift; the `KeyPair` wrapper lives in FlipcashCore) | ~18 C/h |
-| **CodeScanner** | SPM package | C++/OpenCV "Kik Code" circular-2D encode/decode/scan; bundles OpenCV 4.10 | ~12 C++ + bridge |
-| **FlipcashAPI** | SPM package | **All** generated gRPC/protobuf Swift bindings (both backends) | ~45 (100% generated) |
-| **FlipcashCore** | SPM package | Business logic, models, gRPC service wrappers, logging, validation, formatters — **no SwiftUI** | ~216 |
-| **FlipcashUI** | SPM package | Reusable SwiftUI/UIKit components + design tokens — **no networking/persistence** | ~78 |
-| **Flipcash** | Xcode app target | Screens, navigation, controllers (Database, Session, Rates…), 3rd-party SDKs | ~205 |
-| **NotificationService** | Xcode extension | `UNNotificationServiceExtension` — resolves contact names on-device, renders communication notifications | 1 |
-| **Flipcash/Share** | Files in app target | System share-sheet wrapper (`UIActivityViewController`) for cash links | 2 |
-| **FlipcashTests** | Xcode test target | Unit/integration tests (Swift Testing) for app + Core | ~118 |
-| **FlipcashUITests** | Xcode test target | Black-box XCUITest smoke tests | ~35 |
+| Module | Type | Purpose |
+|--------|------|---------|
+| **CodeCurves** | SPM package | Ed25519 crypto — pure-C implementation (zero Swift; the `KeyPair` wrapper lives in FlipcashCore) |
+| **CodeScanner** | SPM package | C++/OpenCV "Kik Code" circular-2D encode/decode/scan; bundles OpenCV 4.10 |
+| **FlipcashAPI** | SPM package | **All** generated gRPC/protobuf Swift bindings (both backends), 100% generated |
+| **FlipcashCore** | SPM package | Business logic, models, gRPC service wrappers, logging, validation, formatters — **no SwiftUI** |
+| **FlipcashUI** | SPM package | Reusable SwiftUI/UIKit components + design tokens — **no networking/persistence** |
+| **Flipcash** | Xcode app target | Screens, navigation, controllers (Database, Session, Rates…), 3rd-party SDKs |
+| **NotificationService** *(contact-sync)* | Xcode extension | `UNNotificationServiceExtension` — resolves contact names on-device, renders communication notifications |
+| **Flipcash/Share** | Files in app target | System share-sheet wrapper (`UIActivityViewController`) for cash links |
+| **FlipcashTests** | Xcode test target | Unit/integration tests (Swift Testing) for app + Core |
+| **FlipcashUITests** | Xcode test target | Black-box XCUITest smoke tests |
 
 ## Dependency graph
 
@@ -30,7 +30,7 @@ graph TD
     Core --> Curves["CodeCurves"]
     Core --> Libs["BigDecimal · PhoneNumberKit · swift-log"]
     API --> gRPC["grpc-swift 1.x"]
-    Ext["NotificationService extension"] --> Core
+    Ext["NotificationService extension (contact-sync)"] --> Core
     Ext --> API
 ```
 *Arrows point to dependencies; the graph is acyclic.*
@@ -60,7 +60,7 @@ The observability/analytics SDKs (Firebase, Bugsnag, Mixpanel) are confined to t
 
 ## Embedded targets
 
-- **NotificationService** — runs in a tight memory/time budget. Server pushes E.164 numbers + positional placeholders; the extension queries `CNContactStore` to resolve names, and renders "Sent You Cash" pushes as `INSendMessageIntent` communication notifications (sender avatar in the banner). Imports FlipcashCore + FlipcashAPI only.
+- **NotificationService** *(contact-sync)* — runs in a tight memory/time budget. Server pushes E.164 numbers + positional placeholders; the extension queries `CNContactStore` to resolve names, and renders "Sent You Cash" pushes as `INSendMessageIntent` communication notifications (sender avatar in the banner). Imports FlipcashCore + FlipcashAPI only.
 - **Share** — `ShareCashLinkItem` (`UIActivityItemSource` providing a cash-link URL) + `ShareSheet` (`UIViewControllerRepresentable` over `UIActivityViewController`). Embedded in the app target, not a separate bundle.
 
 ## Why this matters

--- a/docs/architecture/02-state-and-dependency-injection.md
+++ b/docs/architecture/02-state-and-dependency-injection.md
@@ -35,16 +35,16 @@ SessionContainer (struct)
 ├── ratesController                     verified rate/reserve proofs + live streams
 ├── historyController                   activity history sync
 ├── pushController                      APNs token registration
-├── contactSyncController               contact upload + match
+├── contactSyncController               contact upload + match (contact-sync)
 ├── walletConnection                    external-wallet sessions
 ├── verificationCoordinator             phone/email verification
 ├── coinbaseService                     Coinbase onramp orders
 ├── onrampDeeplinkInbox                 onramp deeplink callbacks
 ├── usdcSweepOperation                  USDC→USDF sweep (not in env; called from AppDelegate)
-└── quickActionsController              Home Screen shortcuts (not in env)
+└── quickActionsController              Home Screen shortcuts (not in env) (contact-sync)
 ```
 
-`Database`, `usdcSweepOperation`, and `quickActionsController` are accessed directly (via `AppDelegate.sessionContainer` or by their owners), not the environment.
+`Database`, `usdcSweepOperation`, and `quickActionsController` *(contact-sync)* are accessed directly (via `AppDelegate.sessionContainer` or by their owners), not the environment.
 
 ## `Session` — the main state object
 
@@ -60,7 +60,7 @@ Responsibility buckets:
 | Profile & flags | `profile`, `userFlags`, `syncUserPreferences()` |
 | UI presentation | `billState`, `toast`, `dialogItem`, `isShowingBillDesigner` |
 | Cash bill / ops | `scanOperation`, `sendOperation`, `showCashBill(_:)`, `receiveCash`, `dismissCashBill` |
-| Transactions | `buy`, `sell`, `withdraw`, `send`, `launchCurrency`, `resolveContact` |
+| Transactions | `buy`, `sell`, `withdraw`, `launchCurrency`, plus `send` / `resolveContact` *(contact-sync)* |
 | Lifecycle | `didBecomeActive()`, `didEnterBackground()`, `updatePostTransaction()` |
 
 DB-backed properties use an `Updateable<T>` wrapper that re-reads the query on `.databaseDidChange` and republishes into a tracked slot — SwiftUI refreshes without polling. Private deps (`client`, `database`, `ratesController`, …) are `@ObservationIgnored`.
@@ -75,7 +75,7 @@ DB-backed properties use an `Updateable<T>` wrapper that re-reads the query on `
 `SessionAuthenticator` (`@Observable`). States: `.migrating` (initial) → `.loggedOut` / `.loggedIn(SessionContainer)`. (A `.pending` case exists in the enum and is handled by `ContainerScreen`, but is currently never assigned.)
 
 - **Auto-login** (non-test): reads `UserAccount` from Keychain via `AccountManager`; if present, `completeLogin` directly (no network). Otherwise falls back to the historical account — if present, runs `flipClient.login` + `client.createAccounts` once. If `wasLoggedIn` is true but the Keychain hasn't decoded the historical account yet, the *lookup* is retried up to 6× with 1s delays.
-- **`completeLogin`** derives `owner: AccountCluster` from the mnemonic, runs `initializeDatabase(owner:)` (version-gates the SQLite store — see [05](05-persistence.md)), constructs the controllers + `Session`, fires `historyController.sync()` and (conditionally) `contactSyncController.activate()`, then sets `.loggedIn`.
+- **`completeLogin`** derives `owner: AccountCluster` from the mnemonic, runs `initializeDatabase(owner:)` (version-gates the SQLite store — see [05](05-persistence.md)), constructs the controllers + `Session`, fires `historyController.sync()` and (conditionally) `contactSyncController.activate()` *(contact-sync)*, then sets `.loggedIn`.
 - **Background polling**: a 30s `Poller` checks `fetchUnauthenticatedUserFlags` (force-upgrade gate) and `checkForUnusableAccount` (force-logout gate).
 
 `AccountManager` (`Flipcash/Core/Session/AccountManager.swift`) owns two Keychain slots: the current `UserAccount` and an iCloud-synced `historicalAccounts` map (multi-account). Logout nils the current account; historical is preserved.

--- a/docs/architecture/02-state-and-dependency-injection.md
+++ b/docs/architecture/02-state-and-dependency-injection.md
@@ -1,0 +1,100 @@
+# State & Dependency Injection
+
+The app has two DI scopes: a process-wide `Container` (always present) and a per-login `SessionContainer` (present only when authenticated). State is held in `@Observable` objects injected through the SwiftUI environment. `Session` is the central post-login state object.
+
+```mermaid
+graph TD
+    Launch["App launch — AppDelegate builds Container"] --> State{"SessionAuthenticator state"}
+    State -->|loggedOut| Intro["IntroScreen"]
+    State -->|migrating| Loading["LoadingView"]
+    State -->|loggedIn| SC["Build SessionContainer — Session · controllers · Database · AppRouter"]
+    Intro -->|login or register| SC
+    SC --> Scan["ScanScreen — injected environment"]
+```
+
+## The two containers
+
+### `Container` — pre-auth scope
+`Flipcash/Core/Container.swift`. A plain `class` (not `@Observable`, not a singleton), constructed once in `AppDelegate.init()` and passed by reference for the app's lifetime.
+
+Holds: `client: Client` (gRPC payments), `flipClient: FlipClient` (Flipcash API), `accountManager` (Keychain), `betaFlags`, `preferences`, `notificationController`, `cameraSession`, and lazily the `sessionAuthenticator` + `deepLinkController`.
+
+Injected in `FlipcashApp` via `.injectingEnvironment(from: container)` — `.environmentObject(client/flipClient)` (legacy) plus `.environment(...)` for `sessionAuthenticator`, `betaFlags`, `preferences`, and `notificationController`. `cameraSession` and `deepLinkController` are held by `Container` but accessed by direct reference, not through the environment.
+
+### `SessionContainer` — post-auth scope
+Defined in `SessionAuthenticator.swift`. A plain **`struct`** (value type, no observation), created by `SessionAuthenticator.createSessionContainer(...)` after login and stored in `state = .loggedIn(sessionContainer)`.
+
+Composition tree (everything `@Observable` unless noted):
+
+```
+SessionContainer (struct)
+├── session: Session                    main per-login state
+├── database: Database                  SQLite (not in environment)
+├── flipClient: FlipClient              shared Flipcash API client (legacy ObservableObject; not in env)
+├── appRouter: AppRouter                @MainActor; navigation truth
+├── ratesController                     verified rate/reserve proofs + live streams
+├── historyController                   activity history sync
+├── pushController                      APNs token registration
+├── contactSyncController               contact upload + match
+├── walletConnection                    external-wallet sessions
+├── verificationCoordinator             phone/email verification
+├── coinbaseService                     Coinbase onramp orders
+├── onrampDeeplinkInbox                 onramp deeplink callbacks
+├── usdcSweepOperation                  USDC→USDF sweep (not in env; called from AppDelegate)
+└── quickActionsController              Home Screen shortcuts (not in env)
+```
+
+`Database`, `usdcSweepOperation`, and `quickActionsController` are accessed directly (via `AppDelegate.sessionContainer` or by their owners), not the environment.
+
+## `Session` — the main state object
+
+`Flipcash/Core/Session/Session.swift`. `@Observable class`, injected via `.environment(session)`, read with `@Environment(Session.self)` or `@Bindable var session`.
+
+Responsibility buckets:
+
+| Bucket | Examples |
+|--------|----------|
+| Identity | `owner: AccountCluster`, `userID`, `ownerKeyPair` |
+| Balances | `balances`, `totalBalance`, `balance(for:)`, `hasSufficientFunds(for:)` |
+| Limits | `limits`, `sendLimitFor(currency:)` |
+| Profile & flags | `profile`, `userFlags`, `syncUserPreferences()` |
+| UI presentation | `billState`, `toast`, `dialogItem`, `isShowingBillDesigner` |
+| Cash bill / ops | `scanOperation`, `sendOperation`, `showCashBill(_:)`, `receiveCash`, `dismissCashBill` |
+| Transactions | `buy`, `sell`, `withdraw`, `send`, `launchCurrency`, `resolveContact` |
+| Lifecycle | `didBecomeActive()`, `didEnterBackground()`, `updatePostTransaction()` |
+
+DB-backed properties use an `Updateable<T>` wrapper that re-reads the query on `.databaseDidChange` and republishes into a tracked slot — SwiftUI refreshes without polling. Private deps (`client`, `database`, `ratesController`, …) are `@ObservationIgnored`.
+
+### Don't grow `Session` flatly
+`Session` is already large and is the app's API surface for **network/transaction** work — not a junk drawer. New concerns go to:
+- a **sibling controller on `SessionContainer`** (preferred for non-transactional concerns), or
+- a **namespaced service composed inside `Session`** (acceptable for transactional concerns: `session.foo.bar()`).
+
+## Auth & login lifecycle
+
+`SessionAuthenticator` (`@Observable`). States: `.migrating` (initial) → `.loggedOut` / `.loggedIn(SessionContainer)`. (A `.pending` case exists in the enum and is handled by `ContainerScreen`, but is currently never assigned.)
+
+- **Auto-login** (non-test): reads `UserAccount` from Keychain via `AccountManager`; if present, `completeLogin` directly (no network). Otherwise falls back to the historical account — if present, runs `flipClient.login` + `client.createAccounts` once. If `wasLoggedIn` is true but the Keychain hasn't decoded the historical account yet, the *lookup* is retried up to 6× with 1s delays.
+- **`completeLogin`** derives `owner: AccountCluster` from the mnemonic, runs `initializeDatabase(owner:)` (version-gates the SQLite store — see [05](05-persistence.md)), constructs the controllers + `Session`, fires `historyController.sync()` and (conditionally) `contactSyncController.activate()`, then sets `.loggedIn`.
+- **Background polling**: a 30s `Poller` checks `fetchUnauthenticatedUserFlags` (force-upgrade gate) and `checkForUnusableAccount` (force-logout gate).
+
+`AccountManager` (`Flipcash/Core/Session/AccountManager.swift`) owns two Keychain slots: the current `UserAccount` and an iCloud-synced `historicalAccounts` map (multi-account). Logout nils the current account; historical is preserved.
+
+### Environment split: dev | prod
+There are only two environments — **dev** and **prod**. There is no staging. `Client`/`FlipClient` are constructed with a fixed network at `Container.init`.
+
+## App lifecycle
+
+- `FlipcashApp` (`@main`) hosts `AppDelegate` via `@UIApplicationDelegateAdaptor`; root is `ContainerScreen`.
+- `ContainerScreen` switches on `SessionAuthenticator.state`: `.loggedOut → IntroScreen`, `.migrating/.pending → LoadingView`, `.loggedIn → ScanScreen`. `requiresUpgrade` / `requiresForceLogout` take priority.
+- **scenePhase handlers are single-line fire-and-forgets.** Each case in `AppDelegate.scenePhaseChanged` is a one-liner optional-chain call (`session.didBecomeActive()`, `usdcSweepOperation.start()`, …). Multi-step async work is encapsulated inside the callee (e.g. `UsdcSweepOperation.start()` spawns its own `Task`) — never inlined into the switch.
+- **Auto-return**: after 5 minutes backgrounded, the next `.active` (or an incoming deeplink, whichever wins an atomic gate) calls `appRouter.dismissAll()`.
+
+## Observation model
+
+| Type | System | Injection |
+|------|--------|-----------|
+| `Client`, `FlipClient` | `ObservableObject` (legacy) | `.environmentObject` |
+| `Session`, `AppRouter`, `RatesController`, `SessionAuthenticator`, all new controllers | `@Observable` | `.environment` |
+
+`Client`/`FlipClient` stay `ObservableObject` until all their `@EnvironmentObject` consumers migrate. **A single class must use one system** — mixing `@Observable` with `@Published` causes silent observation failures. New code uses `@Observable` + `@Environment`.

--- a/docs/architecture/02-state-and-dependency-injection.md
+++ b/docs/architecture/02-state-and-dependency-injection.md
@@ -15,36 +15,38 @@ graph TD
 ## The two containers
 
 ### `Container` — pre-auth scope
-`Flipcash/Core/Container.swift`. A plain `class` (not `@Observable`, not a singleton), constructed once in `AppDelegate.init()` and passed by reference for the app's lifetime.
+`Flipcash/Core/Container.swift`. An `@Observable class` (not a singleton), constructed once in `AppDelegate.init()` and passed by reference for the app's lifetime.
 
 Holds: `client: Client` (gRPC payments), `flipClient: FlipClient` (Flipcash API), `accountManager` (Keychain), `betaFlags`, `preferences`, `notificationController`, `cameraSession`, and lazily the `sessionAuthenticator` + `deepLinkController`.
 
-Injected in `FlipcashApp` via `.injectingEnvironment(from: container)` — `.environmentObject(client/flipClient)` (legacy) plus `.environment(...)` for `sessionAuthenticator`, `betaFlags`, `preferences`, and `notificationController`. `cameraSession` and `deepLinkController` are held by `Container` but accessed by direct reference, not through the environment.
+Injected in `FlipcashApp` via `.injectingEnvironment(from: container)` — `.environment(self)` (read with `@Environment(Container.self)`), `.environmentObject(client/flipClient)` (legacy), plus `.environment(...)` for `sessionAuthenticator`, `betaFlags`, `preferences`, and `notificationController`. `cameraSession` and `deepLinkController` are held by `Container` but accessed by direct reference, not through the environment.
 
 ### `SessionContainer` — post-auth scope
-Defined in `SessionAuthenticator.swift`. A plain **`struct`** (value type, no observation), created by `SessionAuthenticator.createSessionContainer(...)` after login and stored in `state = .loggedIn(sessionContainer)`.
+Defined in `SessionAuthenticator.swift`. An **`@Observable final class`**, created by `SessionAuthenticator.createSessionContainer(...)` after login, stored in `state = .loggedIn(sessionContainer)`, and itself injected via `.environment(self)` (read with `@Environment(SessionContainer.self)`).
 
 Composition tree (everything `@Observable` unless noted):
 
 ```
-SessionContainer (struct)
+SessionContainer (@Observable class)
 ├── session: Session                    main per-login state
-├── database: Database                  SQLite (not in environment)
+├── database: Database                  SQLite (plain class; not in environment)
 ├── flipClient: FlipClient              shared Flipcash API client (legacy ObservableObject; not in env)
 ├── appRouter: AppRouter                @MainActor; navigation truth
 ├── ratesController                     verified rate/reserve proofs + live streams
 ├── historyController                   activity history sync
 ├── pushController                      APNs token registration
-├── contactSyncController               contact upload + match (contact-sync)
+├── contactSyncController               contact upload + match
+├── conversationController              @MainActor; DM feed + per-user chat event stream
+├── chatSpotlightIndexer                mirrors DM chats into Spotlight (@MainActor class; not in env)
 ├── walletConnection                    external-wallet sessions
 ├── verificationCoordinator             phone/email verification
 ├── coinbaseService                     Coinbase onramp orders
 ├── onrampDeeplinkInbox                 onramp deeplink callbacks
-├── usdcSweepOperation                  USDC→USDF sweep (not in env; called from AppDelegate)
-└── quickActionsController              Home Screen shortcuts (not in env) (contact-sync)
+├── usdcSweepOperation                  USDC→USDF sweep (actor; not in env; called from AppDelegate)
+└── quickActionsController              Home Screen shortcuts (@MainActor class; not in env)
 ```
 
-`Database`, `usdcSweepOperation`, and `quickActionsController` *(contact-sync)* are accessed directly (via `AppDelegate.sessionContainer` or by their owners), not the environment.
+`Database`, `usdcSweepOperation`, `quickActionsController`, and `chatSpotlightIndexer` are accessed directly (via `AppDelegate.sessionContainer` or by their owners), not the environment.
 
 ## `Session` — the main state object
 
@@ -60,7 +62,7 @@ Responsibility buckets:
 | Profile & flags | `profile`, `userFlags`, `syncUserPreferences()` |
 | UI presentation | `billState`, `toast`, `dialogItem`, `isShowingBillDesigner` |
 | Cash bill / ops | `scanOperation`, `sendOperation`, `showCashBill(_:)`, `receiveCash`, `dismissCashBill` |
-| Transactions | `buy`, `sell`, `withdraw`, `launchCurrency`, plus `send` / `resolveContact` *(contact-sync)* |
+| Transactions | `buy`, `sell`, `withdraw`, `launchCurrency`, `resolveContact`, `send` (carries an optional `ChatPaymentMetadata` so a contact payment lands in its DM chat) |
 | Lifecycle | `didBecomeActive()`, `didEnterBackground()`, `updatePostTransaction()` |
 
 DB-backed properties use an `Updateable<T>` wrapper that re-reads the query on `.databaseDidChange` and republishes into a tracked slot — SwiftUI refreshes without polling. Private deps (`client`, `database`, `ratesController`, …) are `@ObservationIgnored`.
@@ -75,7 +77,7 @@ DB-backed properties use an `Updateable<T>` wrapper that re-reads the query on `
 `SessionAuthenticator` (`@Observable`). States: `.migrating` (initial) → `.loggedOut` / `.loggedIn(SessionContainer)`. (A `.pending` case exists in the enum and is handled by `ContainerScreen`, but is currently never assigned.)
 
 - **Auto-login** (non-test): reads `UserAccount` from Keychain via `AccountManager`; if present, `completeLogin` directly (no network). Otherwise falls back to the historical account — if present, runs `flipClient.login` + `client.createAccounts` once. If `wasLoggedIn` is true but the Keychain hasn't decoded the historical account yet, the *lookup* is retried up to 6× with 1s delays.
-- **`completeLogin`** derives `owner: AccountCluster` from the mnemonic, runs `initializeDatabase(owner:)` (version-gates the SQLite store — see [05](05-persistence.md)), constructs the controllers + `Session`, fires `historyController.sync()` and (conditionally) `contactSyncController.activate()` *(contact-sync)*, then sets `.loggedIn`.
+- **`completeLogin`** derives `owner: AccountCluster` from the mnemonic, runs `initializeDatabase(owner:)` (version-gates the SQLite store — see [05](05-persistence.md)), constructs the controllers + `Session`, fires `historyController.sync()` and — only if the stored profile already has a verified phone — `contactSyncController.activate()`, then sets `.loggedIn`. `SessionContainer.init` starts `conversationController` and `chatSpotlightIndexer`; `logout()` stops both and clears the cached notification previews.
 - **Background polling**: a 30s `Poller` checks `fetchUnauthenticatedUserFlags` (force-upgrade gate) and `checkForUnusableAccount` (force-logout gate).
 
 `AccountManager` (`Flipcash/Core/Session/AccountManager.swift`) owns two Keychain slots: the current `UserAccount` and an iCloud-synced `historicalAccounts` map (multi-account). Logout nils the current account; historical is preserved.
@@ -88,13 +90,12 @@ There are only two environments — **dev** and **prod**. There is no staging. `
 - `FlipcashApp` (`@main`) hosts `AppDelegate` via `@UIApplicationDelegateAdaptor`; root is `ContainerScreen`.
 - `ContainerScreen` switches on `SessionAuthenticator.state`: `.loggedOut → IntroScreen`, `.migrating/.pending → LoadingView`, `.loggedIn → ScanScreen`. `requiresUpgrade` / `requiresForceLogout` take priority.
 - **scenePhase handlers are single-line fire-and-forgets.** Each case in `AppDelegate.scenePhaseChanged` is a one-liner optional-chain call (`session.didBecomeActive()`, `usdcSweepOperation.start()`, …). Multi-step async work is encapsulated inside the callee (e.g. `UsdcSweepOperation.start()` spawns its own `Task`) — never inlined into the switch.
-- **Auto-return**: after 5 minutes backgrounded, the next `.active` (or an incoming deeplink, whichever wins an atomic gate) calls `appRouter.dismissAll()`.
 
 ## Observation model
 
 | Type | System | Injection |
 |------|--------|-----------|
 | `Client`, `FlipClient` | `ObservableObject` (legacy) | `.environmentObject` |
-| `Session`, `AppRouter`, `RatesController`, `SessionAuthenticator`, all new controllers | `@Observable` | `.environment` |
+| `Container`, `SessionContainer`, `Session`, `AppRouter`, `RatesController`, `SessionAuthenticator`, all new controllers | `@Observable` | `.environment` |
 
 `Client`/`FlipClient` stay `ObservableObject` until all their `@EnvironmentObject` consumers migrate. **A single class must use one system** — mixing `@Observable` with `@Published` causes silent observation failures. New code uses `@Observable` + `@Environment`.

--- a/docs/architecture/03-navigation.md
+++ b/docs/architecture/03-navigation.md
@@ -34,9 +34,9 @@ Core mutators:
 
 - **`.balance`** — `currencyInfo(mint)`, `currencyInfoForDeposit(mint)`, `discoverCurrencies`, `currencyCreationSummary`, `currencyCreationWizard`, `transactionHistory(mint)`, `give(mint)`, `withdrawCurrency(mint)`, `usdcDepositAddress`, `phantomFlow(...)`, …
 - **`.settings`** — `settingsMyAccount`, `settingsAppSettings`, `settingsAdvancedFeatures`, `settingsBetaFlags`, `accessKey`, `deposit`, `depositAddress(mint)`, `withdraw`, …
-- **`.send`** — `sendAmount(contact:)`
+- **`.send`** — `sendAmount(contact:)` *(contact-sync)*
 
-`AppRouter+DestinationView.swift` (`DestinationView`) is the single exhaustive `Destination → View` map. Screens whose case can recur with a different payload (`currencyInfo`, `give`, `sendAmount`) apply `.id(value)` so a cross-stack `navigate` forces fresh view identity (otherwise SwiftUI keeps the stale leaf's `@State`).
+`AppRouter+DestinationView.swift` (`DestinationView`) is the single exhaustive `Destination → View` map. Screens whose case can recur with a different payload (`currencyInfo`, `give`, `sendAmount` *(contact-sync)*) apply `.id(value)` so a cross-stack `navigate` forces fresh view identity (otherwise SwiftUI keeps the stale leaf's `@State`).
 
 ## Top-level sheets
 
@@ -49,7 +49,7 @@ Core mutators:
 | `.give` | `.give` | Give cash (gated on `hasGiveableBalance`) |
 | `.discover` | `.discover` | Currency discovery |
 | `.buy(mint)` | `.buy` | **Nested-only** — `Stack.buy.sheet` is `nil` because the mint can't be synthesized from the stack |
-| `.send` | `.send` | Send flow (flag-gated) |
+| `.send` | `.send` | Send flow *(contact-sync)* |
 | `.downloadApp` | `.downloadApp` | Full-screen overlay over the scanner |
 
 Each sheet root applies `.appRouterDestinations(...)` (registers `.navigationDestination(for: Destination.self)`). The `RoutedSheet` container inside `ScanScreen` applies `.appRouterNestedSheet(...)` **once**, enabling nested sheets for whichever root sheet is currently showing.
@@ -73,7 +73,7 @@ Each sheet root applies `.appRouterDestinations(...)` (registers `.navigationDes
 | `/login#e=<entropy>` | already logged-in → `session.attemptLogin` (confirm, then `switchAccount`); else `switchAccount` directly |
 | `/cash#e=<entropy>` | `session.receiveCashLink(mnemonic:)` |
 | `/token/<mint>` | `appRouter.navigate(to: .currencyInfo(mint))` |
-| `/give`, `/balance`, `/discover`, `/send` | `appRouter.present(sheet)` (gated where relevant) |
+| `/give`, `/balance`, `/discover`, `/send` *(contact-sync)* | `appRouter.present(sheet)` (gated where relevant) |
 
 Push notifications route through the same URL mechanism. Auto-return is consumed atomically before deeplink navigation so `dismissAll` can't clobber a concurrent `navigate`.
 

--- a/docs/architecture/03-navigation.md
+++ b/docs/architecture/03-navigation.md
@@ -26,7 +26,8 @@ Core mutators:
 | `replaceTopmostAny(_:)` | Atomic pop+push for screen-swap handoffs. |
 | `present(_ sheet)` | Present a root sheet (handles swaps + path-clear-on-reopen). |
 | `presentNested(_ sheet)` | Stack a sheet on top of the current top. |
-| `dismissSheet()` / `dismissAll()` | Pop the topmost / tear down the entire chain (auto-return). |
+| `dismissSheet()` | Pop the topmost sheet (the root itself when it's the only one). |
+| `pop(on:)` / `popTopmost()` / `popToRoot(on:)` / `popToRoot()` / `popLast(_:on:)` | Pop variants; the stack-agnostic forms target whichever stack the presented sheet hosts. |
 
 ## Destinations
 
@@ -34,13 +35,13 @@ Core mutators:
 
 - **`.balance`** — `currencyInfo(mint)`, `currencyInfoForDeposit(mint)`, `discoverCurrencies`, `currencyCreationSummary`, `currencyCreationWizard`, `transactionHistory(mint)`, `give(mint)`, `withdrawCurrency(mint)`, `usdcDepositAddress`, `phantomFlow(...)`, …
 - **`.settings`** — `settingsMyAccount`, `settingsAppSettings`, `settingsAdvancedFeatures`, `settingsBetaFlags`, `accessKey`, `deposit`, `depositAddress(mint)`, `withdraw`, …
-- **`.send`** — `sendAmount(contact:)` *(contact-sync)*
+- **`.send`** — `dmConversation(ConversationContext)` — a DM chat pushed from the recipient picker (Chats section or a synced contact; `.contact` chats may not exist yet — the first payment creates them)
 
-`AppRouter+DestinationView.swift` (`DestinationView`) is the single exhaustive `Destination → View` map. Screens whose case can recur with a different payload (`currencyInfo`, `give`, `sendAmount` *(contact-sync)*) apply `.id(value)` so a cross-stack `navigate` forces fresh view identity (otherwise SwiftUI keeps the stale leaf's `@State`).
+`AppRouter+DestinationView.swift` (`DestinationView`) is the single exhaustive `Destination → View` map. Screens whose case can recur with a different payload (`currencyInfo`, `give`, `dmConversation`) apply `.id(value)` so a cross-stack `navigate` forces fresh view identity (otherwise SwiftUI keeps the stale leaf's `@State`).
 
 ## Top-level sheets
 
-`AppRouter+SheetPresentation.swift` — `enum SheetPresentation`. Each owns a `NavigationStack(path: $router[.<stack>])`:
+`AppRouter+SheetPresentation.swift` — `enum SheetPresentation`. Each owns a `NavigationStack`, bound to `$router[.<stack>]` where the sheet hosts pushes:
 
 | Sheet | Stack | Notes |
 |-------|-------|-------|
@@ -49,10 +50,12 @@ Core mutators:
 | `.give` | `.give` | Give cash (gated on `hasGiveableBalance`) |
 | `.discover` | `.discover` | Currency discovery |
 | `.buy(mint)` | `.buy` | **Nested-only** — `Stack.buy.sheet` is `nil` because the mint can't be synthesized from the stack |
-| `.send` | `.send` | Send flow *(contact-sync)* |
+| `.send` | `.send` | Send flow — recipient picker (phone/contacts gating) → pushed `dmConversation` chats |
+| `.conversation(context)` | `.conversation` | **Root-only** — a DM chat entered via deeplink/push; `resetsStackOnPresent` clears its stack on every present so re-entry lands on the chat, not a stale leaf. `Stack.conversation.sheet` is `nil` (payload can't be synthesized) |
+| `.sendAmount(contact)` | `.sendAmount` | Send Cash amount entry — nested over the chat (in-chat send) *or* a root sheet (notification deeplink / App Intent). Unbound `NavigationStack`; `Stack.sendAmount.sheet` is `nil` |
 | `.downloadApp` | `.downloadApp` | Full-screen overlay over the scanner |
 
-Each sheet root applies `.appRouterDestinations(...)` (registers `.navigationDestination(for: Destination.self)`). The `RoutedSheet` container inside `ScanScreen` applies `.appRouterNestedSheet(...)` **once**, enabling nested sheets for whichever root sheet is currently showing.
+Each sheet root that hosts pushes applies `.appRouterDestinations(...)` (registers `.navigationDestination(for: Destination.self)`) — `.downloadApp` and `.sendAmount` don't push, so they skip it. The `RoutedSheet` container inside `ScanScreen` applies `.appRouterNestedSheet(...)` **once**, enabling nested sheets for whichever root sheet is currently showing.
 
 ## Per-stack paths & sub-flows
 
@@ -62,7 +65,7 @@ Each sheet root applies `.appRouterDestinations(...)` (registers `.navigationDes
 
 ## Nested sheets
 
-`presentedSheets: [SheetPresentation]` is an ordered stack: index 0 is the root (mounted at app root), index 1+ stack visually on top. `AppRouter+NestedSheet.swift` provides `.appRouterNestedSheet(...)`, which reads `@Environment(\.nestedSheetDepth)` and binds `presentedSheets[depth+1]` to a `.sheet(item:)`. SwiftUI requires nested sheets to be mounted **inside** the parent sheet's content tree (sibling `.sheet` modifiers at the root can't stack) — hence the modifier lives in each sheet's content. The buy flow (`.buy(mint)`) is the only nested sheet today.
+`presentedSheets: [SheetPresentation]` is an ordered stack: index 0 is the root (mounted at app root), index 1+ stack visually on top. `AppRouter+NestedSheet.swift` provides `.appRouterNestedSheet(...)`, which reads `@Environment(\.nestedSheetDepth)` and binds `presentedSheets[depth+1]` to a `.sheet(item:)`. SwiftUI requires nested sheets to be mounted **inside** the parent sheet's content tree (sibling `.sheet` modifiers at the root can't stack) — hence the modifier lives in each sheet's content. `.buy(mint)` and `.sendAmount(contact)` are the nested sheets today; the modifier supports one level of nesting.
 
 ## Deeplinks & push-driven navigation
 
@@ -73,20 +76,23 @@ Each sheet root applies `.appRouterDestinations(...)` (registers `.navigationDes
 | `/login#e=<entropy>` | already logged-in → `session.attemptLogin` (confirm, then `switchAccount`); else `switchAccount` directly |
 | `/cash#e=<entropy>` | `session.receiveCashLink(mnemonic:)` |
 | `/token/<mint>` | `appRouter.navigate(to: .currencyInfo(mint))` |
-| `/give`, `/balance`, `/discover`, `/send` *(contact-sync)* | `appRouter.present(sheet)` (gated where relevant) |
+| `/chat/<id>` | `appRouter.present(.conversation(.existing(id)))` — the chat as the root sheet, so anything stacked on top reveals it on dismiss |
+| `/chat/<+E.164>` | resolve the phone against synced contacts → `present(.conversation(.contact(contact)))`; unresolved = silent no-op |
+| `/chat/<id>/send` | resolve the send target → `present(.sendAmount(target))` (gated on `canSend`) — amount entry directly, no chat behind it |
+| `/give`, `/balance`, `/discover`, `/send` | `appRouter.present(sheet)` (gated where relevant) |
 
-Push notifications route through the same URL mechanism. Auto-return is consumed atomically before deeplink navigation so `dismissAll` can't clobber a concurrent `navigate`.
+Push notifications route through the same URL mechanism (`target_url` in the payload; the chat notification's Send Cash action synthesizes `flipcash://chat/<id>/send`), as do Spotlight/Handoff chat continuations (`AppDelegate.handleContinue` rebuilds `flipcash://chat/<id>`).
 
 ## Sheet lifecycle
 
 - `dismissSheet()` pops the top sheet but leaves its `NavigationPath` populated so the close animation runs with contents intact; the path clears on the next `present`/`presentNested` of that stack (re-opens land at root).
 - Swapping root sheets (`present(.other)` without an intervening `dismissSheet`) preserves the swapped-out path for swap-back.
-- `dismissAll()` clears inactive stacks then calls UIKit `dismiss(animated:)` so the whole nested chain tears down in one animation.
+- `.conversation` opts into `resetsStackOnPresent` — presenting it always clears its stack first, covering idempotent re-present, chat→chat swap, and swap-back in one rule.
 - **Don't add manual `popToRoot` calls around your own dismissal** — let the router handle it.
 
 ## When is it a router destination?
 
 > **The test:** if a deeplink could reasonably land the user here, it's a destination — route through `AppRouter`. If not, keep it local.
 
-- **Route via AppRouter**: deeplinkable screens; any full-screen overlay over `ScanScreen` (gets the 5-minute auto-return for free — `DownloadAppScreen` is canonical); multi-step sheet flows (push sub-steps).
+- **Route via AppRouter**: deeplinkable screens; any full-screen overlay over `ScanScreen` (`DownloadAppScreen` is canonical); multi-step sheet flows (push sub-steps).
 - **Keep local**: transient pickers (currency/funding selection) and operation-bound processing modals — they're interactions, not navigation. Unless the modal belongs to a router-managed sheet's flow, in which case push it onto that sheet's stack.

--- a/docs/architecture/03-navigation.md
+++ b/docs/architecture/03-navigation.md
@@ -1,0 +1,92 @@
+# Navigation
+
+All navigation flows through a single `AppRouter` — there are no screen-level sheet flags or `selectedXxx` bindings. The router is the source of truth for which sheets are presented and what's on each sheet's stack.
+
+```mermaid
+graph TD
+    Src["Deeplink · push · in-screen tap"] --> Router["AppRouter — single source of truth"]
+    Router -->|present| Sheet["Top-level sheet — owns NavigationStack"]
+    Router -->|presentNested| Nested["Nested sheet — presentedSheets + 1"]
+    Router -->|push / pushAny| Path["Stack NavigationPath"]
+    Sheet --> Path
+    Path --> View["DestinationView — Destination to View"]
+```
+
+## `AppRouter`
+
+`Flipcash/Core/Navigation/AppRouter.swift`. `@Observable @MainActor final class` on `SessionContainer`, injected via `@Environment(AppRouter.self)`. Every mutation logs one INFO entry under the **`flipcash.router`** label — filter by it to trace any navigation interaction.
+
+Core mutators:
+
+| Mutator | Purpose |
+|---------|---------|
+| `navigate(to: Destination)` | Cross-stack: present the destination's owning sheet, set it as the sole path entry. Used by deeplinks/push. |
+| `push(_ destination)` | Push a typed `Destination` onto the topmost stack. |
+| `pushAny(_ value: Hashable)` | Push any sub-flow value (`WithdrawNavigationPath`, `BuyFlowPath`) onto the topmost stack. |
+| `replaceTopmostAny(_:)` | Atomic pop+push for screen-swap handoffs. |
+| `present(_ sheet)` | Present a root sheet (handles swaps + path-clear-on-reopen). |
+| `presentNested(_ sheet)` | Stack a sheet on top of the current top. |
+| `dismissSheet()` / `dismissAll()` | Pop the topmost / tear down the entire chain (auto-return). |
+
+## Destinations
+
+`AppRouter+Destination.swift` — `enum Destination: Hashable, Sendable`. Every push-reachable screen is a case, grouped by `owningStack`:
+
+- **`.balance`** — `currencyInfo(mint)`, `currencyInfoForDeposit(mint)`, `discoverCurrencies`, `currencyCreationSummary`, `currencyCreationWizard`, `transactionHistory(mint)`, `give(mint)`, `withdrawCurrency(mint)`, `usdcDepositAddress`, `phantomFlow(...)`, …
+- **`.settings`** — `settingsMyAccount`, `settingsAppSettings`, `settingsAdvancedFeatures`, `settingsBetaFlags`, `accessKey`, `deposit`, `depositAddress(mint)`, `withdraw`, …
+- **`.send`** — `sendAmount(contact:)`
+
+`AppRouter+DestinationView.swift` (`DestinationView`) is the single exhaustive `Destination → View` map. Screens whose case can recur with a different payload (`currencyInfo`, `give`, `sendAmount`) apply `.id(value)` so a cross-stack `navigate` forces fresh view identity (otherwise SwiftUI keeps the stale leaf's `@State`).
+
+## Top-level sheets
+
+`AppRouter+SheetPresentation.swift` — `enum SheetPresentation`. Each owns a `NavigationStack(path: $router[.<stack>])`:
+
+| Sheet | Stack | Notes |
+|-------|-------|-------|
+| `.balance` | `.balance` | Portfolio / token browsing |
+| `.settings` | `.settings` | Account settings |
+| `.give` | `.give` | Give cash (gated on `hasGiveableBalance`) |
+| `.discover` | `.discover` | Currency discovery |
+| `.buy(mint)` | `.buy` | **Nested-only** — `Stack.buy.sheet` is `nil` because the mint can't be synthesized from the stack |
+| `.send` | `.send` | Send flow (flag-gated) |
+| `.downloadApp` | `.downloadApp` | Full-screen overlay over the scanner |
+
+Each sheet root applies `.appRouterDestinations(...)` (registers `.navigationDestination(for: Destination.self)`). The `RoutedSheet` container inside `ScanScreen` applies `.appRouterNestedSheet(...)` **once**, enabling nested sheets for whichever root sheet is currently showing.
+
+## Per-stack paths & sub-flows
+
+`AppRouter` stores `paths: [Stack: NavigationPath]`. Because `NavigationPath` is type-erased, one stack carries both `Destination` cases (via `push`) and arbitrary `Hashable` sub-flow values (via `pushAny`) — e.g. `WithdrawNavigationPath` on `.settings`, `BuyFlowPath` on `.buy`. Sub-flow roots register their own `.navigationDestination(for: SubFlowPath.self)`.
+
+> **Hard rule: never nest a `NavigationStack` inside another stack's destination.** Push/pop/push corrupts SwiftUI's stack state with `comparisonTypeMismatch`. Drop the inner stack and register the sub-flow's destinations on the destination's root view.
+
+## Nested sheets
+
+`presentedSheets: [SheetPresentation]` is an ordered stack: index 0 is the root (mounted at app root), index 1+ stack visually on top. `AppRouter+NestedSheet.swift` provides `.appRouterNestedSheet(...)`, which reads `@Environment(\.nestedSheetDepth)` and binds `presentedSheets[depth+1]` to a `.sheet(item:)`. SwiftUI requires nested sheets to be mounted **inside** the parent sheet's content tree (sibling `.sheet` modifiers at the root can't stack) — hence the modifier lives in each sheet's content. The buy flow (`.buy(mint)`) is the only nested sheet today.
+
+## Deeplinks & push-driven navigation
+
+`Flipcash/Core/Controllers/Deep Links/`. `AppDelegate.handleOpenURL` → `DeepLinkController.handle(open:)` parses a `Route` (normalizes Universal Links and the `flipcash://` scheme). Examples:
+
+| Path | Action |
+|------|--------|
+| `/login#e=<entropy>` | already logged-in → `session.attemptLogin` (confirm, then `switchAccount`); else `switchAccount` directly |
+| `/cash#e=<entropy>` | `session.receiveCashLink(mnemonic:)` |
+| `/token/<mint>` | `appRouter.navigate(to: .currencyInfo(mint))` |
+| `/give`, `/balance`, `/discover`, `/send` | `appRouter.present(sheet)` (gated where relevant) |
+
+Push notifications route through the same URL mechanism. Auto-return is consumed atomically before deeplink navigation so `dismissAll` can't clobber a concurrent `navigate`.
+
+## Sheet lifecycle
+
+- `dismissSheet()` pops the top sheet but leaves its `NavigationPath` populated so the close animation runs with contents intact; the path clears on the next `present`/`presentNested` of that stack (re-opens land at root).
+- Swapping root sheets (`present(.other)` without an intervening `dismissSheet`) preserves the swapped-out path for swap-back.
+- `dismissAll()` clears inactive stacks then calls UIKit `dismiss(animated:)` so the whole nested chain tears down in one animation.
+- **Don't add manual `popToRoot` calls around your own dismissal** — let the router handle it.
+
+## When is it a router destination?
+
+> **The test:** if a deeplink could reasonably land the user here, it's a destination — route through `AppRouter`. If not, keep it local.
+
+- **Route via AppRouter**: deeplinkable screens; any full-screen overlay over `ScanScreen` (gets the 5-minute auto-return for free — `DownloadAppScreen` is canonical); multi-step sheet flows (push sub-steps).
+- **Keep local**: transient pickers (currency/funding selection) and operation-bound processing modals — they're interactions, not navigation. Unless the modal belongs to a router-managed sheet's flow, in which case push it onto that sheet's stack.

--- a/docs/architecture/04-networking.md
+++ b/docs/architecture/04-networking.md
@@ -1,0 +1,77 @@
+# Networking
+
+The app speaks gRPC to two backends and JSON-RPC to Solana. Generated stubs are wrapped by hand-written service classes; every request is self-authenticating via an Ed25519 signature in the payload (no auth tokens). All cached responses land in SQLite.
+
+```mermaid
+graph LR
+    UI["View / Session"] --> C["Client / FlipClient"]
+    C -->|Ed25519-signed request| Svc["CodeService wrapper"]
+    Svc --> Stub["Generated NIO stub"]
+    Stub -->|"unary · default 15s"| BE["Backend — OCP / Flipcash"]
+    Stub -->|"streaming · no timeout"| BE
+```
+
+## Transport: two gRPC channels
+
+| Client | Backend | Host | Owns |
+|--------|---------|------|------|
+| `Client` | Payments / OCP server | `ocp-v2.api.flipcash-infra.net:443` | On-chain transfers, account creation, messaging (rendezvous), swap orchestration |
+| `FlipClient` | Flipcash core server | `fc-v2.api.flipcash-infra.net:443` | Identity, activity, push tokens, contacts, profile, settings, moderation |
+
+Both `@MainActor ObservableObject`, both built from `ClientConnection.appConnection(host:port:)` (`Client.swift`): TLS via NIO SSL, keepalive 30s/10s with `permitWithoutCalls`, 5-minute idle timeout, errors logged to `flipcash.grpc`. `mainNet`/`testNet` currently point at the same live hosts (no staging).
+
+## Service layer
+
+Pattern: **generated `*NIOClient` stub → `CodeService<T>` subclass → method on `Client`/`FlipClient`**.
+
+`CodeService<T>` (`CodeService.swift`) is a generic base holding the connection, a `DispatchQueue`, and the generated stub (configured with `defaultCallOptions: .default` + `InterceptorFactory()`). Concrete services subclass it: `TransactionService`, `CurrencyService`, `MessagingService`, `AccountInfoService`, `SwapService` (payments side); `AccountService`, `PushService`, `ActivityService`, `PhoneService`, `EmailService`, `ProfileService`, `SettingsService`, `ModerationService`, `ContactListService`, `ResolverService`, `ThirdPartyService`, … (Flipcash side). Unary calls dispatch their result back onto the capture queue via a `handle(on:success:failure:)` helper.
+
+## CallOptions — the 15s trap
+
+`CodeService.swift`:
+
+```swift
+extension CallOptions {
+    static let `default`  = CallOptions(timeLimit: .timeout(.seconds(15)))  // unary
+    static let streaming  = CallOptions(timeLimit: .none)                   // streaming
+}
+```
+
+Stubs default to `.default`, so unary calls get the 15s deadline automatically. **Streaming RPCs must explicitly pass `callOptions: .streaming`** — omitting it silently kills the long-lived stream after 15s. The streaming RPCs:
+
+| RPC | Service | Type |
+|-----|---------|------|
+| `openMessageStream` | Messaging | server-streaming |
+| `submitIntent` | Transaction | bidirectional |
+| `statefulSwap` / `statelessSwap` | Swap | bidirectional |
+| `streamLiveMintData` | Currency (via `LiveMintDataStreamer`) | bidirectional |
+
+## Streaming patterns
+
+- **Message stream** (`openMessageStream`) — the give/grab rendezvous channel. Auto-reconnects on `.unavailable`. Drives `SendCashOperation`/`ScanCashOperation`.
+- **Intent submission** (`submitIntent`) — bidirectional handshake: client `submitActions` → server `serverParameters` → client `submitSignatures` → server `success`/`error`. Uses a `BidirectionalStreamReference` with a deliberate retain so callers needn't hold the stream; released on completion.
+- **Stateful swap** (`statefulSwap`) — same retain pattern; `initiate` → `serverParameters` → `submitSignatures` → `success`. Three server-parameter variants (reserve-existing, reserve-new, stablecoin).
+- **Live mint data** (`streamLiveMintData`) — a Swift `actor`. Subscription updates reuse the open stream; ping/pong keepalive; exponential backoff reconnect (1s→30s); a generation counter prevents stale callbacks from tearing down a newer stream. Feeds verified rate/reserve protos to `VerifiedProtoService`.
+
+## Auth on the wire — signature-per-request
+
+There is **no auth token, cookie, or bearer header**. Every request authenticates itself:
+
+- **Payments (OCP)**: each request has a `signature` field. `SwiftProtobuf.Message.sign(with: KeyPair)` serializes the proto and signs it with the owner's Ed25519 key (CodeCurves).
+- **Flipcash (Core)**: requests carry a `Flipcash_Common_V1_Auth` (public key + signature) built by `KeyPair.authFor(message:)`.
+
+The only interceptor is `UserAgentInterceptor` (adds a `User-Agent` header — `OpenCodeProtocol/iOS/...` for OCP paths, `Flipcash/iOS/...` otherwise).
+
+## Solana RPC
+
+Separate from gRPC. `SolanaRPC` (JSON-RPC 2.0 over `URLSession`, default `api.mainnet-beta.solana.com`): `getLatestBlockhash`, `sendTransaction`, `simulateTransaction`. Used by the external-wallet (Phantom) onramp to submit stateless-swap transactions that bypass the Code VM. All transaction *building* and key derivation is pure local logic in `FlipcashCore/Solana/` (no network).
+
+## Push notifications
+
+`FlipcashCore/.../Push/`: `NotificationPayload` decodes a base64 `Flipcash_Push_V1_Payload` from `userInfo` (key `flipcash_payload`); `SubstitutionApplier` fills `{0}`/`{1}` placeholders (resolved contact names). APNs tokens registered via `PushService` (`addToken`/`deleteTokens`). The NotificationService extension resolves names on-device (see [01](01-modules-and-boundaries.md)).
+
+## Generated code
+
+`FlipcashAPI/Sources/FlipcashAPI/` holds both proto trees: **`Payments/`** (namespace `ocp.*`: account, currency, messaging, transaction) and **`Core/`** (namespace `flipcash.*`: account, activity, contact, email, phone, profile, push, resolver, settings, moderation, …), each with a `Generated/` subdir. Regenerate via `Scripts/run -a flipcashPayments` / `flipcashCore` (needs `protoc`, `protoc-gen-swift`, `protoc-gen-grpc-swift` **v1.x**). Never edit `Generated/` by hand.
+
+> The repo root also contains an empty `FlipcashCoreAPI/` directory (and CLAUDE.md still lists it as a package). It is a legacy placeholder with no sources — all core bindings live under `FlipcashAPI/Sources/FlipcashAPI/Core/`.

--- a/docs/architecture/04-networking.md
+++ b/docs/architecture/04-networking.md
@@ -24,7 +24,7 @@ Both `@MainActor ObservableObject`, both built from `ClientConnection.appConnect
 
 Pattern: **generated `*NIOClient` stub → `CodeService<T>` subclass → method on `Client`/`FlipClient`**.
 
-`CodeService<T>` (`CodeService.swift`) is a generic base holding the connection, a `DispatchQueue`, and the generated stub (configured with `defaultCallOptions: .default` + `InterceptorFactory()`). Concrete services subclass it: `TransactionService`, `CurrencyService`, `MessagingService`, `AccountInfoService`, `SwapService` (payments side); `AccountService`, `PushService`, `ActivityService`, `PhoneService`, `EmailService`, `ProfileService`, `SettingsService`, `ModerationService`, `ContactListService`, `ResolverService`, `ThirdPartyService`, … (Flipcash side). Unary calls dispatch their result back onto the capture queue via a `handle(on:success:failure:)` helper.
+`CodeService<T>` (`CodeService.swift`) is a generic base holding the connection, a `DispatchQueue`, and the generated stub (configured with `defaultCallOptions: .default` + `InterceptorFactory()`). Concrete services subclass it: `TransactionService`, `CurrencyService`, `MessagingService`, `AccountInfoService`, `SwapService` (payments side); `AccountService`, `PushService`, `ActivityService`, `PhoneService`, `EmailService`, `ProfileService`, `SettingsService`, `ModerationService`, `ThirdPartyService`, plus `ContactListService` / `ResolverService` *(contact-sync)* (Flipcash side). Unary calls dispatch their result back onto the capture queue via a `handle(on:success:failure:)` helper.
 
 ## CallOptions — the 15s trap
 
@@ -68,10 +68,10 @@ Separate from gRPC. `SolanaRPC` (JSON-RPC 2.0 over `URLSession`, default `api.ma
 
 ## Push notifications
 
-`FlipcashCore/.../Push/`: `NotificationPayload` decodes a base64 `Flipcash_Push_V1_Payload` from `userInfo` (key `flipcash_payload`); `SubstitutionApplier` fills `{0}`/`{1}` placeholders (resolved contact names). APNs tokens registered via `PushService` (`addToken`/`deleteTokens`). The NotificationService extension resolves names on-device (see [01](01-modules-and-boundaries.md)).
+`FlipcashCore/.../Push/`: `NotificationPayload` decodes a base64 `Flipcash_Push_V1_Payload` from `userInfo` (key `flipcash_payload`); `SubstitutionApplier` fills `{0}`/`{1}` placeholders (resolved contact names). APNs tokens registered via `PushService` (`addToken`/`deleteTokens`). The NotificationService extension *(contact-sync)* resolves names on-device (see [01](01-modules-and-boundaries.md)).
 
 ## Generated code
 
 `FlipcashAPI/Sources/FlipcashAPI/` holds both proto trees: **`Payments/`** (namespace `ocp.*`: account, currency, messaging, transaction) and **`Core/`** (namespace `flipcash.*`: account, activity, contact, email, phone, profile, push, resolver, settings, moderation, …), each with a `Generated/` subdir. Regenerate via `Scripts/run -a flipcashPayments` / `flipcashCore` (needs `protoc`, `protoc-gen-swift`, `protoc-gen-grpc-swift` **v1.x**). Never edit `Generated/` by hand.
 
-> The repo root also contains an empty `FlipcashCoreAPI/` directory (and CLAUDE.md still lists it as a package). It is a legacy placeholder with no sources — all core bindings live under `FlipcashAPI/Sources/FlipcashAPI/Core/`.
+> The repo root also contains an empty `FlipcashCoreAPI/` directory. It is a legacy placeholder with no sources — all core bindings live under `FlipcashAPI/Sources/FlipcashAPI/Core/`.

--- a/docs/architecture/04-networking.md
+++ b/docs/architecture/04-networking.md
@@ -1,14 +1,14 @@
 # Networking
 
-The app speaks gRPC to two backends and JSON-RPC to Solana. Generated stubs are wrapped by hand-written service classes; every request is self-authenticating via an Ed25519 signature in the payload (no auth tokens). All cached responses land in SQLite.
+The app speaks gRPC (grpc-swift 2: `GRPCCore` + the Network.framework `TransportServices` transport) to two backends and JSON-RPC to Solana. Generated stubs are wrapped by hand-written service classes; every request is self-authenticating via an Ed25519 signature in the payload (no auth tokens). All cached responses land in SQLite.
 
 ```mermaid
 graph LR
     UI["View / Session"] --> C["Client / FlipClient"]
-    C -->|Ed25519-signed request| Svc["CodeService wrapper"]
-    Svc --> Stub["Generated NIO stub"]
-    Stub -->|"unary · default 15s"| BE["Backend — OCP / Flipcash"]
-    Stub -->|"streaming · no timeout"| BE
+    C -->|Ed25519-signed request| Svc["Service class"]
+    Svc --> Stub["Generated v2 Client wrapper"]
+    Stub -->|"unary · .unaryDefault 15s"| BE["Backend — OCP / Flipcash"]
+    Stub -->|"streaming · no deadline"| BE
 ```
 
 ## Transport: two gRPC channels
@@ -16,28 +16,33 @@ graph LR
 | Client | Backend | Host | Owns |
 |--------|---------|------|------|
 | `Client` | Payments / OCP server | `ocp-v2.api.flipcash-infra.net:443` | On-chain transfers, account creation, messaging (rendezvous), swap orchestration |
-| `FlipClient` | Flipcash core server | `fc-v2.api.flipcash-infra.net:443` | Identity, activity, push tokens, contacts, profile, settings, moderation |
+| `FlipClient` | Flipcash core server | `fc-v2.api.flipcash-infra.net:443` | Identity, activity, push tokens, contacts, chat, profile, settings, moderation |
 
-Both `@MainActor ObservableObject`, both built from `ClientConnection.appConnection(host:port:)` (`Client.swift`): TLS via NIO SSL, keepalive 30s/10s with `permitWithoutCalls`, 5-minute idle timeout, errors logged to `flipcash.grpc`. `mainNet`/`testNet` currently point at the same live hosts (no staging).
+Both `@MainActor ObservableObject`, both built the same way (`Client.swift` / `FlipClient.swift`): `GRPCTransport.makeTransportServices(host:port:)` (`GRPCTransport.swift`) builds an `HTTP2ClientTransport.TransportServices` (aliased `AppTransport`) — TLS via the system trust store, keepalive 30s/10s permitted without calls, 5-minute idle timeout — and it's wrapped in a `GRPCClient` with the shared `UserAgentClientInterceptor`. The client does nothing until `runConnections()` is running; that loop lives in a retained `connectionTask` — dropping it makes the client inert and every RPC hangs. `deinit` calls `beginGracefulShutdown()` (drains in-flight streams) then cancels the task. `Network` has a single `.mainNet` case pointing at the live hosts (no staging).
 
 ## Service layer
 
-Pattern: **generated `*NIOClient` stub → `CodeService<T>` subclass → method on `Client`/`FlipClient`**.
+Pattern: **generated `*.Client<AppTransport>` wrapper → `Sendable` service class → method on `Client`/`FlipClient`**.
 
-`CodeService<T>` (`CodeService.swift`) is a generic base holding the connection, a `DispatchQueue`, and the generated stub (configured with `defaultCallOptions: .default` + `InterceptorFactory()`). Concrete services subclass it: `TransactionService`, `CurrencyService`, `MessagingService`, `AccountInfoService`, `SwapService` (payments side); `AccountService`, `PushService`, `ActivityService`, `PhoneService`, `EmailService`, `ProfileService`, `SettingsService`, `ModerationService`, `ThirdPartyService`, plus `ContactListService` / `ResolverService` *(contact-sync)* (Flipcash side). Unary calls dispatch their result back onto the capture queue via a `handle(on:success:failure:)` helper.
+There is no shared base class — each service wraps the shared `GRPCClient<AppTransport>` in its generated client (e.g. `Ocp_Transaction_V1_Transaction.Client(wrapping: client)` in `TransactionService`). Payments side: `AccountInfoService`, `TransactionService` (owns `SwapService`), `CurrencyService`, `MessagingService`, plus the `LiveMintDataStreamer` / `VerifiedProtoService` actors. Flipcash side: `AccountService`, `ActivityService`, `PushService`, `ThirdPartyService`, `PhoneService`, `EmailService`, `ProfileService`, `SettingsService`, `ModerationService`, `ContactListService`, `ResolverService`, `ChatService` (DM feed, chat lookup), `ChatMessagingService` (messages, send, read pointers, typing), and `EventStreamingService` behind the `EventStreamer` actor. Unary calls run in a `Task`, `await` the generated method with `options: .unaryDefault`, and deliver their completion back on the main actor.
+
+`ChatNotificationClient` (`Clients/Chat/`) is a lean standalone façade for the NotificationService extension: its own `GRPCClient` + `ChatMessagingService`, no `FlipClient`/`Client`/`Database` graph; mint metadata is fetched over a transient second connection rather than a resident one.
 
 ## CallOptions — the 15s trap
 
-`CodeService.swift`:
+`GRPCTransport.swift`:
 
 ```swift
 extension CallOptions {
-    static let `default`  = CallOptions(timeLimit: .timeout(.seconds(15)))  // unary
-    static let streaming  = CallOptions(timeLimit: .none)                   // streaming
+    static var unaryDefault: CallOptions {      // unary: 15s deadline
+        var options = CallOptions.defaults
+        options.timeout = .seconds(15)
+        return options
+    }
 }
 ```
 
-Stubs default to `.default`, so unary calls get the 15s deadline automatically. **Streaming RPCs must explicitly pass `callOptions: .streaming`** — omitting it silently kills the long-lived stream after 15s. The streaming RPCs:
+Deadlines are per-call in v2 — nothing is inherited from the stub. **Unary calls must pass `options: .unaryDefault`** so they fail fast on a dead connection; **streaming calls pass nothing** (`.defaults`, no deadline) — a stray deadline silently kills the long-lived stream after 15s. The streaming RPCs:
 
 | RPC | Service | Type |
 |-----|---------|------|
@@ -45,13 +50,26 @@ Stubs default to `.default`, so unary calls get the 15s deadline automatically. 
 | `submitIntent` | Transaction | bidirectional |
 | `statefulSwap` / `statelessSwap` | Swap | bidirectional |
 | `streamLiveMintData` | Currency (via `LiveMintDataStreamer`) | bidirectional |
+| `streamEvents` | EventStreaming (via `EventStreamer`) | bidirectional |
+| `discover` | Currency | server-streaming |
+| `getFlipcashContacts` | ContactList | server-streaming |
 
 ## Streaming patterns
 
-- **Message stream** (`openMessageStream`) — the give/grab rendezvous channel. Auto-reconnects on `.unavailable`. Drives `SendCashOperation`/`ScanCashOperation`.
-- **Intent submission** (`submitIntent`) — bidirectional handshake: client `submitActions` → server `serverParameters` → client `submitSignatures` → server `success`/`error`. Uses a `BidirectionalStreamReference` with a deliberate retain so callers needn't hold the stream; released on completion.
-- **Stateful swap** (`statefulSwap`) — same retain pattern; `initiate` → `serverParameters` → `submitSignatures` → `success`. Three server-parameter variants (reserve-existing, reserve-new, stablecoin).
-- **Live mint data** (`streamLiveMintData`) — a Swift `actor`. Subscription updates reuse the open stream; ping/pong keepalive; exponential backoff reconnect (1s→30s); a generation counter prevents stale callbacks from tearing down a newer stream. Feeds verified rate/reserve protos to `VerifiedProtoService`.
+v2 streaming is closure-scoped — the `RPCWriter` only exists inside the call's `requestProducer` closure. The adapters in `GRPCStream.swift` bridge that to the retained, multi-sender handle the consumers need:
+
+- **`BidirectionalGRPCStream<Request, Response>`** — buffers outbound messages through an `AsyncStream` that the `requestProducer` drains; the call runs in a retained `Task`. `sendMessage(_:)` is safe from any point after `open`; `cancel()` closes the outbound side and cancels the call, suppressing `onComplete` (explicit teardown is not a stream error). `onComplete` otherwise fires exactly once with the terminal result.
+- **`ServerGRPCStream`** — no outbound writer, just a retained cancellable `Task` iterating inbound messages. Re-openable on the same handle (a generation counter stops a superseded connection from firing a stale completion); `cancel()` is sticky.
+
+The consumers:
+
+- **Message stream** (`openMessageStream`) — the give/grab rendezvous channel. Auto-reconnects on `.unavailable` by re-opening the same `ServerGRPCStream`. Drives `SendCashOperation`/`ScanCashOperation`.
+- **Intent submission** (`submitIntent`) — bidirectional handshake: client `submitActions` → server `serverParameters` → client `submitSignatures` → server `success`/`error`.
+- **Stateful swap** (`statefulSwap`) — `initiate` → `serverParameters` → `submitSignatures` → `success`. Three server-parameter variants (reserve-existing, reserve-new, stablecoin).
+- **Live mint data** (`streamLiveMintData`) — `LiveMintDataStreamer`, a Swift `actor`. Subscription updates reuse the open stream; ping/pong keepalive; exponential backoff reconnect (1s→30s); a generation counter prevents stale callbacks from tearing down a newer stream. Feeds verified rate/reserve protos to `VerifiedProtoService`.
+- **Event stream** (`streamEvents`) — `EventStreamer`, an `actor` with the same ping/backoff/generation shape. The single per-user chat event stream (new messages, conversation metadata, read pointers), surfaced as an `AsyncStream<ConversationStreamEvent>`; started on login, stopped on logout.
+
+A failed RPC classifies transport weather via `TransportClassifiableError` (`FlipcashCore/Models/`): typed error enums map an `RPCError` to a `.transportFailure` case with the shared `from(transportError:)` helper, so timeouts and dead channels report as `.suppressed` instead of Bugsnag errors — see [09](09-cross-cutting-concerns.md).
 
 ## Auth on the wire — signature-per-request
 
@@ -60,7 +78,7 @@ There is **no auth token, cookie, or bearer header**. Every request authenticate
 - **Payments (OCP)**: each request has a `signature` field. `SwiftProtobuf.Message.sign(with: KeyPair)` serializes the proto and signs it with the owner's Ed25519 key (CodeCurves).
 - **Flipcash (Core)**: requests carry a `Flipcash_Common_V1_Auth` (public key + signature) built by `KeyPair.authFor(message:)`.
 
-The only interceptor is `UserAgentInterceptor` (adds a `User-Agent` header — `OpenCodeProtocol/iOS/...` for OCP paths, `Flipcash/iOS/...` otherwise).
+The only interceptor is `UserAgentClientInterceptor` (registered on each `GRPCClient`; adds a lowercase `user-agent` header — `OpenCodeProtocol/iOS/...` for `ocp.*` services, `Flipcash/iOS/...` otherwise).
 
 ## Solana RPC
 
@@ -68,10 +86,8 @@ Separate from gRPC. `SolanaRPC` (JSON-RPC 2.0 over `URLSession`, default `api.ma
 
 ## Push notifications
 
-`FlipcashCore/.../Push/`: `NotificationPayload` decodes a base64 `Flipcash_Push_V1_Payload` from `userInfo` (key `flipcash_payload`); `SubstitutionApplier` fills `{0}`/`{1}` placeholders (resolved contact names). APNs tokens registered via `PushService` (`addToken`/`deleteTokens`). The NotificationService extension *(contact-sync)* resolves names on-device (see [01](01-modules-and-boundaries.md)).
+`FlipcashCore/.../Push/`: `NotificationPayload` decodes a base64 `Flipcash_Push_V1_Payload` from `userInfo` (key `flipcash_payload`); `SubstitutionApplier` fills `{0}`/`{1}` placeholders (resolved contact names). APNs tokens registered via `PushService` (`addToken`/`deleteTokens`). The NotificationService extension resolves names on-device and prefetches chat transcripts via `ChatNotificationClient` (see [01](01-modules-and-boundaries.md)).
 
 ## Generated code
 
-`FlipcashAPI/Sources/FlipcashAPI/` holds both proto trees: **`Payments/`** (namespace `ocp.*`: account, currency, messaging, transaction) and **`Core/`** (namespace `flipcash.*`: account, activity, contact, email, phone, profile, push, resolver, settings, moderation, …), each with a `Generated/` subdir. Regenerate via `Scripts/run -a flipcashPayments` / `flipcashCore` (needs `protoc`, `protoc-gen-swift`, `protoc-gen-grpc-swift` **v1.x**). Never edit `Generated/` by hand.
-
-> The repo root also contains an empty `FlipcashCoreAPI/` directory. It is a legacy placeholder with no sources — all core bindings live under `FlipcashAPI/Sources/FlipcashAPI/Core/`.
+`FlipcashAPI/Sources/FlipcashAPI/` holds both proto trees: **`Payments/`** (namespace `ocp.*`: account, currency, messaging, transaction) and **`Core/`** (namespace `flipcash.*`: account, activity, chat, contact, email, event, phone, profile, push, resolver, settings, moderation, …), each with a `Generated/` subdir. Regenerate via `Scripts/run -a flipcashPayments` / `flipcashCore` (needs `protoc`, `protoc-gen-swift`, and `protoc-gen-grpc-swift-2` — grpc-swift **2.x**, installed by `Scripts/install-grpc-swift-2-plugin.sh`). Never edit `Generated/` by hand.

--- a/docs/architecture/05-persistence.md
+++ b/docs/architecture/05-persistence.md
@@ -1,0 +1,77 @@
+# Persistence
+
+Three storage layers with a strict division of labour: **SQLite** holds all cached server data, **Keychain** holds secrets, **UserDefaults** holds preferences and small flags. There are no migrations — a schema change deletes and rebuilds the database from the server.
+
+```mermaid
+graph LR
+    BE["Server response"] --> Svc["Service"]
+    Svc -->|upsert in transaction| DB["SQLite — writer, WAL"]
+    DB -->|databaseDidChange| Upd["Updateable&lt;T&gt;"]
+    Upd -->|re-query on MainActor| View["SwiftUI view"]
+```
+
+## Storage layers
+
+| Layer | What lives here | Implementation |
+|-------|-----------------|----------------|
+| **SQLite** | All cached server data: balances, mint metadata, activity history, rates, verified proofs, limits, profile, user flags, contact-sync state, local contacts snapshot | `Database.swift` over the `dbart01/SQLite.swift` fork |
+| **Keychain** | Secrets: current `UserAccount` (keypair), `historicalAccounts` (iCloud-synced) | `AccountManager` via a `@SecureCodable` wrapper |
+| **UserDefaults** | Preferences/flags only: `wasLoggedIn`, `launchCount`, camera prefs, `balanceCurrency`, `recentCurrencies`, `localCurrencyAdded`, `storedTokenMint`, `betaFlags` | a custom `@Defaults` wrapper (the project does **not** use `@AppStorage`) |
+
+> **Rule:** cached backend data → SQLite. UserDefaults is only for preferences and small local flags. Rates/balances/metadata/activities/limits all belong in SQLite.
+
+## Database controller
+
+`Flipcash/Core/Controllers/Database/Database.swift` — `nonisolated class … @unchecked Sendable` (not actor-isolated; Swift 6 sendability asserted manually). Opens **two connections**: a `writer` (WAL mode, foreign keys on, 10k-page cache) and a read-only `reader`, both with a 2s busy timeout. SQLite.swift serializes each connection through its own private queue.
+
+- **`transaction(silent:_:)`** counts `totalChanges` and posts `.databaseDidChange` (coalesced) when rows actually changed. `silent: true` skips the notification for write-throughs with no UI listeners (e.g. verified-rate upserts).
+- **Reactive reads**: `@Observable Updateable<T>` subscribes to `.databaseDidChange` and re-runs its query on `@MainActor`, giving views automatic refresh without polling.
+- One database file per owner: `Application Support/flipcash-<owner.base58>.sqlite` (+ `-wal`/`-shm`) — multi-account safe. `Database` is a `SessionContainer` property injected by reference into Session, the controllers, and the cash operations.
+
+## Schema
+
+`Schema.swift` — all tables are `WITHOUT ROWID` (explicit primary key as the B-tree key):
+
+| Table | Key | Stores |
+|-------|-----|--------|
+| `balance` | mint | Per-mint quark balance + cost basis |
+| `mint` | mint | Full mint metadata (name, symbol, decimals, image, VM metadata, launchpad curve/vault/supply/fees, social links, bill colors, createdAt) |
+| `activity` | id | Transaction history rows (kind, state, title, quarks, native amount, currency, mint, date) |
+| `cashLinkMetadata` | id → activity (CASCADE) | Vault address + `canCancel` for cash-link activities |
+| `limits` | 1 (singleton) | Serialized `Limits` proto |
+| `rate` | currency | One JSON `Rate` per fiat (cold-launch rehydration) |
+| `verified_rate` | currency | Raw signed `rateProto` per fiat |
+| `verified_reserve` | mint | Raw signed `reserveProto` per launchpad mint |
+| `profile` / `userFlags` | 1 (singleton) | Serialized blobs |
+| `contact_sync_state` | 1 (singleton) | Sync cursor (checksum) |
+| `flipcash_contact` | e164 | Numbers server-confirmed on Flipcash |
+| `local_contacts_snapshot` | (e164, contactId) | Last uploaded contact set; `contactId` resolves name/avatar at render |
+
+Custom `Value` conformances store `UInt64` as `Int64`, `PublicKey`/`Key32` as `Blob`, `CurrencyCode` as `String`.
+
+## Query organization
+
+Extension-per-concern, all `nonisolated extension Database`: `Database+Balance`, `+Activities`, `+Rates`, `+VerifiedProtos` (conforms `Database` to `VerifiedProtoStore`), `+Limits`, `+Profile`, `+ContactSync`. Each owns the reads/upserts for its domain.
+
+Row models live in `Database/Models/`. Only two dedicated structs exist — `StoredBalance` (from the `balance JOIN mint` query, computes the USDF equivalent inline via the bonding curve) and `StoredMintMetadata` (converts to/from the domain `MintMetadata`). Singleton-row tables decode directly to their domain type inline; no separate model struct.
+
+## Versioning & migrations — there are none
+
+`SessionAuthenticator.initializeDatabase` version-gates the store:
+
+1. Read persisted version from a companion text file `flipcash-<owner.base58>version`.
+2. Read `SQLiteVersion` (an integer) from `Info.plist`.
+3. If the Info.plist version is higher → delete the three SQLite files, write the new version.
+4. Open a fresh `Database` (`createTablesIfNeeded()` runs in `init`).
+
+> **Bump `SQLiteVersion` in Info.plist on every schema change** — adding/removing a table or column, or changing which table a query reads from when the old schema can't satisfy it. No migration code is needed, but **all data must be recoverable from the server**, because the local store is thrown away.
+
+## The SQLite.swift fork
+
+`github.com/dbart01/SQLite.swift` (pinned to `master`), forked off the official `0.15.4`. It adds:
+
+1. **Upsert WHERE fix** — moves `whereClause` after `DO UPDATE SET` (the official repo puts it before `ON CONFLICT`, producing invalid SQL for filtered upserts like `table.filter(...).upsert(...)`). Load-bearing in `Database+Balance`.
+2. **Custom `DispatchQueue` injection** — the fork *adds* a `queue:` parameter to `Connection.init` (upstream has none); the project currently omits it, so the default queue is used.
+3. **Public `Setter` access (pending)** — to build `COALESCE(excluded.col, col)` ON CONFLICT clauses; until then a two-statement workaround is used.
+
+Do not switch to the official repo without verifying filtered upserts still emit valid SQL.

--- a/docs/architecture/05-persistence.md
+++ b/docs/architecture/05-persistence.md
@@ -14,7 +14,7 @@ graph LR
 
 | Layer | What lives here | Implementation |
 |-------|-----------------|----------------|
-| **SQLite** | All cached server data: balances, mint metadata, activity history, rates, verified proofs, limits, profile, user flags, contact-sync state, local contacts snapshot | `Database.swift` over the `dbart01/SQLite.swift` fork |
+| **SQLite** | All cached server data: balances, mint metadata, activity history, rates, verified proofs, limits, profile, user flags, plus contact-sync state + local contacts snapshot *(contact-sync)* | `Database.swift` over the `dbart01/SQLite.swift` fork |
 | **Keychain** | Secrets: current `UserAccount` (keypair), `historicalAccounts` (iCloud-synced) | `AccountManager` via a `@SecureCodable` wrapper |
 | **UserDefaults** | Preferences/flags only: `wasLoggedIn`, `launchCount`, camera prefs, `balanceCurrency`, `recentCurrencies`, `localCurrencyAdded`, `storedTokenMint`, `betaFlags` | a custom `@Defaults` wrapper (the project does **not** use `@AppStorage`) |
 
@@ -43,15 +43,15 @@ graph LR
 | `verified_rate` | currency | Raw signed `rateProto` per fiat |
 | `verified_reserve` | mint | Raw signed `reserveProto` per launchpad mint |
 | `profile` / `userFlags` | 1 (singleton) | Serialized blobs |
-| `contact_sync_state` | 1 (singleton) | Sync cursor (checksum) |
-| `flipcash_contact` | e164 | Numbers server-confirmed on Flipcash |
-| `local_contacts_snapshot` | (e164, contactId) | Last uploaded contact set; `contactId` resolves name/avatar at render |
+| `contact_sync_state` | 1 (singleton) | Sync cursor (checksum) *(contact-sync)* |
+| `flipcash_contact` | e164 | Numbers server-confirmed on Flipcash *(contact-sync)* |
+| `local_contacts_snapshot` | (e164, contactId) | Last uploaded contact set; `contactId` resolves name/avatar at render *(contact-sync)* |
 
 Custom `Value` conformances store `UInt64` as `Int64`, `PublicKey`/`Key32` as `Blob`, `CurrencyCode` as `String`.
 
 ## Query organization
 
-Extension-per-concern, all `nonisolated extension Database`: `Database+Balance`, `+Activities`, `+Rates`, `+VerifiedProtos` (conforms `Database` to `VerifiedProtoStore`), `+Limits`, `+Profile`, `+ContactSync`. Each owns the reads/upserts for its domain.
+Extension-per-concern, all `nonisolated extension Database`: `Database+Balance`, `+Activities`, `+Rates`, `+VerifiedProtos` (conforms `Database` to `VerifiedProtoStore`), `+Limits`, `+Profile`, `+ContactSync` *(contact-sync)*. Each owns the reads/upserts for its domain.
 
 Row models live in `Database/Models/`. Only two dedicated structs exist — `StoredBalance` (from the `balance JOIN mint` query, computes the USDF equivalent inline via the bonding curve) and `StoredMintMetadata` (converts to/from the domain `MintMetadata`). Singleton-row tables decode directly to their domain type inline; no separate model struct.
 

--- a/docs/architecture/05-persistence.md
+++ b/docs/architecture/05-persistence.md
@@ -14,7 +14,7 @@ graph LR
 
 | Layer | What lives here | Implementation |
 |-------|-----------------|----------------|
-| **SQLite** | All cached server data: balances, mint metadata, activity history, rates, verified proofs, limits, profile, user flags, plus contact-sync state + local contacts snapshot *(contact-sync)* | `Database.swift` over the `dbart01/SQLite.swift` fork |
+| **SQLite** | All cached server data: balances, mint metadata, activity history, rates, verified proofs, limits, profile, user flags, contact-sync state + local contacts snapshot, DM conversation feed + messages | `Database.swift` over the `dbart01/SQLite.swift` fork |
 | **Keychain** | Secrets: current `UserAccount` (keypair), `historicalAccounts` (iCloud-synced) | `AccountManager` via a `@SecureCodable` wrapper |
 | **UserDefaults** | Preferences/flags only: `wasLoggedIn`, `launchCount`, camera prefs, `balanceCurrency`, `recentCurrencies`, `localCurrencyAdded`, `storedTokenMint`, `betaFlags` | a custom `@Defaults` wrapper (the project does **not** use `@AppStorage`) |
 
@@ -30,7 +30,7 @@ graph LR
 
 ## Schema
 
-`Schema.swift` — all tables are `WITHOUT ROWID` (explicit primary key as the B-tree key):
+`Schema.swift` — all tables are `WITHOUT ROWID` (explicit primary key as the B-tree key), except `conversation_member`, a rowid table because its nullable `userId` can't be part of a `WITHOUT ROWID` key:
 
 | Table | Key | Stores |
 |-------|-----|--------|
@@ -43,17 +43,20 @@ graph LR
 | `verified_rate` | currency | Raw signed `rateProto` per fiat |
 | `verified_reserve` | mint | Raw signed `reserveProto` per launchpad mint |
 | `profile` / `userFlags` | 1 (singleton) | Serialized blobs |
-| `contact_sync_state` | 1 (singleton) | Sync cursor (checksum) *(contact-sync)* |
-| `flipcash_contact` | e164 | Numbers server-confirmed on Flipcash *(contact-sync)* |
-| `local_contacts_snapshot` | (e164, contactId) | Last uploaded contact set; `contactId` resolves name/avatar at render *(contact-sync)* |
+| `contact_sync_state` | 1 (singleton) | Sync cursor (checksum) |
+| `flipcash_contact` | e164 | Numbers server-confirmed on Flipcash (+ `dmChatId`, join timestamp) |
+| `local_contacts_snapshot` | (e164, contactId) | Last uploaded contact set; `contactId` resolves name/avatar at render |
+| `conversation` | id (32-byte ChatId blob) | DM feed row: `lastActivity`; the feed preview is the newest `conversation_message` row |
+| `conversation_member` | rowid (no explicit PK — nullable `userId`) | Member display name, phone, read pointer; replaced wholesale per conversation |
+| `conversation_message` | (conversationId, id) | Text or decomposed cash content (kind, quarks, native amount, currency, mint), date, `unreadSeq`; pruned to the newest 100 per conversation (20-row slack) |
 
-Custom `Value` conformances store `UInt64` as `Int64`, `PublicKey`/`Key32` as `Blob`, `CurrencyCode` as `String`.
+Custom `Value` conformances store `UInt64` as `Int64`, `PublicKey`/`Key32` as `Blob`, `CurrencyCode` as `String`. The conversation tables store dates as raw `timeIntervalSinceReferenceDate` doubles so decoding is a struct init, not a per-row `DateFormatter` parse.
 
 ## Query organization
 
-Extension-per-concern, all `nonisolated extension Database`: `Database+Balance`, `+Activities`, `+Rates`, `+VerifiedProtos` (conforms `Database` to `VerifiedProtoStore`), `+Limits`, `+Profile`, `+ContactSync` *(contact-sync)*. Each owns the reads/upserts for its domain.
+Extension-per-concern, all `nonisolated extension Database`: `Database+Balance`, `+Activities`, `+Rates`, `+VerifiedProtos` (conforms `Database` to `VerifiedProtoStore`), `+Limits`, `+Profile`, `+ContactSync`, `+Conversations`. Each owns the reads/upserts for its domain.
 
-Row models live in `Database/Models/`. Only two dedicated structs exist — `StoredBalance` (from the `balance JOIN mint` query, computes the USDF equivalent inline via the bonding curve) and `StoredMintMetadata` (converts to/from the domain `MintMetadata`). Singleton-row tables decode directly to their domain type inline; no separate model struct.
+Row models live in `Database/Models/`. Only two dedicated structs exist — `StoredBalance` (from the `balance JOIN mint` query, computes the USDF equivalent inline via the bonding curve) and `StoredMintMetadata` (converts to/from the domain `MintMetadata`). Everything else decodes directly to its domain type inline (singleton-row blobs, `Conversation`/`ConversationMessage` rows); no separate model struct.
 
 ## Versioning & migrations — there are none
 

--- a/docs/architecture/06-payments-and-operations.md
+++ b/docs/architecture/06-payments-and-operations.md
@@ -27,7 +27,7 @@ A payment is submitted via the **`submitIntent` bidirectional stream** (`Transac
 Freshness: client ceiling `clientMaxAge = 13 min` (2-min buffer under the server's 15-min limit); `SendCashOperation` also pre-flights a 15-min ceiling on the reserve proof before transfer.
 
 ### The pin-at-compute invariant
-Amount-entry viewmodels (`BuyAmountViewModel`, `CurrencySellViewModel`, `WithdrawViewModel`, `GiveViewModel`, `SendAmountViewModel`) call `prepareSubmission()` **at commit time** to pin the `VerifiedState`, and compute `ExchangedFiat.quarks` against *that same proof's rate*. The pinned state is carried unchanged through `Session.showCashBill → BillDescription.verifiedState → SendCashOperation` / `createCashLink`.
+Amount-entry viewmodels (`BuyAmountViewModel`, `CurrencySellViewModel`, `WithdrawViewModel`, `GiveViewModel`, and `SendAmountViewModel` *(contact-sync)*) call `prepareSubmission()` **at commit time** to pin the `VerifiedState`, and compute `ExchangedFiat.quarks` against *that same proof's rate*. The pinned state is carried unchanged through `Session.showCashBill → BillDescription.verifiedState → SendCashOperation` / `createCashLink`.
 
 > Using a different (or re-fetched) proof at the transfer step makes `quarks × rate` disagree with what the server validates → "native amount does not match expected value" rejection. Pin once, at compute.
 

--- a/docs/architecture/06-payments-and-operations.md
+++ b/docs/architecture/06-payments-and-operations.md
@@ -1,0 +1,78 @@
+# Payments & Operations
+
+Money movement is the heart of the app. Every payment carries a **server-signed proof** of the exchange rate, submitted over a streaming intent RPC. Face-to-face transfer uses a peer-to-peer rendezvous handshake. External funding (Apple Pay, Coinbase, Phantom) is abstracted behind a `FundingOperation` protocol.
+
+```mermaid
+graph TD
+    Pin["Pin VerifiedState at commit"] --> Adv["Sender: sendRequestToGiveBill — advertise"]
+    Adv --> Wait["Sender: awaitGrabRequest"]
+    Scan["Receiver: awaitGiveRequest"] --> Grab["Receiver: sendRequestToGrabBill"]
+    Grab --> Wait
+    Wait --> Verify{"Valid grab signature?"}
+    Verify -->|no| Reject["reject — possible MITM"]
+    Verify -->|yes| Transfer["transfer + submitIntent — same VerifiedState"]
+    Transfer --> Poll["pollIntentMetadata to settlement"]
+```
+
+## Payment intents & `VerifiedState`
+
+A payment is submitted via the **`submitIntent` bidirectional stream** (`TransactionService.submit`, `callOptions: .streaming`): client sends `submitActions` → server replies `serverParameters` (nonce + blockhash) → client applies, signs, sends `submitSignatures` → server replies `success`/`error`.
+
+`VerifiedState` (`FlipcashCore/.../Models/VerifiedState.swift`) bundles the proofs the server requires:
+
+- `rateProto` — server-signed exchange-rate proof (**always required**)
+- `reserveProto?` — reserve-state proof; `nil` for USDF, **mandatory for launchpad currencies** (server rejects without it)
+- `serverTimestamp` — the older of the two proof timestamps (staleness anchor)
+
+Freshness: client ceiling `clientMaxAge = 13 min` (2-min buffer under the server's 15-min limit); `SendCashOperation` also pre-flights a 15-min ceiling on the reserve proof before transfer.
+
+### The pin-at-compute invariant
+Amount-entry viewmodels (`BuyAmountViewModel`, `CurrencySellViewModel`, `WithdrawViewModel`, `GiveViewModel`, `SendAmountViewModel`) call `prepareSubmission()` **at commit time** to pin the `VerifiedState`, and compute `ExchangedFiat.quarks` against *that same proof's rate*. The pinned state is carried unchanged through `Session.showCashBill → BillDescription.verifiedState → SendCashOperation` / `createCashLink`.
+
+> Using a different (or re-fetched) proof at the transfer step makes `quarks × rate` disagree with what the server validates → "native amount does not match expected value" rejection. Pin once, at compute.
+
+## SendCashOperation — the give/grab rendezvous
+
+`Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift`. The sender's side. `start()` spawns a `Task` (`runTask`); `cancel()` and `isolated deinit` cancel it. `run()` executes two sequential phases sharing one resolved `VerifiedState`:
+
+- **Path 1 — advertise the bill**: resolve the `VerifiedState` (prefer the pinned one from `BillDescription`, else `RatesController` cache), then `client.sendRequestToGiveBill(mint:exchangedFiat:verifiedState:rendezvous:)` publishes the bill on the rendezvous channel.
+- **Path 2 — listen → transfer**: `client.awaitGrabRequest(...)` waits for the receiver's grab → verify the destination signature against the rendezvous key (MITM protection) → pre-flight reserve-proof age → `client.transfer(...)` using the **same** `VerifiedState` → `client.pollIntentMetadata(...)` until settlement.
+
+> **Never explicitly `cancel()` or `invalidateMessageStream()` a `SendCashOperation` from `dismissCashBill`.** After a grab, the received bill is a *live* `SendCashOperation` (the "quick give-and-grab" chain — someone can scan it next). Setting `sendOperation = nil` is fine (deinit cleans up); explicit teardown kills a live bill. Teardown is implicit: `run()` returning (success) or throwing (failure) ends the `runTask`, and `deinit`/`cancel()` handle external teardown. `ignoresStream` (set by Session while a share sheet is up) suppresses processing a grab that arrives mid-share.
+
+## ScanCashOperation — the receiver's side
+
+`ScanCashOperation.swift`. `client.awaitGiveRequest(...)` waits for the sender's advertisement (which carries `mint`, `verifiedState`, and `mintMetadata`). Resolves the VM authority (prefers the message's metadata → DB → `fetchMints`), ensures token accounts (`createAccounts`), sends `sendRequestToGrabBill(destination:rendezvous:)`, then `pollIntentMetadata` for settlement. Because both `VerifiedState` and `MintMetadata` come from the sender's advertisement, the scan works even if the receiver never subscribed to that currency's stream.
+
+> Every `showCashBill` must pass `verifiedState` — even for received bills — or launchpad transfers fail with "reserve state is required".
+
+## Funding operations
+
+`FundingOperation` (`FundingOperation.swift`) — single-concern protocol: `start(_ operation: PaymentOperation) async throws -> StartedSwap`, `confirm()`, `cancel()`. Three implementations:
+
+| Operation | When | External step |
+|-----------|------|---------------|
+| `ReservesFundingOperation` | User has USDF; fund from reserves | none (straight through) |
+| `CoinbaseFundingOperation` | Apple Pay onramp (USDF bought via Coinbase) | Apple Pay sheet (WebView) |
+| `PhantomFundingOperation` | External Solana wallet | Phantom connect + sign (two deeplink round-trips) |
+
+Notes: both external operations **record the swap server-side before any money moves**. Coinbase rebuilds `ExchangedFiat` from Coinbase's *recorded* purchase amount before submitting (Coinbase's USD→USDF rate differs by 1–2 quarks; using the requested amount would reject). Phantom pre-flights the signed transaction via `rpc.simulateTransaction`.
+
+**`UsdcSweepOperation`** (`Flipcash/Core/Operations/UsdcSweepOperation.swift`) — an `actor` that converts the user's USDC ATA balance to USDF via `statelessSwap`. Called as a one-line fire-and-forget from `AppDelegate` on `.active` (`usdcSweepOperation.start()`, which is `nonisolated`). Re-entrant calls are skipped while a sweep is in flight.
+
+## Rates & verified proofs
+
+`RatesController` (`@Observable`) owns two actors:
+
+- **`LiveMintDataStreamer`** — the bidirectional `streamLiveMintData`; receives `VerifiedCoreMintFiatExchangeRate` and `VerifiedLaunchpadCurrencyReserveState` protos, dispatches them to `VerifiedProtoService`.
+- **`VerifiedProtoService`** — caches `exchangeRates` (by currency) and `reserveStates` (by mint); deduplicates rate changes for the publisher (avoids no-op re-renders) but always stores the freshest proof; persists to SQLite (`VerifiedProtoStore`) and warm-loads at init.
+
+Flow into a payment: stream → `VerifiedProtoService` (memory + SQLite) → `RatesController.cachedRates` (display) → at commit, `RatesController.currentPinnedState(for:mint:)` returns the cached `VerifiedState` (rejects stale). Amount-entry uses `verifiedState.rate` (the rate embedded in the proof), **not** the live `cachedRates`, so the server's validation matches. `awaitVerifiedState(...)` polls up to 25× at 200ms, and for non-USDF mints also waits for `reserveProto != nil`.
+
+## After every transaction
+
+`Session.updatePostTransaction()` = `updateBalance()` + `updateLimits()` + `historyController.sync()`. **Call it after any operation that moves funds** — buy, sell, withdraw, launch, transfer, receive, cash-link, and on push-triggered receipt.
+
+## Swaps
+
+`SignedSwapResult` is the typed callback result from external funding: `.buyExisting(swapId:)` or `.launch(swapId:, mint:)`. The `statefulSwap` stream (`SwapService`) is used for buy/sell/withdraw (build + sign the swap transaction, then `submitIntent` Phase 2 funds it from USDF). `statelessSwap` is single-purpose for the USDC→USDF sweep — no funding intent, no `VerifiedState`.

--- a/docs/architecture/06-payments-and-operations.md
+++ b/docs/architecture/06-payments-and-operations.md
@@ -16,7 +16,7 @@ graph TD
 
 ## Payment intents & `VerifiedState`
 
-A payment is submitted via the **`submitIntent` bidirectional stream** (`TransactionService.submit`, `callOptions: .streaming`): client sends `submitActions` → server replies `serverParameters` (nonce + blockhash) → client applies, signs, sends `submitSignatures` → server replies `success`/`error`.
+A payment is submitted via the **`submitIntent` bidirectional stream** (`TransactionService.submit`, through the `BidirectionalGRPCStream` adapter — no deadline): client sends `submitActions` → server replies `serverParameters` (nonce + blockhash) → client applies, signs, sends `submitSignatures` → server replies `success`/`error`.
 
 `VerifiedState` (`FlipcashCore/.../Models/VerifiedState.swift`) bundles the proofs the server requires:
 
@@ -24,10 +24,12 @@ A payment is submitted via the **`submitIntent` bidirectional stream** (`Transac
 - `reserveProto?` — reserve-state proof; `nil` for USDF, **mandatory for launchpad currencies** (server rejects without it)
 - `serverTimestamp` — the older of the two proof timestamps (staleness anchor)
 
-Freshness: client ceiling `clientMaxAge = 13 min` (2-min buffer under the server's 15-min limit); `SendCashOperation` also pre-flights a 15-min ceiling on the reserve proof before transfer.
+Freshness: one unified check — `isStale` measures age from `serverTimestamp` against `clientMaxAge = 13 min` (2-min buffer under the server's 15-min limit), so rate and reserve proofs fold into a single ceiling. `SendCashOperation` pre-flights `isStale` just before transfer, throwing `verifiedStateStale` instead of failing server-side as `invalidIntent` when a pin went stale while the bill sat open.
+
+Direct contact payments attach **`ChatPaymentMetadata`** (`FlipcashCore/.../Models/Conversation/ChatPaymentMetadata.swift`) — the contact's server-issued DM chat ID (`MatchedContact.dmChatID`, from contact sync) plus source/destination E.164 — serialized as `flipcash.intent.v1.AppMetadata` into the transfer intent's `app_metadata`. The server posts the payment as a cash message in that DM, creating the chat if it doesn't exist yet; both sides must be payment-linked or the server rejects the intent. When the contact has no `dmChatID` or the sender has no linked phone, `SendAmountViewModel` submits the payment without chat metadata.
 
 ### The pin-at-compute invariant
-Amount-entry viewmodels (`BuyAmountViewModel`, `CurrencySellViewModel`, `WithdrawViewModel`, `GiveViewModel`, and `SendAmountViewModel` *(contact-sync)*) call `prepareSubmission()` **at commit time** to pin the `VerifiedState`, and compute `ExchangedFiat.quarks` against *that same proof's rate*. The pinned state is carried unchanged through `Session.showCashBill → BillDescription.verifiedState → SendCashOperation` / `createCashLink`.
+Amount-entry viewmodels (`BuyAmountViewModel`, `CurrencySellViewModel`, `WithdrawViewModel`, `GiveViewModel`, and `SendAmountViewModel`) call `prepareSubmission()` **at commit time** to pin the `VerifiedState`, and compute `ExchangedFiat.quarks` against *that same proof's rate*. The pinned state is carried unchanged through `Session.showCashBill → BillDescription.verifiedState → SendCashOperation` / `createCashLink`; `SendAmountViewModel` (contact send) hands its pin directly to `Session.send(amount:verifiedState:to:chat:)`.
 
 > Using a different (or re-fetched) proof at the transfer step makes `quarks × rate` disagree with what the server validates → "native amount does not match expected value" rejection. Pin once, at compute.
 
@@ -36,7 +38,7 @@ Amount-entry viewmodels (`BuyAmountViewModel`, `CurrencySellViewModel`, `Withdra
 `Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift`. The sender's side. `start()` spawns a `Task` (`runTask`); `cancel()` and `isolated deinit` cancel it. `run()` executes two sequential phases sharing one resolved `VerifiedState`:
 
 - **Path 1 — advertise the bill**: resolve the `VerifiedState` (prefer the pinned one from `BillDescription`, else `RatesController` cache), then `client.sendRequestToGiveBill(mint:exchangedFiat:verifiedState:rendezvous:)` publishes the bill on the rendezvous channel.
-- **Path 2 — listen → transfer**: `client.awaitGrabRequest(...)` waits for the receiver's grab → verify the destination signature against the rendezvous key (MITM protection) → pre-flight reserve-proof age → `client.transfer(...)` using the **same** `VerifiedState` → `client.pollIntentMetadata(...)` until settlement.
+- **Path 2 — listen → transfer**: `client.awaitGrabRequest(...)` waits for the receiver's grab → verify the destination signature against the rendezvous key (MITM protection) → pre-flight `isStale` on the resolved state → `client.transfer(...)` using the **same** `VerifiedState` → `client.pollIntentMetadata(...)` until settlement.
 
 > **Never explicitly `cancel()` or `invalidateMessageStream()` a `SendCashOperation` from `dismissCashBill`.** After a grab, the received bill is a *live* `SendCashOperation` (the "quick give-and-grab" chain — someone can scan it next). Setting `sendOperation = nil` is fine (deinit cleans up); explicit teardown kills a live bill. Teardown is implicit: `run()` returning (success) or throwing (failure) ends the `runTask`, and `deinit`/`cancel()` handle external teardown. `ignoresStream` (set by Session while a share sheet is up) suppresses processing a grab that arrives mid-share.
 

--- a/docs/architecture/07-currency-and-domain-model.md
+++ b/docs/architecture/07-currency-and-domain-model.md
@@ -1,0 +1,81 @@
+# Currency & Domain Model
+
+The domain layer lives in `FlipcashCore/Sources/FlipcashCore/Models/`. It keeps money exact (integer quarks + `Decimal` fiat), travels mint identity with every amount, mirrors the on-chain bonding curve precisely, and routes validation and errors through single sources of truth.
+
+```mermaid
+graph TD
+    Entered["Entered fiat amount"] --> Rate["Rate from pinned VerifiedState"]
+    Rate --> EF["ExchangedFiat.compute"]
+    EF -->|USDF| Direct["nativeAmount / rate"]
+    EF -->|launchpad| Curve["DiscreteBondingCurve"]
+    Direct --> TA["TokenAmount — UInt64 quarks + mint"]
+    Curve --> TA
+    TA --> Tx["on-chain transfer / intent"]
+```
+
+## Money primitives
+
+- **`TokenAmount`** (colloquially "Quarks") — `(quarks: UInt64, mint: PublicKey)`. A quark is the smallest on-chain integer unit. USDF has `mintDecimals = 6`; **all other mints (including USDC) have `mintDecimals = 10`**. `decimalValue = quarks.scaleDown(mint.mintDecimals)` is integer-only — no floats. Cross-mint arithmetic is a `precondition` crash, so mint identity can never be lost.
+- **`FiatAmount`** — `(value: Decimal, currency: CurrencyCode)`. Human-facing money; base-10 exact `Decimal` math; cross-currency arithmetic also `precondition`-guarded.
+- **`ExchangedFiat`** — the bridge between the two worlds: `onChainAmount: TokenAmount` (integer quarks for the SPL transfer), `nativeAmount: FiatAmount` (what the user sees), `currencyRate: Rate`, and a computed `usdfValue`. Built via `init(nativeAmount:rate:)` for USDF or `compute(fromEntered:rate:mint:supplyQuarks:)` for bonded mints. Money stays in `UInt64` quarks / `Decimal` throughout, so there's no float error.
+- **`Rate`** — `(fx: Decimal, currency: CurrencyCode)`, always native-per-USD; `Rate.oneToOne` is USD identity.
+
+## Currencies & mints
+
+- **`CurrencyCode`** — `enum: String` of ~160 ISO fiat codes (the *display* currency, not a mint). Exposes `maximumFractionDigits` (ICU-resolved, cached behind a lock to avoid main-thread hangs), single-char symbols, and a `region` for flags.
+- **`MintMetadata`** — rich per-mint info: address, decimals, name, symbol, image, optional `VMMetadata` (timelock VM authority + lockout), optional `LaunchpadMetadata` (bonding-curve state: config, liquidity pool, seed, authority, vault/fee addresses, `supplyFromBonding`, `sellFeeBps`, price/market-cap). `.usdf` and `.usdc` are static singletons.
+- A mint **is a launchpad/custom currency iff `launchpadMetadata != nil`** — those require the `reserveProto` for payments.
+- Constants (`PublicKey+Definitions.swift`): `PublicKey.usdf`, `PublicKey.usdc`. `PublicKey.mintDecimals` has a single branch — `.usdf → 6`, **everything else (including `.usdc`) → 10**. USDC's real 6-decimal precision comes from `MintMetadata.usdc.decimals`, not from `PublicKey.mintDecimals`.
+
+## Bonding curve
+
+**`DiscreteBondingCurve`** mirrors the Solana program exactly so client and server price identically. Step-based:
+
+| Constant | Value |
+|----------|-------|
+| `maxSupply` | 21,000,000 tokens |
+| `stepSize` | 100 tokens/step |
+| `tableSize` | 210,001 entries |
+| `decimals` | 10 |
+| price range | ~$0.01 → ~$1M at max supply |
+
+The pricing and cumulative-cost tables are pre-computed and shipped as binary `.bin` resources (loaded at runtime — large array literals blow up the Swift compiler). Operations: `spotPrice(at:)`, `buy(usdcQuarks:feeBps:supplyQuarks:)`, `sell(tokenQuarks:...)`, `tokensForValueExchange(fiat:fiatRate:supplyQuarks:)`. `ExchangedFiat` holds a private curve instance and delegates its `compute(...)` factories to it.
+
+## Account clusters & keys (Solana)
+
+- **`AccountCluster`** — groups the keys for one mint+user: an `authority: DerivedKey` (Ed25519 from the mnemonic via BIP-44) plus `timelock` PDAs for the USDF timelock VM. Exposes `authorityPublicKey`, `vaultPublicKey`, `depositPublicKey`. `use(mint:)` reuses the authority for a different token.
+- **Derivation** — BIP-44 paths off the mnemonic (`Derive.Path`): primary `m/44'/501'/0'/0'`, pool `…/7665'/<index>`, rendezvous pool `…/2335'/<index>`, relationship `…/0'/0` with a domain password. `LaunchpadMint` PDA helpers mirror the server's `pda.rs` to derive mint/config/pool/vault from `(authority, name, seed)`.
+
+(Crypto internals — CodeCurves, programs, transaction building — are covered in [09](09-cross-cutting-concerns.md).)
+
+## Error model
+
+**`ServerError`** (`ServerError.swift`):
+
+```swift
+public protocol ServerError: Error { var isReportable: Bool { get } }
+public extension ServerError { var isReportable: Bool { false } }  // default: suppress
+```
+
+~30 service error enums conform; each has cases per gRPC result code plus a `.unknown` for unrecognized values (client/server drift) — `.unknown` is the canonical reportable case. `ErrorReporting.capture(_:)` is the **single gating point**; call sites always call `captureError` unconditionally and never re-check `isReportable`.
+
+> To suppress reporting for an error, conform it to `ServerError` and return `false` from `isReportable`. That's the one source of truth.
+
+## Validation
+
+**`Validator`** (`Validation/Validator.swift`):
+
+```swift
+public protocol Validator<Output>: Sendable {
+    associatedtype Output: Sendable
+    func validate(_ input: String) -> Output?   // canonical form, or nil
+}
+```
+
+One concrete validator per input type owns the rule, returns the canonical `Output`, and is unit-testable in isolation. `EmailValidator` exists (PGV regex from `email/v1/model.proto`, max 254 bytes, returns trimmed). **Submit the validator's `Output`, not the raw input** — that makes trim/regex divergence structurally impossible. Client rules must mirror the server PGV regex; inline regex/trim/length checks in viewmodels are forbidden because they drift the moment the proto changes.
+
+## Formatters
+
+`Formatters/`: `NumberFormatter.fiat(...)` (locale-aware, cached behind a lock, manual single-char currency prefix, half-up rounding / `.down` when truncated) backs `FiatAmount.formatted`. `CompactCurrencyFormatStyle` renders `$1M`/`$690K` for market-cap/supply. `DateFormatter` extensions provide tiered relative dates (time today → Today/Yesterday → full weekday name within 6 days → `EEE, MMM dd` for older).
+
+> **Keypad amount strings use the locale's decimal separator** (`Metrics.localizedDecimalSeparator`, `.` as fallback) — not a hardcoded `.`. Any parser consuming `KeyPadView` output must account for the locale separator. (This reverses an older convention; CLAUDE.md still documents the keypad as always emitting `.` — that guidance is stale.)

--- a/docs/architecture/07-currency-and-domain-model.md
+++ b/docs/architecture/07-currency-and-domain-model.md
@@ -53,13 +53,22 @@ The pricing and cumulative-cost tables are pre-computed and shipped as binary `.
 **`ServerError`** (`ServerError.swift`):
 
 ```swift
-public protocol ServerError: Error { var isReportable: Bool { get } }
-public extension ServerError { var isReportable: Bool { false } }  // default: suppress
+public enum ErrorReportingLevel: Sendable, Equatable {
+    case suppressed   // never sent — network weather, success sentinels
+    case info         // Bugsnag info severity — expected business outcomes (denied, not-found, rate-limited)
+    case error        // Bugsnag error severity — client/proto defects (unrecognized codes, parse failures)
+}
+
+public protocol ServerError: Error {
+    var reportingLevel: ErrorReportingLevel { get }
+}
 ```
 
-~30 service error enums conform; each has cases per gRPC result code plus a `.unknown` for unrecognized values (client/server drift) — `.unknown` is the canonical reportable case. `ErrorReporting.capture(_:)` is the **single gating point**; call sites always call `captureError` unconditionally and never re-check `isReportable`.
+There is **deliberately no protocol default** — every conformer classifies each case explicitly; a defaulted level would let a forgotten or drifted conformance compile while silently muting its errors. ~35 service error enums conform; each has cases per gRPC result code plus a `.unknown` for unrecognized values (client/server drift) — `.unknown` is the canonical `.error`-level case.
 
-> To suppress reporting for an error, conform it to `ServerError` and return `false` from `isReportable`. That's the one source of truth.
+**`TransportClassifiableError`** (`TransportClassifiableError.swift`) refines `ServerError` for enums whose failure can be a transport condition rather than a server result code: it requires static `.transportFailure` (which the conformer maps to `.suppressed`) and `.unknown`, and the single shared `from(transportError: RPCError)` default maps transient codes (`RPCError.Code.isTransientNetworkError` — deadline expired / unavailable) to `.transportFailure` and everything else to `.unknown` — no per-enum mapping. `RPCError` itself conforms to `ServerError` (`RPCError+Extensions.swift`): transient → `.suppressed`, `.cancelled` → `.info` (app-initiated teardown), all other codes → `.error` — so unary RPCs that ship the existential `Error` classify correctly with no per-call-site mapping. `FlipcashCoreTests/TransportClassificationTests` asserts every conformer is wired.
+
+The level is **enforced in one place**: `ErrorReporting.capture(_:)` (`Flipcash/Utilities/ErrorReporting.swift`) reads `(error as? ServerError)?.reportingLevel ?? .error` (an unclassified error is treated as a real bug), returns without sending on `.suppressed`, and maps `.info`/`.error` onto Bugsnag severities. Call sites always call `captureError` unconditionally and never re-check the level.
 
 ## Validation
 
@@ -72,10 +81,20 @@ public protocol Validator<Output>: Sendable {
 }
 ```
 
-One concrete validator per input type owns the rule, returns the canonical `Output`, and is unit-testable in isolation. `EmailValidator` exists (PGV regex from `email/v1/model.proto`, max 254 bytes, returns trimmed). **Submit the validator's `Output`, not the raw input** — that makes trim/regex divergence structurally impossible. Client rules must mirror the server PGV regex; inline regex/trim/length checks in viewmodels are forbidden because they drift the moment the proto changes.
+One concrete validator per input type owns the rule, returns the canonical `Output`, and is unit-testable in isolation. Five validators today:
+
+| Validator | Output | Rule |
+|-----------|--------|------|
+| `EmailValidator` | `String` (trimmed) | PGV regex from `email/v1/model.proto`, max 254 bytes |
+| `PhoneValidator` | `Phone` | PhoneNumberKit parse, then E.164 checked against the PGV rule from `phone/v1/model.proto` |
+| `CurrencyNameValidator` | `String` (unchanged) | printable ASCII, no leading/trailing space, 1–32 chars; rejects rather than trims — the moderation attestation is bound to the exact string |
+| `LengthValidator` | `String` (unchanged) | non-blank, `maxLength` cap |
+| `AmountValidator` | `Decimal` | canonicalises the locale decimal separator to `.` before parsing — `Decimal(string:)` alone stops at "," and silently drops the fraction |
+
+**Submit the validator's `Output`, not the raw input** — that makes trim/regex divergence structurally impossible. Client rules must mirror the server PGV regex; inline regex/trim/length checks in viewmodels are forbidden because they drift the moment the proto changes. **Any string bound to `KeyPadView`/`EnterAmountView` is parsed exclusively by `AmountValidator`** — never raw `Decimal(string:)` or `NumberFormatter.decimal(from:)`.
 
 ## Formatters
 
 `Formatters/`: `NumberFormatter.fiat(...)` (locale-aware, cached behind a lock, manual single-char currency prefix, half-up rounding / `.down` when truncated) backs `FiatAmount.formatted`. `CompactCurrencyFormatStyle` renders `$1M`/`$690K` for market-cap/supply. `DateFormatter` extensions provide tiered relative dates (time today → Today/Yesterday → full weekday name within 6 days → `EEE, MMM dd` for older).
 
-> **Keypad amount strings use the locale's decimal separator** (`Metrics.localizedDecimalSeparator`, `.` as fallback) — not a hardcoded `.`. Any parser consuming `KeyPadView` output must account for the locale separator.
+> **Keypad amount strings use the locale's decimal separator** (`AmountValidator.localizedDecimalSeparator`, `.` as fallback) — not a hardcoded `.`. Any parser consuming `KeyPadView` output must go through `AmountValidator`, which normalizes the separator before parsing.

--- a/docs/architecture/07-currency-and-domain-model.md
+++ b/docs/architecture/07-currency-and-domain-model.md
@@ -78,4 +78,4 @@ One concrete validator per input type owns the rule, returns the canonical `Outp
 
 `Formatters/`: `NumberFormatter.fiat(...)` (locale-aware, cached behind a lock, manual single-char currency prefix, half-up rounding / `.down` when truncated) backs `FiatAmount.formatted`. `CompactCurrencyFormatStyle` renders `$1M`/`$690K` for market-cap/supply. `DateFormatter` extensions provide tiered relative dates (time today → Today/Yesterday → full weekday name within 6 days → `EEE, MMM dd` for older).
 
-> **Keypad amount strings use the locale's decimal separator** (`Metrics.localizedDecimalSeparator`, `.` as fallback) — not a hardcoded `.`. Any parser consuming `KeyPadView` output must account for the locale separator. (This reverses an older convention; CLAUDE.md still documents the keypad as always emitting `.` — that guidance is stale.)
+> **Keypad amount strings use the locale's decimal separator** (`Metrics.localizedDecimalSeparator`, `.` as fallback) — not a hardcoded `.`. Any parser consuming `KeyPadView` output must account for the locale separator.

--- a/docs/architecture/08-design-system.md
+++ b/docs/architecture/08-design-system.md
@@ -1,0 +1,54 @@
+# Design System (FlipcashUI)
+
+`FlipcashUI` is the reusable component library and design-token layer. It imports `FlipcashCore` for model types and formatters (e.g. `FiatAmount`, `CurrencyCode`) but contains **no networking, persistence, or session state**. All files default to `@MainActor` isolation; minimum iOS 17.
+
+```mermaid
+graph TD
+    Tokens["Theme tokens — Colors · Fonts · Metrics"] --> Comp["Reusable components — buttons · containers · BillView · chart"]
+    Comp --> Screen["App screens"]
+    Dlg["session.dialogItem"] --> DW["DialogWindow — UIWindow at .alert level"]
+    DW -.->|renders above| Sheets["all sheets / screens"]
+```
+
+## Design tokens
+
+- **Colors** (`Theme/Colors.swift`) — exposed as dot-syntax statics on `Color`/`ShapeStyle`, no `Theme` type. Categories: text (`.textMain`, `.textSecondary`, `.textAction`, `.textError`/`Success`/`Warning`), action (`.action`, `.actionDisabled`), background (`.backgroundMain`, `.backgroundRow`, `.rowSeparator`), banners, and a `Color.Sentiment` family (positive/negative/neutral). Plus `Color(hex:)` / `.hexString` helpers. Named dynamic color assets (`background`, `backgroundSecondary`, `error`, `success`) live in the app's `Assets.xcassets/Colors/`, referenced by name.
+- **Typography** (`Theme/AppFonts.swift`, `FontBook.swift`) — primary face **AvenirNextLTPro**; `FontBook.registerApplicationFonts()` registers fonts at launch. Named scale tokens on `Font`/`UIFont`: `appDisplayLarge` (55) → `appDisplayXS` (20), `appTitle`, `appTextXL`→`appTextCaption`, `appKeyboard`, `appTextAccessKey`.
+- **Spacing/metrics** (`Metrics.swift`) — `enum Metrics`: `buttonHeight` 60 / `buttonHeightThin` 44, `buttonRadius` 6, `boxRadius` 12, `buttonPadding` 20, plus input-field stroke/border helpers.
+
+## Component catalog
+
+- **Button styles** (`.buttonStyle`): `.filled` / `.filled20`, `.subtle`, `.icon(asset)`, `.card(icon:)`, and version-gated `.liquidGlassButtonStyle(shape:)` (glass on iOS 26, `.ultraThinMaterial` below).
+- **Buttons**: `CapsuleButton`, `LargeButton`, `BubbleButton`, `DialogButton` (`.primary`/`.secondary`/`.destructive`/`.outline`/`.subtle`, with `.loading`/`.success` states). `CodeButton` is deprecated.
+- **Toolbar**: `CloseButton` — `xmark` in `.topBarTrailing`. **This is the project's standard sheet-dismiss affordance** (not Apple's `Button("Cancel")`); don't flag it as Apple-divergent.
+- **Containers**: `Background`, `BorderedContainer`, `InputContainer`, `PartialSheet` (content-sized detents), `GlassContainer`, `LazyTable` (parallax header), `VerticalContainer` (rotated children), `ToastContainer`, `Loadable`.
+- **Controls**: `SwipeControl` (slide-to-confirm, idle-nudge), `KeyPadView` (numeric; the decimal key uses `Metrics.localizedDecimalSeparator` — the device locale's separator, `.` as fallback).
+- **Bill**: `BillView` (full cash-bill renderer — gradient, security strip, textures, rotated labels, centered code; `drawingGroup`), `CodeView`, `KikCode` (pure-Swift circular code generator — independent of the `CodeScanner` package).
+- **Chart**: `StockChart` (+ `ChartViewModel`), `ChartLineView`, `ChartRangePicker` (1D/1W/1M/1Y/all).
+- **Contacts**: `ContactAvatarView` (image or monogram, `NSCache`-backed).
+- **Misc**: `AmountText`/`AmountField`, `Flag`, `Badge`/`Bubble`/`BadgedIcon`, `QRCode`, `TwoFactorCodeView`, `CheckView`, `LoadingView`/`CircularLoadingView`, `ExpandableText`, `TextBubble`, `AccessKey`, `ValueAppreciation`.
+- **List**: `ListHeader`, `Row` (insets, `.chevron`/`.loader` accessory, auto separator).
+- **Modifiers**: `.badged(count:)`, `.vSeparator`/`.hSeparator` (pixel-precise hairlines), `.if(condition:)`, `.liquidGlassButtonStyle`.
+
+## Dialog system
+
+`Dialog/`. `DialogItem` is `Identifiable` with a `style`, title/subtitle, and `[DialogAction]` built via `@ActionBuilder`. Factories: `.error` (red, tracked), `.alert` (red, untracked), `.info` (grey), `.success` (grey — same `backgroundSecondary` as `.info`, non-dismissable by default).
+
+> `.dialog(item:)` is `.sheet(item:)` under the hood. Binding the same `dialogItem` to two live views triggers UIKit's "only one sheet" warning. **`DialogWindow` (in the app target) hosts `session.dialogItem` in a separate `UIWindow` at `.alert` level**, so it renders above every sheet without joining the main presentation queue. Use `session.dialogItem` for any dialog that must fire across a sheet boundary; a local `@State DialogItem?` bound by exactly one view is fine.
+
+## Camera & scanning UI
+
+`Camera/`. `CameraSession<T: CameraSessionExtractor>` is a generic `@MainActor` class managing the `AVCaptureSession`; it publishes extracted frames via Combine subjects. The `CameraSessionExtractor` protocol is the extension point — the app's `CodeExtractor` (using the `CodeScanner` package) decodes KikCodes from sample buffers. `CameraViewport`/`CameraPreviewView` wrap an `AVCaptureVideoPreviewLayer` (the underlying preview view is a **singleton** — one live preview at a time) with pinch-zoom and tap-to-focus. `CameraAuthorizer` (`@Observable`) wraps permission state.
+
+## UIKit bridges
+
+`View Controllers/SafariView.swift` (`SFSafariViewController`), `CameraPreviewView` (`AVFoundation`), plus direct UIKit use in `ContactAvatarCache` (`NSCache`/`UIImage`), `QRCode` (CoreImage), `KikCode` (`UIBezierPath`), `Haptics`, and `FontBook`. App-level UIKit (AppDelegate, navigation) lives in the app target.
+
+## Conventions
+
+- **No view functions.** Reusable UI is always extracted to a `struct`; `@ViewBuilder` funcs appear only as `private` helpers inside a struct's `body`. There is no such thing as premature view extraction.
+- **Modern SwiftUI throughout** — `@Observable`, `@Bindable`, two-closure `onChange(of:initial:_:)`. No `ObservableObject`/`@Published` inside FlipcashUI.
+- **Loading uses explicit placeholder data**, not `.redacted(.placeholder)` (under which only geometry — font/frame/length — renders; color and `lineLimit` are suppressed). `Loadable`/`ButtonState.loading`/explicit placeholder `Data` cover the cases.
+- **`matchedGeometryEffect` must come *before* `.frame`** in the chain, or hero animations silently fail. `.transition(.identity)` on a parent kills matched-geometry interpolation entirely.
+- **Liquid Glass / iOS 26** features are `if #available(iOS 26, *)`-gated with `.ultraThinMaterial` fallbacks.
+- **Assets** go through typed enums (`Asset`, `Symbol`, `SystemSymbol`) via `Image.asset/.system/.symbol/.regionFlag`. **Haptics** use named presets (`.tap()`, `.buttonTap()`, `.softest()`…), not raw floats.

--- a/docs/architecture/08-design-system.md
+++ b/docs/architecture/08-design-system.md
@@ -25,7 +25,7 @@ graph TD
 - **Controls**: `SwipeControl` (slide-to-confirm, idle-nudge), `KeyPadView` (numeric; the decimal key uses `Metrics.localizedDecimalSeparator` — the device locale's separator, `.` as fallback).
 - **Bill**: `BillView` (full cash-bill renderer — gradient, security strip, textures, rotated labels, centered code; `drawingGroup`), `CodeView`, `KikCode` (pure-Swift circular code generator — independent of the `CodeScanner` package).
 - **Chart**: `StockChart` (+ `ChartViewModel`), `ChartLineView`, `ChartRangePicker` (1D/1W/1M/1Y/all).
-- **Contacts**: `ContactAvatarView` (image or monogram, `NSCache`-backed).
+- **Contacts**: `ContactAvatarView` (image or monogram, `NSCache`-backed) *(contact-sync)*.
 - **Misc**: `AmountText`/`AmountField`, `Flag`, `Badge`/`Bubble`/`BadgedIcon`, `QRCode`, `TwoFactorCodeView`, `CheckView`, `LoadingView`/`CircularLoadingView`, `ExpandableText`, `TextBubble`, `AccessKey`, `ValueAppreciation`.
 - **List**: `ListHeader`, `Row` (insets, `.chevron`/`.loader` accessory, auto separator).
 - **Modifiers**: `.badged(count:)`, `.vSeparator`/`.hSeparator` (pixel-precise hairlines), `.if(condition:)`, `.liquidGlassButtonStyle`.

--- a/docs/architecture/08-design-system.md
+++ b/docs/architecture/08-design-system.md
@@ -1,10 +1,10 @@
 # Design System (FlipcashUI)
 
-`FlipcashUI` is the reusable component library and design-token layer. It imports `FlipcashCore` for model types and formatters (e.g. `FiatAmount`, `CurrencyCode`) but contains **no networking, persistence, or session state**. All files default to `@MainActor` isolation; minimum iOS 17.
+`FlipcashUI` is the reusable component library and design-token layer. It imports `FlipcashCore` for model types and formatters (e.g. `FiatAmount`, `CurrencyCode`) but contains **no networking, persistence, or session state**. Its only third-party dependencies are `ChatLayout` and `DifferenceKit`, for the chat transcript. All files default to `@MainActor` isolation; minimum iOS 18.
 
 ```mermaid
 graph TD
-    Tokens["Theme tokens — Colors · Fonts · Metrics"] --> Comp["Reusable components — buttons · containers · BillView · chart"]
+    Tokens["Theme tokens — Colors · Fonts · Metrics"] --> Comp["Reusable components — buttons · containers · BillView · chart · chat transcript"]
     Comp --> Screen["App screens"]
     Dlg["session.dialogItem"] --> DW["DialogWindow — UIWindow at .alert level"]
     DW -.->|renders above| Sheets["all sheets / screens"]
@@ -18,17 +18,18 @@ graph TD
 
 ## Component catalog
 
-- **Button styles** (`.buttonStyle`): `.filled` / `.filled20`, `.subtle`, `.icon(asset)`, `.card(icon:)`, and version-gated `.liquidGlassButtonStyle(shape:)` (glass on iOS 26, `.ultraThinMaterial` below).
+- **Button styles** (`.buttonStyle`): `.filled` / `.filledCompact` / `.filled20`, `.subtle`, `.icon(asset)`, `.card(icon:)`, and version-gated `.liquidGlassButtonStyle(shape:)` (glass on iOS 26, `.ultraThinMaterial` below).
 - **Buttons**: `CapsuleButton`, `LargeButton`, `BubbleButton`, `DialogButton` (`.primary`/`.secondary`/`.destructive`/`.outline`/`.subtle`, with `.loading`/`.success` states). `CodeButton` is deprecated.
 - **Toolbar**: `CloseButton` — `xmark` in `.topBarTrailing`. **This is the project's standard sheet-dismiss affordance** (not Apple's `Button("Cancel")`); don't flag it as Apple-divergent.
 - **Containers**: `Background`, `BorderedContainer`, `InputContainer`, `PartialSheet` (content-sized detents), `GlassContainer`, `LazyTable` (parallax header), `VerticalContainer` (rotated children), `ToastContainer`, `Loadable`.
-- **Controls**: `SwipeControl` (slide-to-confirm, idle-nudge), `KeyPadView` (numeric; the decimal key uses `Metrics.localizedDecimalSeparator` — the device locale's separator, `.` as fallback).
+- **Controls**: `SwipeControl` (slide-to-confirm, idle-nudge), `KeyPadView` (numeric; the decimal key inserts `AmountValidator.localizedDecimalSeparator` from `FlipcashCore` — the device locale's separator, `.` as fallback — so keypad strings are parsed with `AmountValidator`).
 - **Bill**: `BillView` (full cash-bill renderer — gradient, security strip, textures, rotated labels, centered code; `drawingGroup`), `CodeView`, `KikCode` (pure-Swift circular code generator — independent of the `CodeScanner` package).
 - **Chart**: `StockChart` (+ `ChartViewModel`), `ChartLineView`, `ChartRangePicker` (1D/1W/1M/1Y/all).
-- **Contacts**: `ContactAvatarView` (image or monogram, `NSCache`-backed) *(contact-sync)*.
-- **Misc**: `AmountText`/`AmountField`, `Flag`, `Badge`/`Bubble`/`BadgedIcon`, `QRCode`, `TwoFactorCodeView`, `CheckView`, `LoadingView`/`CircularLoadingView`, `ExpandableText`, `TextBubble`, `AccessKey`, `ValueAppreciation`.
+- **Contacts**: `ContactAvatarView` (image or monogram, `NSCache`-backed), `ContactsAuthorizer` (`@Observable` permission-state wrapper, mirrors `CameraAuthorizer`).
+- **Chat** (`Chat/`): `ChatViewController` — a `ChatLayout`-backed `UICollectionViewController` transcript; dumb and push-driven (`update(items:)` with DifferenceKit diffing, older pages requested via `onReachTop`). `ChatScreenViewController` composes it with two injected SwiftUI bars — a resting bar pinned to the safe area and a composer pinned to the keyboard layout guide. Cells: `ChatMessageCell`, `ChatCashCardCell`, `ChatDateSeparatorCell`, `ChatTypingIndicatorCell`, plus `ChatBubbleView`/`ChatReceiptLabel`.
+- **Misc**: `AmountText`/`AmountField`, `ImmutableField`, `Flag`, `Badge`/`Bubble`/`BadgedIcon`, `QRCode`, `TwoFactorCodeView`, `CheckView`, `LoadingView`/`CircularLoadingView` (both `ProgressView`-backed — circular-styled and a custom determinate ring style respectively), `ExpandableText`, `TextBubble`, `AccessKey`, `ValueAppreciation`.
 - **List**: `ListHeader`, `Row` (insets, `.chevron`/`.loader` accessory, auto separator).
-- **Modifiers**: `.badged(count:)`, `.vSeparator`/`.hSeparator` (pixel-precise hairlines), `.if(condition:)`, `.liquidGlassButtonStyle`.
+- **Modifiers**: `.pill(_:)` (compact pill label inside a tappable row), `.vSeparator` (pixel-precise hairline), `.if(condition:)`, `.liquidGlassButtonStyle`.
 
 ## Dialog system
 
@@ -42,7 +43,7 @@ graph TD
 
 ## UIKit bridges
 
-`View Controllers/SafariView.swift` (`SFSafariViewController`), `CameraPreviewView` (`AVFoundation`), plus direct UIKit use in `ContactAvatarCache` (`NSCache`/`UIImage`), `QRCode` (CoreImage), `KikCode` (`UIBezierPath`), `Haptics`, and `FontBook`. App-level UIKit (AppDelegate, navigation) lives in the app target.
+The chat transcript (`Chat/` — `UICollectionViewController` + `ChatLayout`, the package's largest UIKit surface), `View Controllers/SafariView.swift` (`SFSafariViewController`), `CameraPreviewView` (`AVFoundation`), plus direct UIKit use in `ContactAvatarCache` (`NSCache`/`UIImage`), `QRCode` (CoreImage), `KikCode` (`UIBezierPath`), `Haptics`, and `FontBook`. App-level UIKit (AppDelegate, navigation) lives in the app target.
 
 ## Conventions
 
@@ -51,4 +52,4 @@ graph TD
 - **Loading uses explicit placeholder data**, not `.redacted(.placeholder)` (under which only geometry — font/frame/length — renders; color and `lineLimit` are suppressed). `Loadable`/`ButtonState.loading`/explicit placeholder `Data` cover the cases.
 - **`matchedGeometryEffect` must come *before* `.frame`** in the chain, or hero animations silently fail. `.transition(.identity)` on a parent kills matched-geometry interpolation entirely.
 - **Liquid Glass / iOS 26** features are `if #available(iOS 26, *)`-gated with `.ultraThinMaterial` fallbacks.
-- **Assets** go through typed enums (`Asset`, `Symbol`, `SystemSymbol`) via `Image.asset/.system/.symbol/.regionFlag`. **Haptics** use named presets (`.tap()`, `.buttonTap()`, `.softest()`…), not raw floats.
+- **Assets** go through typed enums (`Asset`, `SystemSymbol`) via `Image.asset/.system/.regionFlag`. **Haptics** use named presets (`.tap()`, `.buttonTap()`, `.softest()`…), not raw floats.

--- a/docs/architecture/09-cross-cutting-concerns.md
+++ b/docs/architecture/09-cross-cutting-concerns.md
@@ -1,0 +1,70 @@
+# Cross-Cutting Concerns
+
+Infrastructure that every feature touches: logging (with redaction), error reporting, analytics, cryptography, the circular-code scanner, and build/config plumbing.
+
+```mermaid
+graph LR
+    Log["logger.info — message + metadata"] --> MW["Middleware — redactors scan metadata only"]
+    MW --> H["FlipcashLogHandler"]
+    H --> OS["OSLog"]
+    H --> Ring["RingBuffer — last 100"]
+    H --> File["File export"]
+    Ring --> ER["ErrorReporting.captureError"]
+    ER --> BS["Bugsnag"]
+```
+
+## Logging
+
+`FlipcashCore/.../Logging/`, built on **swift-log**. `LogStore.bootstrap` registers one `FlipcashLogHandler` for all labels; it processes each entry once and fans out to three sinks:
+
+- **OSLog** — `os.Logger(subsystem: bundleId, category: label)` for Console.app / Instruments.
+- **RingBuffer** (capacity 100) — drained by `ErrorReporting` to attach recent logs to every crash.
+- **File** — batched writes to `Caches/Logs/`, exported as one `.log`.
+
+A **middleware pipeline** runs before the sinks (each gets `inout LogEntry`, returns `false` to drop):
+
+- `PatternRedactor` — scrubs **metadata values** matching base58 keys, emails, phone numbers (bare all-digit strings are exempt so quark counts survive).
+- `SensitiveKeyRedactor` — replaces values whose **key** contains `token`/`key`/`secret`/`password`/`seed`/`mnemonic`/`phone`/`email` with `[REDACTED]`.
+
+> Both redactors scan **only `entry.metadata`**, never the message string. Hence the rule: **the message is a constant; every variable goes in structured `metadata`.** This gives all values the redactor safety net and keeps logs queryable (`grep owner=`). Never log a proto blob whole (`\(response)` recursively serializes base58 fields) — extract the specific count/type/error you need. Labels follow `flipcash.<domain>` (`flipcash.router`, `.session`, `.database`, `.send-cash`, `.rates-controller`, …).
+
+## Error reporting
+
+`Flipcash/Utilities/ErrorReporting.swift`, backed by **Bugsnag**. `ErrorReporting.captureError(_:reason:id:metadata:)` takes any error **unconditionally**; the private `capture(_:)` centralizes the `isReportable` filter (a `ServerError` with `isReportable == false` returns early). Survivors are wrapped, enriched with `file:function:line`, caller metadata, and the last 100 ring-buffer lines; the **grouping hash is `fileName:function`** (no line numbers, so it survives refactors). `capturePayment(...)` helpers attach rendezvous/exchange context. Identity (hex `UserID`) is shared with Mixpanel.
+
+> Call `captureError` directly — never gate on `isReportable` at the call site (that's dead code that drifts). Every crash fixed from Bugsnag gets a regression test in `FlipcashTests/Regressions/Regression_{id}.swift`. CI uploads dSYMs in `ci_scripts/ci_post_xcodebuild.sh`.
+
+## Analytics
+
+`Flipcash/Utilities/Analytics.swift` + `Events.swift` + `Analytics+ErrorModal.swift`, backed by **Mixpanel** (identity shared with Bugsnag). Single entry point `Analytics.track(event:properties:error:)`. Event domains: `General`, `Account`, `Button`, `Transfer` (grab/give/withdraw/cash-link), `Onramp`, `Send`, `Wallet`, `TokenInfo`, `TokenTransaction`, `CurrencyLaunch`, `Deeplink`, `Error`. Standard properties: `state`, `quarks`, `mint`, `fiat`, `currency`, `fx`, `screen`, `callSite`. Every error dialog shown to a user is tracked via `errorModalDisplayed(...)`.
+
+## Cryptography
+
+- **CodeCurves** — pure-C Ed25519 (`keypair.c`, `sign.c`, `verify.c`, `ge/fe/sc.c`, `sha512.c`). The Swift layer is a thin `KeyPair` (`init(seed:)`, `sign(_:)`) over the C header.
+- **Solana keys** (`FlipcashCore/Solana/Keys/`) — `PublicKey = Key32`, `Signature = Key64`, etc. (fixed-length byte arrays with base58). `Derive` does SLIP-0010/BIP-39: phrase → PBKDF2-SHA512 seed → HMAC-SHA512 master → hardened child per path → `KeyPair`. `AccountCluster` bundles a derived authority + timelock PDAs per mint. `Mnemonic` handles BIP-39 entropy↔phrase.
+- **Solana programs** (`Solana/Programs/`) — client-side transaction construction, no Solana SDK: `SystemProgram`, `TokenProgram`, `AssociatedTokenProgram`, `MemoProgram`, `TimelockProgram`, `VMProgram`, `CurrencyCreatorProgram`, `SwapValidatorProgram`, etc. `SwapInstructionBuilder` assembles multi-instruction transactions (buy/sell/newCurrency/statelessSwap/usdc↔usdf); `TransactionBuilder`/`VersionedMessageV0` serialize to wire format.
+- **Signing flow** — `KeyPair.sign` produces the signature attached to every gRPC request (see [04](04-networking.md)) and to payment transactions (the bytes from `SwapInstructionBuilder`), alongside the server-signed `VerifiedState`.
+
+## CodeScanner (Kik Codes)
+
+A separate C++/OpenCV framework that encodes/decodes/scans circular 2D codes; bundles OpenCV 4.10 + a ZXing Reed-Solomon subset. ObjC API `KikCodes` (`+encode`, `+decode`, `+scan:width:height:quality:`). Consumers:
+
+- **`CodeExtractor.swift`** — live camera: extracts the YUV plane (vImage/Accelerate), `KikCodes.scan(quality: .best)` → `KikCodes.decode` → `CashCode.Payload`; uses a `RedundancyContainer` (1-scan confirmation). Still image: all quality levels, then a 5×5 sliding-window fallback.
+- **`CashCode.Payload+Encoding.swift`** — `payload.codeData()` → `KikCodes.encode` for the rendered scan target. The 20-byte payload is `[type:1][currency_index:1][fiat_scaled:8][nonce:10]` (the fiat field is an 8-byte slot; encode writes 7 significant bytes, leaving the high byte zero).
+
+Updating OpenCV: `cd CodeScanner && ./Scripts/build_opencv.sh --version <v>`.
+
+## Build & config infra
+
+| File/Dir | Purpose |
+|----------|---------|
+| `Configurations/base.xcconfig` | Includes `secrets.xcconfig` then `secrets.local.xcconfig` (local override wins) — all API keys in secrets files, never in source |
+| `Scripts/build.sh` | `xcodebuild` wrapper for the `Flipcash` scheme; `--device [name]` resolves a paired iPhone UDID via `devicectl` |
+| `Scripts/test.sh` | Targeted simulator test runner (iPhone 17); disables clone-spawning parallelism; no `AllTargets` |
+| `Scripts/run` | Proto regeneration: pulls `.proto`, runs `protoc` + plugins (grpc-swift **v1**), writes `Generated/` |
+| `ci_scripts/ci_post_xcodebuild.sh` | Xcode Cloud: uploads dSYMs to Bugsnag on successful archives |
+| `fastlane/Fastfile` | `release` lane: submits a tagged build to App Store Review |
+
+## Shared utilities
+
+`FlipcashCore/Utilities/`: `Poller` (cancellable repeating async task, awaits each tick), `Keychain` (Security.framework wrapper), `InfoPlist` (typed plist access), `Queue` (blocked/unblocked action queue), `DataPointResampler` (chart resampling). `Extensions/`: `Task.retry`/`Task.delay`, `Data+Hex`/`+Slice`, `Decimal`/`BigDecimal` operations, `FixedWidthInteger+Bytes` (Solana wire serialization), `KeyPair+Rendezvous`, `GRPCStatus+Extensions` (status → `ServerError`).

--- a/docs/architecture/09-cross-cutting-concerns.md
+++ b/docs/architecture/09-cross-cutting-concerns.md
@@ -30,13 +30,13 @@ A **middleware pipeline** runs before the sinks (each gets `inout LogEntry`, ret
 
 ## Error reporting
 
-`Flipcash/Utilities/ErrorReporting.swift`, backed by **Bugsnag**. `ErrorReporting.captureError(_:reason:id:metadata:)` takes any error **unconditionally**; the private `capture(_:)` centralizes the `isReportable` filter (a `ServerError` with `isReportable == false` returns early). Survivors are wrapped, enriched with `file:function:line`, caller metadata, and the last 100 ring-buffer lines; the **grouping hash is `fileName:function`** (no line numbers, so it survives refactors). `capturePayment(...)` helpers attach rendezvous/exchange context. Identity (hex `UserID`) is shared with Mixpanel.
+`Flipcash/Utilities/ErrorReporting.swift`, backed by **Bugsnag**. `ErrorReporting.captureError(_:reason:id:metadata:)` takes any error **unconditionally**; the private `capture(_:)` centralizes the level switch — `(error as? ServerError)?.reportingLevel ?? .error` (an unclassified non-`ServerError` is a real bug), then `.suppressed` returns early and `.info`/`.error` map onto Bugsnag severity. Survivors are wrapped, enriched with `file:function:line`, caller metadata, and the last 100 ring-buffer lines; the **grouping hash is `fileName:function`** (no line numbers, so it survives refactors). `capturePayment(...)` helpers attach rendezvous/exchange context. Identity (hex `UserID`) is shared with Mixpanel.
 
-> Call `captureError` directly — never gate on `isReportable` at the call site (that's dead code that drifts). Every crash fixed from Bugsnag gets a regression test in `FlipcashTests/Regressions/Regression_{id}.swift`. CI uploads dSYMs in `ci_scripts/ci_post_xcodebuild.sh`.
+> Call `captureError` directly — never gate on `reportingLevel` at the call site (that's dead code that drifts). Every crash fixed from Bugsnag gets a regression test in `FlipcashTests/Regressions/Regression_{id}.swift`. CI uploads dSYMs in `ci_scripts/ci_post_xcodebuild.sh`.
 
 ## Analytics
 
-`Flipcash/Utilities/Analytics.swift` + `Events.swift` + `Analytics+ErrorModal.swift`, backed by **Mixpanel** (identity shared with Bugsnag). Single entry point `Analytics.track(event:properties:error:)`. Event domains: `General`, `Account`, `Button`, `Transfer` (grab/give/withdraw/cash-link), `Onramp`, `Send`, `Wallet`, `TokenInfo`, `TokenTransaction`, `CurrencyLaunch`, `Deeplink`, `Error`. Standard properties: `state`, `quarks`, `mint`, `fiat`, `currency`, `fx`, `screen`, `callSite`. Every error dialog shown to a user is tracked via `errorModalDisplayed(...)`.
+`Flipcash/Utilities/Analytics.swift` + `Events.swift` + `Analytics+ErrorModal.swift`, backed by **Mixpanel** (identity shared with Bugsnag). Single entry point `Analytics.track(event:properties:error:)`. Event domains: `General`, `Account`, `Button`, `Transfer` (grab/give/withdraw/cash-link), `Onramp`, `Send`, `Conversation`, `Onboarding`, `Wallet`, `TokenInfo`, `TokenTransaction`, `CurrencyLaunch`, `Deeplink`, `Error`. Standard properties: `state`, `quarks`, `mint`, `fiat`, `currency`, `fx`, `screen`, `callSite`. Every error dialog shown to a user is tracked via `errorModalDisplayed(...)`.
 
 ## Cryptography
 
@@ -49,7 +49,7 @@ A **middleware pipeline** runs before the sinks (each gets `inout LogEntry`, ret
 
 A separate C++/OpenCV framework that encodes/decodes/scans circular 2D codes; bundles OpenCV 4.10 + a ZXing Reed-Solomon subset. ObjC API `KikCodes` (`+encode`, `+decode`, `+scan:width:height:quality:`). Consumers:
 
-- **`CodeExtractor.swift`** — live camera: extracts the YUV plane (vImage/Accelerate), `KikCodes.scan(quality: .best)` → `KikCodes.decode` → `CashCode.Payload`; uses a `RedundancyContainer` (1-scan confirmation). Still image: all quality levels, then a 5×5 sliding-window fallback.
+- **`CodeExtractor.swift`** — live camera: copies the luma plane out of the `CVPixelBuffer` (CoreVideo), `KikCodes.scan(quality: .best)` → `KikCodes.decode` → `CashCode.Payload`; uses a `RedundancyContainer` (1-scan confirmation).
 - **`CashCode.Payload+Encoding.swift`** — `payload.codeData()` → `KikCodes.encode` for the rendered scan target. The 20-byte payload is `[type:1][currency_index:1][fiat_scaled:8][nonce:10]` (the fiat field is an 8-byte slot; encode writes 7 significant bytes, leaving the high byte zero).
 
 Updating OpenCV: `cd CodeScanner && ./Scripts/build_opencv.sh --version <v>`.
@@ -61,10 +61,10 @@ Updating OpenCV: `cd CodeScanner && ./Scripts/build_opencv.sh --version <v>`.
 | `Configurations/base.xcconfig` | Includes `secrets.xcconfig` then `secrets.local.xcconfig` (local override wins) — all API keys in secrets files, never in source |
 | `Scripts/build.sh` | `xcodebuild` wrapper for the `Flipcash` scheme; `--device [name]` resolves a paired iPhone UDID via `devicectl` |
 | `Scripts/test.sh` | Targeted simulator test runner (iPhone 17); disables clone-spawning parallelism; no `AllTargets` |
-| `Scripts/run` | Proto regeneration: pulls `.proto`, runs `protoc` + plugins (grpc-swift **v1**), writes `Generated/` |
-| `ci_scripts/ci_post_xcodebuild.sh` | Xcode Cloud: uploads dSYMs to Bugsnag on successful archives |
+| `Scripts/run` | Proto regeneration: pulls `.proto`, runs `protoc` + plugins (`protoc-gen-swift`, `protoc-gen-grpc-swift-2` — installed via `install-grpc-swift-2-plugin.sh`), writes `Generated/` |
+| `ci_scripts/ci_post_xcodebuild.sh` | Xcode Cloud: uploads dSYMs to Bugsnag on successful archives (deliberately gitignored — lives on the CI host, not in the tree) |
 | `fastlane/Fastfile` | `release` lane: submits a tagged build to App Store Review |
 
 ## Shared utilities
 
-`FlipcashCore/Utilities/`: `Poller` (cancellable repeating async task, awaits each tick), `Keychain` (Security.framework wrapper), `InfoPlist` (typed plist access), `Queue` (blocked/unblocked action queue), `DataPointResampler` (chart resampling). `Extensions/`: `Task.retry`/`Task.delay`, `Data+Hex`/`+Slice`, `Decimal`/`BigDecimal` operations, `FixedWidthInteger+Bytes` (Solana wire serialization), `KeyPair+Rendezvous`, `GRPCStatus+Extensions` (status → `ServerError`).
+`FlipcashCore/Utilities/`: `Poller` (cancellable repeating async task, awaits each tick), `Keychain` (Security.framework wrapper), `InfoPlist` (typed plist access), `DataPointResampler` (chart resampling). `Extensions/`: `Task.retry`/`Task.delay`, `Data+Hex`/`+Slice`, `Decimal`/`BigDecimal` operations, `FixedWidthInteger+Bytes` (Solana wire serialization), `KeyPair+Rendezvous`, `RPCError+Extensions` (`RPCError` → `ServerError`: transient codes `.suppressed`, `.cancelled` `.info`, rest `.error`).

--- a/docs/architecture/10-separation-of-concerns.md
+++ b/docs/architecture/10-separation-of-concerns.md
@@ -5,8 +5,8 @@ The principles that hold the architecture together. The other docs describe *wha
 ```mermaid
 graph LR
     Nav["Navigation"] --> O1["AppRouter"]
-    Err["Error reportability"] --> O2["ServerError.isReportable"]
-    Val["Input rules"] --> O3["Validator"]
+    Err["Error reportability"] --> O2["ServerError.reportingLevel"]
+    Val["Input rules"] --> O3["Validator family"]
     Rate["Exchange-rate proof"] --> O4["pinned VerifiedState"]
     Dlg["Cross-sheet dialogs"] --> O5["session.dialogItem + DialogWindow"]
     LogR["Log redaction"] --> O6["metadata + redactor middleware"]
@@ -19,7 +19,7 @@ The dependency graph only ever points down (see [01](01-modules-and-boundaries.m
 
 ## 2. MVVM, but only where it earns its keep
 
-- **ViewModels** exist for multi-screen flows, async-operation coordination, or complex state (onboarding, verification, buy/sell/swap, withdraw, send-amount *(contact-sync)*, currency creation).
+- **ViewModels** exist for multi-screen flows, async-operation coordination, or complex state (onboarding, verification, buy/sell/swap, withdraw, send-amount, currency creation).
 - **Standalone, self-contained screens** use `@State` + `@Observable` directly and make router calls inline in their action closures (balance, settings, deposit, discovery, most modals).
 
 The test is *complexity and reach*, not *every screen gets a VM*. See the [feature catalog](features/README.md) for which features fall on which side.
@@ -31,8 +31,8 @@ The codebase repeatedly chooses a single canonical place for a decision, then fo
 | Concern | Single source | Call sites must NOT… |
 |---------|---------------|----------------------|
 | Navigation | `AppRouter` | …keep `@State` sheet flags or `selectedXxx` bindings |
-| Error reportability | `ServerError.isReportable` | …re-check `isReportable` before `captureError` |
-| Input rules | the `Validator` for that type | …inline regex/trim/length checks |
+| Error reportability | `ServerError.reportingLevel` | …re-check `reportingLevel` before `captureError` |
+| Input rules | the `Validator` family — one concrete validator per input type (`AmountValidator` for entered amounts) | …inline regex/trim/length checks |
 | Exchange-rate proof | the pinned `VerifiedState` | …re-fetch or pin a second proof mid-flow |
 | Cross-sheet dialogs | `session.dialogItem` + `DialogWindow` | …bind the same `DialogItem` to two live views |
 | Log redaction | metadata + redactor middleware | …interpolate variables into the message string |
@@ -44,7 +44,7 @@ When you find yourself re-implementing one of these at a call site, that's the s
 State is owned at the narrowest scope that still satisfies its readers:
 
 - **Process scope** → `Container` (clients, account manager, preferences).
-- **Login scope** → `SessionContainer` (Session + controllers + database + router), torn down on logout.
+- **Login scope** → `SessionContainer` (Session + controllers + database + router), torn down on logout — e.g. chat's `ConversationController` (DM feed + live event stream) and its sibling `ChatSpotlightIndexer` live here, not as methods on `Session`.
 - **Transactional concerns** → `Session` (the network/transaction API surface) — but kept from sprawling: new concerns become **sibling controllers** (non-transactional) or **namespaced services** (transactional), never flat methods on `Session`.
 - **Screen scope** → `@State` view models / local state.
 

--- a/docs/architecture/10-separation-of-concerns.md
+++ b/docs/architecture/10-separation-of-concerns.md
@@ -1,0 +1,71 @@
+# Separation of Concerns
+
+The principles that hold the architecture together. The other docs describe *what* each part is; this one describes *why the seams are where they are* and the single-source-of-truth rules that keep them clean.
+
+```mermaid
+graph LR
+    Nav["Navigation"] --> O1["AppRouter"]
+    Err["Error reportability"] --> O2["ServerError.isReportable"]
+    Val["Input rules"] --> O3["Validator"]
+    Rate["Exchange-rate proof"] --> O4["pinned VerifiedState"]
+    Dlg["Cross-sheet dialogs"] --> O5["session.dialogItem + DialogWindow"]
+    LogR["Log redaction"] --> O6["metadata + redactor middleware"]
+```
+*Each concern routes to exactly one owner — never re-implemented at the call site.*
+
+## 1. Strict, acyclic module layering
+
+The dependency graph only ever points down (see [01](01-modules-and-boundaries.md)): app → UI → Core → API → leaf crypto/scanning. The payoff is **bounded blast radius** — a proto change can't reach a screen except through a service wrapper; a UI tweak can't touch business logic; generated code is sealed behind one package. Each boundary is also a *capability* boundary: Core can't render, UI can't fetch, the scanner can't see the network.
+
+## 2. MVVM, but only where it earns its keep
+
+- **ViewModels** exist for multi-screen flows, async-operation coordination, or complex state (onboarding, verification, buy/sell/swap, withdraw, send-amount, currency creation).
+- **Standalone, self-contained screens** use `@State` + `@Observable` directly and make router calls inline in their action closures (balance, settings, deposit, discovery, most modals).
+
+The test is *complexity and reach*, not *every screen gets a VM*. See the [feature catalog](features/README.md) for which features fall on which side.
+
+## 3. One source of truth per concern
+
+The codebase repeatedly chooses a single canonical place for a decision, then forbids duplicating it at call sites:
+
+| Concern | Single source | Call sites must NOT… |
+|---------|---------------|----------------------|
+| Navigation | `AppRouter` | …keep `@State` sheet flags or `selectedXxx` bindings |
+| Error reportability | `ServerError.isReportable` | …re-check `isReportable` before `captureError` |
+| Input rules | the `Validator` for that type | …inline regex/trim/length checks |
+| Exchange-rate proof | the pinned `VerifiedState` | …re-fetch or pin a second proof mid-flow |
+| Cross-sheet dialogs | `session.dialogItem` + `DialogWindow` | …bind the same `DialogItem` to two live views |
+| Log redaction | metadata + redactor middleware | …interpolate variables into the message string |
+
+When you find yourself re-implementing one of these at a call site, that's the smell — route through the canonical owner instead.
+
+## 4. State ownership is layered and scoped
+
+State is owned at the narrowest scope that still satisfies its readers:
+
+- **Process scope** → `Container` (clients, account manager, preferences).
+- **Login scope** → `SessionContainer` (Session + controllers + database + router), torn down on logout.
+- **Transactional concerns** → `Session` (the network/transaction API surface) — but kept from sprawling: new concerns become **sibling controllers** (non-transactional) or **namespaced services** (transactional), never flat methods on `Session`.
+- **Screen scope** → `@State` view models / local state.
+
+Reactive flow is uniform: SQLite is the cache of record, `Updateable<T>` republishes DB changes into `@Observable` slots, and views observe without polling.
+
+## 5. The wire contract is the spec — mirror it, don't reinvent it
+
+Client behavior is anchored to the server's contract, not to local convenience:
+
+- Validators mirror server **PGV regexes**; the bonding curve mirrors the server's **Rust program** (identical pricing tables); amounts are computed against the **server-signed rate proof** the server will validate.
+- Generated proto code is never edited; service wrappers adapt it. When a proto changes, the canonical client mirror (validator / curve / model) updates in one place.
+- Every request is **self-authenticating** (Ed25519 signature in the payload) — auth is a property of the message, not a session token to manage.
+
+## 6. Recoverable cache vs durable secret
+
+A hard split governs where data lives (see [05](05-persistence.md)): anything the server can re-send is a **disposable SQLite cache** (so schema changes just rebuild it — no migrations); only true secrets go in the **Keychain**; only preferences go in **UserDefaults**. This is why "no schema bump / no migration" is treated as an *anti-signal* when planning — it usually means a concern is being put in the wrong layer.
+
+## 7. Platform-idiomatic, modernizing incrementally
+
+New and isolated code uses modern Swift/SwiftUI (`@Observable`, `@Environment`, structured concurrency, modern `onChange`); legacy `ObservableObject` types (`Client`, `FlipClient`) stay until all their consumers migrate, because mixing observation systems on one type fails silently. UI leads with Apple-canonical / HIG-aligned APIs, with a few documented, deliberate deviations (e.g. the `CloseButton` "X" instead of a "Cancel" button). The bias is *gradual migration in the direction of the platform's grain*, not big-bang rewrites.
+
+---
+
+**In one sentence:** every concern has exactly one home, the homes are layered so dependencies only point downward, and the client is a faithful mirror of the server's wire contract.

--- a/docs/architecture/10-separation-of-concerns.md
+++ b/docs/architecture/10-separation-of-concerns.md
@@ -19,7 +19,7 @@ The dependency graph only ever points down (see [01](01-modules-and-boundaries.m
 
 ## 2. MVVM, but only where it earns its keep
 
-- **ViewModels** exist for multi-screen flows, async-operation coordination, or complex state (onboarding, verification, buy/sell/swap, withdraw, send-amount, currency creation).
+- **ViewModels** exist for multi-screen flows, async-operation coordination, or complex state (onboarding, verification, buy/sell/swap, withdraw, send-amount *(contact-sync)*, currency creation).
 - **Standalone, self-contained screens** use `@State` + `@Observable` directly and make router calls inline in their action closures (balance, settings, deposit, discovery, most modals).
 
 The test is *complexity and reach*, not *every screen gets a VM*. See the [feature catalog](features/README.md) for which features fall on which side.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -3,12 +3,10 @@
 A map of how the app is put together. Each document classifies one architectural concern; read this index first, then jump to whatever you need.
 
 > These docs describe **structure and intent**, not every line. When a doc and the code disagree, the code wins — fix the doc. When you change a subsystem, update its doc in the *same* change (see the **Architecture Docs** rule in [CLAUDE.md](../../CLAUDE.md)), and run `/verify-architecture-docs` to fact-check a doc against the code.
->
-> Items tagged ***(contact-sync)*** describe the in-flight `feat/contact-sync` epic and are **not yet on `main`** — remove the tags when the epic merges.
 
 ## The 30-second picture
 
-Flipcash is a multi-currency crypto wallet. Users hold balances in **USDF** (a USD stablecoin) and in **launchpad currencies** (custom tokens priced by an on-chain bonding curve). The core interaction is **face-to-face cash transfer**: one device shows an animated circular "cash bill" (a Kik Code) on its camera screen; another device scans it; a peer-to-peer rendezvous handshake moves the money. Money can also be sent to phone contacts *(contact-sync)*, bought via Apple Pay / Coinbase / an external Solana wallet, and withdrawn on-chain.
+Flipcash is a multi-currency crypto wallet. Users hold balances in **USDF** (a USD stablecoin) and in **launchpad currencies** (custom tokens priced by an on-chain bonding curve). The core interaction is **face-to-face cash transfer**: one device shows an animated circular "cash bill" (a Kik Code) on its camera screen; another device scans it; a peer-to-peer rendezvous handshake moves the money. Money can also be sent to phone contacts, bought via Apple Pay / Coinbase / an external Solana wallet, and withdrawn on-chain. Contact payments live inside **DM conversations** — threaded chats (`Screens/Conversation`, `ChatService`) where sent cash renders inline alongside text messages.
 
 The app talks to **two gRPC backends** (a payments/OCP server and the Flipcash core server) plus the **Solana** network. Every payment carries a **server-signed proof** of the exchange rate. All state is **cached locally in SQLite**, secrets live in the **Keychain**, and the UI is **SwiftUI** built on `@Observable`.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -3,10 +3,12 @@
 A map of how the app is put together. Each document classifies one architectural concern; read this index first, then jump to whatever you need.
 
 > These docs describe **structure and intent**, not every line. When a doc and the code disagree, the code wins — fix the doc. When you change a subsystem, update its doc in the *same* change (see the **Architecture Docs** rule in [CLAUDE.md](../../CLAUDE.md)), and run `/verify-architecture-docs` to fact-check a doc against the code.
+>
+> Items tagged ***(contact-sync)*** describe the in-flight `feat/contact-sync` epic and are **not yet on `main`** — remove the tags when the epic merges.
 
 ## The 30-second picture
 
-Flipcash is a multi-currency crypto wallet. Users hold balances in **USDF** (a USD stablecoin) and in **launchpad currencies** (custom tokens priced by an on-chain bonding curve). The core interaction is **face-to-face cash transfer**: one device shows an animated circular "cash bill" (a Kik Code) on its camera screen; another device scans it; a peer-to-peer rendezvous handshake moves the money. Money can also be sent to phone contacts, bought via Apple Pay / Coinbase / an external Solana wallet, and withdrawn on-chain.
+Flipcash is a multi-currency crypto wallet. Users hold balances in **USDF** (a USD stablecoin) and in **launchpad currencies** (custom tokens priced by an on-chain bonding curve). The core interaction is **face-to-face cash transfer**: one device shows an animated circular "cash bill" (a Kik Code) on its camera screen; another device scans it; a peer-to-peer rendezvous handshake moves the money. Money can also be sent to phone contacts *(contact-sync)*, bought via Apple Pay / Coinbase / an external Solana wallet, and withdrawn on-chain.
 
 The app talks to **two gRPC backends** (a payments/OCP server and the Flipcash core server) plus the **Solana** network. Every payment carries a **server-signed proof** of the exchange rate. All state is **cached locally in SQLite**, secrets live in the **Keychain**, and the UI is **SwiftUI** built on `@Observable`.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,52 @@
+# Flipcash iOS — Architecture
+
+A map of how the app is put together. Each document classifies one architectural concern; read this index first, then jump to whatever you need.
+
+> These docs describe **structure and intent**, not every line. When a doc and the code disagree, the code wins — fix the doc. When you change a subsystem, update its doc in the *same* change (see the **Architecture Docs** rule in [CLAUDE.md](../../CLAUDE.md)), and run `/verify-architecture-docs` to fact-check a doc against the code.
+
+## The 30-second picture
+
+Flipcash is a multi-currency crypto wallet. Users hold balances in **USDF** (a USD stablecoin) and in **launchpad currencies** (custom tokens priced by an on-chain bonding curve). The core interaction is **face-to-face cash transfer**: one device shows an animated circular "cash bill" (a Kik Code) on its camera screen; another device scans it; a peer-to-peer rendezvous handshake moves the money. Money can also be sent to phone contacts, bought via Apple Pay / Coinbase / an external Solana wallet, and withdrawn on-chain.
+
+The app talks to **two gRPC backends** (a payments/OCP server and the Flipcash core server) plus the **Solana** network. Every payment carries a **server-signed proof** of the exchange rate. All state is **cached locally in SQLite**, secrets live in the **Keychain**, and the UI is **SwiftUI** built on `@Observable`.
+
+## Module layering
+
+```mermaid
+graph TD
+    App["Flipcash app — screens · navigation · controllers · SDKs"]
+    UI["FlipcashUI — SwiftUI components + design tokens"]
+    Core["FlipcashCore — models · service wrappers · logging · no SwiftUI"]
+    API["FlipcashAPI — generated gRPC bindings · never hand-edited"]
+    Curves["CodeCurves — Ed25519"]
+    Scanner["CodeScanner — Kik Codes / OpenCV"]
+    App --> UI --> Core --> API
+    App --> Scanner
+    Core --> Curves
+```
+*Arrows point to dependencies (depends-on / imports).*
+
+The graph is strictly acyclic — nothing reaches "up" toward the app. See [01-modules-and-boundaries](01-modules-and-boundaries.md).
+
+## Documents
+
+| # | Document | Covers |
+|---|----------|--------|
+| 01 | [Modules & boundaries](01-modules-and-boundaries.md) | The 7 modules, dependency graph, what each owns, enforced boundaries |
+| 02 | [State & dependency injection](02-state-and-dependency-injection.md) | `Container`, `SessionContainer`, `Session`, auth lifecycle, `@Observable` model |
+| 03 | [Navigation](03-navigation.md) | `AppRouter`, sheets, stacks, nested sheets, deeplinks |
+| 04 | [Networking](04-networking.md) | gRPC transport, service layer, call options, streaming, request signing, Solana RPC, push |
+| 05 | [Persistence](05-persistence.md) | SQLite (cached server data), Keychain, UserDefaults, schema, no-migration policy |
+| 06 | [Payments & operations](06-payments-and-operations.md) | Intents, `VerifiedState`, the give/grab rendezvous, funding operations, swaps |
+| 07 | [Currency & domain model](07-currency-and-domain-model.md) | Quarks, fiat, `ExchangedFiat`, bonding curve, account clusters, errors, validation |
+| 08 | [Design system](08-design-system.md) | FlipcashUI theme tokens, component catalog, dialogs, camera, conventions |
+| 09 | [Cross-cutting concerns](09-cross-cutting-concerns.md) | Logging, error reporting, analytics, crypto, scanning, build/config infra |
+| 10 | [Separation of concerns](10-separation-of-concerns.md) | The principles that tie it together — layering, MVVM, single-source-of-truth rules |
+| — | [Feature catalog](features/README.md) | Every user-facing feature: purpose, screens, viewmodels, MVVM pattern |
+
+## Reading order by goal
+
+- **New to the codebase** → README → 01 → 02 → 10, then the feature catalog.
+- **Adding a screen/feature** → feature catalog → 03 (navigation) → 08 (components) → 02 (where state lives).
+- **Touching money movement** → 06 → 07 → 04.
+- **Backend/proto change** → 04 → 05 (schema/version bump) → 07.

--- a/docs/architecture/features/README.md
+++ b/docs/architecture/features/README.md
@@ -10,7 +10,7 @@ The dominant convention (per [10 — Separation of Concerns](../10-separation-of
 graph TD
     Scan["ScanScreen — home"] --> Give["Give — show cash bill"]
     Scan --> Grab["Scan & grab a bill"]
-    Scan --> Send["Send to a contact"]
+    Scan --> Send["Send to a contact (contact-sync)"]
     Scan --> Balance["Balance / portfolio"]
     Scan --> Discover["Discover currencies"]
     Balance --> Info["Currency info"]
@@ -26,13 +26,13 @@ graph TD
 | Feature | Purpose | Screens / VM | Pattern |
 |---------|---------|--------------|---------|
 | **Intro / Splash** | Entry point; animates into login or recovery | `Onboarding/IntroScreen` | screen-local |
-| **Login** | Phone-number auth / account creation | `Onboarding/LoginScreen` | screen-local |
+| **Login** | Log in with the 12-word access key (mnemonic entry) | `Onboarding/LoginScreen` | screen-local |
 | **Access Key** | Show/enter the 12-word Ed25519 seed (+ help) | `AccessKeyScreen`, `AccessKeyHelpScreen` | screen-local |
 | **Notification permission** | Request push permission (+ denied recovery) | `NotificationPermissionScreen`(+`Denied`) | screen-local |
-| **Onboarding flow** | Coordinates access key → contacts → phone → notifications | `OnboardingViewModel` (`@Observable`) | **VM-driven** (owns a child `PhoneVerificationViewModel`) |
+| **Onboarding flow** | Coordinates access key → notifications (contacts → phone steps *(contact-sync)*) | `OnboardingViewModel` (`@Observable`) | **VM-driven** |
 | **Email verification** | Enter email → confirm code; also a Coinbase gate | `EnterEmailScreen`, `ConfirmEmailScreen` · `EmailVerificationViewModel` | **VM-driven** (`EmailVerifying`) |
 | **Phone verification** | Enter phone → confirm SMS (+ country picker); gates Send | `EnterPhoneScreen`, `ConfirmPhoneScreen`, `CountryCodeSelectionScreen` · `PhoneVerificationViewModel` | **VM-driven** (`PhoneVerifying`) |
-| **Contacts permission** | One-shot contacts grant for Send | `ContactsPermission/ContactsPermissionScreen` | screen-local |
+| **Contacts permission** *(contact-sync)* | One-shot contacts grant for Send | `ContactsPermission/ContactsPermissionScreen` | screen-local |
 | **Account selection** | List historical accounts w/ balances; switch/delete | `Onboarding/AccountSelectionScreen` | screen-local |
 
 ## B. Money movement
@@ -42,7 +42,7 @@ graph TD
 | **Scan / Main camera** | The home screen — decodes circular cash codes + QR links | `Main/ScanScreen` · `ScanViewModel` | **VM-driven**; spawns `SendCashOperation`/`ScanCashOperation`, routes deeplinks |
 | **Cash bill** | Animated circular-code bill over the camera (live send/receive) | `Main/Bill/BillCanvas`, `BillState`, `BillValuation` | the give/grab rendezvous (see [06](../06-payments-and-operations.md)) |
 | **Give** | Amount entry for a cash-bill give | `Main/GiveScreen` · `GiveViewModel` | **VM-driven**; pins `VerifiedState`, calls `session.showCashBill` |
-| **Send (contact)** | Contact picker → amount → SMS-invite or direct transfer | `Send/SendRootScreen`, `RecipientPickerScreen`, `SendAmountScreen` · `SendAmountViewModel` | mixed; root gates contacts/phone-verify; `router.push(.sendAmount)` |
+| **Send (contact)** *(contact-sync)* | Contact picker → amount → SMS-invite or direct transfer | `Send/SendRootScreen`, `RecipientPickerScreen`, `SendAmountScreen` · `SendAmountViewModel` | mixed; root gates contacts/phone-verify; `router.push(.sendAmount)` |
 | **Buy** | Amount + method (Apple Pay / Phantom / Coinbase) | `Main/Buy/BuyAmountScreen`, `PurchaseMethodSheet`, `PhantomFlowScreen` · `BuyAmountViewModel` | **VM-driven**; nested `BuyFlowPath`; dispatches the three `FundingOperation`s |
 | **Sell** | Sell a custom currency back to USDF via the curve | `CurrencySellAmountScreen`, `CurrencySellConfirmationScreen` · `CurrencySellViewModel`(+`Confirmation`) | **VM-driven**; → swap processing |
 | **Swap processing** | Blocking screen during any buy/sell swap; polls state | `Main/Currency Swap/SwapProcessingScreen` · `SwapProcessingViewModel` | **VM-driven**; calls `updatePostTransaction` |
@@ -75,7 +75,7 @@ graph TD
 | **Beta flags** | Developer feature-flag toggles | `Settings/BetaFlagsScreen` | screen-local; `BetaFlags` |
 | **Access key backup** | Show the 12-word key from Settings | `Settings/AccessKeyBackupScreen` | screen-local |
 | **Application logs** | In-app log viewer | `Settings/ApplicationLogsScreen` | screen-local |
-| **Download app** | Full-screen prompt for a counterparty to install (over scanner) | `Main/DownloadAppScreen` | screen-local; **router destination** (gets 5-min auto-return) |
+| **Download app** | Full-screen prompt for a counterparty to install (over scanner) | `Main/DownloadAppScreen` | screen-local; **router sheet** (gets 5-min auto-return) |
 | **Force logout / upgrade** | Blocking screens on server demand | `ForceLogoutScreen`, `ForceUpgradeScreen` | screen-local |
-| **Quick actions** | Dynamic Home Screen shortcuts (Scan, flag-gated Send) | `Controllers/QuickActionsController` | no screen; deeplinks in |
+| **Quick actions** *(contact-sync)* | Dynamic Home Screen shortcuts (Scan, flag-gated Send) | `Controllers/QuickActionsController` | no screen; deeplinks in |
 | **Dialog window** | Hosts `session.dialogItem` above all sheets | `Main/DialogWindow` | infrastructure (see [08](../08-design-system.md)) |

--- a/docs/architecture/features/README.md
+++ b/docs/architecture/features/README.md
@@ -10,7 +10,9 @@ The dominant convention (per [10 — Separation of Concerns](../10-separation-of
 graph TD
     Scan["ScanScreen — home"] --> Give["Give — show cash bill"]
     Scan --> Grab["Scan & grab a bill"]
-    Scan --> Send["Send to a contact (contact-sync)"]
+    Scan --> Send["Send to a contact"]
+    Send --> Chat["DM conversation"]
+    Chat --> SendCash["Send Cash (nested sheet)"]
     Scan --> Balance["Balance / portfolio"]
     Scan --> Discover["Discover currencies"]
     Balance --> Info["Currency info"]
@@ -29,10 +31,10 @@ graph TD
 | **Login** | Log in with the 12-word access key (mnemonic entry) | `Onboarding/LoginScreen` | screen-local |
 | **Access Key** | Show/enter the 12-word Ed25519 seed (+ help) | `AccessKeyScreen`, `AccessKeyHelpScreen` | screen-local |
 | **Notification permission** | Request push permission (+ denied recovery) | `NotificationPermissionScreen`(+`Denied`) | screen-local |
-| **Onboarding flow** | Coordinates access key → notifications (contacts → phone steps *(contact-sync)*) | `OnboardingViewModel` (`@Observable`) | **VM-driven** |
+| **Onboarding flow** | Coordinates access key → phone (shown when Send is available) → notifications | `OnboardingViewModel` (`@Observable`) | **VM-driven** |
 | **Email verification** | Enter email → confirm code; also a Coinbase gate | `EnterEmailScreen`, `ConfirmEmailScreen` · `EmailVerificationViewModel` | **VM-driven** (`EmailVerifying`) |
 | **Phone verification** | Enter phone → confirm SMS (+ country picker); gates Send | `EnterPhoneScreen`, `ConfirmPhoneScreen`, `CountryCodeSelectionScreen` · `PhoneVerificationViewModel` | **VM-driven** (`PhoneVerifying`) |
-| **Contacts permission** *(contact-sync)* | One-shot contacts grant for Send | `ContactsPermission/ContactsPermissionScreen` | screen-local |
+| **Contacts permission** | One-shot contacts grant for Send | `ContactsPermission/ContactsPermissionScreen` | screen-local |
 | **Account selection** | List historical accounts w/ balances; switch/delete | `Onboarding/AccountSelectionScreen` | screen-local |
 
 ## B. Money movement
@@ -42,26 +44,27 @@ graph TD
 | **Scan / Main camera** | The home screen — decodes circular cash codes + QR links | `Main/ScanScreen` · `ScanViewModel` | **VM-driven**; spawns `SendCashOperation`/`ScanCashOperation`, routes deeplinks |
 | **Cash bill** | Animated circular-code bill over the camera (live send/receive) | `Main/Bill/BillCanvas`, `BillState`, `BillValuation` | the give/grab rendezvous (see [06](../06-payments-and-operations.md)) |
 | **Give** | Amount entry for a cash-bill give | `Main/GiveScreen` · `GiveViewModel` | **VM-driven**; pins `VerifiedState`, calls `session.showCashBill` |
-| **Send (contact)** *(contact-sync)* | Contact picker → amount → SMS-invite or direct transfer | `Send/SendRootScreen`, `RecipientPickerScreen`, `SendAmountScreen` · `SendAmountViewModel` | mixed; root gates contacts/phone-verify; `router.push(.sendAmount)` |
+| **Send (contact)** | Recipient picker merging synced contacts + DM chats (SMS invite for non-members) | `Send/SendRootScreen`, `RecipientPickerScreen` | mixed; root gates phone-verify/contacts; rows push `.dmConversation` |
+| **DM conversation** | iMessage-style transcript + Send Cash / Send Message bar; the first payment creates the chat | `Conversation/ConversationScreen` (+`ChatScreenRepresentable`, `ConversationBottomBar`, `ConversationSheetRoot`) | screen-local; reads `ConversationController` (feed + event stream); `.dmConversation` push or `.conversation` root sheet; `/chat/{id}`, `/chat/{E.164}` deeplinks |
+| **Send cash (chat)** | Amount entry + swipe-to-send for a direct payment carrying `ChatPaymentMetadata` | `Send/SendAmountScreen` · `SendAmountViewModel` | **VM-driven**; pins `VerifiedState` in `prepareSubmission()`; nested `.sendAmount` sheet over the chat (`/chat/{id}/send`) |
 | **Buy** | Amount + method (Apple Pay / Phantom / Coinbase) | `Main/Buy/BuyAmountScreen`, `PurchaseMethodSheet`, `PhantomFlowScreen` · `BuyAmountViewModel` | **VM-driven**; nested `BuyFlowPath`; dispatches the three `FundingOperation`s |
 | **Sell** | Sell a custom currency back to USDF via the curve | `CurrencySellAmountScreen`, `CurrencySellConfirmationScreen` · `CurrencySellViewModel`(+`Confirmation`) | **VM-driven**; → swap processing |
 | **Swap processing** | Blocking screen during any buy/sell swap; polls state | `Main/Currency Swap/SwapProcessingScreen` · `SwapProcessingViewModel` | **VM-driven**; calls `updatePostTransaction` |
 | **Withdraw** | Intro → currency → amount → address → confirm → submit | `Settings/Withdraw/*` · `WithdrawViewModel` | **VM-driven** (injected `pushSubstep` closure) |
 | **Deposit (USDC)** | Education → show deposit address (QR + copy) per currency | `Settings/Deposit/DepositScreen`, `DepositCurrencyListScreen`, `Main/Buy/USDCDepositEducationScreen` | screen-local; `router.push(.depositAddress)` |
-| **Onramp / Coinbase** | KYC-gated fiat on-ramp; deep-link verification callback | `Onramp/VerifyInfoScreen` · `OnrampVerificationViewModel` | **VM-driven**; `Controllers/Onramp/*` (coordinator, inbox, Coinbase service, Apple Pay overlay) |
+| **Onramp / Coinbase** | KYC-gated fiat on-ramp; deep-link verification callback | `Onramp/VerifyInfoScreen` · `OnrampVerificationViewModel` | **VM-driven**; `Screens/Onramp/VerificationCoordinator` + `Controllers/Onramp/*` (inbox, Coinbase service, Apple Pay overlay) |
 | **Transaction history** | List past activities; cancel cash-link | `Main/TransactionHistoryScreen` | screen-local; reads `HistoryController` |
-| **Transaction details** | Sheet of one activity's line items | `Main/TransactionDetailsModal` | screen-local (display) |
 | **Cash received** | Celebration overlay on grab | `Main/Modals/ModalCashReceived` | screen-local (display) |
 
 ## C. Currencies
 
 | Feature | Purpose | Screens / VM | Pattern & integration |
 |---------|---------|--------------|------------------------|
-| **Currency discovery** | Leaderboard of launchpad currencies | `Main/Currency Discovery/CurrencyDiscoveryScreen` (+rows/skeleton) | screen-local; `MarketCapController`; `push(.currencyInfo)` |
+| **Currency discovery** | Leaderboard of launchpad currencies | `Main/Currency Discovery/CurrencyDiscoveryScreen` (+rows/skeleton) | screen-local; streams `client.discoverCurrencies(category:)`; `push(.currencyInfo)` |
 | **Currency info** | Mint detail: price, market cap, socials, buy/sell | `Main/Currency Info/CurrencyInfoScreen` · `CurrencyInfoViewModel` | **VM-driven**; live `Updateable` feed; nested `.buy(mint)` |
 | **Currency selection** | Picker for active send/receive currency (+ recents/search) | `Main/Currency Selection/CurrencySelectionScreen` · `CurrencySelectionViewModel` | **VM-driven** |
-| **Select currency (balances)** | Owned-balance picker for Give/Send/Withdraw/Buy | `Main/SelectCurrencyScreen` | screen-local |
-| **Currency creation wizard** | Launch a new token (name, symbol, image, color, funding) | `Currency Creation/CurrencyCreationScreen`/`Summary`/`Wizard` · `CurrencyCreationState` (`@Observable`) | **VM-driven** step engine; drives `FundingOperation` + onramp |
+| **Select currency (balances)** | Owned-balance picker for Give and chat Send (Withdraw and Buy have their own pickers) | `Main/SelectCurrencyScreen` | screen-local |
+| **Currency creation wizard** | Launch a new token (name, symbol, image, color, funding) | `Main/Currency Creation/CurrencyCreationSummaryScreen`/`WizardScreen` · `CurrencyCreationState` (`@Observable`) | **VM-driven** step engine; drives `FundingOperation` + onramp |
 | **Currency launch processing** | Blocking screen while the launch swap settles | `CurrencyLaunchProcessingScreen` · `CurrencyLaunchProcessingViewModel` | **VM-driven**; `session.showCashBill` on success |
 | **Bill designer** | Visual editor for a currency's bill artwork | `Main/Bill Designer/BillDesigner`(+`Overlay`) | reusable component; parent owns state |
 | **Color editor** | Gradient picker (presets + custom stops) | `Main/Color Editor/ColorEditorControl`, `CustomPanelView` | screen-local; reusable |
@@ -75,7 +78,8 @@ graph TD
 | **Beta flags** | Developer feature-flag toggles | `Settings/BetaFlagsScreen` | screen-local; `BetaFlags` |
 | **Access key backup** | Show the 12-word key from Settings | `Settings/AccessKeyBackupScreen` | screen-local |
 | **Application logs** | In-app log viewer | `Settings/ApplicationLogsScreen` | screen-local |
-| **Download app** | Full-screen prompt for a counterparty to install (over scanner) | `Main/DownloadAppScreen` | screen-local; **router sheet** (gets 5-min auto-return) |
+| **Download app** | Full-screen prompt for a counterparty to install (over scanner) | `Main/DownloadAppScreen` | screen-local; **router sheet** |
 | **Force logout / upgrade** | Blocking screens on server demand | `ForceLogoutScreen`, `ForceUpgradeScreen` | screen-local |
-| **Quick actions** *(contact-sync)* | Dynamic Home Screen shortcuts (Scan, flag-gated Send) | `Controllers/QuickActionsController` | no screen; deeplinks in |
+| **Quick actions** | Dynamic Home Screen shortcuts (Scan, flag-gated Send) | `Controllers/QuickActionsController` | no screen; deeplinks in |
+| **Rich chat notifications** | Contact-named, communication-styled chat pushes + long-press transcript preview | `NotificationService/NotificationService.swift`, `NotificationContent/NotificationViewController.swift` | extension targets; the NSE resolves names on-device and prefetches the transcript into the shared `NotificationPreviewCache`; the content extension renders from it |
 | **Dialog window** | Hosts `session.dialogItem` above all sheets | `Main/DialogWindow` | infrastructure (see [08](../08-design-system.md)) |

--- a/docs/architecture/features/README.md
+++ b/docs/architecture/features/README.md
@@ -1,0 +1,81 @@
+# Feature Catalog
+
+Every user-facing feature, grouped by area. Each entry: purpose · key screen(s)/viewmodel(s) · the MVVM pattern it uses · notable router/operation integration. Screens live in `Flipcash/Core/Screens/`.
+
+The dominant convention (per [10 — Separation of Concerns](../10-separation-of-concerns.md)): **ViewModels appear only for multi-step flows or async-operation coordination; single-purpose display screens use `@State` + `@Observable` directly** and call the router inline.
+
+---
+
+```mermaid
+graph TD
+    Scan["ScanScreen — home"] --> Give["Give — show cash bill"]
+    Scan --> Grab["Scan & grab a bill"]
+    Scan --> Send["Send to a contact"]
+    Scan --> Balance["Balance / portfolio"]
+    Scan --> Discover["Discover currencies"]
+    Balance --> Info["Currency info"]
+    Info --> Buy["Buy"]
+    Info --> Sell["Sell"]
+    Balance --> Withdraw["Withdraw"]
+    Discover --> Create["Create currency"]
+    Buy --> Fund["Coinbase / Phantom / Reserves"]
+```
+
+## A. Onboarding & Auth
+
+| Feature | Purpose | Screens / VM | Pattern |
+|---------|---------|--------------|---------|
+| **Intro / Splash** | Entry point; animates into login or recovery | `Onboarding/IntroScreen` | screen-local |
+| **Login** | Phone-number auth / account creation | `Onboarding/LoginScreen` | screen-local |
+| **Access Key** | Show/enter the 12-word Ed25519 seed (+ help) | `AccessKeyScreen`, `AccessKeyHelpScreen` | screen-local |
+| **Notification permission** | Request push permission (+ denied recovery) | `NotificationPermissionScreen`(+`Denied`) | screen-local |
+| **Onboarding flow** | Coordinates access key → contacts → phone → notifications | `OnboardingViewModel` (`@Observable`) | **VM-driven** (owns a child `PhoneVerificationViewModel`) |
+| **Email verification** | Enter email → confirm code; also a Coinbase gate | `EnterEmailScreen`, `ConfirmEmailScreen` · `EmailVerificationViewModel` | **VM-driven** (`EmailVerifying`) |
+| **Phone verification** | Enter phone → confirm SMS (+ country picker); gates Send | `EnterPhoneScreen`, `ConfirmPhoneScreen`, `CountryCodeSelectionScreen` · `PhoneVerificationViewModel` | **VM-driven** (`PhoneVerifying`) |
+| **Contacts permission** | One-shot contacts grant for Send | `ContactsPermission/ContactsPermissionScreen` | screen-local |
+| **Account selection** | List historical accounts w/ balances; switch/delete | `Onboarding/AccountSelectionScreen` | screen-local |
+
+## B. Money movement
+
+| Feature | Purpose | Screens / VM | Pattern & integration |
+|---------|---------|--------------|------------------------|
+| **Scan / Main camera** | The home screen — decodes circular cash codes + QR links | `Main/ScanScreen` · `ScanViewModel` | **VM-driven**; spawns `SendCashOperation`/`ScanCashOperation`, routes deeplinks |
+| **Cash bill** | Animated circular-code bill over the camera (live send/receive) | `Main/Bill/BillCanvas`, `BillState`, `BillValuation` | the give/grab rendezvous (see [06](../06-payments-and-operations.md)) |
+| **Give** | Amount entry for a cash-bill give | `Main/GiveScreen` · `GiveViewModel` | **VM-driven**; pins `VerifiedState`, calls `session.showCashBill` |
+| **Send (contact)** | Contact picker → amount → SMS-invite or direct transfer | `Send/SendRootScreen`, `RecipientPickerScreen`, `SendAmountScreen` · `SendAmountViewModel` | mixed; root gates contacts/phone-verify; `router.push(.sendAmount)` |
+| **Buy** | Amount + method (Apple Pay / Phantom / Coinbase) | `Main/Buy/BuyAmountScreen`, `PurchaseMethodSheet`, `PhantomFlowScreen` · `BuyAmountViewModel` | **VM-driven**; nested `BuyFlowPath`; dispatches the three `FundingOperation`s |
+| **Sell** | Sell a custom currency back to USDF via the curve | `CurrencySellAmountScreen`, `CurrencySellConfirmationScreen` · `CurrencySellViewModel`(+`Confirmation`) | **VM-driven**; → swap processing |
+| **Swap processing** | Blocking screen during any buy/sell swap; polls state | `Main/Currency Swap/SwapProcessingScreen` · `SwapProcessingViewModel` | **VM-driven**; calls `updatePostTransaction` |
+| **Withdraw** | Intro → currency → amount → address → confirm → submit | `Settings/Withdraw/*` · `WithdrawViewModel` | **VM-driven** (injected `pushSubstep` closure) |
+| **Deposit (USDC)** | Education → show deposit address (QR + copy) per currency | `Settings/Deposit/DepositScreen`, `DepositCurrencyListScreen`, `Main/Buy/USDCDepositEducationScreen` | screen-local; `router.push(.depositAddress)` |
+| **Onramp / Coinbase** | KYC-gated fiat on-ramp; deep-link verification callback | `Onramp/VerifyInfoScreen` · `OnrampVerificationViewModel` | **VM-driven**; `Controllers/Onramp/*` (coordinator, inbox, Coinbase service, Apple Pay overlay) |
+| **Transaction history** | List past activities; cancel cash-link | `Main/TransactionHistoryScreen` | screen-local; reads `HistoryController` |
+| **Transaction details** | Sheet of one activity's line items | `Main/TransactionDetailsModal` | screen-local (display) |
+| **Cash received** | Celebration overlay on grab | `Main/Modals/ModalCashReceived` | screen-local (display) |
+
+## C. Currencies
+
+| Feature | Purpose | Screens / VM | Pattern & integration |
+|---------|---------|--------------|------------------------|
+| **Currency discovery** | Leaderboard of launchpad currencies | `Main/Currency Discovery/CurrencyDiscoveryScreen` (+rows/skeleton) | screen-local; `MarketCapController`; `push(.currencyInfo)` |
+| **Currency info** | Mint detail: price, market cap, socials, buy/sell | `Main/Currency Info/CurrencyInfoScreen` · `CurrencyInfoViewModel` | **VM-driven**; live `Updateable` feed; nested `.buy(mint)` |
+| **Currency selection** | Picker for active send/receive currency (+ recents/search) | `Main/Currency Selection/CurrencySelectionScreen` · `CurrencySelectionViewModel` | **VM-driven** |
+| **Select currency (balances)** | Owned-balance picker for Give/Send/Withdraw/Buy | `Main/SelectCurrencyScreen` | screen-local |
+| **Currency creation wizard** | Launch a new token (name, symbol, image, color, funding) | `Currency Creation/CurrencyCreationScreen`/`Summary`/`Wizard` · `CurrencyCreationState` (`@Observable`) | **VM-driven** step engine; drives `FundingOperation` + onramp |
+| **Currency launch processing** | Blocking screen while the launch swap settles | `CurrencyLaunchProcessingScreen` · `CurrencyLaunchProcessingViewModel` | **VM-driven**; `session.showCashBill` on success |
+| **Bill designer** | Visual editor for a currency's bill artwork | `Main/Bill Designer/BillDesigner`(+`Overlay`) | reusable component; parent owns state |
+| **Color editor** | Gradient picker (presets + custom stops) | `Main/Color Editor/ColorEditorControl`, `CustomPanelView` | screen-local; reusable |
+
+## D. Settings & misc
+
+| Feature | Purpose | Screens / VM | Pattern |
+|---------|---------|--------------|---------|
+| **Balance** | Top-level multi-currency portfolio + appreciation | `Main/BalanceScreen` | screen-local; `push(.currencyInfo/.discoverCurrencies)` |
+| **Settings** | Section list (Deposit, Withdraw, Account, App, Advanced, Beta) | `Settings/SettingsScreen` (+ sub-screens) | screen-local; all `router.push` |
+| **Beta flags** | Developer feature-flag toggles | `Settings/BetaFlagsScreen` | screen-local; `BetaFlags` |
+| **Access key backup** | Show the 12-word key from Settings | `Settings/AccessKeyBackupScreen` | screen-local |
+| **Application logs** | In-app log viewer | `Settings/ApplicationLogsScreen` | screen-local |
+| **Download app** | Full-screen prompt for a counterparty to install (over scanner) | `Main/DownloadAppScreen` | screen-local; **router destination** (gets 5-min auto-return) |
+| **Force logout / upgrade** | Blocking screens on server demand | `ForceLogoutScreen`, `ForceUpgradeScreen` | screen-local |
+| **Quick actions** | Dynamic Home Screen shortcuts (Scan, flag-gated Send) | `Controllers/QuickActionsController` | no screen; deeplinks in |
+| **Dialog window** | Hosts `session.dialogItem` above all sheets | `Main/DialogWindow` | infrastructure (see [08](../08-design-system.md)) |


### PR DESCRIPTION
## Summary

Adds a set of architecture documents covering how the app fits together — modules, state and dependency injection, navigation, networking, persistence, payments, the currency domain model, the design system, cross-cutting concerns, and a catalog of every user-facing feature. A new guideline ties code changes to doc updates in the same diff, and a verification command fact-checks the docs against the source and reports drift.

Everything was adversarially fact-checked against the code: content that belongs to the in-flight contact-sync epic is tagged until that work merges, several stale guideline facts were refreshed, and a few incorrect claims were fixed.

## Test plan

- [ ] Read the docs index and confirm the structure and reading order make sense.
- [ ] Spot-check a few tagged items and confirm they only exist on the contact-sync branch.
- [ ] Run the verify command and confirm it reports no drift against the current code.