### PR TITLE
chore: temporarily remove the Bill Designer row from Advanced Features

### DIFF
--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
@@ -12,7 +12,6 @@ import FlipcashUI
 struct SettingsAdvancedFeaturesScreen: View {
 
     @Environment(AppRouter.self) private var router
-    @Environment(Session.self) private var session
     @Environment(BetaFlags.self) private var betaFlags
 
     private let insets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
@@ -29,14 +28,6 @@ struct SettingsAdvancedFeaturesScreen: View {
                     }
                     .padding(insets)
                     .vSeparator(color: .rowSeparator, position: .bottom)
-
-                    SettingsRow(systemImage: "slider.horizontal.3", title: "Bill Designer", insets: insets) {
-                        Task {
-                            router.dismissSheet()
-                            try await Task.delay(milliseconds: 250)
-                            session.isShowingBillDesigner = true
-                        }
-                    }
 
                     SettingsRow(systemImage: "doc.text", title: "Application Logs", insets: insets) {
                         router.push(.settingsApplicationLogs)


### PR DESCRIPTION
Temporarily removes the Bill Designer row from Settings → Advanced Features. The Send Cash toggle and Application Logs row are untouched. This is a temporary removal — revert this PR to restore the row.

## Test plan
- [ ] Open Settings → Advanced Features and confirm the Bill Designer row is gone.
- [ ] Confirm the Send Cash toggle and Application Logs row still work.