### PR TITLE
feat: gate Send behind an Enable Send beta flag

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -60,6 +60,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         if Container.isRunningUITests {
             UIView.setAnimationsEnabled(false)
+            BetaFlags.shared.applyLaunchArgumentOverrides()
         }
 
         NotificationCenter.default.addObserver(

--- a/Flipcash/Core/Controllers/BetaFlags.swift
+++ b/Flipcash/Core/Controllers/BetaFlags.swift
@@ -48,6 +48,20 @@ class BetaFlags {
         writeToCache()
     }
     
+    /// Resets every flag, then enables each option named in the
+    /// `--beta-flags=<comma-separated rawValues>` launch argument.
+    func applyLaunchArgumentOverrides() {
+        let prefix = "--beta-flags="
+        let enabled = CommandLine.arguments
+            .first { $0.hasPrefix(prefix) }?
+            .dropFirst(prefix.count)
+            .split(separator: ",")
+            .compactMap { Option(rawValue: String($0)) }
+
+        options = Set(enabled ?? [])
+        writeToCache()
+    }
+
     /// Toggles whether the beta features section is visible in Settings.
     /// Controlled by the 9-tap easter egg on the app version label.
     func setAccessGranted(_ granted: Bool) {
@@ -97,6 +111,7 @@ extension BetaFlags {
 
         case vibrateOnScan
         case enableCoinbase
+        case enableSend
 
         var id: String {
             localizedTitle
@@ -108,6 +123,8 @@ extension BetaFlags {
                 return "Vibrate on scan"
             case .enableCoinbase:
                 return "Enable Coinbase"
+            case .enableSend:
+                return "Enable Send"
             }
         }
 
@@ -117,6 +134,8 @@ extension BetaFlags {
                 return "If enabled, the device will vibrate to indicate that the camera has registered the code on the bill"
             case .enableCoinbase:
                 return "If enabled, Coinbase onramp will be available regardless of region"
+            case .enableSend:
+                return "If enabled, the Send feature is available from the scan screen"
             }
         }
     }

--- a/Flipcash/Core/Screens/Main/ScanBottomBar.swift
+++ b/Flipcash/Core/Screens/Main/ScanBottomBar.swift
@@ -8,6 +8,7 @@ import FlipcashUI
 
 struct ScanBottomBar: View {
     let toast: String?
+    let showSend: Bool
     let onGive: () -> Void
     let onWallet: () -> Void
     let onDiscover: () -> Void
@@ -29,12 +30,14 @@ struct ScanBottomBar: View {
             )
             .accessibilityIdentifier("scan-cash-button")
 
-            LargeButton(
-                title: "Send",
-                image: Image(.Icons.send),
-                action: onSend
-            )
-            .accessibilityIdentifier("scan-send-button")
+            if showSend {
+                LargeButton(
+                    title: "Send",
+                    image: Image(.Icons.send),
+                    action: onSend
+                )
+                .accessibilityIdentifier("scan-send-button")
+            }
 
             ToastContainer(toast: toast) {
                 LargeButton(

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -255,6 +255,7 @@ struct ScanScreen: View {
             Spacer()
             ScanBottomBar(
                 toast: toast,
+                showSend: session.canSend,
                 onGive: presentGive,
                 onWallet: { router.present(.balance) },
                 onDiscover: { router.present(.discover) },

--- a/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
@@ -123,15 +123,19 @@ class OnboardingViewModel {
         accessKeyButtonState = .success
         try await Task.delay(milliseconds: 500)
 
-        // No Session yet (completeLogin runs after the permission gates),
-        // and a fresh registration has no verified phone. Always show.
-        navigateToPhoneVerification()
+        // Phone verification only exists to power Send; show it when the Send
+        // beta flag is on, otherwise advance straight to the next step.
+        if BetaFlags.shared.hasEnabled(.enableSend) {
+            navigateToPhoneVerification()
+        } else {
+            await advanceFromPhoneVerificationStep()
+        }
 
         try await Task.delay(milliseconds: 500) // Delay deferred state change
     }
 
-    /// Phone-step success handler: advance to push permission when undetermined,
-    /// otherwise finish login. Contacts access is requested later, from Send.
+    /// Advances past the phone step: requests push permission when undetermined,
+    /// otherwise finishes login. Contacts access is requested later, from Send.
     private func advanceFromPhoneVerificationStep() async {
         let pushStatus = await PushController.fetchStatus()
         switch pushStatus {

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -100,7 +100,11 @@ class Session {
     var hasCoinbaseOnramp: Bool {
         BetaFlags.shared.hasEnabled(.enableCoinbase) || userFlags?.hasCoinbase == true
     }
-    
+
+    var canSend: Bool {
+        BetaFlags.shared.hasEnabled(.enableSend) || userFlags?.enablePhoneNumberSend == true
+    }
+
     var hasPreferredOnrampProvider: Bool {
         userFlags?.hasPreferredOnrampProvider == true
     }
@@ -323,9 +327,8 @@ class Session {
 
     /// Links an already-verified phone for payment once per session. Best-effort; server-idempotent.
     private func linkPhoneForPaymentIfNeeded() async {
-        // TODO: gate on (BetaFlags || userFlags?.enablePhoneNumberSend) once
-        // enablePhoneNumberSend ships; runs unconditionally until then.
-        guard let phone = profile?.phone,
+        guard canSend,
+              let phone = profile?.phone,
               !hasLinkedPhoneForPayment else { return }
         // Claim before the await so two concurrent callers can't double-fire; released on failure below.
         hasLinkedPhoneForPayment = true

--- a/FlipcashTests/SessionTests.swift
+++ b/FlipcashTests/SessionTests.swift
@@ -707,30 +707,20 @@ struct SessionCanSendTests {
         return try body()
     }
 
-    @Test("The server flag enablePhoneNumberSend enables Send")
-    func serverFlagEnablesSend() throws {
-        try Self.withSendBetaFlag(enabled: false) {
+    @Test(
+        "canSend is the beta flag OR the server flag",
+        arguments: [
+            (beta: false, server: false, expected: false),
+            (beta: false, server: true,  expected: true),
+            (beta: true,  server: false, expected: true),
+            (beta: true,  server: true,  expected: true),
+        ]
+    )
+    func canSend(beta: Bool, server: Bool, expected: Bool) {
+        Self.withSendBetaFlag(enabled: beta) {
             let session = Session.makeMock(database: .mock)
-            session.userFlags = Self.makeUserFlags(enablePhoneNumberSend: true)
-            #expect(session.canSend)
-        }
-    }
-
-    @Test("Send is off when neither the beta flag nor the server flag is set")
-    func defaultsOff() throws {
-        try Self.withSendBetaFlag(enabled: false) {
-            let session = Session.makeMock(database: .mock)
-            session.userFlags = Self.makeUserFlags(enablePhoneNumberSend: false)
-            #expect(!session.canSend)
-        }
-    }
-
-    @Test("The beta flag enables Send even without the server flag")
-    func betaFlagEnablesSend() throws {
-        try Self.withSendBetaFlag(enabled: true) {
-            let session = Session.makeMock(database: .mock)
-            session.userFlags = Self.makeUserFlags(enablePhoneNumberSend: false)
-            #expect(session.canSend)
+            session.userFlags = Self.makeUserFlags(enablePhoneNumberSend: server)
+            #expect(session.canSend == expected)
         }
     }
 }

--- a/FlipcashTests/SessionTests.swift
+++ b/FlipcashTests/SessionTests.swift
@@ -677,6 +677,64 @@ struct SessionOfflineCacheTests {
     }
 }
 
+/// Runs serialized — the beta-flag cases mutate the `BetaFlags.shared`
+/// singleton (UserDefaults-backed), so parallel execution with any other
+/// suite that reads `enableSend` would race on the global flag.
+@Suite("Session.canSend", .serialized)
+@MainActor
+struct SessionCanSendTests {
+
+    private static func makeUserFlags(enablePhoneNumberSend: Bool) -> UserFlags {
+        UserFlags(
+            isRegistered: true,
+            isStaff: false,
+            onrampProviders: [],
+            preferredOnrampProvider: .coinbaseVirtual,
+            minBuildNumber: 0,
+            billExchangeDataTimeout: nil,
+            newCurrencyPurchaseAmount: .zero(mint: .usdf),
+            newCurrencyFeeAmount: .zero(mint: .usdf),
+            withdrawalFeeAmount: .zero(mint: .usdf),
+            minimumHolderValue: .zero(mint: .usdf),
+            enablePhoneNumberSend: enablePhoneNumberSend
+        )
+    }
+
+    private static func withSendBetaFlag<R>(enabled: Bool, _ body: () throws -> R) rethrows -> R {
+        let original = BetaFlags.shared.hasEnabled(.enableSend)
+        BetaFlags.shared.set(.enableSend, enabled: enabled)
+        defer { BetaFlags.shared.set(.enableSend, enabled: original) }
+        return try body()
+    }
+
+    @Test("The server flag enablePhoneNumberSend enables Send")
+    func serverFlagEnablesSend() throws {
+        try Self.withSendBetaFlag(enabled: false) {
+            let session = Session.makeMock(database: .mock)
+            session.userFlags = Self.makeUserFlags(enablePhoneNumberSend: true)
+            #expect(session.canSend)
+        }
+    }
+
+    @Test("Send is off when neither the beta flag nor the server flag is set")
+    func defaultsOff() throws {
+        try Self.withSendBetaFlag(enabled: false) {
+            let session = Session.makeMock(database: .mock)
+            session.userFlags = Self.makeUserFlags(enablePhoneNumberSend: false)
+            #expect(!session.canSend)
+        }
+    }
+
+    @Test("The beta flag enables Send even without the server flag")
+    func betaFlagEnablesSend() throws {
+        try Self.withSendBetaFlag(enabled: true) {
+            let session = Session.makeMock(database: .mock)
+            session.userFlags = Self.makeUserFlags(enablePhoneNumberSend: false)
+            #expect(session.canSend)
+        }
+    }
+}
+
 @MainActor
 @Suite("Session.hasGiveableBalance")
 struct SessionHasGiveableBalanceTests {

--- a/FlipcashUITests/Smoke/CreateAccountSmokeTests.swift
+++ b/FlipcashUITests/Smoke/CreateAccountSmokeTests.swift
@@ -8,6 +8,7 @@ import XCTest
 final class CreateAccountSmokeTests: BaseUITestCase {
 
     override var resetPermissions: [XCUIProtectedResource] { [.photos, .contacts] }
+    override var enabledBetaFlags: [String] { ["enableSend"] }
 
     // MARK: - Tests
 

--- a/FlipcashUITests/Smoke/SendSmokeTests.swift
+++ b/FlipcashUITests/Smoke/SendSmokeTests.swift
@@ -9,6 +9,7 @@ final class SendSmokeTests: BaseUITestCase {
 
     override var requiresAuthentication: Bool { true }
     override var resetPermissions: [XCUIProtectedResource] { [.contacts] }
+    override var enabledBetaFlags: [String] { ["enableSend"] }
 
     func testSendFlow_picker_inviteFallback() {
         assertMainScreenReached()

--- a/FlipcashUITests/Support/BaseUITestCase.swift
+++ b/FlipcashUITests/Support/BaseUITestCase.swift
@@ -24,11 +24,18 @@ class BaseUITestCase: XCTestCase {
     /// Example: `[.photos, .camera]`
     var resetPermissions: [XCUIProtectedResource] { [] }
 
+    /// Beta-flag option rawValues to enable for the test via `--beta-flags`.
+    var enabledBetaFlags: [String] { [] }
+
     override func setUp() async throws {
         try await super.setUp()
         continueAfterFailure = false
 
         app.launchArguments = ["--ui-testing", "-AppleLocale", "en_US", "-AppleLanguages", "(en)"]
+
+        if !enabledBetaFlags.isEmpty {
+            app.launchArguments.append("--beta-flags=\(enabledBetaFlags.joined(separator: ","))")
+        }
 
         for permission in resetPermissions {
             app.resetAuthorizationStatus(for: permission)


### PR DESCRIPTION
Adds an "Enable Send" beta flag that keeps the Send option off the scan screen until the feature is ready to ship. The same flag gates the phone-verification step during onboarding, since that step only exists to support sending. When sending is enabled for a user on the server, the Send option and phone verification appear automatically; the beta flag is the local override for testing before then.

## Test plan
- [x] With Enable Send off, the scan screen shows no Send button.
- [x] With Enable Send on, the Send button appears and opens the send flow.
- [x] Onboarding skips phone verification when Enable Send is off, and shows it when on.
- [x] The unit tests covering the send-availability check pass.
