### PR TITLE
feat: add Recents section to the recipient picker

### DIFF
--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -174,10 +174,10 @@ private struct RecipientSearchEmptyState: View {
 
 // MARK: - List items -
 
-/// One row of the merged "On Flipcash" section: a synced contact, a DM
-/// conversation, or both joined by the contact's `dmChatID`. Rows with a
-/// conversation sort by activity (newest first) ahead of chat-less contacts,
-/// which keep the directory's order.
+/// One row of the picker: a synced contact, a DM conversation, or both joined
+/// by the contact's `dmChatID`. `partition(...)` sorts these into the "Recents"
+/// section (rows backed by a conversation, newest activity first) and the
+/// "On Flipcash" section (chat-less contacts, in the directory's order).
 nonisolated enum RecipientListItem: Identifiable, Equatable {
 
     case contact(ResolvedContact)
@@ -211,28 +211,42 @@ nonisolated enum RecipientListItem: Identifiable, Equatable {
         }
     }
 
-    static func items(contacts: [ResolvedContact], conversations: [Conversation]) -> [RecipientListItem] {
+    /// Splits picker rows into the two sections the list renders. `contacts` is
+    /// the already-filtered on-Flipcash set; `conversationNames` carries each
+    /// chat's resolved display name and is consulted only while searching, to
+    /// keep contact-less chats whose name matches the query.
+    nonisolated static func partition(
+        contacts: [ResolvedContact],
+        conversations: [Conversation],
+        searchText: String,
+        conversationNames: [ConversationID: String]
+    ) -> (recents: [RecipientListItem], onFlipcash: [RecipientListItem]) {
         var unmatched: [ConversationID: Conversation] = [:]
         for conversation in conversations {
             unmatched[conversation.id] = conversation
         }
 
-        var active: [RecipientListItem] = []
-        var chatless: [RecipientListItem] = []
+        var recents: [RecipientListItem] = []
+        var onFlipcash: [RecipientListItem] = []
         for contact in contacts {
             if let chatID = contact.dmChatID.map(ConversationID.init(data:)),
                let conversation = unmatched.removeValue(forKey: chatID) {
-                active.append(.matched(contact, conversation))
+                recents.append(.matched(contact, conversation))
             } else {
-                chatless.append(.contact(contact))
+                onFlipcash.append(.contact(contact))
             }
         }
+
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         for conversation in conversations where unmatched[conversation.id] != nil {
-            active.append(.conversation(conversation))
+            let matchesSearch = query.isEmpty || (conversationNames[conversation.id]?.lowercased().contains(query) ?? false)
+            if matchesSearch {
+                recents.append(.conversation(conversation))
+            }
         }
 
-        active.sort { ($0.conversation?.lastActivity ?? .distantPast) > ($1.conversation?.lastActivity ?? .distantPast) }
-        return active + chatless
+        recents.sort { ($0.conversation?.lastActivity ?? .distantPast) > ($1.conversation?.lastActivity ?? .distantPast) }
+        return (recents, onFlipcash)
     }
 }
 
@@ -248,35 +262,43 @@ private struct RecipientPickerList: View {
     let onFlipcashTap: (ResolvedContact) -> Void
     let onInviteTap: (ResolvedContact) -> Void
 
-    /// Searching filters by contact, so conversations whose counterpart isn't
-    /// a synced contact only appear with an empty query — matched rows keep
-    /// their conversation join either way.
-    private var items: [RecipientListItem] {
-        var items = RecipientListItem.items(contacts: filtered.onFlipcash, conversations: conversations)
-        if !searchText.isEmpty {
-            items.removeAll { item in
-                if case .conversation = item { true } else { false }
-            }
-        }
-        return items
+    @Environment(ConversationController.self) private var conversationController
+
+    /// Chat display names keyed by conversation, resolved through the controller
+    /// so the search matches what each row shows. Built only while searching.
+    private var conversationNames: [ConversationID: String] {
+        guard !searchText.isEmpty else { return [:] }
+        return Dictionary(
+            uniqueKeysWithValues: conversations.map { ($0.id, conversationController.displayName(for: $0)) }
+        )
+    }
+
+    private var partitioned: (recents: [RecipientListItem], onFlipcash: [RecipientListItem]) {
+        RecipientListItem.partition(
+            contacts: filtered.onFlipcash,
+            conversations: conversations,
+            searchText: searchText,
+            conversationNames: conversationNames
+        )
     }
 
     var body: some View {
+        let sections = partitioned
         List {
-            if !items.isEmpty {
+            if !sections.recents.isEmpty {
                 Section {
-                    ForEach(items) { item in
-                        RecipientListItemRow(
-                            item: item,
-                            onTap: {
-                                switch item {
-                                case .contact(let contact), .matched(let contact, _):
-                                    onFlipcashTap(contact)
-                                case .conversation(let conversation):
-                                    onConversationTap(conversation)
-                                }
-                            }
-                        )
+                    ForEach(sections.recents) { item in
+                        RecipientListItemRow(item: item, onTap: { tap(item) })
+                    }
+                } header: {
+                    RecipientSectionHeader(title: "Recents")
+                }
+                .listSectionSeparator(.hidden, edges: .top)
+            }
+            if !sections.onFlipcash.isEmpty {
+                Section {
+                    ForEach(sections.onFlipcash) { item in
+                        RecipientListItemRow(item: item, onTap: { tap(item) })
                     }
                 } header: {
                     RecipientSectionHeader(title: "On Flipcash")
@@ -321,12 +343,21 @@ private struct RecipientPickerList: View {
         // to the feed so search-driven filtering stays instant.
         .animation(.snappy, value: conversations)
         .overlay {
-            // Search isn't meaningful under denied access (no contacts to match,
-            // conversations are intentionally hidden while searching), so skip
-            // the "No Results" overlay there and keep the CTA card visible.
-            if !searchText.isEmpty && filtered.isEmpty && contactAccess != .denied {
+            // "No Results" only when neither a contact nor a chat matched — a
+            // chat can match on its name while no contact does. Skipped under
+            // denied access so the CTA card stays visible.
+            if !searchText.isEmpty && filtered.isEmpty && sections.recents.isEmpty && contactAccess != .denied {
                 RecipientSearchEmptyState(searchText: searchText)
             }
+        }
+    }
+
+    private func tap(_ item: RecipientListItem) {
+        switch item {
+        case .contact(let contact), .matched(let contact, _):
+            onFlipcashTap(contact)
+        case .conversation(let conversation):
+            onConversationTap(conversation)
         }
     }
 }

--- a/FlipcashTests/Chat/ChatCashCardSizingTests.swift
+++ b/FlipcashTests/Chat/ChatCashCardSizingTests.swift
@@ -47,12 +47,12 @@ struct ChatCashCardSizingTests {
         #expect(size.height == ChatCashCardCell.cardSize.height)
     }
 
-    @Test("Text, date separator, and receipt rows keep self-sizing (.auto)")
+    @Test("Text, date separator, and receipt-bearing rows keep self-sizing (.auto)")
     func nonCashRows_areAuto() {
         let items: [ChatItem] = [
             .dateSeparator(id: "sep", text: "Today 1:00 PM"),
             .message(ChatMessage(id: "1", text: "hello", sender: .other)),
-            .receipt(id: "r", text: "Delivered"),
+            .message(ChatMessage(id: "r", text: "ok", sender: .me, receipt: "Delivered")),
         ]
         for index in items.indices {
             #expect(sized(items, at: index) == .auto, "row \(index) should self-size")

--- a/FlipcashTests/RecipientListItemTests.swift
+++ b/FlipcashTests/RecipientListItemTests.swift
@@ -33,59 +33,128 @@ struct RecipientListItemTests {
         )
     }
 
-    @Test("A contact joins its feed conversation into one matched row")
+    @Test("A contact joins its feed conversation into a matched Recents row")
     func contactJoinsConversation() {
         let chat = conversation(byte: 0x01, lastActivity: .now)
         let matched = contact("Anna", dmChatID: chat.id.data)
 
-        let items = RecipientListItem.items(contacts: [matched, contact("Ben")], conversations: [chat])
+        let result = RecipientListItem.partition(
+            contacts: [matched, contact("Ben")],
+            conversations: [chat],
+            searchText: "",
+            conversationNames: [:]
+        )
 
-        #expect(items == [.matched(matched, chat), .contact(contact("Ben"))])
-        #expect(items[0].id == matched.id)
+        #expect(result.recents == [.matched(matched, chat)])
+        #expect(result.onFlipcash == [.contact(contact("Ben"))])
     }
 
-    @Test("Rows with conversations sort by activity, newest first")
-    func activeRowsSortByActivity() {
+    @Test("Recents rows sort by activity, newest first")
+    func recentsSortByActivity() {
         let older = conversation(byte: 0x01, lastActivity: Date(timeIntervalSince1970: 100))
         let newer = conversation(byte: 0x02, lastActivity: Date(timeIntervalSince1970: 200))
         let first = contact("Anna", dmChatID: older.id.data)
         let second = contact("Ben", dmChatID: newer.id.data)
 
-        let items = RecipientListItem.items(contacts: [first, second], conversations: [older, newer])
+        let result = RecipientListItem.partition(
+            contacts: [first, second],
+            conversations: [older, newer],
+            searchText: "",
+            conversationNames: [:]
+        )
 
-        #expect(items == [.matched(second, newer), .matched(first, older)])
+        #expect(result.recents == [.matched(second, newer), .matched(first, older)])
+        #expect(result.onFlipcash.isEmpty)
     }
 
-    @Test("Chat-less contacts keep the directory's order, after active rows")
-    func chatlessContactsKeepOrder() {
+    @Test("Chat-less contacts land in On Flipcash in directory order")
+    func chatlessContactsInOnFlipcash() {
         let chat = conversation(byte: 0x01, lastActivity: .now)
         let matched = contact("Zoe", dmChatID: chat.id.data)
 
-        let items = RecipientListItem.items(
+        let result = RecipientListItem.partition(
             contacts: [contact("Anna"), matched, contact("Ben")],
-            conversations: [chat]
+            conversations: [chat],
+            searchText: "",
+            conversationNames: [:]
         )
 
-        #expect(items == [.matched(matched, chat), .contact(contact("Anna")), .contact(contact("Ben"))])
+        #expect(result.recents == [.matched(matched, chat)])
+        #expect(result.onFlipcash == [.contact(contact("Anna")), .contact(contact("Ben"))])
     }
 
-    @Test("A conversation without a synced contact still gets a row")
-    func unmatchedConversationIsIncluded() {
+    @Test("A conversation without a synced contact is a Recents row")
+    func unmatchedConversationInRecents() {
         let older = conversation(byte: 0x01, lastActivity: Date(timeIntervalSince1970: 100))
         let newer = conversation(byte: 0x02, lastActivity: Date(timeIntervalSince1970: 200))
         let matched = contact("Anna", dmChatID: older.id.data)
 
-        let items = RecipientListItem.items(contacts: [matched], conversations: [older, newer])
+        let result = RecipientListItem.partition(
+            contacts: [matched],
+            conversations: [older, newer],
+            searchText: "",
+            conversationNames: [:]
+        )
 
-        #expect(items == [.conversation(newer), .matched(matched, older)])
+        #expect(result.recents == [.conversation(newer), .matched(matched, older)])
+        #expect(result.onFlipcash.isEmpty)
     }
 
-    @Test("A pre-assigned chat ID with no feed conversation stays a contact row")
-    func preassignedChatIDWithoutFeedStaysContact() {
+    @Test("A pre-assigned chat ID with no feed conversation stays in On Flipcash")
+    func preassignedChatIDStaysOnFlipcash() {
         let preassigned = contact("Anna", dmChatID: Data(repeating: 0x09, count: 32))
 
-        let items = RecipientListItem.items(contacts: [preassigned], conversations: [])
+        let result = RecipientListItem.partition(
+            contacts: [preassigned],
+            conversations: [],
+            searchText: "",
+            conversationNames: [:]
+        )
 
-        #expect(items == [.contact(preassigned)])
+        #expect(result.recents.isEmpty)
+        #expect(result.onFlipcash == [.contact(preassigned)])
+    }
+
+    @Test("Searching keeps an unmatched conversation whose chat name matches")
+    func searchKeepsMatchingUnmatchedConversation() {
+        let chat = conversation(byte: 0x05, lastActivity: .now)
+
+        let result = RecipientListItem.partition(
+            contacts: [],
+            conversations: [chat],
+            searchText: "ali",
+            conversationNames: [chat.id: "Alice"]
+        )
+
+        #expect(result.recents == [.conversation(chat)])
+    }
+
+    @Test("Searching drops an unmatched conversation whose chat name doesn't match")
+    func searchDropsNonMatchingUnmatchedConversation() {
+        let chat = conversation(byte: 0x06, lastActivity: .now)
+
+        let result = RecipientListItem.partition(
+            contacts: [],
+            conversations: [chat],
+            searchText: "zzz",
+            conversationNames: [chat.id: "Alice"]
+        )
+
+        #expect(result.recents.isEmpty)
+    }
+
+    @Test("Searching keeps a matched contact's conversation regardless of chat name")
+    func searchKeepsMatchedContactConversation() {
+        let chat = conversation(byte: 0x07, lastActivity: .now)
+        let matched = contact("Anna", dmChatID: chat.id.data)
+
+        let result = RecipientListItem.partition(
+            contacts: [matched],
+            conversations: [chat],
+            searchText: "ann",
+            conversationNames: [:]
+        )
+
+        #expect(result.recents == [.matched(matched, chat)])
     }
 }


### PR DESCRIPTION
The Send recipient list now leads with a Recents section showing your active chats, sorted by most recent activity. People you've chatted with move out of On Flipcash into Recents, and Recents is what appears when you've denied contacts access but still have conversations. Search also matches chat names now, so chats with people who aren't saved contacts are findable. Also repairs a pre-existing chat test that referenced a removed case so the test suite compiles.

## Test plan
- [ ] Recents shows active chats newest-first, above On Flipcash and Not on Flipcash Yet.
- [ ] A contact you've chatted with appears only in Recents, not in On Flipcash.
- [ ] Starting a chat moves that contact into Recents and empties On Flipcash when it was the only one left.
- [ ] With contacts access denied, Recents shows your chats above the invite prompt.
- [ ] Searching finds a chat by the other person's name even when they aren't a saved contact.
- [ ] A search matching nothing shows the empty state; a search matching only a chat does not.