### PR TITLE
refactor: route phone and currency-name validation through validators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ To suppress reporting for a specific error type, conform it to `ServerError` (in
 
 ### Form Input Validation: Use the `Validator` Family
 
-**Validate free-form input through `Validator` (in `FlipcashCore/Sources/FlipcashCore/Validation/`), not inline regex/trim/length checks.** Each input type gets a concrete validator (`EmailValidator`, and the in-flight `PhoneValidator` / `LengthValidator`) that owns the rule, returns the canonical form, and is unit-testable in isolation.
+**Validate free-form input through `Validator` (in `FlipcashCore/Sources/FlipcashCore/Validation/`), not inline regex/trim/length checks.** Each input type gets a concrete validator (`EmailValidator`, `PhoneValidator`, `CurrencyNameValidator`, `LengthValidator`) that owns the rule, returns the canonical form, and is unit-testable in isolation.
 
 ```swift
 // ❌ BAD: inline rule in the viewmodel — drifts from the server contract, untestable

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationScreen.swift
@@ -64,7 +64,7 @@ final class CurrencyCreationState {
     var encodedIconData: Data?
 
     @ObservationIgnored private let nameValidator = CurrencyNameValidator()
-    @ObservationIgnored private let descriptionValidator = LengthValidator(maxLength: Self.descriptionCharLimit)
+    @ObservationIgnored private let descriptionValidator = LengthValidator(maxLength: CurrencyCreationState.descriptionCharLimit)
 
     /// The name accepted by the Launch RPC's contract, or nil while the
     /// current input is invalid. This exact string flows to availability,

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationScreen.swift
@@ -32,6 +32,11 @@ enum CurrencyCreationStep: Hashable {
 
 @Observable
 final class CurrencyCreationState {
+
+    /// UI clamp and validator bound for the description. The server allows
+    /// 4096; 500 is the product choice.
+    static let descriptionCharLimit = 500
+
     var currencyName: String = "" {
         didSet { if currencyName != oldValue { nameAttestation = nil } }
     }
@@ -58,15 +63,21 @@ final class CurrencyCreationState {
     /// when the user changes the selected image.
     var encodedIconData: Data?
 
-    /// True when the current name passes both the char-range check and the
-    /// printable-ASCII pattern enforced by the server's Launch RPC:
-    /// `^[!-~]([ -~]*[!-~])?$` — no leading or trailing space, 1-32 chars.
+    @ObservationIgnored private let nameValidator = CurrencyNameValidator()
+    @ObservationIgnored private let descriptionValidator = LengthValidator(maxLength: Self.descriptionCharLimit)
+
+    /// The name accepted by the Launch RPC's contract, or nil while the
+    /// current input is invalid. This exact string flows to availability,
+    /// moderation, and launch.
+    var validatedCurrencyName: String? {
+        nameValidator.validate(currencyName)
+    }
+
     var isCurrencyNameValid: Bool {
-        guard !currencyName.isEmpty, currencyName.count <= 32 else { return false }
-        return currencyName.wholeMatch(of: currencyNameAllowedPattern) != nil
+        validatedCurrencyName != nil
+    }
+
+    var isCurrencyDescriptionValid: Bool {
+        descriptionValidator.validate(currencyDescription) != nil
     }
 }
-
-/// Matches server validation pattern `^[!-~]([ -~]*[!-~])?$`:
-/// printable ASCII, no leading or trailing space, 1+ chars.
-private let currencyNameAllowedPattern = #/^[!-~]([ -~]*[!-~])?$/#

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -82,8 +82,6 @@ struct CurrencyCreationWizardScreen: View {
         var id: String { swapId.publicKey.base58 }
     }
 
-    static let nameCharLimit = 32
-    static let descriptionCharLimit = 500
     static let iconCircleSize: CGFloat = 150
 
     /// USDF amount the user buys to mint their first bill. Driven by the
@@ -183,7 +181,7 @@ struct CurrencyCreationWizardScreen: View {
                     NameStep(
                         state: state,
                         focusedField: $focusedField,
-                        characterLimit: Self.nameCharLimit,
+                        characterLimit: CurrencyNameValidator.maxLength,
                         isValidating: isValidating,
                         onNext: { validateAndAdvanceName() }
                     )
@@ -203,7 +201,7 @@ struct CurrencyCreationWizardScreen: View {
                     DescriptionStep(
                         state: state,
                         focusedField: $focusedField,
-                        characterLimit: Self.descriptionCharLimit,
+                        characterLimit: CurrencyCreationState.descriptionCharLimit,
                         isValidating: isValidating,
                         onNext: { validateAndAdvanceDescription() }
                     )
@@ -421,7 +419,7 @@ struct CurrencyCreationWizardScreen: View {
             isValidating = true
             defer { isValidating = false }
 
-            let name = state.currencyName
+            guard let name = state.validatedCurrencyName else { return }
 
             // 1. Uniqueness check
             let isAvailable: Bool
@@ -1164,7 +1162,7 @@ private struct DescriptionStep: View {
                 }
             }
             .buttonStyle(.filled)
-            .disabled(state.currencyDescription.allSatisfy(\.isWhitespace) || isValidating)
+            .disabled(!state.isCurrencyDescriptionValid || isValidating)
             .padding(.bottom, 20)
         }
         .padding(.horizontal, 20)

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -1004,11 +1004,7 @@ private struct NameStep: View {
                 .focused($focusedField, equals: .name)
                 .padding(.top, 32)
                 .disabled(isValidating)
-                .onChange(of: state.currencyName) { _, newValue in
-                    if newValue.count > characterLimit {
-                        state.currencyName = String(newValue.prefix(characterLimit))
-                    }
-                }
+                .characterLimit(characterLimit, text: $state.currencyName)
 
             Spacer()
 
@@ -1136,11 +1132,7 @@ private struct DescriptionStep: View {
                         .focused($focusedField, equals: .description)
                         .padding(.top, 16)
                         .disabled(isValidating)
-                        .onChange(of: state.currencyDescription) { _, newValue in
-                            if newValue.count > characterLimit {
-                                state.currencyDescription = String(newValue.prefix(characterLimit))
-                            }
-                        }
+                        .characterLimit(characterLimit, text: $state.currencyDescription)
 
                     Color.clear.frame(height: 100)
                 }
@@ -1316,5 +1308,27 @@ private struct ImagePickerWithEditor: UIViewControllerRepresentable {
         func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
             onDismiss()
         }
+    }
+}
+
+// MARK: - CharacterLimit
+
+private struct CharacterLimit: ViewModifier {
+    @Binding var text: String
+    let limit: Int
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: text) { _, newValue in
+                if newValue.count > limit {
+                    text = String(newValue.prefix(limit))
+                }
+            }
+    }
+}
+
+private extension View {
+    func characterLimit(_ limit: Int, text: Binding<String>) -> some View {
+        modifier(CharacterLimit(text: text, limit: limit))
     }
 }

--- a/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationViewModel.swift
@@ -46,6 +46,7 @@ final class PhoneVerificationViewModel: PhoneVerifying {
     @ObservationIgnored private let owner: KeyPair
 
     @ObservationIgnored private let phoneFormatter = PhoneFormatter()
+    @ObservationIgnored private let phoneValidator = PhoneValidator()
 
     // MARK: - Analytics hooks -
 
@@ -107,7 +108,7 @@ final class PhoneVerificationViewModel: PhoneVerifying {
     }
 
     var phone: Phone? {
-        Phone(enteredPhone)
+        phoneValidator.validate(enteredPhone)
     }
 
     var canSendVerificationCode: Bool {

--- a/FlipcashCore/Sources/FlipcashCore/Validation/CurrencyNameValidator.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Validation/CurrencyNameValidator.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Validates a launchpad currency name: printable ASCII, no leading or
+/// trailing space, 1–32 characters.
+///
+/// Returns the name unchanged — rejecting rather than trimming, because the
+/// moderation attestation is bound to the exact string that is later
+/// submitted to the Launch RPC.
+public struct CurrencyNameValidator: Validator {
+
+    public static let maxLength = 32
+
+    public init() {}
+
+    public func validate(_ input: String) -> String? {
+        guard !input.isEmpty, input.count <= Self.maxLength else {
+            return nil
+        }
+
+        guard input.wholeMatch(of: Self.pattern) != nil else {
+            return nil
+        }
+
+        return input
+    }
+
+    /// PGV regex from `FlipcashAPI/Payments/proto/currency/v1/currency_service.proto`.
+    private nonisolated(unsafe) static let pattern = #/^[!-~]([ -~]*[!-~])?$/#
+}

--- a/FlipcashCore/Sources/FlipcashCore/Validation/LengthValidator.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Validation/LengthValidator.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Validates free-form text against a maximum length, rejecting blank
+/// (empty or whitespace-only) input. Returns the text unchanged.
+public struct LengthValidator: Validator {
+
+    public let maxLength: Int
+
+    public init(maxLength: Int) {
+        self.maxLength = maxLength
+    }
+
+    public func validate(_ input: String) -> String? {
+        guard !input.allSatisfy(\.isWhitespace), input.count <= maxLength else {
+            return nil
+        }
+
+        return input
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Validation/PhoneValidator.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Validation/PhoneValidator.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Validates a free-form phone number string and returns the parsed `Phone`.
+///
+/// Parsing is delegated to `Phone` (PhoneNumberKit); the resulting E.164 form
+/// is then checked against the server's PGV rule. Callers submit the output's
+/// `e164`, never the raw input.
+public struct PhoneValidator: Validator {
+
+    public init() {}
+
+    public func validate(_ input: String) -> Phone? {
+        guard let phone = Phone(input) else {
+            return nil
+        }
+
+        guard phone.e164.wholeMatch(of: Self.pattern) != nil else {
+            return nil
+        }
+
+        return phone
+    }
+
+    /// PGV regex from `FlipcashAPI/Core/proto/phone/v1/model.proto`.
+    private nonisolated(unsafe) static let pattern = /^\+[1-9]\d{1,14}$/
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/CurrencyNameValidatorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/CurrencyNameValidatorTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("CurrencyNameValidator")
+struct CurrencyNameValidatorTests {
+
+    @Test("Accepts printable-ASCII names and returns them unchanged", arguments: [
+        "A",
+        "My Coin",
+        "Coin!$#@",
+        String(repeating: "A", count: 32),
+    ])
+    func accepts_validName(input: String) {
+        let validator = CurrencyNameValidator()
+        #expect(validator.validate(input) == input)
+    }
+
+    @Test("Rejects empty, overlong, non-ASCII, and edge-whitespace names", arguments: [
+        "",
+        String(repeating: "A", count: 33),
+        " Coin",
+        "Coin ",
+        "   ",
+        "café",
+        "Coin🎉",
+        "Co\nin",
+    ])
+    func rejects_invalidName(input: String) {
+        let validator = CurrencyNameValidator()
+        #expect(validator.validate(input) == nil)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/LengthValidatorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/LengthValidatorTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("LengthValidator")
+struct LengthValidatorTests {
+
+    @Test("Accepts non-blank input up to the limit", arguments: [
+        "a",
+        " padded ",
+        String(repeating: "x", count: 10),
+    ])
+    func accepts_withinLimit(input: String) {
+        let validator = LengthValidator(maxLength: 10)
+        #expect(validator.validate(input) == input)
+    }
+
+    @Test("Rejects blank and overlong input", arguments: [
+        "",
+        "   ",
+        "\n\t",
+        String(repeating: "x", count: 11),
+    ])
+    func rejects_blankOrOverlong(input: String) {
+        let validator = LengthValidator(maxLength: 10)
+        #expect(validator.validate(input) == nil)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/PhoneValidatorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/PhoneValidatorTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("PhoneValidator")
+struct PhoneValidatorTests {
+
+    @Test("Accepts parseable numbers and returns the E.164 form", arguments: [
+        ("+1 415 555 0100", "+14155550100"),
+        ("+14155550100", "+14155550100"),
+        ("+44 7400 123456", "+447400123456"),
+        ("+1 (415) 555-0100", "+14155550100"),
+    ])
+    func accepts_validPhone(input: String, e164: String) {
+        let validator = PhoneValidator()
+        #expect(validator.validate(input)?.e164 == e164)
+    }
+
+    @Test("Rejects strings that do not parse to a valid number", arguments: [
+        "",
+        "   ",
+        "hello",
+        "+1",
+        "+1 415 555",
+        "+999 123 4567",
+    ])
+    func rejects_invalidPhone(input: String) {
+        let validator = PhoneValidator()
+        #expect(validator.validate(input) == nil)
+    }
+}

--- a/FlipcashTests/Models/CurrencyCreationStateTests.swift
+++ b/FlipcashTests/Models/CurrencyCreationStateTests.swift
@@ -12,90 +12,43 @@ import FlipcashCore
 @Suite("CurrencyCreationState")
 struct CurrencyCreationStateTests {
 
-    // MARK: - isCurrencyNameValid
+    // MARK: - Validation routing
 
-    @Test("empty name is invalid")
-    func emptyName_invalid() {
-        let state = CurrencyCreationState()
-        state.currencyName = ""
-        #expect(state.isCurrencyNameValid == false)
-    }
-
-    @Test("single printable ASCII char is valid")
-    func singleChar_valid() {
-        let state = CurrencyCreationState()
-        state.currencyName = "A"
-        #expect(state.isCurrencyNameValid == true)
-    }
-
-    @Test("exactly 32 chars is valid")
-    func thirtyTwoChars_valid() {
-        let state = CurrencyCreationState()
-        state.currencyName = String(repeating: "A", count: 32)
-        #expect(state.isCurrencyNameValid == true)
-    }
-
-    @Test("more than 32 chars is invalid")
-    func moreThan32Chars_invalid() {
-        let state = CurrencyCreationState()
-        state.currencyName = String(repeating: "A", count: 33)
-        #expect(state.isCurrencyNameValid == false)
-    }
-
-    @Test("name with internal space is valid")
-    func internalSpace_valid() {
+    @Test("valid name passes and surfaces the validated form")
+    func validName_passesValidation() {
         let state = CurrencyCreationState()
         state.currencyName = "My Coin"
-        #expect(state.isCurrencyNameValid == true)
+        #expect(state.isCurrencyNameValid)
+        #expect(state.validatedCurrencyName == "My Coin")
     }
 
-    @Test("leading space is invalid")
-    func leadingSpace_invalid() {
+    @Test("invalid name fails and yields no validated form")
+    func invalidName_failsValidation() {
         let state = CurrencyCreationState()
         state.currencyName = " Coin"
         #expect(state.isCurrencyNameValid == false)
+        #expect(state.validatedCurrencyName == nil)
     }
 
-    @Test("trailing space is invalid")
-    func trailingSpace_invalid() {
+    @Test("non-blank description within the limit is valid")
+    func description_withinLimit_valid() {
         let state = CurrencyCreationState()
-        state.currencyName = "Coin "
-        #expect(state.isCurrencyNameValid == false)
+        state.currencyDescription = "A coin for testing"
+        #expect(state.isCurrencyDescriptionValid)
     }
 
-    @Test("whitespace-only is invalid")
-    func whitespaceOnly_invalid() {
+    @Test("blank description is invalid")
+    func blankDescription_invalid() {
         let state = CurrencyCreationState()
-        state.currencyName = "   "
-        #expect(state.isCurrencyNameValid == false)
+        state.currencyDescription = "   "
+        #expect(state.isCurrencyDescriptionValid == false)
     }
 
-    @Test("non-ASCII characters are invalid")
-    func nonASCII_invalid() {
+    @Test("description over the limit is invalid")
+    func overlongDescription_invalid() {
         let state = CurrencyCreationState()
-        state.currencyName = "café"
-        #expect(state.isCurrencyNameValid == false)
-    }
-
-    @Test("emoji is invalid")
-    func emoji_invalid() {
-        let state = CurrencyCreationState()
-        state.currencyName = "Coin🎉"
-        #expect(state.isCurrencyNameValid == false)
-    }
-
-    @Test("newline is invalid")
-    func newline_invalid() {
-        let state = CurrencyCreationState()
-        state.currencyName = "Co\nin"
-        #expect(state.isCurrencyNameValid == false)
-    }
-
-    @Test("printable ASCII punctuation is valid")
-    func printableAsciiPunctuation_valid() {
-        let state = CurrencyCreationState()
-        state.currencyName = "Coin!$#@"
-        #expect(state.isCurrencyNameValid == true)
+        state.currencyDescription = String(repeating: "x", count: CurrencyCreationState.descriptionCharLimit + 1)
+        #expect(state.isCurrencyDescriptionValid == false)
     }
 
     // MARK: - Attestation invalidation on field edit

--- a/FlipcashTests/Models/CurrencyCreationStateTests.swift
+++ b/FlipcashTests/Models/CurrencyCreationStateTests.swift
@@ -37,13 +37,6 @@ struct CurrencyCreationStateTests {
         #expect(state.isCurrencyDescriptionValid)
     }
 
-    @Test("blank description is invalid")
-    func blankDescription_invalid() {
-        let state = CurrencyCreationState()
-        state.currencyDescription = "   "
-        #expect(state.isCurrencyDescriptionValid == false)
-    }
-
     @Test("description over the limit is invalid")
     func overlongDescription_invalid() {
         let state = CurrencyCreationState()


### PR DESCRIPTION
Adds the remaining validators from the validation family: phone number, currency name, and bounded free-form text. Phone entry and the currency creation flow now validate through them instead of inline checks, keeping the client rules mirrored to the server contracts in one place. Also dedupes the copy-pasted character-limit handling in the creation wizard and consolidates rule-level test coverage into the validator suites.

## Test plan

- [x] Run the new validator test suites
- [x] Run the currency creation and phone verification test suites
- [x] Verify phone number entry still formats and submits correctly
- [x] Verify currency name and description limits behave as before when creating a currency