### PR TITLE
chore: remove restating comments, fix wrong file headers and stale param docs

### DIFF
--- a/Flipcash/Core/Controllers/Coinbase.swift
+++ b/Flipcash/Core/Controllers/Coinbase.swift
@@ -30,10 +30,8 @@ public actor Coinbase {
 
     public func createOrder(request: OnrampOrderRequest, idempotencyKey: UUID? = nil) async throws -> OnrampOrderResponse {
 
-        // 1. Build URL
         let url = config.baseURL.appendingPathComponent("onramp/orders")
         
-        // 2. Encode body
         let bodyData: Data
         do {
             bodyData = try encoder.encode(request)
@@ -41,7 +39,6 @@ public actor Coinbase {
             throw Error.decoding(error)
         }
         
-        // 3. Build request
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         urlRequest.httpBody   = bodyData
@@ -54,7 +51,6 @@ public actor Coinbase {
         let token = try await config.bearerTokenProvider("POST", "platform/v2/onramp/orders")
         urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
-        // 4. Fire
         let (data, response): (Data, URLResponse)
         do {
             (data, response) = try await config.urlSession.data(for: urlRequest)
@@ -63,7 +59,6 @@ public actor Coinbase {
             throw Error.transport(error)
         }
 
-        // 5. Validate
         guard let http = response as? HTTPURLResponse else {
             throw Error.invalidResponse
         }
@@ -86,7 +81,6 @@ public actor Coinbase {
             }
         }
         
-        // 6. Decode
         do {
             return try decoder.decode(OnrampOrderResponse.self, from: data)
         } catch {

--- a/Flipcash/Core/Controllers/Database/Updateable.swift
+++ b/Flipcash/Core/Controllers/Database/Updateable.swift
@@ -1,5 +1,5 @@
 //
-//  AutoUpdating.swift
+//  Updateable.swift
 //  Code
 //
 //  Created by Dima Bart on 2024-12-23.

--- a/Flipcash/Core/Screens/Main/Color Editor/ColorEditorControl.swift
+++ b/Flipcash/Core/Screens/Main/Color Editor/ColorEditorControl.swift
@@ -96,8 +96,6 @@ public nonisolated struct GradientStop: Identifiable, Equatable, Sendable {
     
     @MainActor
     init(from color: Color) {
-        // Convert Color to HSB - this is a simplified approach
-        // In production, you might want more precise color space conversion
         let uiColor = UIColor(color)
         var h: CGFloat = 0
         var s: CGFloat = 0

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationScreen.swift
@@ -70,6 +70,3 @@ final class CurrencyCreationState {
 /// Matches server validation pattern `^[!-~]([ -~]*[!-~])?$`:
 /// printable ASCII, no leading or trailing space, 1+ chars.
 private let currencyNameAllowedPattern = #/^[!-~]([ -~]*[!-~])?$/#
-
-// MARK: - CurrencyCreationFlow
-

--- a/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellConfirmationViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellConfirmationViewModel.swift
@@ -17,6 +17,7 @@ class CurrencySellConfirmationViewModel {
 
     var dialogItem: DialogItem?
     private(set) var actionButtonState: ButtonState = .normal
+    /// Swap id of a successfully submitted sell. The confirmation screen observes this to push the processing screen.
     var pendingSwapId: SwapId?
 
     var canDismissSheet: Bool = false
@@ -72,7 +73,6 @@ class CurrencySellConfirmationViewModel {
         Task {
             do {
                 let swapId = try await session.sell(amount: amount, verifiedState: pinnedState, in: mint)
-                // Navigate to processing screen
                 pendingSwapId = swapId
             } catch Session.Error.verifiedStateStale {
                 // Session.assertFresh already logged this. Reset button only.

--- a/Flipcash/Core/Screens/Onboarding/LoginScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/LoginScreen.swift
@@ -117,7 +117,6 @@ struct LoginScreen: View {
             return
         }
         
-        // Remove suggestions
         suggestAutoCompleteResults(for: "")
         
         dismissKeyboard()

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -350,7 +350,6 @@ class WithdrawViewModel {
 
         let result = session.hasSufficientFunds(for: exchangedFiat)
 
-        // Use switch for exhaustive checking - compiler will error if new cases are added
         switch result {
         case .sufficient:
             pushEnterAddressScreen()

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -196,7 +196,6 @@ class Session {
             try? self?.database.getLimits()
         }
 
-        // Ensure we have a valid token selected on initialization
         ensureValidTokenSelection()
 
         registerPoller()

--- a/Flipcash/UI/ApplePayWebView.swift
+++ b/Flipcash/UI/ApplePayWebView.swift
@@ -121,10 +121,6 @@ extension ApplePayWebView {
             parent.onMessage?(applePayEvent)
         }
 
-        public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            // Optional: handle load completion
-        }
-
         public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
             logger.error("Navigation failed", metadata: ["error": "\(error.localizedDescription)"])
         }

--- a/Flipcash/UI/EnterAmountView.swift
+++ b/Flipcash/UI/EnterAmountView.swift
@@ -1,5 +1,5 @@
 //
-//  WithdrawAmountScreen.swift
+//  EnterAmountView.swift
 //  Code
 //
 //  Created by Dima Bart on 2021-04-05.

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentFundSwap.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentFundSwap.swift
@@ -68,7 +68,6 @@ extension IntentFundSwap {
                 $0.destinationOwner = destinationOwner.solanaAccountID
                 $0.mint = amount.mint.solanaAccountID
 
-                // Use clientExchangeData with embedded proofs for submitting intents
                 $0.clientExchangeData = .with {
                     $0.mint = amount.mint.solanaAccountID
                     $0.quarks = amount.onChainAmount.quarks

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentSendCashLink.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentSendCashLink.swift
@@ -68,7 +68,6 @@ extension IntentSendCashLink {
                 $0.destination  = giftCard.cluster.vaultPublicKey.solanaAccountID
                 $0.mint         = exchangedFiat.mint.solanaAccountID
 
-                // Use clientExchangeData with embedded proofs for submitting intents
                 $0.clientExchangeData = .with {
                     $0.mint = exchangedFiat.mint.solanaAccountID
                     $0.quarks = exchangedFiat.onChainAmount.quarks

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentTransfer.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentTransfer.swift
@@ -50,7 +50,6 @@ extension IntentTransfer {
                 $0.destination  = destination.solanaAccountID
                 $0.mint         = exchangedFiat.mint.solanaAccountID
 
-                // Use clientExchangeData with embedded proofs for submitting intents
                 $0.clientExchangeData = .with {
                     $0.mint = exchangedFiat.mint.solanaAccountID
                     $0.quarks = exchangedFiat.onChainAmount.quarks

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentWithdraw.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentWithdraw.swift
@@ -85,7 +85,6 @@ extension IntentWithdraw {
                 $0.destination  = destinationMetadata.destination.token.solanaAccountID
                 $0.mint         = exchangedFiat.mint.solanaAccountID
 
-                // Use clientExchangeData with embedded proofs for submitting intents
                 $0.clientExchangeData = .with {
                     $0.mint = exchangedFiat.mint.solanaAccountID
                     $0.quarks = exchangedFiat.onChainAmount.quarks

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -499,7 +499,6 @@ class TransactionService: CodeService<Ocp_Transaction_V1_TransactionNIOClient> {
                 "symbol": "\(token.symbol)",
                 "mint": "\(token.address.base58)"
             ])
-            // Map ErrorSubmitIntent to ErrorSwap
             completion(.failure(.unknown))
             return
         }
@@ -562,7 +561,7 @@ class TransactionService: CodeService<Ocp_Transaction_V1_TransactionNIOClient> {
         reference.stream = service.submitIntent(callOptions: .streaming) { result in
             switch result.response {
                 
-            // 2. Upon successful submission of intent action the server will
+            // Upon successful submission of intent action the server will
             // respond with parameters that we'll need to apply to the intent
             // before crafting and signing the transactions.
             case .serverParameters(let parameters):
@@ -592,7 +591,7 @@ class TransactionService: CodeService<Ocp_Transaction_V1_TransactionNIOClient> {
                     completion(.failure(.unknown))
                 }
                 
-            // 3. If submitted transaction signatures are valid and match
+            // If submitted transaction signatures are valid and match
             // the server, we'll receive a success for the submitted intent.
             case .success(let success):
                 logger.info("Intent submitted successfully", metadata: [
@@ -603,7 +602,7 @@ class TransactionService: CodeService<Ocp_Transaction_V1_TransactionNIOClient> {
                 _ = reference.stream?.sendEnd()
                 completion(.success(intent))
                 
-            // 3. If the submitted transaction signatures don't match, the
+            // If the submitted transaction signatures don't match, the
             // intent is considered failed. Something must have gone wrong
             // on the transaction creation or signing on our side.
             case .error(let error):

--- a/FlipcashCore/Sources/FlipcashCore/Extensions/BigDecimal+Operations.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Extensions/BigDecimal+Operations.swift
@@ -1,5 +1,5 @@
 //
-//  BigDecimal.swift
+//  BigDecimal+Operations.swift
 //  FlipcashCore
 //
 //  Created by Raul Riera on 2026-02-07.

--- a/FlipcashCore/Sources/FlipcashCore/Extensions/UInt64+Operations.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Extensions/UInt64+Operations.swift
@@ -1,5 +1,5 @@
 //
-//  Decimal+Operations.swift
+//  UInt64+Operations.swift
 //  FlipcashCore
 //
 //  Created by Raul Riera on 2026-02-07.

--- a/FlipcashCore/Sources/FlipcashCore/Logging/Handlers/FlipcashLogHandler.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Logging/Handlers/FlipcashLogHandler.swift
@@ -3,8 +3,7 @@ import Logging
 import os
 
 /// Single log handler that processes entries once and dispatches to
-/// console, ring buffer, and file writer. Replaces MultiplexLogHandler
-/// to avoid 3x entry construction and middleware processing per log call.
+/// console, ring buffer, and file writer.
 struct FlipcashLogHandler: LogHandler {
 
     var logLevel: Logging.Logger.Level

--- a/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CurrencyCreatorProgram.BuyAndDepositIntoVm.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CurrencyCreatorProgram.BuyAndDepositIntoVm.swift
@@ -13,7 +13,7 @@ extension CurrencyCreatorProgram {
     /// Buy tokens from a launchpad currency and deposit them into a VM account.
     /// This performs a bounded buy operation where the maximum slippage is controlled.
     ///
-    /// Account structure (matching Android/server implementation):
+    /// Account structure:
     /// 0. `[writable, signer]` Buyer/authority (payer and signer)
     /// 1. `[]` Pool account
     /// 2. `[]` Target token mint

--- a/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CurrencyCreatorProgram.SellAndDepositIntoVm.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CurrencyCreatorProgram.SellAndDepositIntoVm.swift
@@ -13,7 +13,7 @@ extension CurrencyCreatorProgram {
     /// Sell tokens from a launchpad currency and deposit the proceeds into a VM account.
     /// This performs a bounded sell operation where the minimum output is controlled.
     ///
-    /// Account structure (matching Android/server implementation):
+    /// Account structure:
     /// 0. `[writable, signer]` Seller/authority (payer and signer)
     /// 1. `[writable]` Pool account
     /// 2. `[]` Target token mint

--- a/FlipcashCore/Sources/FlipcashCore/Solana/Programs/InstructionType.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/Programs/InstructionType.swift
@@ -67,7 +67,6 @@ extension CommandType where Definition.RawValue: FixedWidthInteger {
         
         var data = instruction.data
         
-        // Consume the command type into the void
         _ = data.consume(commandByteLength)
         
         return data

--- a/FlipcashCore/Sources/FlipcashCore/Solana/SolanaTransaction.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SolanaTransaction.swift
@@ -76,7 +76,6 @@ public struct SolanaTransaction: Equatable, Sendable {
         
         instructions.forEach {
             accounts.append(
-                // Maybe needs to be .program()
                 .program(publicKey: $0.program)
             )
             accounts.append(contentsOf: $0.accounts)

--- a/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+Buy.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+Buy.swift
@@ -17,8 +17,6 @@ extension SwapInstructionBuilder {
     ///   - swapAuthority: The swap authority signing the transaction
     ///   - coreMintMetadata: Metadata for the Core Mint (source)
     ///   - targetMintMetadata: Metadata for the target mint (destination)
-    ///   - coreMintTemporary: Temporary account for Core Mint
-    ///   - coreMintOwner: Owner of the Core Mint account
     ///   - amount: Amount to buy
     ///   - minOutput: Minimum output required
     /// - Returns: Array of instructions in the correct order

--- a/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+Sell.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+Sell.swift
@@ -14,14 +14,11 @@ extension SwapInstructionBuilder {
     ///   - serverParameters: Server-provided parameters including compute budget and memo
     ///   - nonce: The nonce account
     ///   - authority: The authority signing the transaction
+    ///   - swapAuthority: The swap authority signing the transaction
     ///   - sourceMintMetadata: Metadata for the source mint (launchpad currency)
     ///   - coreMintMetadata: Metadata for the Core Mint (destination)
-    ///   - fromMintTemporary: Temporary account for the source mint
-    ///   - fromMintOwner: Owner of the from mint account
-    ///   - vmSwapAccount: VM swap ATA for the source mint
     ///   - amount: Amount to sell
     ///   - minOutput: Minimum output required
-    ///   - additionalAccounts: Additional accounts required by the currency creator program
     /// - Returns: Array of instructions in the correct order
     public static func buildSellInstructions(
         serverParameters: SwapResponseServerParameters,

--- a/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+StatelessSwap.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+StatelessSwap.swift
@@ -50,8 +50,7 @@ extension SwapInstructionBuilder {
         }
 
         // Owner's destination-mint VM Deposit ATA — the address Geyser watches.
-        // Same derivation as `SwapInstructionBuilder+NewCurrency.swift`: ATA
-        // owned by the VM Deposit PDA, not by the user authority directly.
+        // The ATA is owned by the VM Deposit PDA, not by the user authority directly.
         guard let ownerToVmDepositPda = PublicKey.deriveDepositAccount(
             owner: owner,
             mint: toMint.address,
@@ -98,9 +97,7 @@ extension SwapInstructionBuilder {
             fatalError("Failed to derive Coinbase whitelist address")
         }
 
-        // Fee recipient's source-mint ATA — fee is paid in the from-mint,
-        // matching the existing USDF→USDC pattern in
-        // `SwapInstructionBuilder+UsdfToUsdc.swift`.
+        // Fee recipient's source-mint ATA — fee is paid in the from-mint.
         guard let feeRecipientFromAta = PublicKey.deriveAssociatedAccount(
             from: serverParameters.poolFeeRecipient,
             mint: fromMint.address

--- a/FlipcashCore/Sources/FlipcashCore/Solana/VersionedMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/VersionedMessage.swift
@@ -22,8 +22,6 @@ public struct VersionedMessageV0: Equatable, Sendable {
     public func encode() -> Data {
         var data = Data()
         data.append(Byte(MessageVersion.v0.rawValue + messageVersionSerializationOffset))
-        // message content
-        // same as legacy
         data.append(header.encode())
         data.append(
             ShortVec.encode(staticAccountKeys.map { $0.data })
@@ -154,7 +152,6 @@ extension VersionedMessageV0 {
             addressTableLookups.append(lookup)
         }
 
-        // Now we have everything, store it
         self.header = header
         self.staticAccountKeys = staticKeys
         self.recentBlockhash = hash

--- a/FlipcashCore/Sources/FlipcashCore/Utilities/Poller.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Utilities/Poller.swift
@@ -10,10 +10,6 @@ import Foundation
 
 /// Repeating async poller that serializes actions — each invocation
 /// completes before the next sleep begins.
-///
-/// The internal `Task` inherits the caller's actor isolation.
-/// Both current callers are `@MainActor` (Session, SessionAuthenticator),
-/// matching the old `RunLoop.main` behavior.
 public final class Poller: Sendable {
 
     private let task: Task<Void, Never>

--- a/FlipcashUI/Sources/FlipcashUI/Dialog/ActionBuilder.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Dialog/ActionBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  Dialog+View.swift
+//  ActionBuilder.swift
 //  FlipcashUI
 //
 //  Created by Dima Bart on 2025-05-06.
@@ -9,27 +9,22 @@ import SwiftUI
 
 @resultBuilder
 public enum ActionBuilder {
-    // Handle single Action
     public static func buildExpression(_ expression: DialogAction) -> [DialogAction] {
         [expression]
     }
 
-    // Handle arrays of Action (e.g., from optional blocks)
     public static func buildExpression(_ expression: [DialogAction]) -> [DialogAction] {
         expression
     }
 
-    // Combine arrays into a single array
     public static func buildBlock(_ components: [DialogAction]...) -> [DialogAction] {
         components.flatMap { $0 }
     }
 
-    // Handle optional arrays (e.g., from `if let`)
     public static func buildOptional(_ component: [DialogAction]?) -> [DialogAction] {
         component ?? []
     }
 
-    // Conditional logic (if/else)
     public static func buildEither(first: [DialogAction]) -> [DialogAction] {
         first
     }

--- a/FlipcashUI/Sources/FlipcashUI/Modifiers/Badged.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Modifiers/Badged.swift
@@ -78,7 +78,6 @@ struct Badged_Previews: PreviewProvider {
     static var previews: some View {
         Background(color: .blue) {
             Button {
-                // Do nothing
             } label: {
                 Rectangle()
                     .fill(.red)

--- a/FlipcashUI/Sources/FlipcashUI/Views/Bill/BillView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Bill/BillView.swift
@@ -39,7 +39,6 @@ public struct BillView: View {
         self.string     = fiat.formatted(suffix: nil)
         self.billSize   = Self.size(fitting: canvasSize, aspectRatio: aspectRatio)
 
-        // Use provided colors or get default colors based on mint
         // Invert the color since the coordinate space given by theserver is not the same as iOS
         self.backgroundColors = backgroundColors?.reversed() ?? Self.defaultColors(for: mint)
     }

--- a/FlipcashUI/Sources/FlipcashUI/Views/Bill/KikCode.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Bill/KikCode.swift
@@ -52,7 +52,6 @@ nonisolated enum KikCode {
         var dots: [UIBezierPath] = []
         var arcs: [UIBezierPath] = []
         
-        // Then draw the inner circle
         centerPath.addArc(
             withCenter: center,
             radius: innerRingWidth,

--- a/FlipcashUI/Sources/FlipcashUI/Views/Chart/ChartLineView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Chart/ChartLineView.swift
@@ -95,7 +95,6 @@ public struct ChartLineView: View {
             LongPressGestureView(
                 minimumDuration: 0.15,
                 onBegan: { [dataPoints, onScrubChange] location in
-                    // Find closest point by normalized position
                     if let normalizedX: Double = proxy.value(atX: location.x),
                        let closest = dataPoints.min(by: {
                            abs($0.normalizedPosition - normalizedX) < abs($1.normalizedPosition - normalizedX)
@@ -105,7 +104,6 @@ public struct ChartLineView: View {
                     Self.triggerSelectionHaptic(at: location)
                 },
                 onChanged: { [dataPoints, onScrubChange] location in
-                    // Find closest point by normalized position
                     if let normalizedX: Double = proxy.value(atX: location.x),
                        let closest = dataPoints.min(by: {
                            abs($0.normalizedPosition - normalizedX) < abs($1.normalizedPosition - normalizedX)
@@ -151,7 +149,6 @@ public struct ChartLineView: View {
         if #available(iOS 17.5, *) {
             generator.selectionChanged(at: location)
         } else {
-            // Fallback on earlier versions
             generator.selectionChanged()
         }
     }


### PR DESCRIPTION
Cleans up the comments flagged by the repository audit. Deletes narration that restates the next line of code, step numbering, template hedging, and migration history; corrects five file headers that named the wrong file; and rewrites the buy and sell builder doc blocks so they document the parameters that actually exist today. Also removes one empty optional web view delegate method whose body was only a comment.

No behavior changes — every edit is a comment or doc comment except the empty delegate, which is an optional protocol method.

## Test plan

- [x] Build the app and confirm there are no new warnings
- [x] Skim the diff to confirm every removed comment was narration rather than a real constraint