### PR TITLE
feat: suppress notifications for the open chat

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -45,6 +45,12 @@ final class ConversationController {
     /// The signed-in user, used to tell own messages from the counterpart's.
     let selfUserID: UserID
 
+    /// The conversation currently on screen, set by `ConversationScreen` while
+    /// it's visible and cleared when it leaves. Read by the push delegate to
+    /// suppress foreground banners for the open chat; never drives a view, so
+    /// it's excluded from observation.
+    @ObservationIgnored var visibleConversationID: ConversationID?
+
     private var store = ConversationStore()
 
     @ObservationIgnored private let fetching: any ConversationFetching

--- a/Flipcash/Core/Controllers/PushController.swift
+++ b/Flipcash/Core/Controllers/PushController.swift
@@ -28,6 +28,13 @@ class PushController {
     /// The current notification authorization status, refreshed on app activation.
     private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
 
+    /// Queried in the foreground to decide whether an incoming chat push targets
+    /// the conversation the user is already viewing, in which case it's suppressed.
+    var isViewingConversation: (@MainActor (ConversationID) -> Bool)? {
+        get { delegate.isViewingConversation }
+        set { delegate.isViewingConversation = newValue }
+    }
+
     @ObservationIgnored private let owner: KeyPair
     @ObservationIgnored private let client: FlipClient
     @ObservationIgnored private let center: UNUserNotificationCenter
@@ -184,7 +191,8 @@ extension PushController {
 private class NotificationDelegate: NSObject, @preconcurrency UNUserNotificationCenterDelegate, @preconcurrency MessagingDelegate {
     
     var didReceiveFCMToken: (@MainActor (String?) async throws -> Void)?
-    
+    var isViewingConversation: (@MainActor (ConversationID) -> Bool)?
+
     override init() {
         super.init()
     }
@@ -198,9 +206,11 @@ private class NotificationDelegate: NSObject, @preconcurrency UNUserNotification
             "body":     "\(notification.request.content.body)",
         ])
         
-        Messaging.messaging().appDidReceiveMessage(notification.request.content.userInfo)
+        let userInfo = notification.request.content.userInfo
 
-        postContactJoinIfNeeded(notification.request.content.userInfo)
+        Messaging.messaging().appDidReceiveMessage(userInfo)
+
+        postContactJoinIfNeeded(userInfo)
 
         // We intentionally don't call handleTargetUrlIfNeeded here.
         // Deep link navigation should only happen when user taps the notification,
@@ -210,7 +220,17 @@ private class NotificationDelegate: NSObject, @preconcurrency UNUserNotification
         Task { @MainActor in
             NotificationCenter.default.post(name: .pushNotificationWillPresent, object: nil)
         }
-        
+
+        // Stay silent for the conversation the user is already reading; other
+        // chats and every non-chat push still present normally.
+        if let conversationID = NotificationPayload.chatID(userInfo),
+           isViewingConversation?(conversationID) == true {
+            logger.info("Suppressing chat push for the open conversation", metadata: [
+                "conversationID": "\(conversationID)",
+            ])
+            return []
+        }
+
         return [.badge, .list, .sound, .banner]
     }
     

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -221,11 +221,25 @@ struct ConversationScreen: View {
             conversationController.scheduleMarkRead(conversationID: conversationID)
         }
         .onAppear {
+            // Suppress foreground chat banners while this transcript is on
+            // screen — set every appear, including a pop back from Send.
+            conversationController.visibleConversationID = conversationID
             if hasAppeared {
                 refreshChatBinding()
             } else {
                 captureSeenBoundaryIfNeeded()
                 hasAppeared = true
+            }
+        }
+        // A matched contact's chat is created mid-screen on the first payment,
+        // flipping the ID from nil to the new conversation; track it live.
+        .onChange(of: conversationID) { _, id in
+            conversationController.visibleConversationID = id
+        }
+        .onDisappear {
+            // Guarded so a forward push that already set another ID isn't cleared.
+            if conversationController.visibleConversationID == conversationID {
+                conversationController.visibleConversationID = nil
             }
         }
     }

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -532,6 +532,12 @@ struct SessionContainer {
         )
         conversationController.start()
         self.conversationController = conversationController
+
+        // Suppress foreground chat pushes for the conversation that's currently
+        // on screen — the user is already reading it.
+        pushController.isViewingConversation = { [weak conversationController] conversationID in
+            conversationController?.visibleConversationID == conversationID
+        }
     }
 
     fileprivate func injectingEnvironment<SomeView>(into view: SomeView) -> some View where SomeView: View {

--- a/FlipcashCore/Sources/FlipcashCore/Push/NotificationPayload.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Push/NotificationPayload.swift
@@ -28,4 +28,12 @@ public enum NotificationPayload {
     public static func isContactJoin(_ userInfo: [AnyHashable: Any]) -> Bool {
         decode(userInfo)?.category == .contactJoin
     }
+
+    /// The conversation a CHAT push targets, or `nil` when the push isn't a chat
+    /// message or carries no chat navigation.
+    public static func chatID(_ userInfo: [AnyHashable: Any]) -> ConversationID? {
+        guard let payload = decode(userInfo), payload.category == .chat else { return nil }
+        guard case .chatID(let chatID) = payload.navigation.type else { return nil }
+        return ConversationID(chatID)
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/Push/NotificationPayloadTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/Push/NotificationPayloadTests.swift
@@ -72,4 +72,70 @@ struct NotificationPayloadTests {
         let garbage = Data([0xff, 0xff, 0xff, 0xff, 0xff]).base64EncodedString()
         #expect(NotificationPayload.decode([NotificationPayload.userInfoKey: garbage]) == nil)
     }
+
+    // MARK: - chatID
+
+    /// The 32-byte ChatId used across the chat-targeting tests.
+    private static let chatIDBytes = Data((0..<32).map { UInt8($0) })
+
+    private static func base64(for payload: Flipcash_Push_V1_Payload) throws -> String {
+        try payload.serializedData().base64EncodedString()
+    }
+
+    @Test("chatID returns the target conversation for a CHAT push")
+    func chatIDForChatPush() throws {
+        let payload = Flipcash_Push_V1_Payload.with {
+            $0.category = .chat
+            $0.navigation = .with { $0.chatID = .with { $0.value = Self.chatIDBytes } }
+        }
+        let userInfo = [NotificationPayload.userInfoKey: try Self.base64(for: payload)]
+        #expect(NotificationPayload.chatID(userInfo) == ConversationID(data: Self.chatIDBytes))
+    }
+
+    @Test("chatID resolves a CHAT push nested under aps")
+    func chatIDNestedUnderAps() throws {
+        let payload = Flipcash_Push_V1_Payload.with {
+            $0.category = .chat
+            $0.navigation = .with { $0.chatID = .with { $0.value = Self.chatIDBytes } }
+        }
+        let userInfo = ["aps": [NotificationPayload.userInfoKey: try Self.base64(for: payload)]]
+        #expect(NotificationPayload.chatID(userInfo) == ConversationID(data: Self.chatIDBytes))
+    }
+
+    @Test("chatID is nil for a non-chat payload")
+    func chatIDNilForNonChat() {
+        #expect(NotificationPayload.chatID([NotificationPayload.userInfoKey: Self.knownPayloadBase64]) == nil)
+    }
+
+    @Test("chatID is nil for a CHAT push without chat navigation")
+    func chatIDNilWhenNavigationMissing() throws {
+        let payload = Flipcash_Push_V1_Payload.with { $0.category = .chat }
+        let userInfo = [NotificationPayload.userInfoKey: try Self.base64(for: payload)]
+        #expect(NotificationPayload.chatID(userInfo) == nil)
+    }
+
+    @Test("chatID is nil for a non-chat category even when chat navigation is present")
+    func chatIDNilForNonChatCategoryWithChatNavigation() throws {
+        let payload = Flipcash_Push_V1_Payload.with {
+            $0.category = .default
+            $0.navigation = .with { $0.chatID = .with { $0.value = Self.chatIDBytes } }
+        }
+        let userInfo = [NotificationPayload.userInfoKey: try Self.base64(for: payload)]
+        #expect(NotificationPayload.chatID(userInfo) == nil)
+    }
+
+    @Test("chatID is nil for a CHAT push whose navigation targets currency info")
+    func chatIDNilForCurrencyInfoNavigation() throws {
+        let payload = Flipcash_Push_V1_Payload.with {
+            $0.category = .chat
+            $0.navigation = .with { $0.currencyInfo = .with { $0.value = Self.chatIDBytes } }
+        }
+        let userInfo = [NotificationPayload.userInfoKey: try Self.base64(for: payload)]
+        #expect(NotificationPayload.chatID(userInfo) == nil)
+    }
+
+    @Test("chatID is nil when no payload is present")
+    func chatIDNilWhenAbsent() {
+        #expect(NotificationPayload.chatID([:]) == nil)
+    }
 }


### PR DESCRIPTION
When you're reading a conversation, push notifications for new messages in that same chat no longer interrupt you with a banner. Messages from other chats, and every non-chat notification, still come through as before. The app already marks those messages as read while you're viewing them, so silencing the banner keeps the two consistent. Suppression only applies while the chat is on screen — backgrounding the app or moving to another screen restores normal notifications.

## Test plan
- [ ] Open a chat and receive a new message in it — no banner appears
- [ ] While in one chat, receive a message in a different chat — banner appears
- [ ] Receive a non-chat notification while viewing a chat — banner appears
- [ ] Background the app while in a chat, then receive a message in it — banner appears