### PR TITLE
fix: fall back to the counterpart's phone number in DM titles

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -232,22 +232,24 @@ final class ConversationController {
 
     // MARK: - Names
 
-    /// Counterpart name shown when neither the synced contacts nor the feed
-    /// provides one.
+    /// Counterpart name shown when neither the synced contacts, the feed, nor a
+    /// shared phone number provides one.
     static let fallbackCounterpartName = "Flipcash User"
 
     /// The counterpart's name for a conversation: the synced contact's
     /// address-book name, else the server-provided member name from the feed,
-    /// else a generic fallback.
+    /// else the counterpart's shared phone number, else a generic fallback.
     func displayName(for conversation: Conversation) -> String {
         if let contactName = contactName(for: conversation.id) {
             return contactName
         }
-        guard let counterpart = conversation.counterpart(excluding: selfUserID),
-              !counterpart.displayName.isEmpty else {
+        guard let counterpart = conversation.counterpart(excluding: selfUserID) else {
             return Self.fallbackCounterpartName
         }
-        return counterpart.displayName
+        if !counterpart.displayName.isEmpty {
+            return counterpart.displayName
+        }
+        return counterpart.formattedPhoneNumber ?? Self.fallbackCounterpartName
     }
 
     func displayName(forConversationID conversationID: ConversationID) -> String {

--- a/Flipcash/Core/Controllers/Database/Database+Conversations.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Conversations.swift
@@ -44,6 +44,7 @@ nonisolated extension Database {
                 member: ConversationMember(
                     userID: row[m.userId],
                     displayName: row[m.displayName],
+                    phoneE164: row[m.phoneE164],
                     readPointer: row[m.readPointer].map(MessageID.init(value:)),
                     readPointerTimestamp: row[m.readPointerTimestamp].map { Date(timeIntervalSinceReferenceDate: $0) }
                 )
@@ -168,6 +169,7 @@ nonisolated extension Database {
                     m.conversationId        <- conversation.id.data,
                     m.userId                <- member.userID,
                     m.displayName           <- member.displayName,
+                    m.phoneE164             <- member.phoneE164,
                     m.readPointer           <- member.readPointer?.value,
                     m.readPointerTimestamp  <- member.readPointerTimestamp?.timeIntervalSinceReferenceDate
                 )

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -178,6 +178,7 @@ nonisolated struct ConversationMemberTable: Sendable {
     let conversationId        = Expression <Data>    ("conversationId")
     let userId                = Expression <UUID?>   ("userId")
     let displayName           = Expression <String>  ("displayName")
+    let phoneE164             = Expression <String?> ("phoneE164")
     let readPointer           = Expression <UInt64?> ("readPointer")
     let readPointerTimestamp  = Expression <Double?> ("readPointerTimestamp")
 }
@@ -393,6 +394,7 @@ nonisolated extension Database {
                 t.column(conversationMemberTable.conversationId)
                 t.column(conversationMemberTable.userId)
                 t.column(conversationMemberTable.displayName)
+                t.column(conversationMemberTable.phoneE164)
                 t.column(conversationMemberTable.readPointer)
                 t.column(conversationMemberTable.readPointerTimestamp)
             })

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -22,7 +22,7 @@
 		<string>INSendMessageIntent</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>19</integer>
+	<integer>20</integer>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Conversation.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Conversation.swift
@@ -86,6 +86,10 @@ public struct ConversationMember: Hashable, Sendable, Identifiable {
 
     public let userID: UserID?
     public var displayName: String
+    /// The member's E.164 phone number, when the server shared it. For DM chats
+    /// the server populates this per member so each party can resolve the other
+    /// to a contact; `nil` for group chats and when no number is on file.
+    public var phoneE164: String?
     /// This member's READ watermark: every message at or before it is read.
     /// `nil` until the server reports one in the feed/stream.
     public var readPointer: MessageID?
@@ -95,11 +99,20 @@ public struct ConversationMember: Hashable, Sendable, Identifiable {
 
     public var id: String { userID?.uuidString ?? displayName }
 
-    public init(userID: UserID?, displayName: String, readPointer: MessageID? = nil, readPointerTimestamp: Date? = nil) {
+    public init(userID: UserID?, displayName: String, phoneE164: String? = nil, readPointer: MessageID? = nil, readPointerTimestamp: Date? = nil) {
         self.userID = userID
         self.displayName = displayName
+        self.phoneE164 = phoneE164
         self.readPointer = readPointer
         self.readPointerTimestamp = readPointerTimestamp
+    }
+
+    /// The member's phone number formatted for display, used as a conversation
+    /// title fallback before the generic name. National format, falling back to
+    /// the raw E.164 when it can't be parsed.
+    public var formattedPhoneNumber: String? {
+        guard let phoneE164, !phoneE164.isEmpty else { return nil }
+        return Phone(phoneE164)?.national ?? phoneE164
     }
 }
 
@@ -107,6 +120,7 @@ extension ConversationMember {
     public init(_ proto: Flipcash_Chat_V1_Member) {
         self.userID = try? UUID(data: proto.userID.value)
         self.displayName = proto.userProfile.displayName
+        self.phoneE164 = proto.userProfile.phoneNumber.value.isEmpty ? nil : proto.userProfile.phoneNumber.value
 
         var read: MessageID?
         var readAt: Date?

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
@@ -141,6 +141,31 @@ struct ConversationModelMappingTests {
         #expect(member.readPointerTimestamp == readAt)
     }
 
+    @Test("Member maps the shared phone number and formats it for display")
+    func memberMapsPhoneNumber() {
+        let proto = Flipcash_Chat_V1_Member.with {
+            $0.userID = .with { $0.value = UUID().data }
+            $0.userProfile = .with {
+                $0.phoneNumber = .with { $0.value = "+14155550100" }
+            }
+        }
+
+        let member = ConversationMember(proto)
+        #expect(member.phoneE164 == "+14155550100")
+        #expect(member.formattedPhoneNumber == "(415) 555-0100")
+    }
+
+    @Test("Member has no phone number when the profile omits one")
+    func memberWithoutPhoneNumber() {
+        let proto = Flipcash_Chat_V1_Member.with {
+            $0.userID = .with { $0.value = UUID().data }
+        }
+
+        let member = ConversationMember(proto)
+        #expect(member.phoneE164 == nil)
+        #expect(member.formattedPhoneNumber == nil)
+    }
+
     @Test("counterpartReadReceipt returns the other member's pointer and read time")
     func counterpartReadReceiptReturnsOtherMember() {
         let me = UUID()

--- a/FlipcashTests/ContactAvatarViewInitialsTests.swift
+++ b/FlipcashTests/ContactAvatarViewInitialsTests.swift
@@ -6,51 +6,61 @@
 import Testing
 import FlipcashUI
 
-@Suite("ContactAvatarView.initials(for:)")
+@Suite("ContactAvatarView.monogram(for:)")
 struct ContactAvatarViewInitialsTests {
 
     @Test("Two-word name yields first letter of first + last word")
     func twoWords() {
-        #expect(ContactAvatarView.initials(for: "Jane Doe") == "JD")
+        #expect(ContactAvatarView.monogram(for: "Jane Doe") == .initials("JD"))
     }
 
     @Test("Three-word name still takes first and LAST word")
     func threeWords() {
-        #expect(ContactAvatarView.initials(for: "Mary Jane Doe") == "MD")
+        #expect(ContactAvatarView.monogram(for: "Mary Jane Doe") == .initials("MD"))
     }
 
     @Test("Single-word name yields first two letters")
     func singleWord() {
-        #expect(ContactAvatarView.initials(for: "Madonna") == "MA")
+        #expect(ContactAvatarView.monogram(for: "Madonna") == .initials("MA"))
     }
 
     @Test("Single short word yields just that character")
     func singleLetter() {
-        #expect(ContactAvatarView.initials(for: "A") == "A")
+        #expect(ContactAvatarView.monogram(for: "A") == .initials("A"))
     }
 
     @Test("Lowercase input is uppercased")
     func lowercased() {
-        #expect(ContactAvatarView.initials(for: "jane doe") == "JD")
+        #expect(ContactAvatarView.monogram(for: "jane doe") == .initials("JD"))
     }
 
-    @Test("Empty string yields fallback")
+    @Test("Empty string yields a placeholder")
     func empty() {
-        #expect(ContactAvatarView.initials(for: "") == "?")
+        #expect(ContactAvatarView.monogram(for: "") == .placeholder)
     }
 
-    @Test("Whitespace-only yields fallback")
+    @Test("Whitespace-only yields a placeholder")
     func whitespaceOnly() {
-        #expect(ContactAvatarView.initials(for: "   \n  ") == "?")
+        #expect(ContactAvatarView.monogram(for: "   \n  ") == .placeholder)
     }
 
     @Test("Leading/trailing whitespace is trimmed before split")
     func surroundingWhitespace() {
-        #expect(ContactAvatarView.initials(for: "  Jane Doe  ") == "JD")
+        #expect(ContactAvatarView.monogram(for: "  Jane Doe  ") == .initials("JD"))
     }
 
     @Test("Repeated inner whitespace collapses")
     func collapsedWhitespace() {
-        #expect(ContactAvatarView.initials(for: "Jane   Doe") == "JD")
+        #expect(ContactAvatarView.monogram(for: "Jane   Doe") == .initials("JD"))
+    }
+
+    @Test("A phone number has no letters, so it yields a placeholder")
+    func phoneNumber() {
+        #expect(ContactAvatarView.monogram(for: "(586) 980-2333") == .placeholder)
+    }
+
+    @Test("Non-letter words are ignored when forming initials")
+    func nonLetterWordsIgnored() {
+        #expect(ContactAvatarView.monogram(for: "John (work)") == .initials("JO"))
     }
 }

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -133,7 +133,27 @@ struct ConversationControllerTests {
         #expect(controller.displayName(forConversationID: ConversationID.test(1)) == "Alice")
     }
 
-    @Test("falls back to a generic title when the counterpart has no name")
+    @Test("falls back to the counterpart's phone number when it has no name")
+    func counterpartPhoneFallback() async {
+        let me = UUID()
+        let other = UUID()
+        let mock = MockConversations()
+        mock.feed = [Conversation(
+            id: ConversationID.test(1),
+            members: [
+                ConversationMember(userID: me, displayName: ""),
+                ConversationMember(userID: other, displayName: "", phoneE164: "+14155550100"),
+            ],
+            lastMessage: nil,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )]
+        let controller = makeController(mock, selfUserID: me)
+
+        await controller.loadFeed()
+        #expect(controller.displayName(forConversationID: ConversationID.test(1)) == "(415) 555-0100")
+    }
+
+    @Test("falls back to a generic title when the counterpart has no name or phone")
     func counterpartNameFallback() async {
         let me = UUID()
         let other = UUID()

--- a/FlipcashTests/Database/Database+ConversationsTests.swift
+++ b/FlipcashTests/Database/Database+ConversationsTests.swift
@@ -237,13 +237,13 @@ struct DatabaseConversationsTests {
 
     // MARK: - Conversations -
 
-    @Test("A conversation round-trips with members, read pointers, and the newest message as preview")
+    @Test("A conversation round-trips with members, phone numbers, read pointers, and the newest message as preview")
     func conversationRoundTrip() throws {
         let (database, url) = try Database.makeTemp()
         defer { Database.removeTemp(at: url) }
         let members = [
             ConversationMember(userID: selfID, displayName: "Self", readPointer: MessageID(value: 1)),
-            ConversationMember(userID: otherID, displayName: "Them", readPointer: nil),
+            ConversationMember(userID: otherID, displayName: "Them", phoneE164: "+14155550100", readPointer: nil),
         ]
         let preview = textMessage(id: 2, at: 60)
         let stored = conversation(byte: 1, members: members, lastMessage: preview)

--- a/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactAvatarView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactAvatarView.swift
@@ -42,9 +42,16 @@ public struct ContactAvatarView: View {
                     endPoint: UnitPoint(x: 0.5, y: 1)
                 )
                 .overlay {
-                    Text(Self.initials(for: displayName))
-                        .font(.appTextMedium)
-                        .foregroundStyle(Color.textMain)
+                    switch Self.monogram(for: displayName) {
+                    case .initials(let text):
+                        Text(text)
+                            .font(.appTextMedium)
+                            .foregroundStyle(Color.textMain)
+                    case .placeholder:
+                        Image(systemName: "person.fill")
+                            .font(.system(size: size * 0.5))
+                            .foregroundStyle(Color.textMain)
+                    }
                 }
             }
         }
@@ -55,20 +62,29 @@ public struct ContactAvatarView: View {
         .accessibilityAddTraits(.isImage)
     }
 
-    /// Two-letter monogram for a display name. Two-word names yield the first
-    /// letter of the first and last words; single-word names yield the first
-    /// two characters; an empty or whitespace-only name yields `"?"`.
-    nonisolated public static func initials(for displayName: String) -> String {
-        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "?" }
+    /// The avatar's text content: letter initials drawn from the display name,
+    /// or `.placeholder` when there are none — in which case the avatar shows a
+    /// generic person glyph instead of an unreadable monogram.
+    nonisolated public enum Monogram: Equatable, Sendable {
+        case initials(String)
+        case placeholder
+    }
 
-        let words = trimmed.split(separator: " ", omittingEmptySubsequences: true)
-        if words.count >= 2 {
-            let first = words.first?.first.map(String.init) ?? ""
-            let last = words.last?.first.map(String.init) ?? ""
-            return (first + last).uppercased()
+    /// A two-letter monogram, considering only words that begin with a letter:
+    /// two such words yield the first letter of the first and last; a single
+    /// word yields its first two characters. A name with no letter-leading
+    /// words (e.g. a bare phone number) yields `.placeholder`.
+    nonisolated public static func monogram(for displayName: String) -> Monogram {
+        let words = displayName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .filter { $0.first?.isLetter == true }
+        guard let first = words.first else { return .placeholder }
+        if words.count >= 2, let last = words.last {
+            let initials = String(first.prefix(1)) + String(last.prefix(1))
+            return .initials(initials.uppercased())
         }
-        return String(words[0].prefix(2)).uppercased()
+        return .initials(String(first.prefix(2)).uppercased())
     }
 }
 
@@ -111,8 +127,14 @@ nonisolated public final class ContactAvatarCache: @unchecked Sendable {
         .background(Color.backgroundMain)
 }
 
-#Preview("Initials — empty") {
-    ContactAvatarView(id: "p3", displayName: "   ")
+#Preview("Placeholder — phone number") {
+    ContactAvatarView(id: "p3", displayName: "(586) 980-2333")
+        .padding()
+        .background(Color.backgroundMain)
+}
+
+#Preview("Placeholder — empty") {
+    ContactAvatarView(id: "p4", displayName: "   ")
         .padding()
         .background(Color.backgroundMain)
 }


### PR DESCRIPTION
Direct-message conversations with someone who isn't in your address book showed a generic "Flipcash User" title. The server already shares each chat member's phone number for exactly this purpose, so we now fall back to the counterpart's phone number — formatted the same way phone numbers appear elsewhere in the app. The generic name only remains when no phone number is on file.

Their avatar also showed garbled initials taken from the number ("(586) 980-2333" became "(9"); it now shows a generic person glyph, matching how Messages and Contacts render an unknown number.

## Test plan
- [x] Open a chat with someone not in your contacts and confirm the title shows their phone number
- [x] Confirm that chat's avatar shows a person icon, not initials of the number
- [x] Open a chat with a saved contact and confirm it still shows their name and initials
- [x] Confirm a chat with no phone number on file still shows "Flipcash User"