### PR TITLE
fix: update ChatCashCardSizingTests for self-sizing chat rows

### DIFF
--- a/FlipcashTests/Chat/ChatCashCardSizingTests.swift
+++ b/FlipcashTests/Chat/ChatCashCardSizingTests.swift
@@ -10,13 +10,11 @@ import UIKit
 import ChatLayout
 @testable import FlipcashUI
 
-/// The cash card is a fixed-size row, so `ChatViewController` reports an exact height for it. That
-/// makes an inserted cash cell lay out at its real 170pt height immediately, instead of being placed
-/// at ChatLayout's small estimate and depending on a follow-up self-size pass — a pass iOS 26 skips
-/// during the animated batch update, which left the card clipped to the estimate (invisible) until
-/// the chat was reopened. Text/date/receipt rows keep self-sizing.
+/// Every chat row self-sizes to its own content: text and date rows to their text, and the cash
+/// card to its fixed-height card plus the inline receipt line below it. `ChatViewController`
+/// overrides no per-row sizes, so each reports ChatLayout's `.auto` default.
 @MainActor
-@Suite("Cash rows report an exact height; other rows self-size")
+@Suite("Every chat row self-sizes (.auto)")
 struct ChatCashCardSizingTests {
 
     private func sized(_ items: [ChatItem], at index: Int) -> ItemSize {
@@ -34,25 +32,21 @@ struct ChatCashCardSizingTests {
         ))
     }
 
-    @Test("A cash row reports an exact height equal to the card height")
-    func cashRow_isExactCardHeight() {
+    @Test("A cash row self-sizes (.auto) like every other row")
+    func cashRow_isAuto() {
         let items: [ChatItem] = [
             .message(ChatMessage(id: "1", text: "hi", sender: .me)),
             cashRow("2", .other),
         ]
-        guard case .exact(let size) = sized(items, at: 1) else {
-            Issue.record("expected the cash row to report an exact size")
-            return
-        }
-        #expect(size.height == ChatCashCardCell.cardSize.height)
+        #expect(sized(items, at: 1) == .auto)
     }
 
-    @Test("Text, date separator, and receipt rows keep self-sizing (.auto)")
-    func nonCashRows_areAuto() {
+    @Test("Date separator, text, and receipt-carrying rows self-size (.auto)")
+    func otherRows_areAuto() {
         let items: [ChatItem] = [
             .dateSeparator(id: "sep", text: "Today 1:00 PM"),
             .message(ChatMessage(id: "1", text: "hello", sender: .other)),
-            .receipt(id: "r", text: "Delivered"),
+            .message(ChatMessage(id: "2", text: "sent", sender: .me, receipt: "Delivered")),
         ]
         for index in items.indices {
             #expect(sized(items, at: index) == .auto, "row \(index) should self-size")


### PR DESCRIPTION
Recent chat changes moved the delivery receipt inline onto each message and let the cash card size itself like every other row. The sizing test wasn't updated — it still referenced the old separate receipt row and asserted a fixed card height, which broke the whole test target's build. This updates it to expect every chat row to size itself, matching current behaviour, so the target compiles and passes again.

## Test plan
- [x] FlipcashTests and FlipcashCoreTests compile and pass.
- [x] The chat row sizing tests pass.