### PR TITLE
fix: stop the chat Send buttons riding the keyboard during the composer swap

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -10,11 +10,11 @@ import UIKit
 import FlipcashCore
 import FlipcashUI
 
-/// Hosts the fully-UIKit chat (transcript + the Send Cash / Send Message bar) inside SwiftUI.
-/// SwiftUI does only two things: supply the already-mapped messages and host the bar so its
-/// send + cash actions keep working. All scroll, keyboard, and flow-under behavior lives in the
-/// UIKit screen. The bar is hosted *inside* the UIKit screen (pinned to the keyboard layout
-/// guide) so the keyboard avoidance stays entirely in UIKit.
+/// Hosts the fully-UIKit chat (transcript + bars) inside SwiftUI. SwiftUI supplies the already-mapped
+/// messages and hosts two bars — the Send Cash / Send Message action bar (pinned to the safe area)
+/// and the composer (pinned to the keyboard). All scroll, keyboard, and flow-under behavior lives in
+/// the UIKit screen. Both bars share `barModel`, so the swap animates through observation rather than
+/// `UIHostingController.rootView` reassignment (which can't carry it).
 struct ChatScreenRepresentable: UIViewControllerRepresentable {
 
     let items: [ChatItem]
@@ -24,29 +24,39 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     let onReachTop: () -> Void
     let showsSendCash: Bool
     let showsSendMessage: Bool
-    /// Reports the bar's composing state so the screen can drive `interactiveDismissDisabled`.
-    let onComposingChange: (Bool) -> Void
     let conversationID: ConversationID?
     let onSendCash: () -> Void
     let conversationController: ConversationController
+    let barModel: ConversationBarModel
 
     func makeUIViewController(context: Context) -> ChatScreenViewController {
-        let host = UIHostingController(rootView: bar(coordinator: context.coordinator))
-        host.view.backgroundColor = .clear
-        let screen = ChatScreenViewController(barView: host.view, barViewController: host)
+        let restingHost = UIHostingController(rootView: restingBar(coordinator: context.coordinator))
+        let keyboardHost = UIHostingController(rootView: keyboardBar(coordinator: context.coordinator))
+        restingHost.view.backgroundColor = .clear
+        keyboardHost.view.backgroundColor = .clear
+        let screen = ChatScreenViewController(
+            restingBar: restingHost.view,
+            keyboardBar: keyboardHost.view,
+            restingBarController: restingHost,
+            keyboardBarController: keyboardHost
+        )
         screen.onReachTop = onReachTop
         screen.update(items: items)
-        context.coordinator.host = host
+        screen.setComposing(barModel.isComposing)
+        context.coordinator.restingHost = restingHost
+        context.coordinator.keyboardHost = keyboardHost
         context.coordinator.screen = screen
         context.coordinator.lastMessageID = lastMessageID(of: items)
         return screen
     }
 
     func updateUIViewController(_ screen: ChatScreenViewController, context: Context) {
-        // Re-supply the bar with current inputs; SwiftUI diffs it, so the composer's draft and
+        // Re-supply both bars with current inputs; SwiftUI diffs them, so the composer's draft and
         // focus survive across updates.
-        context.coordinator.host?.rootView = bar(coordinator: context.coordinator)
+        context.coordinator.restingHost?.rootView = restingBar(coordinator: context.coordinator)
+        context.coordinator.keyboardHost?.rootView = keyboardBar(coordinator: context.coordinator)
         screen.onReachTop = onReachTop
+        screen.setComposing(barModel.isComposing)
 
         // Scroll only when the user's *own* message was just appended — a new trailing message id
         // (skipping any trailing receipt) that is from me. Received messages and prepended history
@@ -70,33 +80,46 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         lastMessage(of: items)?.id
     }
 
-    private func bar(coordinator: Coordinator) -> AnyView {
+    private func restingBar(coordinator: Coordinator) -> AnyView {
         AnyView(
-            ConversationBottomBar(
+            ConversationActionBar(
                 showsSendCash: showsSendCash,
                 showsSendMessage: showsSendMessage,
-                conversationID: conversationID,
                 onSendCash: onSendCash,
-                onComposingChange: onComposingChange
+                model: barModel
             )
-            .environment(conversationController)
-            // Take the natural height at the proposed width so the composer can grow to its full
-            // multiline height, then report that measured height to the UIKit screen, which drives
-            // the bar's height constraint. This keeps the bar's frame matched to its content — the
-            // hosting controller's intrinsic size mis-measures and lets the composer overflow under
-            // the keyboard.
-            .fixedSize(horizontal: false, vertical: true)
-            .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
-                coordinator.screen?.setBarHeight(height)
-            }
+            .modifier(MeasuredBarHeight { coordinator.screen?.setRestingBarHeight($0) })
+        )
+    }
+
+    private func keyboardBar(coordinator: Coordinator) -> AnyView {
+        AnyView(
+            ConversationComposer(conversationID: conversationID, model: barModel)
+                .environment(conversationController)
+                .modifier(MeasuredBarHeight { coordinator.screen?.setKeyboardBarHeight($0) })
         )
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     @MainActor final class Coordinator {
-        var host: UIHostingController<AnyView>?
+        var restingHost: UIHostingController<AnyView>?
+        var keyboardHost: UIHostingController<AnyView>?
         weak var screen: ChatScreenViewController?
         var lastMessageID: String?
+    }
+}
+
+/// Reports a hosted bar's measured natural height to the UIKit screen, which drives its height
+/// constraint. Take the natural height at the proposed width so the composer can grow to its full
+/// multiline height — the hosting controller's intrinsic size mis-measures and lets the composer
+/// overflow under the keyboard.
+private struct MeasuredBarHeight: ViewModifier {
+    let report: (CGFloat) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .fixedSize(horizontal: false, vertical: true)
+            .onGeometryChange(for: CGFloat.self, of: { $0.size.height }, action: report)
     }
 }

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -9,93 +9,30 @@ import SwiftUI
 import FlipcashCore
 import FlipcashUI
 
-/// Send Cash / Send Message buttons, swapped for the message composer while
-/// composing. Hosted inside the UIKit chat screen, pinned to the keyboard.
-struct ConversationBottomBar: View {
+/// Shared state for the action bar and the composer. They live in separately-anchored
+/// hosted views (safe area vs keyboard), so they share state through this model rather
+/// than a parent; each reads `isComposing` to animate its own fade.
+@MainActor @Observable final class ConversationBarModel {
+    var isComposing = false
+    var draft = ""
+    var isSending = false
 
-    let showsSendCash: Bool
-    let showsSendMessage: Bool
-    let conversationID: ConversationID?
-    let onSendCash: () -> Void
-    /// Reports composing state to the host, which drives `interactiveDismissDisabled`.
-    let onComposingChange: (Bool) -> Void
-
-    @Environment(ConversationController.self) private var conversationController
-    @State private var draft = ""
-    @State private var isSending = false
-    /// Local @State, not an injected binding — the swap only animates when composing
-    /// changes inside the bar's own view tree.
-    @State private var isComposing = false
-    @FocusState private var isComposerFocused: Bool
-
-    /// Action bar ⇄ composer swap — the button group springs in/out (scaling
-    /// from 95%) while the composer fades.
-    private static let swapSpring = Animation.spring(duration: 0.27, bounce: 0.31)
-
-    private var canSend: Bool {
+    var canSend: Bool {
         !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending
-    }
-
-    var body: some View {
-        ZStack {
-            if isComposing {
-                ConversationComposer(draft: $draft, focus: $isComposerFocused, canSend: canSend, onSend: send)
-                    .transition(.opacity)
-            } else {
-                ConversationActionBar(
-                    showsSendCash: showsSendCash,
-                    showsSendMessage: showsSendMessage,
-                    onSendCash: onSendCash,
-                    onSendMessage: { isComposing = true }
-                )
-                .transition(.scale(scale: 0.95).combined(with: .opacity))
-            }
-        }
-        .animation(Self.swapSpring, value: isComposing)
-        .animation(Self.swapSpring, value: showsSendMessage)
-        .padding(.bottom, 8)
-        .background {
-            LinearGradient(
-                gradient: Gradient(colors: [Color.backgroundMain, Color.backgroundMain, .clear]),
-                startPoint: .bottom,
-                endPoint: .top
-            )
-            // Scope the bleed to the bottom edge only. The bar is the measured
-            // content of the transcript's bottom `.safeAreaInset`; an all-edges
-            // ignore makes the bar read as extending to the screen bottom, which
-            // collapses the scroll-content inset by the home-indicator height and
-            // drops the newest message under the bar.
-            .ignoresSafeArea(edges: .bottom)
-        }
-        // Collapse to the action buttons when the composer loses focus
-        // (keyboard dismissed). Focus-driven, not a keyboard notification.
-        .onChange(of: isComposerFocused) { _, focused in
-            if !focused { isComposing = false }
-        }
-        .onChange(of: isComposing) { _, composing in onComposingChange(composing) }
-    }
-
-    private func send() {
-        guard let conversationID else { return }
-        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, !isSending else { return }
-        isSending = true
-        draft = ""
-        isComposerFocused = true
-        Task {
-            await conversationController.send(text, to: conversationID)
-            isSending = false
-        }
     }
 }
 
+/// Action bar ⇄ composer swap — the button group springs in/out (scaling
+/// from 95%) while the composer fades.
+private let barSwapSpring = Animation.spring(duration: 0.27, bounce: 0.31)
+
 /// Send Cash alone until the chat exists, then Send Cash + Send Message.
-private struct ConversationActionBar: View {
+struct ConversationActionBar: View {
 
     let showsSendCash: Bool
     let showsSendMessage: Bool
     let onSendCash: () -> Void
-    let onSendMessage: () -> Void
+    let model: ConversationBarModel
 
     var body: some View {
         HStack(spacing: 10) {
@@ -106,7 +43,7 @@ private struct ConversationActionBar: View {
             if showsSendMessage {
                 // Material-only frosted button (no fill) — matches the .filled
                 // metrics (full width, 60pt tall, 6pt radius, appTextMedium).
-                Button(action: onSendMessage) {
+                Button(action: { withAnimation(barSwapSpring) { model.isComposing = true } }) {
                     Text("Send Message")
                         .font(.appTextMedium)
                         .foregroundStyle(Color.textMain)
@@ -120,34 +57,43 @@ private struct ConversationActionBar: View {
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)
+        .padding(.bottom, 8)
+        .animation(barSwapSpring, value: showsSendMessage)
+        // Scales + fades out in place while composing. The bar is pinned to the safe
+        // area (in the UIKit screen), so it never rides the keyboard.
+        .scaleEffect(model.isComposing ? 0.95 : 1)
+        .modifier(BarGradientBackground())
+        .opacity(model.isComposing ? 0 : 1)
+        .animation(barSwapSpring, value: model.isComposing)
     }
 }
 
 /// The glass type box: a multiline field with a send button that appears once
 /// there's text. Swiping the chat down lowers the keyboard and the box.
-private struct ConversationComposer: View {
+struct ConversationComposer: View {
 
-    @Binding var draft: String
-    var focus: FocusState<Bool>.Binding
-    let canSend: Bool
-    let onSend: () -> Void
+    let conversationID: ConversationID?
+    @Bindable var model: ConversationBarModel
+
+    @Environment(ConversationController.self) private var conversationController
+    @FocusState private var isFocused: Bool
 
     /// Send button scale-in/out as text appears/clears.
     private static let sendButtonSpring = Animation.spring(duration: 0.17, bounce: 0.34)
 
     var body: some View {
         let field = HStack(alignment: .bottom, spacing: 10) {
-            TextField("Message", text: $draft, axis: .vertical)
+            TextField("Message", text: $model.draft, axis: .vertical)
                 .font(.appTextMessage)
                 .foregroundStyle(Color.textMain)
                 .tint(.white)
                 .lineLimit(1...5)
-                .focused(focus)
+                .focused($isFocused)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .frame(minHeight: 34)
 
-            if canSend {
-                Button(action: onSend) {
+            if model.canSend {
+                Button(action: send) {
                     Image(systemName: "arrow.up")
                         .font(.default(size: 16, weight: .bold))
                         .foregroundStyle(Color.textAction)
@@ -161,7 +107,7 @@ private struct ConversationComposer: View {
                 .transition(.scale(scale: 0.6).combined(with: .opacity))
             }
         }
-        .animation(Self.sendButtonSpring, value: canSend)
+        .animation(Self.sendButtonSpring, value: model.canSend)
         .padding(.leading, 14)
         .padding(.trailing, 8)
         .padding(.vertical, 8)
@@ -175,8 +121,47 @@ private struct ConversationComposer: View {
             }
         }
         .padding(.horizontal, 12)
-        // Focus must be requested after the field joins the hierarchy; setting
-        // it in the Send Message tap (same transaction) can silently fail.
-        .onAppear { focus.wrappedValue = true }
+        .padding(.bottom, 8)
+        .modifier(BarGradientBackground())
+        .opacity(model.isComposing ? 1 : 0)
+        .animation(barSwapSpring, value: model.isComposing)
+        // Focus follows composing. The field is already mounted, so this is reliable —
+        // `.onAppear` would raise the keyboard on screen entry. Losing focus (keyboard
+        // swiped down) ends composing.
+        .onChange(of: model.isComposing) { _, composing in isFocused = composing }
+        .onChange(of: isFocused) { _, focused in if !focused { withAnimation(barSwapSpring) { model.isComposing = false } } }
+    }
+
+    private func send() {
+        guard let conversationID else { return }
+        let text = model.draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, !model.isSending else { return }
+        model.isSending = true
+        model.draft = ""
+        isFocused = true
+        Task {
+            await conversationController.send(text, to: conversationID)
+            model.isSending = false
+        }
+    }
+}
+
+/// Bottom-edge fade so transcript content scrolling under the bar dissolves into
+/// the background.
+private struct BarGradientBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        content.background {
+            LinearGradient(
+                gradient: Gradient(colors: [Color.backgroundMain, Color.backgroundMain, .clear]),
+                startPoint: .bottom,
+                endPoint: .top
+            )
+            // Scope the bleed to the bottom edge only. The bar is the measured
+            // content of the transcript's bottom `.safeAreaInset`; an all-edges
+            // ignore makes the bar read as extending to the screen bottom, which
+            // collapses the scroll-content inset by the home-indicator height and
+            // drops the newest message under the bar.
+            .ignoresSafeArea(edges: .bottom)
+        }
     }
 }

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -36,7 +36,7 @@ struct ConversationScreen: View {
     @Environment(RatesController.self) private var ratesController
 
     @State private var didInitialRead = false
-    @State private var isComposing = false
+    @State private var barModel = ConversationBarModel()
     @State private var navBarWidth: CGFloat = 0
 
     /// Horizontal space the back button (leading) reserves on each side of the
@@ -140,10 +140,10 @@ struct ConversationScreen: View {
             onReachTop: loadOlderMessages,
             showsSendCash: sendTarget != nil,
             showsSendMessage: chatExists,
-            onComposingChange: { isComposing = $0 },
             conversationID: conversationID,
             onSendCash: sendCash,
-            conversationController: conversationController
+            conversationController: conversationController,
+            barModel: barModel
         )
         .ignoresSafeArea(.keyboard)
         // Extend the transcript under the navigation bar so content scrolls beneath it — that's
@@ -176,7 +176,7 @@ struct ConversationScreen: View {
         }
         // While composing, a downward swipe should lower the keyboard — not
         // tear down the whole Send sheet.
-        .interactiveDismissDisabled(isComposing)
+        .interactiveDismissDisabled(barModel.isComposing)
         // Keyed on existence, not just the ID: a matched contact's chat ID is
         // pre-assigned, and fetching messages for a chat the server hasn't
         // created yet error-reports. Fires when the chat materializes.

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -9,33 +9,47 @@
 import UIKit
 import SwiftUI
 
-/// The full chat screen, entirely in UIKit: the transcript fills the view and an injected bar
-/// floats over its bottom (so content flows under it). The bar is supplied by the owner — a hosted
-/// SwiftUI Send Cash / Send Message bar — so this screen stays agnostic about *what* the bar is and
-/// only owns layout + keyboard handling.
+/// The full chat screen, entirely in UIKit: the transcript fills the view and two injected bars
+/// float over its bottom (so content flows under them). The owner supplies both — a resting Send Cash
+/// / Send Message bar pinned to the safe area, and a composer pinned to the keyboard guide — so this
+/// screen stays agnostic about *what* the bars are and only owns layout + keyboard handling.
 ///
 /// Keyboard handling is deliberately *not* hand-rolled. The host's safe area already grows to
-/// include the keyboard, so the bar is pinned to the keyboard layout guide (it rides the keyboard
-/// for free) and the transcript only reserves the bar's own height — the safe area supplies the
-/// keyboard. Doing both ourselves was what double-counted the keyboard.
+/// include the keyboard, so the keyboard bar is pinned to the keyboard layout guide (it rides the
+/// keyboard for free) and the transcript only reserves the active bar's own height — the safe area
+/// supplies the keyboard. Doing both ourselves was what double-counted the keyboard. The resting bar
+/// pins to the safe area so it never rides the keyboard.
 public final class ChatScreenViewController: UIViewController {
 
     private let transcript = ChatViewController()
-    private let barView: UIView
-    private let barViewController: UIViewController?
-    /// Driven by the bar's *measured* SwiftUI height (`setBarHeight`), so the bar's frame matches its
-    /// content exactly — a hosting controller's intrinsic size mis-measures multiline growth and lets
-    /// the composer overflow below its frame, under the keyboard.
-    private var barHeightConstraint: NSLayoutConstraint!
+    private let restingBar: UIView
+    private let keyboardBar: UIView
+    private let restingBarController: UIViewController?
+    private let keyboardBarController: UIViewController?
+    /// Each bar's height is driven by its *measured* SwiftUI height, so the frame matches its content
+    /// exactly — a hosting controller's intrinsic size mis-measures multiline growth and lets the
+    /// composer overflow below its frame, under the keyboard.
+    private var restingBarHeightConstraint: NSLayoutConstraint!
+    private var keyboardBarHeightConstraint: NSLayoutConstraint!
+    /// Which bar the transcript reserves bottom inset for; the composer can grow tall.
+    private var isComposing = false
 
     /// - Parameters:
-    ///   - barView: the view pinned over the transcript's bottom, riding the keyboard.
-    ///   - barViewController: the view controller owning `barView`, when it's hosted (e.g. a
-    ///     `UIHostingController` for a SwiftUI bar). Adopted as a child so its lifecycle and
-    ///     environment work. Pass `nil` for a plain `UIView` bar.
-    public init(barView: UIView, barViewController: UIViewController? = nil) {
-        self.barView = barView
-        self.barViewController = barViewController
+    ///   - restingBar: pinned over the transcript's bottom safe area; does not ride the keyboard.
+    ///   - keyboardBar: pinned to the keyboard layout guide; rides the keyboard.
+    ///   - restingBarController/keyboardBarController: the view controllers owning each bar, when
+    ///     hosted (e.g. a `UIHostingController` for a SwiftUI bar). Adopted as children so their
+    ///     lifecycle and environment work. Pass `nil` for a plain `UIView` bar.
+    public init(
+        restingBar: UIView,
+        keyboardBar: UIView,
+        restingBarController: UIViewController? = nil,
+        keyboardBarController: UIViewController? = nil
+    ) {
+        self.restingBar = restingBar
+        self.keyboardBar = keyboardBar
+        self.restingBarController = restingBarController
+        self.keyboardBarController = keyboardBarController
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -55,26 +69,37 @@ public final class ChatScreenViewController: UIViewController {
         transcript.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(transcript.view)
         transcript.didMove(toParent: self)
-
-        if let barViewController { addChild(barViewController) }
-        barView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(barView)
-        barViewController?.didMove(toParent: self)
-
-        barHeightConstraint = barView.heightAnchor.constraint(equalToConstant: 80)
         NSLayoutConstraint.activate([
             transcript.view.topAnchor.constraint(equalTo: view.topAnchor),
             transcript.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             transcript.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             transcript.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-
-            barView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            barView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            // The keyboard layout guide tracks the keyboard (interactively too), so the bar rides
-            // it automatically; when the keyboard is down the guide rests at the bottom safe area.
-            barView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
-            barHeightConstraint,
         ])
+
+        // Resting bar first, then the keyboard bar on top — when the keyboard is down they overlap at
+        // the bottom and the keyboard bar (non-interactive then) must not occlude the buttons.
+        restingBarHeightConstraint = addBar(restingBar, controller: restingBarController, pinnedTo: view.safeAreaLayoutGuide.bottomAnchor)
+        keyboardBarHeightConstraint = addBar(keyboardBar, controller: keyboardBarController, pinnedTo: view.keyboardLayoutGuide.topAnchor)
+
+        applyBarInteraction()
+    }
+
+    /// Adds a hosted bar pinned to the view's width and the given bottom anchor; returns its height
+    /// constraint (driven later by the bar's measured SwiftUI content height).
+    private func addBar(_ bar: UIView, controller: UIViewController?, pinnedTo bottomAnchor: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+        if let controller { addChild(controller) }
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bar)
+        controller?.didMove(toParent: self)
+
+        let heightConstraint = bar.heightAnchor.constraint(equalToConstant: 80)
+        NSLayoutConstraint.activate([
+            bar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bar.bottomAnchor.constraint(equalTo: bottomAnchor),
+            heightConstraint,
+        ])
+        return heightConstraint
     }
 
     public override func viewWillAppear(_ animated: Bool) {
@@ -91,12 +116,34 @@ public final class ChatScreenViewController: UIViewController {
         host.setContentScrollView(transcript.collectionView, for: .top)
     }
 
-    /// Set the bar's height to its measured SwiftUI content height. Pinned at the bottom to the
-    /// keyboard guide, so growing the constant grows the bar *upward* — it can never push content
+    /// Set the resting bar's height to its measured SwiftUI content height.
+    public func setRestingBarHeight(_ height: CGFloat) {
+        guard restingBarHeightConstraint != nil, restingBarHeightConstraint.constant != height else { return }
+        restingBarHeightConstraint.constant = height
+    }
+
+    /// Set the keyboard bar's height to its measured SwiftUI content height. Pinned at the bottom to
+    /// the keyboard guide, so growing the constant grows the bar *upward* — it can never push content
     /// below the keyboard.
-    public func setBarHeight(_ height: CGFloat) {
-        guard barHeightConstraint != nil, barHeightConstraint.constant != height else { return }
-        barHeightConstraint.constant = height
+    public func setKeyboardBarHeight(_ height: CGFloat) {
+        guard keyboardBarHeightConstraint != nil, keyboardBarHeightConstraint.constant != height else { return }
+        keyboardBarHeightConstraint.constant = height
+    }
+
+    /// Switch which bar the transcript reserves bottom inset for, and which one takes touches.
+    public func setComposing(_ composing: Bool) {
+        guard isComposing != composing else { return }
+        isComposing = composing
+        applyBarInteraction()
+        view.setNeedsLayout()
+    }
+
+    /// Only the active bar takes touches. The bars overlap at the bottom when the keyboard is down,
+    /// and a hosting controller's view doesn't pass touches through on `.allowsHitTesting(false)`
+    /// alone — disabling the inactive bar at the UIKit layer reliably lets the active one receive them.
+    private func applyBarInteraction() {
+        restingBar.isUserInteractionEnabled = !isComposing
+        keyboardBar.isUserInteractionEnabled = isComposing
     }
 
     // MARK: - Data passthrough
@@ -108,10 +155,10 @@ public final class ChatScreenViewController: UIViewController {
 
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        // Reserve only the bar's own height. On-device the system already grows the collection
+        // Reserve only the active bar's own height. On-device the system already grows the collection
         // view's adjusted content inset by the keyboard when it's up, so adding the keyboard here
         // too (via the bar's risen position) double-counts it and overscrolls by a whole keyboard.
-        transcript.setBottomInset(barView.frame.height)
+        transcript.setBottomInset(isComposing ? keyboardBar.frame.height : restingBar.frame.height)
     }
 }
 #endif


### PR DESCRIPTION
The Send Cash and Send Message buttons used to slide up with the keyboard when switching into the message composer, which was never the intent. They are now pinned to the bottom safe area and fade in place during the swap, while only the composer rides the keyboard. Shared composing and draft state moved to an observable model both views read, so the cross-fade animates reliably across the SwiftUI/UIKit boundary.

## Test plan
- [x] Open a conversation and tap Send Message — the buttons fade in place and only the composer rises with the keyboard.
- [x] Swipe the keyboard down — the composer rides down and the buttons fade back in at the bottom.
- [x] Tap Send Cash and Send Message — both respond.
- [x] Type a multi-line message — the composer grows and the newest message stays visible above it.