### PR TITLE
feat: chat Send Cash as a sheet, chat as the deeplink root

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -218,7 +218,9 @@ struct DeepLinkAction {
         case .chat(let conversationID):
             if case .loggedIn(let container) = sessionAuthenticator.state {
                 Analytics.deeplinkRouted(kind: kind)
-                container.appRouter.navigate(to: .dmConversation(.existing(conversationID)))
+                // Present the chat as the root (bottom) sheet so anything stacked
+                // on top — Send Cash — reveals the chat when dismissed.
+                container.appRouter.present(.conversation(.existing(conversationID)))
             }
 
         case .openSheet(let sheet):

--- a/Flipcash/Core/Navigation/AppRouter+Destination.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Destination.swift
@@ -61,13 +61,12 @@ extension AppRouter {
         case depositAddress(PublicKey)
         case withdraw
 
-        // Send flow
-        case sendAmount(contact: ResolvedContact)
-
         // Conversation flow
         /// A DM conversation, pushed from the Chats section of the recipient
         /// picker (`.existing`) or by tapping a synced contact (`.contact`) —
         /// in that case the chat may not exist yet; the first payment creates it.
+        /// Send Cash presents the amount entry as `SheetPresentation.sendAmount`
+        /// over this; deeplinks enter the chat as `SheetPresentation.conversation`.
         case dmConversation(ConversationContext)
 
         /// The stack this destination naturally belongs in. Cross-stack
@@ -85,7 +84,7 @@ extension AppRouter {
                  .settingsApplicationLogs, .accessKey, .deposit, .depositCurrencyList,
                  .depositAddress, .withdraw:
                 return .settings
-            case .sendAmount, .dmConversation:
+            case .dmConversation:
                 return .send
             }
         }
@@ -120,7 +119,6 @@ extension AppRouter {
             case .depositCurrencyList:          "depositCurrencyList"
             case .depositAddress:               "depositAddress"
             case .withdraw:                     "withdraw"
-            case .sendAmount:                   "sendAmount"
             case .dmConversation:               "dmConversation"
             }
         }
@@ -137,8 +135,6 @@ extension AppRouter {
                  .withdrawCurrency(let mint),
                  .depositAddress(let mint):
                 return mint.base58
-            case .sendAmount(let contact):
-                return contact.contactId
             case .dmConversation(.existing(let conversationID)):
                 return conversationID.description
             case .dmConversation(.contact(let contact)):

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -181,15 +181,6 @@ struct DestinationView: View {
         case .phantomFlow(let fundingOperation):
             PhantomFlowScreen(fundingOperation: fundingOperation)
 
-        // MARK: - Send flow
-
-        case .sendAmount(let contact):
-            SendAmountScreen(
-                sessionContainer: sessionContainer,
-                contact: contact
-            )
-            .id(contact)
-
         // MARK: - Conversation flow
 
         case .dmConversation(let context):

--- a/Flipcash/Core/Navigation/AppRouter+NestedSheet.swift
+++ b/Flipcash/Core/Navigation/AppRouter+NestedSheet.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import FlipcashCore
+import FlipcashUI
 
 extension View {
 
@@ -80,7 +81,13 @@ private struct NestedSheetRootView: View {
                 sessionContainer: sessionContainer
             )
 
-        case .balance, .settings, .give, .discover, .downloadApp, .send:
+        case .sendAmount(let contact):
+            SendAmountSheetRoot(
+                contact: contact,
+                sessionContainer: sessionContainer
+            )
+
+        case .balance, .settings, .give, .discover, .downloadApp, .send, .conversation:
             // Root-only sheets — they shouldn't be presented as nested. If
             // they ever are, we fall through to an empty view; the warning
             // in `presentNested` logs the mistake.
@@ -121,6 +128,28 @@ private struct BuySheetRoot: View {
             // share the same screens reached from the Wallet sheet, so register
             // the app-wide destination map here too.
             .appRouterDestinations(container: container, sessionContainer: sessionContainer)
+        }
+    }
+}
+
+/// Root view for the `.sendAmount(contact)` nested sheet — Send Cash stacks it on
+/// top of the chat. The `NavigationStack` is unbound: nothing pushes onto this
+/// stack, so it exists only to render the screen's toolbar.
+private struct SendAmountSheetRoot: View {
+
+    let contact: ResolvedContact
+    let sessionContainer: SessionContainer
+
+    @Environment(AppRouter.self) private var router
+
+    var body: some View {
+        NavigationStack {
+            SendAmountScreen(sessionContainer: sessionContainer, contact: contact)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        CloseButton(action: router.dismissSheet)
+                    }
+                }
         }
     }
 }

--- a/Flipcash/Core/Navigation/AppRouter+SheetPresentation.swift
+++ b/Flipcash/Core/Navigation/AppRouter+SheetPresentation.swift
@@ -21,6 +21,14 @@ extension AppRouter {
         case buy(PublicKey)
         case downloadApp
         case send
+        /// A DM conversation as a root sheet — the chat is the bottom view.
+        /// Entered via deeplink / push notification (`present(.conversation)`)
+        /// so no recipient picker sits beneath it. The picker → chat flow keeps
+        /// pushing `Destination.dmConversation` onto the `.send` stack instead.
+        case conversation(ConversationContext)
+        /// Send Cash amount entry, stacked on top of the chat via
+        /// `presentNested(.sendAmount)`. Dismissing it reveals the chat.
+        case sendAmount(ResolvedContact)
 
         var id: Self { self }
 
@@ -29,13 +37,15 @@ extension AppRouter {
         /// re-presentation starts at root rather than restoring the stale leaf.
         var stack: Stack {
             switch self {
-            case .balance:     .balance
-            case .settings:    .settings
-            case .give:        .give
-            case .discover:    .discover
-            case .buy:         .buy
-            case .downloadApp: .downloadApp
-            case .send:        .send
+            case .balance:      .balance
+            case .settings:     .settings
+            case .give:         .give
+            case .discover:     .discover
+            case .buy:          .buy
+            case .downloadApp:  .downloadApp
+            case .send:         .send
+            case .conversation: .conversation
+            case .sendAmount:   .sendAmount
             }
         }
 
@@ -44,13 +54,15 @@ extension AppRouter {
         /// comparing the stringly-typed `description`.
         var caseKind: CaseKind {
             switch self {
-            case .balance:     .balance
-            case .settings:    .settings
-            case .give:        .give
-            case .discover:    .discover
-            case .buy:         .buy
-            case .downloadApp: .downloadApp
-            case .send:        .send
+            case .balance:      .balance
+            case .settings:     .settings
+            case .give:         .give
+            case .discover:     .discover
+            case .buy:          .buy
+            case .downloadApp:  .downloadApp
+            case .send:         .send
+            case .conversation: .conversation
+            case .sendAmount:   .sendAmount
             }
         }
 
@@ -62,17 +74,21 @@ extension AppRouter {
             case buy
             case downloadApp
             case send
+            case conversation
+            case sendAmount
         }
 
         var description: String {
             switch self {
-            case .balance:     "balance"
-            case .settings:    "settings"
-            case .give:        "give"
-            case .discover:    "discover"
-            case .buy:         "buy"
-            case .downloadApp: "downloadApp"
-            case .send:        "send"
+            case .balance:      "balance"
+            case .settings:     "settings"
+            case .give:         "give"
+            case .discover:     "discover"
+            case .buy:          "buy"
+            case .downloadApp:  "downloadApp"
+            case .send:         "send"
+            case .conversation: "conversation"
+            case .sendAmount:   "sendAmount"
             }
         }
     }

--- a/Flipcash/Core/Navigation/AppRouter+Stack.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Stack.swift
@@ -20,34 +20,41 @@ extension AppRouter {
         case buy
         case downloadApp
         case send
+        case conversation
+        case sendAmount
 
         /// The sheet a stack is presented in. Cross-stack navigation uses
         /// this to know which top-level modal to surface.
         ///
-        /// `.buy` returns `nil` — its sheet carries a mint payload that can't
-        /// be synthesized from the stack alone. Buy is always entered via
-        /// `router.presentNested(.buy(mint))` directly, never via `navigate(to:)`.
+        /// `.buy`, `.conversation`, and `.sendAmount` return `nil` — their
+        /// sheets carry a payload (mint / conversation / contact) that can't be
+        /// synthesized from the stack alone, so they're entered via
+        /// `presentNested`/`present` directly, never via `navigate(to:)`.
         var sheet: SheetPresentation? {
             switch self {
-            case .balance:     .balance
-            case .settings:    .settings
-            case .give:        .give
-            case .discover:    .discover
-            case .buy:         nil
-            case .downloadApp: .downloadApp
-            case .send:        .send
+            case .balance:      .balance
+            case .settings:     .settings
+            case .give:         .give
+            case .discover:     .discover
+            case .buy:          nil
+            case .downloadApp:  .downloadApp
+            case .send:         .send
+            case .conversation: nil
+            case .sendAmount:   nil
             }
         }
 
         var description: String {
             switch self {
-            case .balance:     "balance"
-            case .settings:    "settings"
-            case .give:        "give"
-            case .discover:    "discover"
-            case .buy:         "buy"
-            case .downloadApp: "downloadApp"
-            case .send:        "send"
+            case .balance:      "balance"
+            case .settings:     "settings"
+            case .give:         "give"
+            case .discover:     "discover"
+            case .buy:          "buy"
+            case .downloadApp:  "downloadApp"
+            case .send:         "send"
+            case .conversation: "conversation"
+            case .sendAmount:   "sendAmount"
             }
         }
     }

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -37,7 +37,6 @@ struct ConversationScreen: View {
 
     @State private var didInitialRead = false
     @State private var isComposing = false
-    @State private var hasAppeared = false
     @State private var navBarWidth: CGFloat = 0
 
     /// Horizontal space the back button (leading) reserves on each side of the
@@ -194,14 +193,14 @@ struct ConversationScreen: View {
             conversationController.scheduleMarkRead(conversationID: conversationID)
         }
         .onAppear {
-            // Suppress foreground chat banners while this transcript is on
-            // screen — set every appear, including a pop back from Send.
+            // Suppress foreground chat banners while this transcript is on screen.
             conversationController.visibleConversationID = conversationID
-            if hasAppeared {
-                refreshChatBinding()
-            } else {
-                hasAppeared = true
-            }
+        }
+        // Send Cash stacks the amount entry as a cover, so the chat stays
+        // mounted and `onAppear` won't re-fire when it's dismissed. Poll for the
+        // chat the first payment just created the moment that cover tears down.
+        .onChange(of: router.presentedSheet) { old, _ in
+            if case .sendAmount? = old { refreshChatBinding() }
         }
         // A matched contact's chat is created mid-screen on the first payment,
         // flipping the ID from nil to the new conversation; track it live.
@@ -224,7 +223,7 @@ struct ConversationScreen: View {
             }
             return
         }
-        router.push(.sendAmount(contact: sendTarget))
+        router.presentNested(.sendAmount(sendTarget))
     }
 
     /// Fetches the next older page when the UIKit transcript nears the top. Guarded so the

--- a/Flipcash/Core/Screens/Conversation/ConversationSheetRoot.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationSheetRoot.swift
@@ -1,0 +1,30 @@
+//
+//  ConversationSheetRoot.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+
+/// Root view for the `.conversation` sheet — a chat entered as the bottom view
+/// via deeplink / push notification. The `NavigationStack` is unbound: nothing
+/// pushes onto this stack, so it exists only to render the toolbar. The trailing
+/// close button is the root-sheet counterpart to the back button the pushed
+/// `.dmConversation` entry gets (push → back, root sheet → close).
+struct ConversationSheetRoot: View {
+
+    let context: ConversationContext
+
+    @Environment(AppRouter.self) private var router
+
+    var body: some View {
+        NavigationStack {
+            ConversationScreen(context: context)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        CloseButton(action: router.dismissSheet)
+                    }
+                }
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -403,6 +403,16 @@ private struct RoutedSheet: View {
             }
         case .send:
             SendRootScreen(container: container, sessionContainer: sessionContainer)
+        case .conversation(let context):
+            // A chat entered as the root (bottom) view — deeplink / push
+            // notification. The picker → chat flow pushes `.dmConversation`
+            // onto the `.send` stack instead.
+            ConversationSheetRoot(context: context)
+        case .sendAmount:
+            // Nested-only sheet — Send Cash enters it via
+            // `presentNested(.sendAmount)`. Rendering EmptyView at root is a
+            // defensive no-op, mirroring `.buy`.
+            EmptyView()
         }
     }
 }

--- a/Flipcash/Core/Screens/Send/SendAmountScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountScreen.swift
@@ -63,7 +63,7 @@ struct SendAmountScreen: View {
                     case .success:
                         didSucceed = true
                     case .recipientNotFound:
-                        router.popTopmost()
+                        router.dismissSheet()
                         throw SendDismissed()
                     case .failed:
                         throw SendDismissed()
@@ -92,16 +92,19 @@ struct SendAmountScreen: View {
         .onChange(of: viewModel.depositMint) { _, mint in
             guard let mint else { return }
             viewModel.depositMint = nil
-            router.push(.currencyInfoForDeposit(mint))
+            // Adding cash is a Wallet flow, so cross-stack to its Currency Info
+            // (which auto-presents Buy) rather than burying it in the Send sheet —
+            // `navigate` also keeps Buy from stacking a third level deep.
+            router.navigate(to: .currencyInfoForDeposit(mint))
         }
-        // Hold the success checkmark briefly, then return to the contact list.
+        // Hold the success checkmark briefly, then dismiss back to the chat.
         // Tied to the view via `.task` so a dismissal during the hold cancels
-        // the pop instead of firing it on a screen that's already gone.
+        // the dismiss instead of firing it on a screen that's already gone.
         .task(id: didSucceed) {
             guard didSucceed else { return }
             try? await Task.delay(seconds: 1)
             guard !Task.isCancelled else { return }
-            router.popTopmost()
+            router.dismissSheet()
         }
         .sheet(isPresented: $isShowingTokenSelection) {
             SelectCurrencyScreen(isPresented: $isShowingTokenSelection) { balance in

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -12,9 +12,9 @@ private let logger = Logger(label: "flipcash.send-amount")
 @Observable
 final class SendAmountViewModel {
 
-    /// Result of a send attempt. `.success` and `.recipientNotFound` both return
-    /// the screen to the contact list; `.failed` keeps it on amount entry. Error
-    /// copy is surfaced internally via `session.dialogItem`.
+    /// Result of a send attempt. `.success` and `.recipientNotFound` both dismiss
+    /// the sheet back to the chat; `.failed` keeps it on amount entry. Error copy
+    /// is surfaced internally via `session.dialogItem`.
     enum SendOutcome: Equatable {
         case success
         case recipientNotFound

--- a/FlipcashTests/Navigation/AppRouterConversationSendTests.swift
+++ b/FlipcashTests/Navigation/AppRouterConversationSendTests.swift
@@ -1,0 +1,145 @@
+//
+//  AppRouterConversationSendTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import SwiftUI
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("AppRouter Conversation & Send Cash sheets")
+struct AppRouterConversationSendTests {
+
+    private static let conversationID = ConversationID.test(0x01)
+
+    private static let contact = ResolvedContact(
+        contactId: "contact-anna",
+        displayName: "Anna",
+        phoneE164: "+15555550001",
+        nationalPhone: "(555) 555-0001",
+        imageData: nil,
+        dmChatID: nil
+    )
+
+    private static var existingContext: ConversationContext {
+        .existing(conversationID)
+    }
+
+    // MARK: - Sheet ↔ Stack wiring
+
+    @Test(".conversation and .sendAmount map to their own stacks")
+    func sheets_mapToOwnStacks() {
+        #expect(AppRouter.SheetPresentation.conversation(Self.existingContext).stack == .conversation)
+        #expect(AppRouter.SheetPresentation.sendAmount(Self.contact).stack == .sendAmount)
+    }
+
+    @Test(".conversation and .sendAmount stacks are never navigate(to:) targets")
+    func stacks_haveNoSynthesizableSheet() {
+        // Like .buy, these carry a payload that can't be rebuilt from the stack
+        // alone, so navigate(to:) must never resolve them.
+        #expect(AppRouter.Stack.conversation.sheet == nil)
+        #expect(AppRouter.Stack.sendAmount.sheet == nil)
+    }
+
+    // MARK: - Chat as the deeplink root
+
+    @Test("present(.conversation) makes the chat the root — no picker beneath")
+    func presentConversation_isRoot() {
+        let router = AppRouter()
+
+        router.present(.conversation(Self.existingContext))
+
+        #expect(router.presentedSheets == [.conversation(Self.existingContext)])
+        #expect(router.rootSheet == .conversation(Self.existingContext))
+        #expect(router.presentedSheet == .conversation(Self.existingContext))
+    }
+
+    @Test("a second chat deeplink swaps the root to the new conversation")
+    func presentConversation_differentChat_swapsRoot() {
+        // `.conversation` is the first root-level sheet with a payload, so
+        // same-case-different-payload at the root (a second chat notification)
+        // is a path the nested-`.buy` swap tests don't cover.
+        let router = AppRouter()
+        let chatA = ConversationContext.existing(.test(0x01))
+        let chatB = ConversationContext.existing(.test(0x02))
+        router.present(.conversation(chatA))
+
+        router.present(.conversation(chatB))
+
+        #expect(router.presentedSheets == [.conversation(chatB)])
+        #expect(router.rootSheet == .conversation(chatB))
+    }
+
+    // MARK: - Send Cash over a pushed chat (picker flow)
+
+    @Test("presentNested(.sendAmount) over .send stacks the amount sheet")
+    func sendAmount_overSend_stacks() {
+        let router = AppRouter()
+        router.present(.send)                       // recipient picker
+        router.push(.dmConversation(.contact(Self.contact)))  // chat pushed on the picker
+
+        router.presentNested(.sendAmount(Self.contact))
+
+        #expect(router.presentedSheets == [.send, .sendAmount(Self.contact)])
+        #expect(router.rootSheet == .send)
+        #expect(router.presentedSheet == .sendAmount(Self.contact))
+    }
+
+    @Test("dismissSheet reveals the pushed chat under the amount sheet")
+    func sendAmount_overSend_dismissRevealsChat() {
+        let router = AppRouter()
+        router.present(.send)
+        router.push(.dmConversation(.contact(Self.contact)))
+        router.presentNested(.sendAmount(Self.contact))
+
+        router.dismissSheet()
+
+        #expect(router.presentedSheets == [.send])
+        // The chat is still on the .send stack underneath.
+        #expect(router[.send] == AppRouter.navigationPath(.dmConversation(.contact(Self.contact))))
+    }
+
+    // MARK: - Send Cash over a deeplinked chat (root flow)
+
+    @Test("presentNested(.sendAmount) over .conversation stacks the amount sheet")
+    func sendAmount_overConversation_stacks() {
+        let router = AppRouter()
+        router.present(.conversation(Self.existingContext))
+
+        router.presentNested(.sendAmount(Self.contact))
+
+        #expect(router.presentedSheets == [.conversation(Self.existingContext), .sendAmount(Self.contact)])
+        #expect(router.rootSheet == .conversation(Self.existingContext))
+    }
+
+    @Test("dismissing the amount sheet reveals the chat root, then closing it lands on the scanner")
+    func sendAmount_overConversation_dismissChain() {
+        let router = AppRouter()
+        router.present(.conversation(Self.existingContext))
+        router.presentNested(.sendAmount(Self.contact))
+
+        router.dismissSheet()  // amount sheet → reveals chat root
+        #expect(router.presentedSheets == [.conversation(Self.existingContext)])
+
+        router.dismissSheet()  // chat root → scanner (chat was the floor)
+        #expect(router.presentedSheets.isEmpty)
+    }
+
+    // MARK: - Deposit redirect leaves the send sheets
+
+    @Test("navigate(to:) from the amount sheet swaps to the Wallet's currency info")
+    func depositRedirect_swapsToBalance() {
+        let router = AppRouter()
+        router.present(.conversation(Self.existingContext))
+        router.presentNested(.sendAmount(Self.contact))
+
+        router.navigate(to: .currencyInfoForDeposit(.usdc))
+
+        #expect(router.presentedSheets == [.balance])
+        #expect(router[.balance] == AppRouter.navigationPath(.currencyInfoForDeposit(.usdc)))
+    }
+}


### PR DESCRIPTION
The chat's Send Cash button now opens the amount entry as a sheet layered over the conversation instead of pushing it onto the same screen. Opening a chat from a deeplink or push notification presents the conversation as the bottom view, so dismissing anything on top returns to the chat and closing the chat returns to the scanner. Adding cash from the amount entry now routes to the wallet's deposit flow.

## Test plan
- [x] Open a chat from the recipient picker, tap Send Cash, and confirm the amount entry appears as a sheet that dismisses back to the chat.
- [x] Open a chat from a deeplink and confirm it's the bottom view, with Send Cash stacking on top and closing the chat returning to the scanner.
- [x] Open the currency and token pickers from the amount entry and confirm they present and dismiss cleanly.
- [x] Enter an amount over your balance, tap Add More Cash, and confirm it opens the deposit flow.