### PR TITLE
fix: resolve Auto Layout constraint warnings in chat cells

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -71,9 +71,16 @@ public final class ChatCashCardCell: UICollectionViewCell {
         leadingConstraint = card.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12)
         trailingConstraint = card.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12)
 
+        // The card has a fixed height, so pinning it to both the top and bottom of the contentView
+        // would conflict with ChatLayout's estimated cell height during the first (pre-self-sizing)
+        // layout pass. The bottom pin yields (priority 999) to that estimate, avoiding an
+        // unsatisfiable-constraints break while still driving the cell to self-size to the card.
+        let cardBottom = card.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        cardBottom.priority = UILayoutPriority(999)
+
         NSLayoutConstraint.activate([
             card.topAnchor.constraint(equalTo: contentView.topAnchor),
-            card.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            cardBottom,
             card.widthAnchor.constraint(equalToConstant: Self.cardSize.width),
             card.heightAnchor.constraint(equalToConstant: Self.cardSize.height),
 
@@ -139,9 +146,13 @@ public final class ChatCashCardCell: UICollectionViewCell {
         applyAlignment(isFromSelf: message.sender == .me)
     }
 
+    /// Exactly one horizontal edge is pinned, so the fixed-width card hugs its sender's side.
+    /// Both edges are deactivated before the wanted one is activated: momentarily pinning both
+    /// edges over-constrains the card's fixed width and trips Auto Layout's unsatisfiable-
+    /// constraints check when the cell is recycled with a flipped sender.
     private func applyAlignment(isFromSelf: Bool) {
-        leadingConstraint.isActive = !isFromSelf
-        trailingConstraint.isActive = isFromSelf
+        NSLayoutConstraint.deactivate([leadingConstraint, trailingConstraint])
+        (isFromSelf ? trailingConstraint : leadingConstraint).isActive = true
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
@@ -50,11 +50,13 @@ public final class ChatMessageCell: UICollectionViewCell {
         applyAlignment(isFromSelf: message.sender == .me)
     }
 
-    /// Exactly one horizontal edge is pinned, so the bubble hugs its content and the
-    /// opposite edge floats — the cell never holds both constraints active at once.
+    /// Exactly one horizontal edge is pinned, so the bubble hugs its content and the opposite
+    /// edge floats. Both edges are deactivated before the wanted one is activated: a recycled cell
+    /// still carries its prior encapsulated layout width, so momentarily pinning both edges
+    /// over-constrains its width and trips Auto Layout's unsatisfiable-constraints check.
     private func applyAlignment(isFromSelf: Bool) {
-        leadingConstraint.isActive = !isFromSelf
-        trailingConstraint.isActive = isFromSelf
+        NSLayoutConstraint.deactivate([leadingConstraint, trailingConstraint])
+        (isFromSelf ? trailingConstraint : leadingConstraint).isActive = true
     }
 }
 


### PR DESCRIPTION
Opening a conversation logged "unable to simultaneously satisfy constraints" warnings from both the message rows and the cash-payment rows. The cash row pinned its fixed-size card to both the top and bottom of its cell, which clashed with the list's estimated row height before the row had sized itself. Separately, both row types briefly pinned a bubble to the left and right edges at the same time while a row was being recycled for a message from the opposite sender. Both rows now lay out cleanly.

## Test plan
- [x] Open a conversation that contains cash payments and confirm no constraint warnings appear in the console.
- [x] Scroll the conversation up and down and confirm no warnings appear as rows recycle.
- [x] Confirm sent bubbles hug the right edge, received bubbles hug the left, and cash cards are sized correctly.