### PR TITLE
fix: animate the chat bar swap when dismissing the keyboard

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -24,7 +24,8 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     let onReachTop: () -> Void
     let showsSendCash: Bool
     let showsSendMessage: Bool
-    @Binding var isComposing: Bool
+    /// Reports the bar's composing state so the screen can drive `interactiveDismissDisabled`.
+    let onComposingChange: (Bool) -> Void
     let conversationID: ConversationID?
     let onSendCash: () -> Void
     let conversationController: ConversationController
@@ -74,9 +75,9 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
             ConversationBottomBar(
                 showsSendCash: showsSendCash,
                 showsSendMessage: showsSendMessage,
-                isComposing: $isComposing,
                 conversationID: conversationID,
-                onSendCash: onSendCash
+                onSendCash: onSendCash,
+                onComposingChange: onComposingChange
             )
             .environment(conversationController)
             // Take the natural height at the proposed width so the composer can grow to its full

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -10,19 +10,22 @@ import FlipcashCore
 import FlipcashUI
 
 /// Send Cash / Send Message buttons, swapped for the message composer while
-/// composing. Pinned via `.safeAreaInset`; native keyboard avoidance handles
-/// the rest.
+/// composing. Hosted inside the UIKit chat screen, pinned to the keyboard.
 struct ConversationBottomBar: View {
 
     let showsSendCash: Bool
     let showsSendMessage: Bool
-    @Binding var isComposing: Bool
     let conversationID: ConversationID?
     let onSendCash: () -> Void
+    /// Reports composing state to the host, which drives `interactiveDismissDisabled`.
+    let onComposingChange: (Bool) -> Void
 
     @Environment(ConversationController.self) private var conversationController
     @State private var draft = ""
     @State private var isSending = false
+    /// Local @State, not an injected binding — the swap only animates when composing
+    /// changes inside the bar's own view tree.
+    @State private var isComposing = false
     @FocusState private var isComposerFocused: Bool
 
     /// Action bar ⇄ composer swap — the button group springs in/out (scaling
@@ -69,6 +72,7 @@ struct ConversationBottomBar: View {
         .onChange(of: isComposerFocused) { _, focused in
             if !focused { isComposing = false }
         }
+        .onChange(of: isComposing) { _, composing in onComposingChange(composing) }
     }
 
     private func send() {

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -141,7 +141,7 @@ struct ConversationScreen: View {
             onReachTop: loadOlderMessages,
             showsSendCash: sendTarget != nil,
             showsSendMessage: chatExists,
-            isComposing: $isComposing,
+            onComposingChange: { isComposing = $0 },
             conversationID: conversationID,
             onSendCash: sendCash,
             conversationController: conversationController


### PR DESCRIPTION
The Send Cash and Send Message buttons used to appear instantly when the keyboard was dismissed, instead of quickly scaling up like the previous version did. This restores that scale-up by letting the bar own its composing state directly, so SwiftUI can animate the swap between the composer and the buttons rather than having it delivered through the hosted view, which lands it with no animation.

## Test plan
- [x] Open a chat, tap Send Message, then dismiss the keyboard — the buttons scale up smoothly instead of appearing instantly.
- [x] Type a draft, dismiss the keyboard, and reopen the composer — the draft is still there.
- [x] While composing, swipe down — the keyboard lowers without dismissing the Send sheet.