### PR TITLE
chore: Send Cash beta label + temporarily hide Bill Designer row

### DIFF
--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
@@ -24,7 +24,7 @@ struct SettingsAdvancedFeaturesScreen: View {
                     HStack(spacing: 12) {
                         Image(systemName: "paperplane")
                             .frame(minWidth: 45)
-                        Toggle("Send Cash", isOn: betaFlags.bindingFor(option: .enableSend))
+                        Toggle("Beta Feature: Send Cash", isOn: betaFlags.bindingFor(option: .enableSend))
                             .tint(.textSuccess)
                     }
                     .padding(insets)

--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
@@ -12,7 +12,6 @@ import FlipcashUI
 struct SettingsAdvancedFeaturesScreen: View {
 
     @Environment(AppRouter.self) private var router
-    @Environment(Session.self) private var session
     @Environment(BetaFlags.self) private var betaFlags
 
     private let insets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
@@ -29,14 +28,6 @@ struct SettingsAdvancedFeaturesScreen: View {
                     }
                     .padding(insets)
                     .vSeparator(color: .rowSeparator, position: .bottom)
-
-                    SettingsRow(systemImage: "slider.horizontal.3", title: "Bill Designer", insets: insets) {
-                        Task {
-                            router.dismissSheet()
-                            try await Task.delay(milliseconds: 250)
-                            session.isShowingBillDesigner = true
-                        }
-                    }
 
                     SettingsRow(systemImage: "doc.text", title: "Application Logs", insets: insets) {
                         router.push(.settingsApplicationLogs)


### PR DESCRIPTION
Two small Advanced Features tweaks:

- Renames the toggle from "Send Cash" to "Beta Feature: Send Cash" so it's clear the feature is still in beta.
- Temporarily removes the Bill Designer row. Revert that commit (or this PR) to restore it.

## Test plan
- [x] Open Settings → Advanced Features and confirm the toggle reads "Beta Feature: Send Cash".
- [x] Confirm the Bill Designer row is gone and the Application Logs row still works.