### PR TITLE
fix: show the read receipt inline on chat cash cards

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -79,16 +79,11 @@ public final class ChatCashCardCell: UICollectionViewCell {
         leadingConstraint = column.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12)
         trailingConstraint = column.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12)
 
-        // The card has a fixed height, so pinning the column to both the top and bottom of the
-        // contentView would conflict with ChatLayout's estimated cell height during the first
-        // (pre-self-sizing) layout pass. The bottom pin yields (priority 999) to that estimate,
-        // avoiding an unsatisfiable-constraints break while still driving the cell to self-size.
-        let columnBottom = column.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
-        columnBottom.priority = UILayoutPriority(999)
-
+        // The column pins top and bottom to the contentView so the cell self-sizes to the fixed-height
+        // card plus the receipt line below it.
         NSLayoutConstraint.activate([
             column.topAnchor.constraint(equalTo: contentView.topAnchor),
-            columnBottom,
+            column.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             card.widthAnchor.constraint(equalToConstant: Self.cardSize.width),
             card.heightAnchor.constraint(equalToConstant: Self.cardSize.height),
 
@@ -120,17 +115,6 @@ public final class ChatCashCardCell: UICollectionViewCell {
         super.prepareForReuse()
         iconTask?.cancel()
         coinIcon.image = nil
-    }
-
-    /// The card is a fixed height, so supply it directly rather than letting the cell self-size.
-    /// An inserted cell is placed at ChatLayout's small estimate and is supposed to self-size up on
-    /// the next pass — but iOS 26 skips that pass during an animated batch update, leaving the card
-    /// clipped to the estimate (the bottom pin is only priority 999, so nothing forces the height).
-    /// Returning the height here makes it deterministic. Per ChatLayout's contract, do NOT call
-    /// `super` — it re-measures via Auto Layout and re-trips the estimate-vs-999 conflict.
-    public override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        layoutAttributes.frame.size.height = Self.cardSize.height
-        return layoutAttributes
     }
 
     public func configure(with message: ChatMessage) {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -271,17 +271,11 @@ public final class ChatViewController: UICollectionViewController {
     }
 }
 
-/// `.auto` self-sizing and `.fullWidth` alignment fit the text/date/receipt rows, which size to
-/// their own content. The cash card is a fixed 232×170 footprint, so it gets an exact height: an
-/// inserted self-sizing cell is placed at the small estimate and relies on a follow-up self-size
-/// pass that iOS 26 skips mid-animated-batch-update, leaving the card clipped to the estimate.
-/// An exact size is applied on insert with no self-size pass, so it can't regress.
+/// Every row self-sizes to its own content: text and date rows to their text, and the cash card to
+/// its fixed-height card plus the optional receipt line below it.
 extension ChatViewController: ChatLayoutDelegate {
     public func sizeForItem(_ chatLayout: CollectionViewChatLayout, at indexPath: IndexPath) -> ItemSize {
-        if case .message(let message) = items[indexPath.item], case .cash = message.content {
-            return .exact(CGSize(width: collectionView.bounds.width, height: ChatCashCardCell.cardSize.height))
-        }
-        return .auto
+        .auto
     }
 }
 


### PR DESCRIPTION
Cash cards in a chat weren't showing the "Delivered"/"Read" receipt that text messages show — the cell's height was pinned to the card alone, leaving no room for the receipt line below it. This lets the cash card self-size like every other row, so the receipt sits inline beneath it.

Verified on an iOS 26 device: existing and freshly-sent cards render full-size with their receipt, no clipping.

## Test plan
- [x] Open a chat where your most recent message is a cash card you sent and confirm the receipt line appears below it.
- [x] Send a fresh cash card and confirm it lands at full size with the receipt, with no clipping on insert.
- [x] Confirm a received cash card (no receipt) renders at its normal size.