### PR TITLE
test: fix AllTargets after Settings "Advanced" rename

### DIFF
--- a/FlipcashTests/TestSupport/WaitForState.swift
+++ b/FlipcashTests/TestSupport/WaitForState.swift
@@ -17,7 +17,7 @@ import Testing
 @MainActor
 func waitUntil<Object: AnyObject>(
     _ object: Object,
-    timeout: Duration = .seconds(2),
+    timeout: Duration = .seconds(10),
     pollInterval: Duration = .milliseconds(5),
     sourceLocation: SourceLocation = #_sourceLocation,
     matches predicate: @MainActor (Object) -> Bool

--- a/FlipcashUITests/Support/Screens/SettingsScreen.swift
+++ b/FlipcashUITests/Support/Screens/SettingsScreen.swift
@@ -20,7 +20,7 @@ struct SettingsUIScreen {
 
     var myAccountRow: XCUIElement { app.buttons["My Account"] }
     var withdrawButton: XCUIElement { app.buttons["Withdraw"] }
-    var advancedFeaturesRow: XCUIElement { app.buttons["Advanced Features"] }
+    var advancedFeaturesRow: XCUIElement { app.buttons["Advanced"] }
     var accessKeyRow: XCUIElement { app.buttons["Access Key"] }
     var depositButton: XCUIElement { app.buttons["Deposit"] }
     var applicationLogsRow: XCUIElement { app.buttons["Application Logs"] }


### PR DESCRIPTION
Two test-only fixes that unblock AllTargets after the Settings reorganization in #389.

The UI test helper still looked for the old "Advanced Features" Settings row, which #389 renamed to "Advanced", so the Application Logs navigation test failed. Separately, a 2-second wait helper intermittently timed out under the full suite's load, so its default ceiling is raised to 10 seconds (it polls and exits on success, so passing tests are unaffected).

## Test plan
- [ ] AllTargets passes, including the Application Logs and Apple Pay Coinbase tests.