### PR TITLE
fix: render received cash cards live on iOS 26

### DIFF
--- a/FlipcashTests/Chat/ChatCashCardSizingTests.swift
+++ b/FlipcashTests/Chat/ChatCashCardSizingTests.swift
@@ -1,0 +1,61 @@
+//
+//  ChatCashCardSizingTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import UIKit
+import ChatLayout
+@testable import FlipcashUI
+
+/// The cash card is a fixed-size row, so `ChatViewController` reports an exact height for it. That
+/// makes an inserted cash cell lay out at its real 170pt height immediately, instead of being placed
+/// at ChatLayout's small estimate and depending on a follow-up self-size pass — a pass iOS 26 skips
+/// during the animated batch update, which left the card clipped to the estimate (invisible) until
+/// the chat was reopened. Text/date/receipt rows keep self-sizing.
+@MainActor
+@Suite("Cash rows report an exact height; other rows self-size")
+struct ChatCashCardSizingTests {
+
+    private func sized(_ items: [ChatItem], at index: Int) -> ItemSize {
+        let controller = ChatViewController()
+        controller.update(items: items)
+        let layout = controller.collectionViewLayout as! CollectionViewChatLayout
+        return controller.sizeForItem(layout, at: IndexPath(item: index, section: 0))
+    }
+
+    private func cashRow(_ id: String, _ sender: ChatMessage.Sender) -> ChatItem {
+        .message(ChatMessage(
+            id: id,
+            content: .cash(ChatCashContent(amount: "$0.01", token: "Launch It", flagImageName: "ca")),
+            sender: sender
+        ))
+    }
+
+    @Test("A cash row reports an exact height equal to the card height")
+    func cashRow_isExactCardHeight() {
+        let items: [ChatItem] = [
+            .message(ChatMessage(id: "1", text: "hi", sender: .me)),
+            cashRow("2", .other),
+        ]
+        guard case .exact(let size) = sized(items, at: 1) else {
+            Issue.record("expected the cash row to report an exact size")
+            return
+        }
+        #expect(size.height == ChatCashCardCell.cardSize.height)
+    }
+
+    @Test("Text, date separator, and receipt rows keep self-sizing (.auto)")
+    func nonCashRows_areAuto() {
+        let items: [ChatItem] = [
+            .dateSeparator(id: "sep", text: "Today 1:00 PM"),
+            .message(ChatMessage(id: "1", text: "hello", sender: .other)),
+            .receipt(id: "r", text: "Delivered"),
+        ]
+        for index in items.indices {
+            #expect(sized(items, at: index) == .auto, "row \(index) should self-size")
+        }
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -18,7 +18,7 @@ public final class ChatCashCardCell: UICollectionViewCell {
     public static let reuseIdentifier = "ChatCashCardCell"
 
     /// The card's fixed footprint.
-    private static let cardSize = CGSize(width: 232, height: 170)
+    static let cardSize = CGSize(width: 232, height: 170)
 
     private let card = BubbleBackgroundView()
     private let coinIcon = UIImageView()
@@ -112,6 +112,17 @@ public final class ChatCashCardCell: UICollectionViewCell {
         super.prepareForReuse()
         iconTask?.cancel()
         coinIcon.image = nil
+    }
+
+    /// The card is a fixed height, so supply it directly rather than letting the cell self-size.
+    /// An inserted cell is placed at ChatLayout's small estimate and is supposed to self-size up on
+    /// the next pass — but iOS 26 skips that pass during an animated batch update, leaving the card
+    /// clipped to the estimate (the bottom pin is only priority 999, so nothing forces the height).
+    /// Returning the height here makes it deterministic. Per ChatLayout's contract, do NOT call
+    /// `super` — it re-measures via Auto Layout and re-trips the estimate-vs-999 conflict.
+    public override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+        layoutAttributes.frame.size.height = Self.cardSize.height
+        return layoutAttributes
     }
 
     public func configure(with message: ChatMessage) {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -279,9 +279,19 @@ public final class ChatViewController: UICollectionViewController {
     }
 }
 
-/// Defaults give `.auto` self-sizing and `.fullWidth` alignment — exactly right for rows
-/// that align their own bubble. Nothing to override.
-extension ChatViewController: ChatLayoutDelegate {}
+/// `.auto` self-sizing and `.fullWidth` alignment fit the text/date/receipt rows, which size to
+/// their own content. The cash card is a fixed 232×170 footprint, so it gets an exact height: an
+/// inserted self-sizing cell is placed at the small estimate and relies on a follow-up self-size
+/// pass that iOS 26 skips mid-animated-batch-update, leaving the card clipped to the estimate.
+/// An exact size is applied on insert with no self-size pass, so it can't regress.
+extension ChatViewController: ChatLayoutDelegate {
+    public func sizeForItem(_ chatLayout: CollectionViewChatLayout, at indexPath: IndexPath) -> ItemSize {
+        if case .message(let message) = items[indexPath.item], case .cash = message.content {
+            return .exact(CGSize(width: collectionView.bounds.width, height: ChatCashCardCell.cardSize.height))
+        }
+        return .auto
+    }
+}
 
 #Preview("Transcript") {
     let controller = ChatViewController()


### PR DESCRIPTION
Received cash payments weren't appearing in an open conversation on iOS 26 — they only showed up after leaving and reopening the chat, while text messages (and iOS 18) were fine. The cash card was the only chat row whose height wasn't held by a required constraint, so on iOS 26 a freshly inserted card stayed collapsed to the layout's placeholder height and rendered blank. It now reports its fixed height to the layout directly, so it appears immediately on arrival.

## Test plan
- [x] Receive a cash payment while the chat is open on an iOS 26 device — the card appears immediately without reopening
- [x] Receive a text and a cash payment together — both appear in order
- [x] Confirm cash cards still render correctly on iOS 18
- [x] Scroll a chat with mixed sent and received cash — no layout glitches