### PR TITLE
feat: Send unread-conversation badge and send-flow polish

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -107,6 +107,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             lastBackgroundedAt = .now
             sessionContainer?.session.didEnterBackground()
             container.preferences.appDidEnterBackground()
+            sessionContainer?.pushController.clearBadgeCount()
         case .active:
             logger.info("scenePhase → active")
             container.client.warmUpChannel()

--- a/Flipcash/Core/Controllers/BetaFlags.swift
+++ b/Flipcash/Core/Controllers/BetaFlags.swift
@@ -124,7 +124,7 @@ extension BetaFlags {
             case .enableCoinbase:
                 return "Enable Coinbase"
             case .enableSend:
-                return "Enable Send"
+                return "Send Cash"
             }
         }
 

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -37,6 +37,11 @@ final class ConversationController {
         conversations.first { $0.id == id }
     }
 
+    /// Number of conversations with unread messages for the signed-in user.
+    var unreadConversationCount: Int {
+        conversations.filter { $0.hasUnread(for: selfUserID) }.count
+    }
+
     /// The signed-in user, used to tell own messages from the counterpart's.
     let selfUserID: UserID
 

--- a/Flipcash/Core/Controllers/PushController.swift
+++ b/Flipcash/Core/Controllers/PushController.swift
@@ -108,8 +108,9 @@ class PushController {
 
     // MARK: - Badge -
 
-    /// Clears the app icon badge. Called when the app becomes active so a
-    /// server-set badge count doesn't linger after the user has opened the app.
+    /// Clears the app icon badge. Called when the app becomes active and when it
+    /// enters the background, so a server-set badge count doesn't linger after the
+    /// user has opened the app.
     func clearBadgeCount() {
         center.setBadgeCount(0)
     }

--- a/Flipcash/Core/Navigation/AppRouter+Destination.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Destination.swift
@@ -44,6 +44,7 @@ extension AppRouter {
         // Settings flow
         case settingsMyAccount
         case settingsAdvancedFeatures
+        case settingsAdvancedBetaFeatures
         case settingsAppSettings
         case settingsBetaFlags
         case settingsAccountSelection
@@ -79,8 +80,8 @@ extension AppRouter {
                  .usdcDepositEducation, .usdcDepositAddress,
                  .phantomFlow:
                 return .balance
-            case .settingsMyAccount, .settingsAdvancedFeatures, .settingsAppSettings,
-                 .settingsBetaFlags, .settingsAccountSelection,
+            case .settingsMyAccount, .settingsAdvancedFeatures, .settingsAdvancedBetaFeatures,
+                 .settingsAppSettings, .settingsBetaFlags, .settingsAccountSelection,
                  .settingsApplicationLogs, .accessKey, .deposit, .depositCurrencyList,
                  .depositAddress, .withdraw:
                 return .settings
@@ -109,6 +110,7 @@ extension AppRouter {
             case .phantomFlow:                  "phantomFlow"
             case .settingsMyAccount:            "settingsMyAccount"
             case .settingsAdvancedFeatures:     "settingsAdvancedFeatures"
+            case .settingsAdvancedBetaFeatures: "settingsAdvancedBetaFeatures"
             case .settingsAppSettings:          "settingsAppSettings"
             case .settingsBetaFlags:            "settingsBetaFlags"
             case .settingsAccountSelection:     "settingsAccountSelection"
@@ -145,8 +147,8 @@ extension AppRouter {
                 return nil
             case .discoverCurrencies, .currencyCreationSummary, .currencyCreationWizard,
                  .usdcDepositEducation, .usdcDepositAddress,
-                 .settingsMyAccount, .settingsAdvancedFeatures, .settingsAppSettings,
-                 .settingsBetaFlags, .settingsAccountSelection,
+                 .settingsMyAccount, .settingsAdvancedFeatures, .settingsAdvancedBetaFeatures,
+                 .settingsAppSettings, .settingsBetaFlags, .settingsAccountSelection,
                  .settingsApplicationLogs, .accessKey, .deposit, .depositCurrencyList,
                  .withdraw:
                 return nil

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -85,6 +85,9 @@ struct DestinationView: View {
         case .settingsAdvancedFeatures:
             SettingsAdvancedFeaturesScreen()
 
+        case .settingsAdvancedBetaFeatures:
+            SettingsAdvancedBetaFeaturesScreen()
+
         case .settingsAppSettings:
             SettingsAppSettingsScreen()
 

--- a/Flipcash/Core/Screens/Conversation/ConversationMessageRow.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationMessageRow.swift
@@ -262,10 +262,13 @@ struct ConversationCashBubble: View {
                     Flag(style: amount.nativeAmount.currency.flagStyle, size: .regular)
                     Text(displayedAmount.formatted())
                         .font(ConversationBubbleStyle.amountFont)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
                         .foregroundStyle(Color.textMain)
                         .contentTransition(.numericText(value: NSDecimalNumber(decimal: displayedAmount.value).doubleValue))
                 }
             }
+            .padding(.horizontal, 16)
         }
         .frame(width: ConversationBubbleStyle.cashSize.width, height: ConversationBubbleStyle.cashSize.height)
         .bubbleChrome(isFromSelf: isFromSelf, groupedAbove: groupedAbove, groupedBelow: groupedBelow)

--- a/Flipcash/Core/Screens/Conversation/ConversationTranscript.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationTranscript.swift
@@ -178,7 +178,7 @@ struct ConversationTranscriptRow: View {
 
 /// Distance from the bottom edge (in points) within which the scroll view is
 /// considered "at the bottom" for auto-scroll purposes.
-private nonisolated let bottomThreshold: CGFloat = 80
+private nonisolated let bottomThreshold: CGFloat = 90
 
 /// The transcript's container and content heights, sampled together so the follow
 /// can tell genuine content growth from a keyboard-driven container resize.
@@ -281,7 +281,7 @@ private struct ScrollToNewestButton: View {
         Button(action: action) {
             Image(systemName: "arrow.down")
                 .font(.body.weight(.semibold))
-                .frame(width: 32, height: 32)
+                .frame(width: 44, height: 44)
                 .contentShape(.interaction, Circle())
         }
         .buttonStyle(.plain)

--- a/Flipcash/Core/Screens/Main/ScanBottomBar.swift
+++ b/Flipcash/Core/Screens/Main/ScanBottomBar.swift
@@ -9,6 +9,7 @@ import FlipcashUI
 struct ScanBottomBar: View {
     let toast: String?
     let showSend: Bool
+    let sendBadgeCount: Int
     let onGive: () -> Void
     let onWallet: () -> Void
     let onDiscover: () -> Void
@@ -34,6 +35,7 @@ struct ScanBottomBar: View {
                 LargeButton(
                     title: "Send",
                     image: Image(.Icons.send),
+                    badgeCount: sendBadgeCount,
                     action: onSend
                 )
                 .accessibilityIdentifier("scan-send-button")

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -256,6 +256,7 @@ struct ScanScreen: View {
             ScanBottomBar(
                 toast: toast,
                 showSend: session.canSend,
+                sendBadgeCount: sessionContainer.conversationController.unreadConversationCount,
                 onGive: presentGive,
                 onWallet: { router.present(.balance) },
                 onDiscover: { router.present(.discover) },

--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedBetaFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedBetaFeaturesScreen.swift
@@ -1,0 +1,39 @@
+//
+//  SettingsAdvancedBetaFeaturesScreen.swift
+//  Flipcash
+//
+//  Created by Raul Riera on 2026-06-18.
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+struct SettingsAdvancedBetaFeaturesScreen: View {
+
+    @Environment(BetaFlags.self) private var betaFlags
+
+    private let insets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "paperplane")
+                            .frame(minWidth: 45)
+                        Toggle("Send Cash", isOn: betaFlags.bindingFor(option: .enableSend))
+                            .tint(.textSuccess)
+                    }
+                    .padding(insets)
+                    .vSeparator(color: .rowSeparator, position: .bottom)
+                }
+                .font(.appDisplayXS)
+                .foregroundStyle(.textMain)
+                .padding(.horizontal, 20)
+            }
+        }
+        .navigationTitle("Beta Features")
+        .toolbarTitleDisplayMode(.inline)
+    }
+}

--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
@@ -12,7 +12,6 @@ import FlipcashUI
 struct SettingsAdvancedFeaturesScreen: View {
 
     @Environment(AppRouter.self) private var router
-    @Environment(BetaFlags.self) private var betaFlags
 
     private let insets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
 
@@ -20,14 +19,9 @@ struct SettingsAdvancedFeaturesScreen: View {
         Background(color: .backgroundMain) {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: 12) {
-                        Image(systemName: "paperplane")
-                            .frame(minWidth: 45)
-                        Toggle("Beta Feature: Send Cash", isOn: betaFlags.bindingFor(option: .enableSend))
-                            .tint(.textSuccess)
+                    SettingsRow(asset: .debug, title: "Beta Features", badge: .beta, insets: insets) {
+                        router.push(.settingsAdvancedBetaFeatures)
                     }
-                    .padding(insets)
-                    .vSeparator(color: .rowSeparator, position: .bottom)
 
                     SettingsRow(systemImage: "doc.text", title: "Application Logs", insets: insets) {
                         router.push(.settingsApplicationLogs)
@@ -38,7 +32,7 @@ struct SettingsAdvancedFeaturesScreen: View {
                 .padding(.horizontal, 20)
             }
         }
-        .navigationTitle("Advanced Features")
+        .navigationTitle("Advanced")
         .toolbarTitleDisplayMode(.inline)
     }
 }

--- a/Flipcash/Core/Screens/Settings/SettingsRow.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsRow.swift
@@ -48,3 +48,8 @@ struct SettingsRow: View {
         }
     }
 }
+
+extension Badge {
+    /// The "Beta" pill shown on settings rows that gate beta features.
+    static let beta = Badge(decoration: .circle(.textWarning), text: "Beta")
+}

--- a/Flipcash/Core/Screens/Settings/SettingsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsScreen.swift
@@ -57,16 +57,16 @@ struct SettingsScreen: View {
                                 router.push(.settingsAppSettings)
                             }
 
-                            SettingsRow(asset: .sliders, title: "Advanced Features", insets: insets) {
+                            SettingsRow(asset: .sliders, title: "Advanced", insets: insets) {
                                 router.push(.settingsAdvancedFeatures)
                             }
 
                             if betaFlags.accessGranted {
-                                SettingsRow(asset: .debug, title: "Beta Features", badge: betaBadge, insets: insets) {
+                                SettingsRow(asset: .debug, title: "Beta Features", badge: .beta, insets: insets) {
                                     router.push(.settingsBetaFlags)
                                 }
 
-                                SettingsRow(asset: .switchAccounts, title: "Switch Accounts", badge: betaBadge, insets: insets) {
+                                SettingsRow(asset: .switchAccounts, title: "Switch Accounts", badge: .beta, insets: insets) {
                                     router.push(.settingsAccountSelection)
                                 }
                             }
@@ -103,10 +103,6 @@ struct SettingsScreen: View {
             .appRouterDestinations(container: container, sessionContainer: sessionContainer)
         }
     }
-
-    // MARK: - Helpers -
-
-    private let betaBadge = Badge(decoration: .circle(.textWarning), text: "Beta")
 
     // MARK: - Actions -
 

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -48,6 +48,45 @@ struct ConversationControllerTests {
         #expect(controller.conversations.map(\.id) == [ConversationID.test(2), ConversationID.test(1)])
     }
 
+    @Test("unreadConversationCount counts only conversations with unread messages")
+    func unreadConversationCount() async {
+        let me = UUID()
+        let mock = MockConversations()
+        mock.feed = [
+            // Unread: last message is past the self read pointer.
+            Conversation(
+                id: ConversationID.test(1),
+                members: [ConversationMember(userID: me, displayName: "", readPointer: MessageID(value: 1))],
+                lastMessage: ConversationMessage(id: MessageID(value: 5), senderID: nil, content: .text("x"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0),
+                lastActivity: Date(timeIntervalSince1970: 400)
+            ),
+            // Read: the read pointer covers the last message.
+            Conversation(
+                id: ConversationID.test(2),
+                members: [ConversationMember(userID: me, displayName: "", readPointer: MessageID(value: 5))],
+                lastMessage: ConversationMessage(id: MessageID(value: 5), senderID: nil, content: .text("y"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0),
+                lastActivity: Date(timeIntervalSince1970: 300)
+            ),
+            // Empty: no last message is never unread.
+            Conversation(
+                id: ConversationID.test(3),
+                members: [ConversationMember(userID: me, displayName: "")],
+                lastMessage: nil,
+                lastActivity: Date(timeIntervalSince1970: 200)
+            ),
+            // Unread: a message with no read pointer.
+            Conversation(
+                id: ConversationID.test(4),
+                members: [ConversationMember(userID: me, displayName: "", readPointer: nil)],
+                lastMessage: ConversationMessage(id: MessageID(value: 2), senderID: nil, content: .text("z"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0),
+                lastActivity: Date(timeIntervalSince1970: 100)
+            ),
+        ]
+        let controller = makeController(mock, selfUserID: me)
+        await controller.loadFeed()
+        #expect(controller.unreadConversationCount == 2)
+    }
+
     @Test("send records the message and appends it to the conversation")
     func send() async {
         let mock = MockConversations()

--- a/FlipcashUI/Sources/FlipcashUI/Views/Bubble.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Bubble.swift
@@ -13,7 +13,8 @@ public struct Bubble: View {
     public let size: Size
     public let count: Int
     public let hasMore: Bool
-    
+    public let color: Color
+
     private var decoration: String {
         if hasMore {
             return "+"
@@ -21,13 +22,14 @@ public struct Bubble: View {
             return ""
         }
     }
-    
-    public init(size: Size, count: Int, hasMore: Bool = false) {
+
+    public init(size: Size, count: Int, hasMore: Bool = false, color: Color = .textSuccess) {
         self.size = size
         self.count = count
         self.hasMore = hasMore
+        self.color = color
     }
-    
+
     public var body: some View {
         Text("\(count)\(decoration)")
             .foregroundStyle(.textMain)
@@ -36,7 +38,7 @@ public struct Bubble: View {
             .padding(.vertical, 2)
             .padding(.horizontal, 6)
             .frame(minWidth: size.dimension, minHeight: size.dimension)
-            .background(Color.textSuccess)
+            .background(color)
             .cornerRadius(999)
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
@@ -38,51 +38,54 @@ public struct LargeButton: View {
 
 // MARK: - Icon -
 
-/// The 40×40 button icon. When `badgeCount > 0` it carries a count badge whose
-/// pill is clipped out of the icon — a badge-shaped hole is masked away so the
-/// background shows through the ring around the pill, like a native app-icon badge.
+/// The 40×40 button icon. When `badgeCount > 0` it carries a count badge that is
+/// clipped out of the icon: the pill draws over a `destinationOut` capsule that
+/// erases a ring around it, so the background shows through — like a native
+/// app-icon badge. The pill and its hole are one view, so they scale and fade
+/// together as the badge transitions in and out.
 private struct LargeButtonIcon: View {
 
     let image: Image
     let badgeCount: Int
 
-    private let ring: CGFloat = 2
+    /// Resting size of the pill (a touch smaller than its natural size) and the
+    /// transparent gap punched around it.
+    private let badgeScale: CGFloat = 0.85
+    private let ring: CGFloat = 3
     private let offset = CGSize(width: 14, height: -10)
 
-    private var displayCount: Int { min(badgeCount, 100) }
-    private var showsMore: Bool { badgeCount > 100 }
+    /// Holds the last non-zero count so the pill keeps showing it while it
+    /// animates out, instead of flashing "0".
+    @State private var shownCount = 0
+
+    private var displayCount: Int { min(shownCount, 100) }
+    private var showsMore: Bool { shownCount > 100 }
+    private var isVisible: Bool { badgeCount > 0 }
 
     var body: some View {
-        let icon = image
+        image
             .resizable()
             .scaledToFit()
             .frame(width: 40, height: 40)
-
-        if badgeCount > 0 {
-            icon
-                .mask(alignment: .topTrailing) {
-                    // Keep the whole icon except a badge-shaped hole — the pill plus
-                    // a thin ring — punched out of it. A hidden Bubble sizes the hole
-                    // to the pill so it tracks the count width ("5" vs "100+").
-                    Rectangle()
-                        .overlay(alignment: .topTrailing) {
-                            Bubble(size: .regular, count: displayCount, hasMore: showsMore)
-                                .fixedSize()
-                                .hidden()
-                                .padding(ring)
-                                .background(Capsule().fill(Color.black).blendMode(.destinationOut))
-                                .offset(x: offset.width, y: offset.height)
-                        }
-                        .compositingGroup()
-                }
-                .overlay(alignment: .topTrailing) {
-                    Bubble(size: .regular, count: displayCount, hasMore: showsMore, color: .unreadIndicator)
-                        .fixedSize()
-                        .offset(x: offset.width, y: offset.height)
-                }
-        } else {
-            icon
-        }
+            .overlay(alignment: .topTrailing) {
+                Bubble(size: .regular, count: displayCount, hasMore: showsMore, color: .unreadIndicator)
+                    .fixedSize()
+                    .padding(ring)
+                    .background(Capsule().fill(Color.black).blendMode(.destinationOut))
+                    // Explicit scaleEffect anchored on the pill's own center so it
+                    // grows/shrinks in place. (`.transition(.scale)` here anchors on
+                    // the compositingGroup's bounds — the whole icon — and drifts.)
+                    .scaleEffect(isVisible ? badgeScale : 0, anchor: .center)
+                    .opacity(isVisible ? 1 : 0)
+                    .offset(x: offset.width, y: offset.height)
+            }
+            // Scopes the `destinationOut` erase to the icon + badge only, so the
+            // ring punches through the icon rather than the screen behind it.
+            .compositingGroup()
+            .animation(.bouncy, value: badgeCount > 0)
+            .onChange(of: badgeCount, initial: true) { _, newValue in
+                if newValue > 0 { shownCount = newValue }
+            }
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
@@ -12,27 +12,77 @@ public struct LargeButton: View {
 
     private let title: String
     private let image: Image
+    private let badgeCount: Int
     private let action: VoidAction
 
-    public init(title: String, image: Image, action: @escaping VoidAction) {
-        self.title  = title
-        self.image  = image
-        self.action = action
+    public init(title: String, image: Image, badgeCount: Int = 0, action: @escaping VoidAction) {
+        self.title      = title
+        self.image      = image
+        self.badgeCount = badgeCount
+        self.action     = action
     }
 
     public var body: some View {
         Button(action: action) {
             VStack(spacing: 12) {
-                image
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 40, height: 40)
+                LargeButtonIcon(image: image, badgeCount: badgeCount)
                 Text(title)
                     .font(.appTextSmall)
             }
             .frame(maxWidth: .infinity, minHeight: 80, alignment: .bottom)
         }
         .foregroundStyle(.textMain)
+        .accessibilityValue(badgeCount > 0 ? "\(badgeCount) unread" : "")
+    }
+}
+
+// MARK: - Icon -
+
+/// The 40×40 button icon. When `badgeCount > 0` it carries a count badge whose
+/// pill is clipped out of the icon — a badge-shaped hole is masked away so the
+/// background shows through the ring around the pill, like a native app-icon badge.
+private struct LargeButtonIcon: View {
+
+    let image: Image
+    let badgeCount: Int
+
+    private let ring: CGFloat = 2
+    private let offset = CGSize(width: 14, height: -10)
+
+    private var displayCount: Int { min(badgeCount, 100) }
+    private var showsMore: Bool { badgeCount > 100 }
+
+    var body: some View {
+        let icon = image
+            .resizable()
+            .scaledToFit()
+            .frame(width: 40, height: 40)
+
+        if badgeCount > 0 {
+            icon
+                .mask(alignment: .topTrailing) {
+                    // Keep the whole icon except a badge-shaped hole — the pill plus
+                    // a thin ring — punched out of it. A hidden Bubble sizes the hole
+                    // to the pill so it tracks the count width ("5" vs "100+").
+                    Rectangle()
+                        .overlay(alignment: .topTrailing) {
+                            Bubble(size: .regular, count: displayCount, hasMore: showsMore)
+                                .fixedSize()
+                                .hidden()
+                                .padding(ring)
+                                .background(Capsule().fill(Color.black).blendMode(.destinationOut))
+                                .offset(x: offset.width, y: offset.height)
+                        }
+                        .compositingGroup()
+                }
+                .overlay(alignment: .topTrailing) {
+                    Bubble(size: .regular, count: displayCount, hasMore: showsMore, color: .unreadIndicator)
+                        .fixedSize()
+                        .offset(x: offset.width, y: offset.height)
+                }
+        } else {
+            icon
+        }
     }
 }
 
@@ -42,7 +92,8 @@ public struct LargeButton: View {
     Background(color: .backgroundMain) {
         HStack(alignment: .bottom) {
             LargeButton(title: "History", image: .asset(.history)) {}
-            LargeButton(title: "Invites", image: .asset(.invites)) {}
+            LargeButton(title: "Invites", image: .asset(.invites), badgeCount: 5) {}
+            LargeButton(title: "Send", image: .asset(.history), badgeCount: 150) {}
         }
     }
 }


### PR DESCRIPTION
Polishes the send flow. The Send button now shows a badge with the number of conversations that have unread messages — it animates in and out and clears when you open a conversation. Also adds a Beta Features section under Settings > Advanced for the Send Cash toggle, clears the notification badge when the app enters the background, enlarges the chat scroll-to-newest button, and keeps cash amounts in chat on a single line.

## Test plan
- [ ] The Send button shows a badge counting conversations with unread messages.
- [ ] The badge animates in and out, and clears after opening a conversation.
- [ ] Settings > Advanced > Beta Features contains the Send Cash toggle.
- [ ] The app icon badge clears when the app goes to the background.
- [ ] The chat scroll-to-newest button is comfortable to tap.
- [ ] Large cash amounts in chat stay on one line.