### PR TITLE
feat: add a Send Cash toggle to Settings > Advanced Features

### DIFF
--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
@@ -13,6 +13,7 @@ struct SettingsAdvancedFeaturesScreen: View {
 
     @Environment(AppRouter.self) private var router
     @Environment(Session.self) private var session
+    @Environment(BetaFlags.self) private var betaFlags
 
     private let insets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
 
@@ -20,6 +21,15 @@ struct SettingsAdvancedFeaturesScreen: View {
         Background(color: .backgroundMain) {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "paperplane")
+                            .frame(minWidth: 45)
+                        Toggle("Send Cash", isOn: betaFlags.bindingFor(option: .enableSend))
+                            .tint(.textSuccess)
+                    }
+                    .padding(insets)
+                    .vSeparator(color: .rowSeparator, position: .bottom)
+
                     SettingsRow(systemImage: "slider.horizontal.3", title: "Bill Designer", insets: insets) {
                         Task {
                             router.dismissSheet()
@@ -34,8 +44,8 @@ struct SettingsAdvancedFeaturesScreen: View {
                 }
                 .font(.appDisplayXS)
                 .foregroundStyle(.textMain)
+                .padding(.horizontal, 20)
             }
-            .padding(.horizontal, 20)
         }
         .navigationTitle("Advanced Features")
         .toolbarTitleDisplayMode(.inline)


### PR DESCRIPTION
The Enable Send beta feature was previously only reachable through the hidden beta-flags menu. This exposes it as a plain Send Cash toggle in Settings > Advanced Features, so it can be turned on or off without the easter egg. Both controls share the same underlying setting, so they always stay in sync.

## Test plan
- [x] Open Settings > Advanced Features and confirm the Send Cash toggle appears at the top.
- [x] Turn the toggle on and confirm the Send button appears on the scan screen.
- [x] Turn the toggle off and confirm the Send button disappears.
- [x] Confirm the toggle matches the Enable Send switch in the beta-flags menu.