### PR TITLE
fix: reset event-stream reconnect backoff on a healthy ping, not on open

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
@@ -33,15 +33,13 @@ public actor EventStreamer {
     private var streamReference: StreamReference?
     private var isStreaming = false
     private var isReconnecting = false
-    private var reconnectAttempts = 0
+    private var backoff = ReconnectBackoff()
     private var reconnectTask: Task<Void, Never>?
     private var pingTimeoutTask: Task<Void, Never>?
     private var pingTracker = PingTracker()
     /// Bumped on every `openStream()`; gRPC callbacks capture the value at open
     /// time so a torn-down stream's late status can't tear down its replacement.
     private var streamGeneration: UInt = 0
-    private static let maxReconnectDelay: TimeInterval = 30
-    private static let baseReconnectDelay: TimeInterval = 1
 
     init(service: EventStreamingService) {
         self.service = service
@@ -85,7 +83,7 @@ public actor EventStreamer {
     public func stop() {
         isStreaming = false
         isReconnecting = false
-        reconnectAttempts = 0
+        backoff.reset()
         owner = nil
         pingTimeoutTask?.cancel()
         pingTimeoutTask = nil
@@ -113,7 +111,6 @@ public actor EventStreamer {
         pingTimeoutTask = nil
         pingTracker = PingTracker()
         isReconnecting = false
-        reconnectAttempts = 0
 
         streamGeneration += 1
         let generation = streamGeneration
@@ -174,6 +171,11 @@ public actor EventStreamer {
     }
 
     private func handlePing(_ ping: Flipcash_Event_V1_ServerPing) {
+        // A received ping is the stream's proof of life — the only safe point to
+        // clear the reconnect backoff, so a stream that dies before its first ping
+        // keeps escalating the delay instead of hammering reconnect.
+        backoff.reset()
+
         let timeout = pingTracker.receivedPing(updatedTimeout: Int(ping.pingDelay.seconds))
         schedulePingTimeout(seconds: timeout)
 
@@ -235,7 +237,7 @@ public actor EventStreamer {
         reconnectTask?.cancel()
         reconnectTask = nil
         isReconnecting = false
-        reconnectAttempts = 0
+        backoff.reset()
         streamReference?.destroy()
         streamReference = nil
     }
@@ -259,15 +261,11 @@ public actor EventStreamer {
         streamReference?.destroy()
         streamReference = nil
 
-        reconnectAttempts += 1
-        let delay = min(
-            Self.baseReconnectDelay * pow(2.0, Double(reconnectAttempts - 1)),
-            Self.maxReconnectDelay
-        )
+        let delay = backoff.next()
 
         logger.debug("Reconnecting event stream", metadata: [
             "delaySeconds": "\(delay)",
-            "attempt": "\(reconnectAttempts)",
+            "attempt": "\(backoff.attempts)",
         ])
 
         reconnectTask = Task { [weak self] in

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/LiveMintDataStreamer.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/LiveMintDataStreamer.swift
@@ -28,7 +28,7 @@ public actor LiveMintDataStreamer {
     private var subscribedMints: Set<PublicKey> = []
     private var isStreaming = false
     private var isReconnecting = false
-    private var reconnectAttempts = 0
+    private var backoff = ReconnectBackoff()
     private var reconnectTask: Task<Void, Never>?
     private var pingTimeoutTask: Task<Void, Never>?
     private var pingTracker = PingTracker()
@@ -41,8 +41,6 @@ public actor LiveMintDataStreamer {
     /// The server typically aborts the stream in response, so the next
     /// close should reconnect immediately without backoff.
     private var sentSubscriptionUpdate = false
-    private static let maxReconnectDelay: TimeInterval = 30.0
-    private static let baseReconnectDelay: TimeInterval = 1.0
 
     // MARK: - Init
 
@@ -99,7 +97,7 @@ public actor LiveMintDataStreamer {
         isStreaming = false
         isReconnecting = false
         sentSubscriptionUpdate = false
-        reconnectAttempts = 0
+        backoff.reset()
         pingTimeoutTask?.cancel()
         pingTimeoutTask = nil
         pingTracker = PingTracker()
@@ -153,9 +151,7 @@ public actor LiveMintDataStreamer {
         pingTimeoutTask = nil
         pingTracker = PingTracker()
 
-        // Reset reconnect state on successful stream open
         isReconnecting = false
-        reconnectAttempts = 0
 
         logger.info("Opening live mint data stream", metadata: ["count": "\(subscribedMints.count)"])
 
@@ -226,6 +222,11 @@ public actor LiveMintDataStreamer {
     }
 
     private func handlePing(_ ping: Ocp_Common_V1_ServerPing) {
+        // A received ping is the stream's proof of life — the only safe point to
+        // clear the reconnect backoff, so a stream that dies before its first ping
+        // keeps escalating the delay instead of hammering reconnect.
+        backoff.reset()
+
         let timeout = pingTracker.receivedPing(updatedTimeout: Int(ping.pingDelay.seconds))
         schedulePingTimeout(seconds: timeout)
 
@@ -295,7 +296,7 @@ public actor LiveMintDataStreamer {
         reconnectTask?.cancel()
         reconnectTask = nil
         isReconnecting = false
-        reconnectAttempts = 0
+        backoff.reset()
         streamReference?.destroy()
         streamReference = nil
     }
@@ -335,19 +336,13 @@ public actor LiveMintDataStreamer {
         streamReference?.destroy()
         streamReference = nil
 
-        // Calculate exponential backoff delay
-        reconnectAttempts += 1
-        let delay = min(
-            Self.baseReconnectDelay * pow(2.0, Double(reconnectAttempts - 1)),
-            Self.maxReconnectDelay
-        )
+        let delay = backoff.next()
 
         logger.debug("Reconnecting live mint data stream", metadata: [
             "delaySeconds": "\(delay)",
-            "attempt": "\(reconnectAttempts)"
+            "attempt": "\(backoff.attempts)"
         ])
 
-        // Delay before reconnecting with exponential backoff
         reconnectTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled else { return }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Utilities/ReconnectBackoff.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Utilities/ReconnectBackoff.swift
@@ -1,0 +1,30 @@
+//
+//  ReconnectBackoff.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+/// Returns an exponentially growing reconnect delay, capped at `maxDelay`, that
+/// increases with each consecutive failure.
+///
+/// Call `reset()` only once the connection proves healthy (a received ping) —
+/// resetting on stream open pins the delay at `baseDelay` and defeats the backoff.
+struct ReconnectBackoff {
+
+    private static let baseDelay: TimeInterval = 1
+    private static let maxDelay: TimeInterval = 30
+
+    private(set) var attempts = 0
+
+    /// Records a failed attempt and returns how long to wait before retrying.
+    mutating func next() -> TimeInterval {
+        attempts += 1
+        return min(Self.baseDelay * pow(2, Double(attempts - 1)), Self.maxDelay)
+    }
+
+    /// Clears the failure count after the connection proves healthy.
+    mutating func reset() {
+        attempts = 0
+    }
+}

--- a/FlipcashTests/ReconnectBackoffTests.swift
+++ b/FlipcashTests/ReconnectBackoffTests.swift
@@ -1,0 +1,40 @@
+//
+//  ReconnectBackoffTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("ReconnectBackoff")
+struct ReconnectBackoffTests {
+
+    // MARK: - next -
+
+    @Test("next doubles each attempt, then caps at the maximum")
+    func next_doublesThenCaps() {
+        var backoff = ReconnectBackoff()
+        // Doubles per attempt — then capped at 30 once 2^n would exceed it.
+        let expected: [TimeInterval] = [1, 2, 4, 8, 16, 30, 30, 30]
+        for delay in expected {
+            #expect(backoff.next() == delay)
+        }
+    }
+
+    // MARK: - reset -
+
+    @Test("Reset returns the delay to the base after consecutive failures")
+    func reset_returnsToBase() {
+        var backoff = ReconnectBackoff()
+        _ = backoff.next() // 1
+        _ = backoff.next() // 2
+        _ = backoff.next() // 4
+        #expect(backoff.attempts == 3)
+
+        backoff.reset()
+
+        #expect(backoff.attempts == 0)
+        #expect(backoff.next() == 1)
+    }
+}


### PR DESCRIPTION
## Summary

The app's event stream could fall into a permanent one-second reconnect loop and never recover — a brief network blip turned into an endless storm of reconnect attempts. The retry backoff was being reset every time a connection was opened, so it never actually backed off. It now resets only once a connection is proven healthy, so repeated failures wait progressively longer and the stream settles. The same flaw existed in the live rates stream and is fixed alongside it.

## Test plan

- [x] Use the app for a few minutes and confirm the event stream stays connected without repeated reconnect spam in the logs.
- [x] Briefly drop and restore the network, and confirm the event stream reconnects and recovers.
- [x] Confirm exchange rates keep updating after a connection blip.