### PR TITLE
feat: show Send Cash in chats with people not in your contacts

### DIFF
--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -42,6 +42,26 @@ nonisolated struct ResolvedContact: Identifiable, Hashable, Sendable {
     var id: String { "\(contactId)|\(phoneE164)" }
 }
 
+extension ResolvedContact {
+    /// Builds a send target for a DM counterpart who isn't in the address book,
+    /// from the phone number the server shared on their chat member, so Send Cash
+    /// works before the person is a synced contact. `nil` when no number is on
+    /// file. The phone resolves the recipient and `dmChatID` carries the chat
+    /// payment metadata; the display fields aren't read by the send flow.
+    init?(counterpart member: ConversationMember, dmChatID: Data?) {
+        guard let phoneE164 = member.phoneE164, !phoneE164.isEmpty else { return nil }
+        let national = member.formattedPhoneNumber ?? phoneE164
+        self.init(
+            contactId: phoneE164,
+            displayName: national,
+            phoneE164: phoneE164,
+            nationalPhone: national,
+            imageData: nil,
+            dmChatID: dmChatID
+        )
+    }
+}
+
 nonisolated struct ResolvedContacts: Equatable, Sendable {
     var onFlipcash: [ResolvedContact]
     var invite: [ResolvedContact]

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -32,6 +32,11 @@ final class ConversationController {
     var conversations: [Conversation] { store.conversations }
     private(set) var isLoadingFeed = false
 
+    /// The conversation with this ID, if the feed currently holds it.
+    func conversation(withID id: ConversationID) -> Conversation? {
+        conversations.first { $0.id == id }
+    }
+
     /// The signed-in user, used to tell own messages from the counterpart's.
     let selfUserID: UserID
 

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -78,6 +78,22 @@ struct ConversationScreen: View {
         }
     }
 
+    /// Who Send Cash pays: the synced address-book contact when there is one,
+    /// otherwise a target built from the counterpart's shared phone number so a
+    /// chat with a non-contact can still receive cash. `nil` only when neither a
+    /// contact nor a counterpart phone number is available.
+    private var sendTarget: ResolvedContact? {
+        if let contact {
+            return contact
+        }
+        guard let conversationID,
+              let counterpart = conversationController.conversation(withID: conversationID)?
+                .counterpart(excluding: conversationController.selfUserID) else {
+            return nil
+        }
+        return ResolvedContact(counterpart: counterpart, dmChatID: conversationID.data)
+    }
+
     /// Whether the DM chat actually exists server-side. Matched contacts carry
     /// a pre-assigned `dmChatID` before any payment (the first intent needs it),
     /// so the ID alone doesn't mean the chat was created — require it to be in
@@ -88,7 +104,7 @@ struct ConversationScreen: View {
         case .existing:
             return true
         case .contact:
-            return conversationController.conversations.contains { $0.id == conversationID }
+            return conversationController.conversation(withID: conversationID) != nil
                 || !conversationController.messages(for: conversationID).isEmpty
         }
     }
@@ -117,8 +133,7 @@ struct ConversationScreen: View {
     /// moment they read.
     private var counterpartRead: ReadReceiptState? {
         guard let conversationID else { return nil }
-        return conversationController.conversations
-            .first { $0.id == conversationID }?
+        return conversationController.conversation(withID: conversationID)?
             .counterpartReadReceipt(excluding: conversationController.selfUserID)
     }
 
@@ -126,8 +141,7 @@ struct ConversationScreen: View {
     /// it's fixed before any cash bubble mounts.
     private func captureSeenBoundaryIfNeeded() {
         guard !didCaptureSeenBoundary, let conversationID, !messages.isEmpty else { return }
-        seenBoundary = conversationController.conversations
-            .first { $0.id == conversationID }?
+        seenBoundary = conversationController.conversation(withID: conversationID)?
             .selfReadPointer(for: conversationController.selfUserID)
         didCaptureSeenBoundary = true
     }
@@ -151,7 +165,7 @@ struct ConversationScreen: View {
         .background(Color.backgroundMain)
         .safeAreaInset(edge: .bottom) {
             ConversationBottomBar(
-                showsSendCash: contact != nil,
+                showsSendCash: sendTarget != nil,
                 showsSendMessage: chatExists,
                 isComposing: $isComposing,
                 conversationID: conversationID,
@@ -217,14 +231,14 @@ struct ConversationScreen: View {
     }
 
     private func sendCash() {
-        guard let contact else { return }
+        guard let sendTarget else { return }
         guard session.hasGiveableBalance(for: ratesController.rateForBalanceCurrency()) else {
             session.dialogItem = .noGiveableBalance {
                 router.navigate(to: .deposit)
             }
             return
         }
-        router.push(.sendAmount(contact: contact))
+        router.push(.sendAmount(contact: sendTarget))
     }
 
     /// Resigns the first responder directly via UIKit so the keyboard lowers
@@ -256,7 +270,7 @@ struct ConversationScreen: View {
                 // Done only once the FEED has the chat — messages arriving over
                 // the stream flip `chatExists` early, but the picker's Recents
                 // section reads the feed.
-                guard conversationController.conversations.contains(where: { $0.id == conversationID }) else { continue }
+                guard conversationController.conversation(withID: conversationID) != nil else { continue }
                 await conversationController.loadMessages(for: conversationID)
                 break
             }

--- a/FlipcashTests/ResolvedContactCounterpartTests.swift
+++ b/FlipcashTests/ResolvedContactCounterpartTests.swift
@@ -1,0 +1,45 @@
+//
+//  ResolvedContactCounterpartTests.swift
+//  FlipcashTests
+//
+
+import Testing
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+@Suite("ResolvedContact(counterpart:dmChatID:)")
+struct ResolvedContactCounterpartTests {
+
+    private let chatID = Data([0xDE, 0xAD, 0xBE, 0xEF])
+
+    @Test("Builds a send target from a counterpart's phone number")
+    func buildsTargetFromPhone() throws {
+        let member = ConversationMember(userID: UUID(), displayName: "", phoneE164: "+14155550100")
+
+        let target = try #require(ResolvedContact(counterpart: member, dmChatID: chatID))
+
+        #expect(target.phoneE164 == "+14155550100")
+        #expect(target.dmChatID == chatID)
+        #expect(target.nationalPhone == member.formattedPhoneNumber)
+        #expect(target.displayName == member.formattedPhoneNumber)
+        #expect(target.imageData == nil)
+    }
+
+    @Test("Falls back to the raw E.164 when the number can't be parsed")
+    func fallsBackToRawNumber() throws {
+        let member = ConversationMember(userID: UUID(), displayName: "", phoneE164: "+1")
+
+        let target = try #require(ResolvedContact(counterpart: member, dmChatID: chatID))
+
+        #expect(target.phoneE164 == "+1")
+        #expect(target.nationalPhone == "+1")
+    }
+
+    @Test("A missing or empty phone number yields no target", arguments: [nil, ""] as [String?])
+    func noUsablePhoneYieldsNil(phone: String?) {
+        let member = ConversationMember(userID: UUID(), displayName: "Alice", phoneE164: phone)
+
+        #expect(ResolvedContact(counterpart: member, dmChatID: chatID) == nil)
+    }
+}


### PR DESCRIPTION
When you open a chat with someone who isn't in your contacts, the footer used to offer only Send Message — Send Cash was hidden because there was no saved contact to pay. Now it falls back to the phone number the chat already carries, so you can send cash to anyone you're already chatting with. The conversation title and avatar are unchanged.

## Test plan
- [x] Open a chat with someone who isn't in your contacts and confirm Send Cash appears next to Send Message.
- [x] Send cash from that chat and confirm it is delivered and shows up in the conversation.
- [x] Open a chat with a saved contact and confirm Send Cash still works as before.