### PR TITLE
feat: polish chat read receipts and buzz on receive

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -64,10 +64,23 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         let newLastMessage = lastMessage(of: items)
         let newLastMessageID = newLastMessage?.id
         let lastIsOwnMessage = if case .message(let message) = newLastMessage { message.sender == .me } else { false }
-        let appendedOwn = newLastMessageID != context.coordinator.lastMessageID && lastIsOwnMessage
+        let trailingMessageChanged = newLastMessageID != context.coordinator.lastMessageID
+        let appendedOwn = trailingMessageChanged && lastIsOwnMessage
+        // A message arrived from the other side while this conversation is the one on screen — buzz.
+        // Guarded against the initial population (no prior id), receipt-only updates (the trailing id
+        // is unchanged), and the chat not being the visible conversation, so it only fires for a
+        // genuine live arrival the user is looking at.
+        let receivedNew = trailingMessageChanged
+            && context.coordinator.lastMessageID != nil
+            && newLastMessageID != nil
+            && !lastIsOwnMessage
+            && conversationController.visibleConversationID == conversationID
         screen.update(items: items)
         if appendedOwn {
             screen.scrollToBottom(animated: true)
+        }
+        if receivedNew {
+            Haptics.soft()
         }
         context.coordinator.lastMessageID = newLastMessageID
     }

--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -64,23 +64,10 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         let newLastMessage = lastMessage(of: items)
         let newLastMessageID = newLastMessage?.id
         let lastIsOwnMessage = if case .message(let message) = newLastMessage { message.sender == .me } else { false }
-        let trailingMessageChanged = newLastMessageID != context.coordinator.lastMessageID
-        let appendedOwn = trailingMessageChanged && lastIsOwnMessage
-        // A message arrived from the other side while this conversation is the one on screen — buzz.
-        // Guarded against the initial population (no prior id), receipt-only updates (the trailing id
-        // is unchanged), and the chat not being the visible conversation, so it only fires for a
-        // genuine live arrival the user is looking at.
-        let receivedNew = trailingMessageChanged
-            && context.coordinator.lastMessageID != nil
-            && newLastMessageID != nil
-            && !lastIsOwnMessage
-            && conversationController.visibleConversationID == conversationID
+        let appendedOwn = newLastMessageID != context.coordinator.lastMessageID && lastIsOwnMessage
         screen.update(items: items)
         if appendedOwn {
             screen.scrollToBottom(animated: true)
-        }
-        if receivedNew {
-            Haptics.soft()
         }
         context.coordinator.lastMessageID = newLastMessageID
     }

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -11,6 +11,10 @@ import Combine
 import FlipcashCore
 import FlipcashUI
 
+// Traces when the on-screen conversation is set or cleared — the signal both the receive haptic and
+// foreground-banner suppression gate on — so a missed buzz or an unsuppressed banner is traceable.
+private let logger = Logger(label: "flipcash.conversation")
+
 /// How a conversation is reached: an existing DM chat from the Chats section,
 /// or a synced contact whose chat may not exist yet — the first cash payment
 /// creates it server-side.
@@ -192,9 +196,19 @@ struct ConversationScreen: View {
             guard didInitialRead, let conversationID else { return }
             conversationController.scheduleMarkRead(conversationID: conversationID)
         }
+        // Buzz on a live message from the other side while this conversation is on screen. `old != nil`
+        // and `didInitialRead` skip the opening history load; the sender and visibility checks skip the
+        // user's own sends and arrivals in a chat they've navigated away from.
+        .sensoryFeedback(.impact(weight: .light), trigger: messages.last?.id) { old, _ in
+            guard old != nil, didInitialRead,
+                  let last = messages.last,
+                  !last.isFromSelf(conversationController.selfUserID),
+                  conversationController.visibleConversationID == conversationID
+            else { return false }
+            return true
+        }
         .onAppear {
-            // Suppress foreground chat banners while this transcript is on screen.
-            conversationController.visibleConversationID = conversationID
+            setVisibleConversation(conversationID, source: "onAppear")
         }
         // Send Cash stacks the amount entry as a cover, so the chat stays
         // mounted and `onAppear` won't re-fire when it's dismissed. Poll for the
@@ -205,14 +219,29 @@ struct ConversationScreen: View {
         // A matched contact's chat is created mid-screen on the first payment,
         // flipping the ID from nil to the new conversation; track it live.
         .onChange(of: conversationID) { _, id in
-            conversationController.visibleConversationID = id
+            setVisibleConversation(id, source: "onChange")
         }
         .onDisappear {
             // Guarded so a forward push that already set another ID isn't cleared.
-            if conversationController.visibleConversationID == conversationID {
+            let matched = conversationController.visibleConversationID == conversationID
+            logger.info("Clearing visible conversation on disappear", metadata: [
+                "conversationID": conversationID.map { "\($0)" } ?? "nil",
+                "matched": "\(matched)",
+            ])
+            if matched {
                 conversationController.visibleConversationID = nil
             }
         }
+    }
+
+    /// Marks this conversation as the one on screen — the gate for foreground-banner suppression and
+    /// the receive haptic — and traces the change so a first-open visibility gap is diagnosable.
+    private func setVisibleConversation(_ id: ConversationID?, source: String) {
+        logger.info("Set visible conversation", metadata: [
+            "source": "\(source)",
+            "conversationID": id.map { "\($0)" } ?? "nil",
+        ])
+        conversationController.visibleConversationID = id
     }
 
     private func sendCash() {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -41,10 +41,30 @@ public class ChatColumnCell: UICollectionViewCell {
 
     /// Sets the receipt line and hugs the column to the sender's edge. Call from `configure`.
     func updateColumn(for message: ChatMessage) {
-        receipt.text = message.receipt
-        receipt.isHidden = message.receipt == nil
+        // A cell already in the window is being reconfigured in place (Delivered→Read, or the line
+        // clearing as a newer sent message takes it over), so cross-fade the change. A freshly
+        // dequeued cell isn't in the window yet, so it's set without animation — a scroll-in or a
+        // send shouldn't flash the line.
+        setReceipt(message.receipt, animated: window != nil)
         column.alignment = message.sender == .me ? .trailing : .leading
         applyAlignment(isFromSelf: message.sender == .me)
+    }
+
+    private func setReceipt(_ text: String?, animated: Bool) {
+        guard receipt.text != text else { return }
+        // Cross-fade the line in (nil→text) and across the Delivered→Read swap; let it snap away when
+        // it clears so the row collapses in step with the batch update rather than after the fade. The
+        // visibility change is applied synchronously, outside the transition, so the cell's self-sized
+        // height never lags the cross-fade.
+        if animated, text != nil {
+            receipt.isHidden = false
+            UIView.transition(with: receipt, duration: 0.25, options: .transitionCrossDissolve) {
+                self.receipt.text = text
+            }
+        } else {
+            receipt.text = text
+            receipt.isHidden = text == nil
+        }
     }
 
     /// Exactly one horizontal edge is pinned, so the column hugs its sender's side and the opposite

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatReceiptLabel.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatReceiptLabel.swift
@@ -13,6 +13,10 @@ import UIKit
 /// animates with its bubble instead of inserting and moving on its own.
 public final class ChatReceiptLabel: UILabel {
 
+    /// Keeps the line off the bubble's trailing edge so "Delivered" / "Read 3:42 PM" don't sit flush
+    /// against the column's right side.
+    private static let textInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         font = .default(size: 12, weight: .medium)
@@ -23,5 +27,15 @@ public final class ChatReceiptLabel: UILabel {
 
     @available(*, unavailable)
     public required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    public override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: Self.textInsets))
+    }
+
+    public override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
+        var rect = super.textRect(forBounds: bounds.inset(by: Self.textInsets), limitedToNumberOfLines: numberOfLines)
+        rect.size.width += Self.textInsets.right
+        return rect
+    }
 }
 #endif


### PR DESCRIPTION
Adds polish to the chat conversation screen. The Delivered/Read line now sits 10pt off the bubble's trailing edge instead of flush against it, and it cross-fades when it appears and when it changes from Delivered to Read rather than swapping instantly. Receiving a message while the conversation is on screen plays a subtle haptic. Also adds lightweight logging of when a conversation becomes or stops being the one on screen, to help diagnose an occasional first-open gap where the haptic and the suppression of that chat's own notifications can briefly miss until the chat is reopened.

## Test plan
- [x] Open a chat and confirm the Delivered/Read line is inset from the bubble's edge
- [x] Have the other person read your latest message and confirm it fades from Delivered to Read
- [x] Receive a message while the chat is open and confirm a haptic plays
- [x] Receive a message while on another screen and confirm no haptic