### PR TITLE
refactor: extract a shared base cell for chat rows

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -8,12 +8,11 @@
 #if canImport(UIKit)
 import UIKit
 
-/// A recycled cell for a cash payment row: a fixed-size card (shared `BubbleBackgroundView`
-/// chrome) with the token name + optional coin icon in the top-left and a centered
-/// "You sent / You received" caption above the currency flag + amount. Aligns to the leading or
-/// trailing edge by sender. Dumb — `configure(with:)` is the only input; the strings, flag name,
-/// and icon URL all arrive on the `ChatMessage`.
-public final class ChatCashCardCell: UICollectionViewCell {
+/// A recycled cell for a cash payment row: a fixed-size card (shared `BubbleBackgroundView` chrome)
+/// with the token name + optional coin icon in the top-left and a centered "You sent / You received"
+/// caption above the currency flag + amount, hosted in a `ChatColumnCell`. Dumb — `configure(with:)`
+/// is the only input; the strings, flag name, and icon URL all arrive on the `ChatMessage`.
+public final class ChatCashCardCell: ChatColumnCell {
 
     public static let reuseIdentifier = "ChatCashCardCell"
 
@@ -26,10 +25,6 @@ public final class ChatCashCardCell: UICollectionViewCell {
     private let flag = UIImageView()
     private let captionLabel = UILabel()
     private let amountLabel = UILabel()
-    private let receipt = ChatReceiptLabel()
-    private let column = UIStackView()
-    private var leadingConstraint: NSLayoutConstraint!
-    private var trailingConstraint: NSLayoutConstraint!
     private var iconTask: Task<Void, Never>?
 
     public override init(frame: CGRect) {
@@ -69,21 +64,9 @@ public final class ChatCashCardCell: UICollectionViewCell {
         centerStack.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(centerStack)
 
-        column.axis = .vertical
-        column.spacing = 4
-        column.addArrangedSubview(card)
-        column.addArrangedSubview(receipt)
-        column.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(column)
+        installColumn(content: card)
 
-        leadingConstraint = column.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12)
-        trailingConstraint = column.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12)
-
-        // The column pins top and bottom to the contentView so the cell self-sizes to the fixed-height
-        // card plus the receipt line below it.
         NSLayoutConstraint.activate([
-            column.topAnchor.constraint(equalTo: contentView.topAnchor),
-            column.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             card.widthAnchor.constraint(equalToConstant: Self.cardSize.width),
             card.heightAnchor.constraint(equalToConstant: Self.cardSize.height),
 
@@ -146,19 +129,7 @@ public final class ChatCashCardCell: UICollectionViewCell {
                 groupedBelow: message.isContinuedByNext
             )
         )
-        receipt.text = message.receipt
-        receipt.isHidden = message.receipt == nil
-        column.alignment = message.sender == .me ? .trailing : .leading
-        applyAlignment(isFromSelf: message.sender == .me)
-    }
-
-    /// Exactly one horizontal edge is pinned, so the column hugs its sender's side. Both edges are
-    /// deactivated before the wanted one is activated: momentarily pinning both edges over-constrains
-    /// the fixed-width card and trips Auto Layout's unsatisfiable-constraints check when the cell is
-    /// recycled with a flipped sender.
-    private func applyAlignment(isFromSelf: Bool) {
-        NSLayoutConstraint.deactivate([leadingConstraint, trailingConstraint])
-        (isFromSelf ? trailingConstraint : leadingConstraint).isActive = true
+        updateColumn(for: message)
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -1,0 +1,59 @@
+//
+//  ChatColumnCell.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+
+/// Base for a chat row that stacks a content view above an optional `ChatReceiptLabel` in a vertical
+/// column, hugging the leading or trailing edge by sender. A subclass builds its content view (a
+/// bubble or a card), hands it to `installColumn(content:)` from `init`, then calls `updateColumn(for:)`
+/// from its own `configure`. The receipt collapses out of the column when the message carries none.
+public class ChatColumnCell: UICollectionViewCell {
+
+    private let receipt = ChatReceiptLabel()
+    private let column = UIStackView()
+    private var leadingConstraint: NSLayoutConstraint!
+    private var trailingConstraint: NSLayoutConstraint!
+
+    /// Stacks `content` above the receipt and pins the column into the contentView, pinning top and
+    /// bottom so the cell self-sizes to the content plus the receipt line. Call once, from the
+    /// subclass's `init`, after the content view exists.
+    func installColumn(content: UIView) {
+        column.axis = .vertical
+        column.spacing = 4
+        column.addArrangedSubview(content)
+        column.addArrangedSubview(receipt)
+        column.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(column)
+
+        leadingConstraint = column.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12)
+        trailingConstraint = column.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12)
+
+        NSLayoutConstraint.activate([
+            column.topAnchor.constraint(equalTo: contentView.topAnchor),
+            column.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+        ])
+    }
+
+    /// Sets the receipt line and hugs the column to the sender's edge. Call from `configure`.
+    func updateColumn(for message: ChatMessage) {
+        receipt.text = message.receipt
+        receipt.isHidden = message.receipt == nil
+        column.alignment = message.sender == .me ? .trailing : .leading
+        applyAlignment(isFromSelf: message.sender == .me)
+    }
+
+    /// Exactly one horizontal edge is pinned, so the column hugs its sender's side and the opposite
+    /// edge floats. Both edges are deactivated before the wanted one is activated: a recycled cell
+    /// still carries its prior encapsulated layout width, so momentarily pinning both edges
+    /// over-constrains it and trips Auto Layout's unsatisfiable-constraints check.
+    private func applyAlignment(isFromSelf: Bool) {
+        NSLayoutConstraint.deactivate([leadingConstraint, trailingConstraint])
+        (isFromSelf ? trailingConstraint : leadingConstraint).isActive = true
+    }
+}
+#endif

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
@@ -8,42 +8,23 @@
 #if canImport(UIKit)
 import UIKit
 
-/// A recycled collection-view cell that hosts a `ChatBubbleView` — and, under the user's latest
-/// sent message, a `ChatReceiptLabel` below it — in a vertical column aligned to the leading or
-/// trailing edge by sender. Self-sizing: the bubble is capped at a *constant* max width supplied
-/// by the owner, so the label wraps at a known width during self-sizing (a width relative to
-/// `contentView` doesn't bound the label — its width floats while the cell is measured, and the
-/// text collapses to one line). The receipt label collapses out of the column when there is no
-/// receipt. Dumb — `configure(with:maxWidth:)` is the only input; no data fetching, no shared state.
-public final class ChatMessageCell: UICollectionViewCell {
+/// A recycled collection-view cell that hosts a `ChatBubbleView` in a `ChatColumnCell`. The bubble is
+/// capped at a *constant* max width supplied by the owner, so the label wraps at a known width during
+/// self-sizing (a width relative to `contentView` doesn't bound the label — its width floats while the
+/// cell is measured, and the text collapses to one line). Dumb — `configure(with:maxWidth:)` is the
+/// only input; no data fetching, no shared state.
+public final class ChatMessageCell: ChatColumnCell {
 
     public static let reuseIdentifier = "ChatMessageCell"
 
     private let bubble = ChatBubbleView()
-    private let receipt = ChatReceiptLabel()
-    private let column = UIStackView()
-    private var leadingConstraint: NSLayoutConstraint!
-    private var trailingConstraint: NSLayoutConstraint!
     private var maxWidthConstraint: NSLayoutConstraint!
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        column.axis = .vertical
-        column.spacing = 4
-        column.addArrangedSubview(bubble)
-        column.addArrangedSubview(receipt)
-        column.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(column)
-
-        leadingConstraint = column.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12)
-        trailingConstraint = column.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12)
+        installColumn(content: bubble)
         maxWidthConstraint = bubble.widthAnchor.constraint(lessThanOrEqualToConstant: 280)
-
-        NSLayoutConstraint.activate([
-            column.topAnchor.constraint(equalTo: contentView.topAnchor),
-            column.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            maxWidthConstraint,
-        ])
+        maxWidthConstraint.isActive = true
     }
 
     @available(*, unavailable)
@@ -54,19 +35,7 @@ public final class ChatMessageCell: UICollectionViewCell {
     public func configure(with message: ChatMessage, maxWidth: CGFloat) {
         bubble.configure(with: message)
         maxWidthConstraint.constant = maxWidth
-        receipt.text = message.receipt
-        receipt.isHidden = message.receipt == nil
-        column.alignment = message.sender == .me ? .trailing : .leading
-        applyAlignment(isFromSelf: message.sender == .me)
-    }
-
-    /// Exactly one horizontal edge is pinned, so the column hugs its content and the opposite
-    /// edge floats. Both edges are deactivated before the wanted one is activated: a recycled cell
-    /// still carries its prior encapsulated layout width, so momentarily pinning both edges
-    /// over-constrains its width and trips Auto Layout's unsatisfiable-constraints check.
-    private func applyAlignment(isFromSelf: Bool) {
-        NSLayoutConstraint.deactivate([leadingConstraint, trailingConstraint])
-        (isFromSelf ? trailingConstraint : leadingConstraint).isActive = true
+        updateColumn(for: message)
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -271,13 +271,9 @@ public final class ChatViewController: UICollectionViewController {
     }
 }
 
-/// Every row self-sizes to its own content: text and date rows to their text, and the cash card to
-/// its fixed-height card plus the optional receipt line below it.
-extension ChatViewController: ChatLayoutDelegate {
-    public func sizeForItem(_ chatLayout: CollectionViewChatLayout, at indexPath: IndexPath) -> ItemSize {
-        .auto
-    }
-}
+/// The controller is the layout delegate so cells inherit ChatLayout's defaults — auto self-sizing
+/// and full-width alignment. No row needs a custom size, so nothing is overridden.
+extension ChatViewController: ChatLayoutDelegate {}
 
 #Preview("Transcript") {
     let controller = ChatViewController()


### PR DESCRIPTION
After the cash card was switched to self-sizing, it and the text message row ended up with the same column layout, alignment, and receipt handling copy-pasted in both. This lifts that shared structure into a common base cell, so each row keeps only its own content — a text bubble or a cash card. It also removes a sizing hook that no longer did anything beyond the framework default.

No behavior change — verified on the simulator that sent and received rows still align to the correct edge and the receipt still renders inline.

## Test plan
- [x] Open a chat with both text and cash messages and confirm sent rows hug the right edge, received rows hug the left.
- [x] Confirm the Delivered/Read receipt still appears under the latest sent message.
- [x] Scroll the conversation and confirm rows recycle without misalignment or layout glitches.