### PR TITLE
fix: read receipts show the relative day, not just the time

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -79,11 +79,12 @@ extension ChatItem {
         return items
     }
 
-    /// "Read 3:42 PM" once the counterpart's read pointer reaches the message, else "Delivered".
+    /// "Read 3:42 PM" / "Read Yesterday" / "Read Monday" / "Read Tue, Jun 17" once the counterpart's
+    /// read pointer reaches the message, else "Delivered".
     private static func receiptText(for messageID: MessageID, counterpartRead: (pointer: MessageID, date: Date?)?) -> String {
         guard let read = counterpartRead, read.pointer >= messageID else { return "Delivered" }
         guard let date = read.date else { return "Read" }
-        return "Read \(date.formattedTime())"
+        return "Read \(date.formattedRelatively(useTimeForToday: true))"
     }
 
     /// "Today 12:13 PM" / "Yesterday 9:05 AM" / "Jun 18 4:30 PM".

--- a/FlipcashCore/Sources/FlipcashCore/Formatters/DateFormatter.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Formatters/DateFormatter.swift
@@ -25,14 +25,6 @@ extension DateFormatter {
         return f
     }()
     
-    public static let relativeTime: DateFormatter = {
-        let f = DateFormatter()
-        f.dateStyle = .none
-        f.timeStyle = .short
-        f.doesRelativeDateFormatting = true
-        return f
-    }()
-    
     public static let timeFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateStyle = .none

--- a/FlipcashCore/Tests/FlipcashCoreTests/FormattedRelativelyTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/FormattedRelativelyTests.swift
@@ -1,0 +1,54 @@
+//
+//  FormattedRelativelyTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+
+/// `formattedRelatively` buckets a date relative to the current day, so dates are built relative
+/// to `.now` at noon to keep them clear of midnight boundaries. The literal day/time strings assume
+/// the en_US test environment; the weekday case derives its expectation independently so it holds
+/// in any locale.
+@Suite("Date.formattedRelatively")
+struct FormattedRelativelyTests {
+
+    private let calendar = Calendar.current
+
+    private func daysAgo(_ days: Int) -> Date {
+        let noonToday = calendar.date(bySettingHour: 12, minute: 0, second: 0, of: .now)!
+        return calendar.date(byAdding: .day, value: -days, to: noonToday)!
+    }
+
+    @Test("Today renders the relative day, or the time of day when requested")
+    func today() {
+        let noonToday = daysAgo(0)
+        #expect(noonToday.formattedRelatively() == "Today")
+        // The time of day, not the relative day. The exact AM/PM separator and 12-/24-hour shape
+        // are locale-dependent, so assert the noon time is present rather than a fixed literal.
+        let withTime = noonToday.formattedRelatively(useTimeForToday: true)
+        #expect(withTime != "Today")
+        #expect(withTime.contains("12:00"))
+    }
+
+    @Test("Yesterday renders the relative day whether or not the time is requested")
+    func yesterday() {
+        let date = daysAgo(1)
+        #expect(date.formattedRelatively() == "Yesterday")
+        #expect(date.formattedRelatively(useTimeForToday: true) == "Yesterday")
+    }
+
+    @Test("Dates two through six days ago render the weekday name", arguments: 2...6)
+    func weekdayWithinTheWeek(daysAgo offset: Int) {
+        let date = daysAgo(offset)
+        let weekday = calendar.weekdaySymbols[calendar.component(.weekday, from: date) - 1]
+        #expect(date.formattedRelatively() == weekday)
+    }
+
+    @Test("Dates older than a week render an abbreviated weekday, month, and day")
+    func olderThanAWeek() {
+        let result = daysAgo(30).formattedRelatively()
+        #expect(result.wholeMatch(of: /[A-Za-z]{3}, [A-Za-z]{3} \d{2}/) != nil)
+    }
+}

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -38,6 +38,10 @@ struct ChatMessageMappingTests {
         items.filter { if case .dateSeparator = $0 { true } else { false } }.count
     }
 
+    private func receiptText(_ items: [ChatItem]) -> String? {
+        items.compactMap { if case .receipt(_, let text) = $0 { text } else { nil } }.last
+    }
+
     @Test("Same-sender run within the gap groups; a sender change breaks it; gaps add separators")
     func grouping() {
         let messages = [
@@ -96,5 +100,41 @@ struct ChatMessageMappingTests {
         #expect(cash.token == "Cash")
         #expect(cash.amount == fiat.nativeAmount.formatted())
         #expect(cash.flagImageName != nil) // currency flag derived from the currency
+    }
+
+    @Test("The latest sent message reads Delivered until the read pointer reaches it")
+    func receiptDelivered() {
+        let items = ChatItem.from(
+            [text(1, me, "hi", after: 0)],
+            selfUserID: me,
+            counterpartRead: (pointer: MessageID(value: 0), date: nil)
+        )
+        #expect(receiptText(items) == "Delivered")
+    }
+
+    @Test("A read pointer without a timestamp reads Read")
+    func receiptReadWithoutDate() {
+        let items = ChatItem.from(
+            [text(1, me, "hi", after: 0)],
+            selfUserID: me,
+            counterpartRead: (pointer: MessageID(value: 1), date: nil)
+        )
+        #expect(receiptText(items) == "Read")
+    }
+
+    @Test("A read from days ago renders the relative day, not a bare time")
+    func receiptUsesRelativeDay() {
+        // Guards the hookup: with the old `formattedTime()` this read as "Read 3:42 PM".
+        let calendar = Calendar.current
+        let noon = calendar.date(bySettingHour: 12, minute: 0, second: 0, of: .now)!
+        let threeDaysAgo = calendar.date(byAdding: .day, value: -3, to: noon)!
+        let weekday = calendar.weekdaySymbols[calendar.component(.weekday, from: threeDaysAgo) - 1]
+
+        let items = ChatItem.from(
+            [text(1, me, "hi", after: 0)],
+            selfUserID: me,
+            counterpartRead: (pointer: MessageID(value: 1), date: threeDaysAgo)
+        )
+        #expect(receiptText(items) == "Read \(weekday)")
     }
 }


### PR DESCRIPTION
A read receipt only ever showed the time a message was read, so a message read days ago gave no sense of when. It now shows the relative day instead — the time if it was read today, "Yesterday", a weekday earlier in the week, or the date for older reads — by reusing the existing relative date formatter. Also removes an unused date formatter.

## Test plan
- [x] A message read today shows the time under it.
- [x] A message read yesterday shows "Yesterday".
- [x] A message read earlier this week shows the weekday name.
- [x] A message read over a week ago shows the date.