### PR TITLE
refactor: present share sheets with SwiftUI ShareLink

### DIFF
--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -81,14 +81,7 @@ struct RecipientPickerScreen: View {
     }
 
     private func presentInvite(for contact: ResolvedContact) {
-        if MessageComposerSheet.isAvailable {
-            inviteTarget = contact
-        } else {
-            // iMessage isn't configured on this device (iPad without SIM, etc.).
-            // Fall back to the system share sheet with the download URL only.
-            logger.info("Presenting share fallback (iMessage unavailable)")
-            ShareSheet.present(url: URL.downloadApp)
-        }
+        inviteTarget = contact
     }
 
     private func refilter() {
@@ -335,35 +328,68 @@ private struct RecipientRowScaffold<Trailing: View>: View {
 
     var body: some View {
         Button(action: onTap) {
-            HStack(spacing: 12) {
-                ContactAvatarView(
-                    id: avatarID,
-                    displayName: title,
-                    imageData: imageData,
-                    size: 44
-                )
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(.appTextMedium)
-                        .foregroundStyle(Color.textMain)
-                        .lineLimit(1)
-                    Text(subtitle)
-                        .font(.appTextSmall)
-                        .foregroundStyle(Color.textSecondary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 12)
+            RecipientRowBody(
+                avatarID: avatarID,
+                title: title,
+                subtitle: subtitle,
+                imageData: imageData
+            ) {
                 trailing
             }
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .listRowInsets(EdgeInsets(top: 14, leading: 20, bottom: 14, trailing: 20))
-        .listRowBackground(Color.clear)
-        .listRowSeparatorTint(.rowSeparator)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Text(accessibilityLabel))
-        .accessibilityAddTraits(.isButton)
+        .recipientRowChrome(accessibilityLabel: accessibilityLabel)
+    }
+}
+
+/// The visual content of a picker row: avatar, title/subtitle, and a trailing
+/// accessory. Shared by the tappable `RecipientRowScaffold` and the `ShareLink`
+/// invite-fallback row.
+private struct RecipientRowBody<Trailing: View>: View {
+
+    let avatarID: String
+    let title: String
+    let subtitle: String
+    let imageData: Data?
+    @ViewBuilder let trailing: Trailing
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ContactAvatarView(
+                id: avatarID,
+                displayName: title,
+                imageData: imageData,
+                size: 44
+            )
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.appTextMedium)
+                    .foregroundStyle(Color.textMain)
+                    .lineLimit(1)
+                Text(subtitle)
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 12)
+            trailing
+        }
+        .contentShape(Rectangle())
+    }
+}
+
+private extension View {
+    /// Row chrome shared by every picker row: list insets, clear background,
+    /// separator tint, and single-element button accessibility. Applied to the
+    /// row's `Button` or `ShareLink`.
+    func recipientRowChrome(accessibilityLabel: String) -> some View {
+        self
+            .buttonStyle(.plain)
+            .listRowInsets(EdgeInsets(top: 14, leading: 20, bottom: 14, trailing: 20))
+            .listRowBackground(Color.clear)
+            .listRowSeparatorTint(.rowSeparator)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text(accessibilityLabel))
+            .accessibilityAddTraits(.isButton)
     }
 }
 
@@ -434,35 +460,61 @@ private struct RecipientListItemRow: View {
     }
 }
 
-/// A "Not on Flipcash Yet" row: the whole row and its trailing button both
-/// start an invite.
+/// A "Not on Flipcash Yet" row. With iMessage available the whole row opens the
+/// invite composer; otherwise it shares the download link through the system
+/// share sheet via `ShareLink`, so SwiftUI owns the presentation.
 private struct RecipientRow: View {
 
     let contact: ResolvedContact
     let onInvite: () -> Void
 
+    private var accessibilityLabel: String {
+        "\(contact.displayName), \(contact.nationalPhone)"
+    }
+
     var body: some View {
-        RecipientRowScaffold(
-            avatarID: contact.contactId,
-            title: contact.displayName,
-            subtitle: contact.nationalPhone,
-            imageData: contact.imageData,
-            accessibilityLabel: "\(contact.displayName), \(contact.nationalPhone)",
-            onTap: onInvite
-        ) {
-            Text("Invite")
-                .font(.appTextSmall)
-                .foregroundStyle(Color.textMain)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background {
-                    RoundedRectangle(cornerRadius: Metrics.buttonRadius)
-                        .fill(Color.backgroundRow)
+        if MessageComposerSheet.isAvailable {
+            RecipientRowScaffold(
+                avatarID: contact.contactId,
+                title: contact.displayName,
+                subtitle: contact.nationalPhone,
+                imageData: contact.imageData,
+                accessibilityLabel: accessibilityLabel,
+                onTap: onInvite
+            ) {
+                InvitePill()
+            }
+            .accessibilityActions {
+                Button("Invite", action: onInvite)
+            }
+        } else {
+            ShareLink(item: URL.downloadApp) {
+                RecipientRowBody(
+                    avatarID: contact.contactId,
+                    title: contact.displayName,
+                    subtitle: contact.nationalPhone,
+                    imageData: contact.imageData
+                ) {
+                    InvitePill()
                 }
+            }
+            .recipientRowChrome(accessibilityLabel: accessibilityLabel)
         }
-        .accessibilityActions {
-            Button("Invite", action: onInvite)
-        }
+    }
+}
+
+/// The trailing "Invite" pill on a "Not on Flipcash Yet" row.
+private struct InvitePill: View {
+    var body: some View {
+        Text("Invite")
+            .font(.appTextSmall)
+            .foregroundStyle(Color.textMain)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background {
+                RoundedRectangle(cornerRadius: Metrics.buttonRadius)
+                    .fill(Color.backgroundRow)
+            }
     }
 }
 

--- a/Flipcash/Core/Screens/Settings/ApplicationLogsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/ApplicationLogsScreen.swift
@@ -9,7 +9,7 @@ import FlipcashCore
 
 struct ApplicationLogsScreen: View {
 
-    @State private var isExporting = false
+    @State private var exportedLogs: URL?
 
     var body: some View {
         Background(color: .backgroundMain) {
@@ -35,27 +35,22 @@ struct ApplicationLogsScreen: View {
 
                 Spacer()
 
-                Button {
-                    isExporting = true
-                    Task {
-                        defer { isExporting = false }
-                        if let url = try? await LogStore.shared.exportLogs() {
-                            ShareSheet.present(url: url)
-                        }
-                    }
-                } label: {
-                    if isExporting {
-                        ProgressView()
-                    } else {
+                if let exportedLogs {
+                    ShareLink(item: exportedLogs) {
                         Text("Share Logs")
                     }
+                    .buttonStyle(.filled)
+                    .padding(20)
+                } else {
+                    ProgressView()
+                        .padding(20)
                 }
-                .buttonStyle(.filled)
-                .disabled(isExporting)
-                .padding(20)
             }
         }
         .navigationTitle("Application Logs")
         .toolbarTitleDisplayMode(.inline)
+        .task {
+            exportedLogs = try? await LogStore.shared.exportLogs()
+        }
     }
 }

--- a/Flipcash/Share/ShareSheet.swift
+++ b/Flipcash/Share/ShareSheet.swift
@@ -21,12 +21,6 @@ enum ShareSheet {
 
         UIApplication.shared.rootViewController?.present(controller, animated: true, completion: nil)
     }
-    
-    static func present(url: URL) {
-        let controller = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-        
-        UIApplication.shared.rootViewController?.present(controller, animated: true, completion: nil)
-    }
 }
 
 // MARK: - UIApplication -

--- a/FlipcashUITests/Regression/ApplicationLogsRegressionTests.swift
+++ b/FlipcashUITests/Regression/ApplicationLogsRegressionTests.swift
@@ -39,7 +39,8 @@ final class ApplicationLogsRegressionTests: BaseUITestCase {
             "Expected description text on the Application Logs screen"
         )
 
-        // Tap "Share Logs" to trigger the export and share sheet
+        // Tap "Share Logs" (a ShareLink over the exported log file) to present
+        // the share sheet.
         waitAndTap(app.buttons["Share Logs"])
 
         // Share sheet actions are cells, not buttons. "Save to Files" only
@@ -47,7 +48,7 @@ final class ApplicationLogsRegressionTests: BaseUITestCase {
         // log export succeeded and produced a real file.
         let saveToFiles = app.cells["Save to Files"]
         XCTAssertTrue(
-            saveToFiles.waitForExistence(timeout: 15),
+            saveToFiles.waitForExistence(timeout: 20),
             "Expected share sheet to appear with Save to Files action"
         )
     }

--- a/FlipcashUITests/Regression/CashLinkRegressionTests.swift
+++ b/FlipcashUITests/Regression/CashLinkRegressionTests.swift
@@ -42,7 +42,7 @@ final class CashLinkRegressionTests: BaseUITestCase {
         // Share sheet appears — tap "Copy" to dismiss it via a completed action.
         let copyButton = app.cells["Copy"]
         XCTAssertTrue(
-            copyButton.waitForExistence(timeout: 10),
+            copyButton.waitForExistence(timeout: 20),
             "Expected the share sheet to appear with a 'Copy' action"
         )
         copyButton.tap()

--- a/FlipcashUITests/Smoke/SendSmokeTests.swift
+++ b/FlipcashUITests/Smoke/SendSmokeTests.swift
@@ -62,32 +62,24 @@ final class SendSmokeTests: BaseUITestCase {
 
         waitAndTap(app.buttons["Anna Haro, (555) 522-8243"].firstMatch)
 
-        // `MFMessageComposeViewController.canSendText()` returns `false`
-        // on the simulator, so `RecipientPickerScreen.presentInvite(for:)`
-        // takes the fallback path and calls `ShareSheet.present(url:)`.
-        // `UIActivityViewController` hosts its actions as cells, not buttons,
-        // since iOS 13.
+        // `MFMessageComposeViewController.canSendText()` returns `false` on the
+        // simulator, so the invite row is a `ShareLink` that presents the system
+        // share sheet. `UIActivityViewController` hosts its actions as cells, not
+        // buttons, since iOS 13.
         let copyCell = app.cells["Copy"]
         XCTAssertTrue(
-            copyCell.waitForExistence(timeout: 10),
+            copyCell.waitForExistence(timeout: 20),
             "Expected the share-sheet fallback (UIActivityViewController) after tapping Invite"
         )
 
-        // Dismiss the share sheet. Its close button's label ("Close") collides
-        // with the Send screen's X behind it, so target it by identifier. Fall
-        // back to "Cancel" (older iOS), then a downward swipe.
-        let close  = app.buttons["header.closeButton"]
-        let cancel = app.buttons["Cancel"]
-        if close.exists {
-            close.tap()
-        } else if cancel.exists {
-            cancel.tap()
-        } else {
-            app.swipeDown(velocity: .fast)
-        }
+        // Tap "Copy" to complete the share and dismiss the sheet (mirrors
+        // CashLinkRegressionTests). A completed action is a deterministic
+        // dismiss that returns to the picker — unlike a swipe or tapping a
+        // close button whose label collides with the Send screen's X.
+        copyCell.tap()
 
         XCTAssertTrue(
-            inviteHeader.waitForExistence(timeout: 10),
+            inviteHeader.waitForExistence(timeout: 15),
             "Expected `RecipientPickerScreen` to remain visible after dismissing the share sheet"
         )
     }


### PR DESCRIPTION
The Application Logs and invite-fallback flows now present the system share sheet through SwiftUI's ShareLink instead of a hand-rolled presentation, matching the rest of the app. This also stabilizes two share-sheet UI tests that were intermittently failing on iOS 26 under the full test suite.

## Test plan
- [x] On Application Logs, tap Share Logs and confirm the share sheet appears with a log file.
- [x] In Send on a device without iMessage, tap a "Not on Flipcash Yet" contact, confirm the share sheet appears, dismiss it, and confirm you're back on the list.
- [x] Create a cash link and confirm the share sheet and "Did you send?" confirmation still work.