### PR TITLE
chore: add send cash and messages to release dogfooding checklist

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -166,6 +166,8 @@ Please verify on the TestFlight build:
 □ Claim a Cash Link on an empty account
 □ Buy a currency with Phantom
 □ Scan & Send between 2 devices
+□ Send cash to a contact
+□ Send a message to a contact
 
 Tell me when you're ready to draft the public release.
 ```


### PR DESCRIPTION
Adds two checks to the release skill's dogfooding gate so on-device verification covers sending cash to a contact and sending a message to a contact, alongside the existing scan-and-send check.

## Test plan
- [x] Run /release and confirm the dogfooding checklist shows the two new items