### PR TITLE
refactor: consolidate UIApplication window/scene lookups

### DIFF
--- a/Flipcash/Core/FlipcashApp.swift
+++ b/Flipcash/Core/FlipcashApp.swift
@@ -54,9 +54,7 @@ private struct DialogWindowModifier: ViewModifier {
         content
             .onAppear {
                 guard dialogWindow == nil,
-                      let scene = UIApplication.shared.connectedScenes
-                          .first(where: { $0 is UIWindowScene })
-                          as? UIWindowScene
+                      let scene = UIApplication.shared.firstWindowScene
                 else { return }
 
                 dialogWindow = DialogWindow(

--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -348,9 +348,7 @@ final class AppRouter {
             paths[stack] = NavigationPath()
         }
 
-        let presenter = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .first { $0.activationState == .foregroundActive }?
+        let presenter = UIApplication.shared.foregroundWindowScene?
             .keyWindow?
             .rootViewController
 

--- a/Flipcash/Extensions/UIApplication+Scene.swift
+++ b/Flipcash/Extensions/UIApplication+Scene.swift
@@ -1,0 +1,41 @@
+//
+//  UIApplication+Scene.swift
+//  Flipcash
+//
+
+import UIKit
+
+/// Resolves a single "current" window/scene from `UIApplication`.
+///
+/// Unambiguous only while the app is single-scene
+/// (`UIApplicationSupportsMultipleScenes` is `false`, iPhone-only). Under true
+/// multi-window (iPad/visionOS/Stage Manager) `connectedScenes` is an unordered
+/// `Set` with possibly several `.foregroundActive` scenes, so each accessor
+/// returns an arbitrary one — derive the scene from view/interaction context
+/// instead.
+extension UIApplication {
+    /// The first connected `UIWindowScene`, regardless of activation state.
+    ///
+    /// Prefer this during early lifecycle (e.g. `onAppear` on cold launch),
+    /// when a scene may have connected but not yet reached `.foregroundActive`.
+    var firstWindowScene: UIWindowScene? {
+        connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first
+    }
+
+    /// The first connected `UIWindowScene` in the `.foregroundActive` state.
+    var foregroundWindowScene: UIWindowScene? {
+        connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+    }
+
+    /// The key window across all connected scenes.
+    var currentKeyWindow: UIWindow? {
+        connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+}

--- a/Flipcash/Share/ShareSheet.swift
+++ b/Flipcash/Share/ShareSheet.swift
@@ -29,13 +29,6 @@ private extension UIApplication {
     var rootViewController: UIViewController? {
         currentKeyWindow?.rootViewController?.topMostController
     }
-    
-    var currentKeyWindow: UIWindow? {
-        connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap { $0.windows }
-            .first { $0.isKeyWindow }
-    }
 }
 
 private extension UIViewController {


### PR DESCRIPTION
Three screens each kept their own copy of the logic for finding the app's current window or scene, with slightly different rules. This moves all of them into one shared, documented helper and points each screen at it, so behavior is identical but now lives in a single place. The helper also records that it's only unambiguous while the app is single-window, as a guardrail for any future iPad or multi-window support.

## Test plan
- [x] The share sheet still opens from the share action.
- [x] Backgrounding the app while inside a sheet still returns to the scanner.
- [x] Error and confirmation dialogs still appear on a fresh cold launch.