### PR TITLE
feat: sort the Send list by activity or join date, drop "On Flipcash" header

### DIFF
--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -26,14 +26,19 @@ nonisolated struct ResolvedContact: Identifiable, Hashable, Sendable {
     /// has stored one. A chat that doesn't exist yet is initiated by sending
     /// the contact cash.
     let dmChatID: Data?
+    /// When this contact joined Flipcash, from the matched-contact set. Sorts a
+    /// chat-less contact into the recipient list by recency. `nil` for a
+    /// not-on-Flipcash contact and when the server omits it.
+    let joinDate: Date?
 
-    init(contactId: String, displayName: String, phoneE164: String, nationalPhone: String, imageData: Data?, dmChatID: Data? = nil) {
+    init(contactId: String, displayName: String, phoneE164: String, nationalPhone: String, imageData: Data?, dmChatID: Data? = nil, joinDate: Date? = nil) {
         self.contactId = contactId
         self.displayName = displayName
         self.phoneE164 = phoneE164
         self.nationalPhone = nationalPhone
         self.imageData = imageData
         self.dmChatID = dmChatID
+        self.joinDate = joinDate
     }
 
     /// Composite identity for `ForEach`. A picker row corresponds to one
@@ -167,6 +172,10 @@ enum RecipientLoader {
                 matched.compactMap { contact in contact.dmChatID.map { (contact.e164, $0) } },
                 uniquingKeysWith: { first, _ in first }
             )
+            let joinDateByPhone = Dictionary(
+                matched.compactMap { contact in contact.joinDate.map { (contact.e164, $0) } },
+                uniquingKeysWith: { first, _ in first }
+            )
 
             let store = CNContactStore()
             // `CNContactFormatter.descriptorForRequiredKeys(for:)` returns the
@@ -220,6 +229,7 @@ enum RecipientLoader {
                     nationalPhone: nationalPhone,
                     imageData: cnContact.thumbnailImageData,
                     dmChatID: dmChatIDByPhone[entry.e164],
+                    joinDate: joinDateByPhone[entry.e164],
                 ))
             }
 

--- a/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
+++ b/Flipcash/Core/Controllers/Database/Database+ContactSync.swift
@@ -45,8 +45,8 @@ nonisolated extension Database {
     /// Contacts the server has confirmed are on Flipcash, with their DM chat IDs.
     func flipcashContacts() throws -> [MatchedContact] {
         let table = FlipcashContactTable()
-        let rows = try reader.prepareRowIterator(table.table.select(table.e164, table.dmChatId))
-        return try rows.map { MatchedContact(e164: $0[table.e164], dmChatID: $0[table.dmChatId]) }
+        let rows = try reader.prepareRowIterator(table.table.select(table.e164, table.dmChatId, table.joinTs))
+        return try rows.map { MatchedContact(e164: $0[table.e164], dmChatID: $0[table.dmChatId], joinDate: $0[table.joinTs]) }
     }
 
     /// Replace the matched-contacts set with the server's latest response and
@@ -65,6 +65,7 @@ nonisolated extension Database {
                     table.table.insert(
                         table.e164 <- contact.e164,
                         table.dmChatId <- contact.dmChatID,
+                        table.joinTs <- contact.joinDate,
                         table.matchedAt <- matchedAt
                     )
                 )

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -146,6 +146,7 @@ nonisolated struct FlipcashContactTable: Sendable {
     let table     = Table(Self.name)
     let e164      = Expression <String> ("e164")
     let dmChatId  = Expression <Data?>  ("dmChatId")
+    let joinTs    = Expression <Date?>  ("joinTs")
     let matchedAt = Expression <Date>   ("matchedAt")
 }
 
@@ -356,6 +357,7 @@ nonisolated extension Database {
             try writer.run(flipcashContactTable.table.create(ifNotExists: true, withoutRowid: true) { t in
                 t.column(flipcashContactTable.e164, primaryKey: true)
                 t.column(flipcashContactTable.dmChatId)
+                t.column(flipcashContactTable.joinTs)
                 t.column(flipcashContactTable.matchedAt)
             })
         }

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -174,10 +174,11 @@ private struct RecipientSearchEmptyState: View {
 
 // MARK: - List items -
 
-/// One row of the merged "On Flipcash" section: a synced contact, a DM
-/// conversation, or both joined by the contact's `dmChatID`. Rows with a
-/// conversation sort by activity (newest first) ahead of chat-less contacts,
-/// which keep the directory's order.
+/// One row of the merged on-Flipcash recipient feed: a synced contact, a DM
+/// conversation, or both joined by the contact's `dmChatID`. Rows sort by
+/// recency — the more recent of conversation activity and the contact's
+/// Flipcash join date — so a just-joined chat-less contact interleaves with
+/// active chats instead of trailing them.
 nonisolated enum RecipientListItem: Identifiable, Equatable {
 
     case contact(ResolvedContact)
@@ -211,28 +212,46 @@ nonisolated enum RecipientListItem: Identifiable, Equatable {
         }
     }
 
+    /// Recency for the merged feed sort: the more recent of the row's
+    /// conversation activity and its contact's Flipcash join date. A chat-less
+    /// contact sorts by join date; an active chat by its (always later) activity.
+    private var sortDate: Date {
+        max(conversation?.lastActivity ?? .distantPast, contact?.joinDate ?? .distantPast)
+    }
+
+    /// Stable tiebreak for rows that share a `sortDate` — e.g. contacts from one
+    /// join batch: the contact's name, falling back to the row id.
+    private var tiebreak: String {
+        contact?.displayName ?? id
+    }
+
     static func items(contacts: [ResolvedContact], conversations: [Conversation]) -> [RecipientListItem] {
         var unmatched: [ConversationID: Conversation] = [:]
         for conversation in conversations {
             unmatched[conversation.id] = conversation
         }
 
-        var active: [RecipientListItem] = []
-        var chatless: [RecipientListItem] = []
+        var items: [RecipientListItem] = []
         for contact in contacts {
             if let chatID = contact.dmChatID.map(ConversationID.init(data:)),
                let conversation = unmatched.removeValue(forKey: chatID) {
-                active.append(.matched(contact, conversation))
+                items.append(.matched(contact, conversation))
             } else {
-                chatless.append(.contact(contact))
+                items.append(.contact(contact))
             }
         }
         for conversation in conversations where unmatched[conversation.id] != nil {
-            active.append(.conversation(conversation))
+            items.append(.conversation(conversation))
         }
 
-        active.sort { ($0.conversation?.lastActivity ?? .distantPast) > ($1.conversation?.lastActivity ?? .distantPast) }
-        return active + chatless
+        return items.sorted { lhs, rhs in
+            if lhs.sortDate != rhs.sortDate { return lhs.sortDate > rhs.sortDate }
+            let byName = lhs.tiebreak.localizedCaseInsensitiveCompare(rhs.tiebreak)
+            if byName != .orderedSame { return byName == .orderedAscending }
+            // Final discriminator on the unique row id keeps the order a total
+            // order, so equal date + name rows don't flicker across re-sorts.
+            return lhs.id < rhs.id
+        }
     }
 }
 
@@ -278,8 +297,6 @@ private struct RecipientPickerList: View {
                             }
                         )
                     }
-                } header: {
-                    RecipientSectionHeader(title: "On Flipcash")
                 }
                 .listSectionSeparator(.hidden, edges: .top)
             }
@@ -414,9 +431,10 @@ private extension View {
     }
 }
 
-/// A merged "On Flipcash" row. Rows with a conversation show the last-message
-/// preview; chatless contacts and chats with no messages show no subtitle. An
-/// unread chat marks the row with a leading dot.
+/// A merged recipient row: a synced contact, a DM conversation, or both. Rows
+/// with a conversation show the last-message preview; chat-less contacts and
+/// chats with no messages show no subtitle. An unread chat marks the row with
+/// a leading dot.
 private struct RecipientListItemRow: View {
 
     let item: RecipientListItem

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -215,13 +215,13 @@ nonisolated enum RecipientListItem: Identifiable, Equatable {
     /// Recency for the merged feed sort: the more recent of the row's
     /// conversation activity and its contact's Flipcash join date. A chat-less
     /// contact sorts by join date; an active chat by its (always later) activity.
-    private var sortDate: Date {
+    fileprivate var sortDate: Date {
         max(conversation?.lastActivity ?? .distantPast, contact?.joinDate ?? .distantPast)
     }
 
     /// Stable tiebreak for rows that share a `sortDate` — e.g. contacts from one
     /// join batch: the contact's name, falling back to the row id.
-    private var tiebreak: String {
+    fileprivate var tiebreak: String {
         contact?.displayName ?? id
     }
 
@@ -244,14 +244,40 @@ nonisolated enum RecipientListItem: Identifiable, Equatable {
             items.append(.conversation(conversation))
         }
 
-        return items.sorted { lhs, rhs in
-            if lhs.sortDate != rhs.sortDate { return lhs.sortDate > rhs.sortDate }
-            let byName = lhs.tiebreak.localizedCaseInsensitiveCompare(rhs.tiebreak)
-            if byName != .orderedSame { return byName == .orderedAscending }
-            // Final discriminator on the unique row id keeps the order a total
-            // order, so equal date + name rows don't flicker across re-sorts.
-            return lhs.id < rhs.id
+        return items.sorted(using: RecipientFeedOrder())
+    }
+}
+
+/// The Send feed's row order as a reusable `SortComparator`: most-recent first
+/// by each row's recency (the later of its conversation activity and the
+/// contact's Flipcash join date), then by name, then by the unique row id. The
+/// id discriminator makes the order total, so rows sharing a date and name keep
+/// a stable position across re-sorts instead of flickering.
+nonisolated struct RecipientFeedOrder: SortComparator {
+
+    var order: SortOrder = .forward
+
+    func compare(_ lhs: RecipientListItem, _ rhs: RecipientListItem) -> ComparisonResult {
+        let forward = forwardComparison(lhs, rhs)
+        guard order == .reverse else { return forward }
+        switch forward {
+        case .orderedAscending:  return .orderedDescending
+        case .orderedDescending: return .orderedAscending
+        case .orderedSame:       return .orderedSame
         }
+    }
+
+    /// The ranking in `.forward` (most-recent-first) order.
+    private func forwardComparison(_ lhs: RecipientListItem, _ rhs: RecipientListItem) -> ComparisonResult {
+        if lhs.sortDate != rhs.sortDate {
+            return lhs.sortDate > rhs.sortDate ? .orderedAscending : .orderedDescending
+        }
+        let byName = lhs.tiebreak.localizedCaseInsensitiveCompare(rhs.tiebreak)
+        if byName != .orderedSame { return byName }
+        if lhs.id != rhs.id {
+            return lhs.id < rhs.id ? .orderedAscending : .orderedDescending
+        }
+        return .orderedSame
     }
 }
 
@@ -282,6 +308,10 @@ private struct RecipientPickerList: View {
 
     var body: some View {
         List {
+            // The on-Flipcash group keeps its `Section` even without a header:
+            // `.listSectionSeparator(.hidden, edges: .top)` is the only clean way
+            // to suppress the separator the grouped list draws above the first
+            // row. `.contentMargins` (below) handles the top gap instead.
             if !items.isEmpty {
                 Section {
                     ForEach(items) { item in
@@ -332,6 +362,10 @@ private struct RecipientPickerList: View {
         }
         .listStyle(.grouped)
         .listSectionSpacing(.compact)
+        // The grouped list's default top inset leaves a wide gap under the
+        // search bar now that the first group has no header; tighten it so the
+        // list sits just below the search field.
+        .contentMargins(.top, 8, for: .scrollContent)
         .scrollContentBackground(.hidden)
         .scrollDismissesKeyboard(.interactively)
         // New messages re-sort and re-style rows — animate those moves. Keyed

--- a/Flipcash/Core/Screens/Send/SendMoneyPromoCard.swift
+++ b/Flipcash/Core/Screens/Send/SendMoneyPromoCard.swift
@@ -41,7 +41,7 @@ struct SendMoneyPromoCard: View {
 private struct FakeCashCardsHero: View {
     var body: some View {
         ZStack {
-            FakeCashCard(caption: "You give", amount: "$60.00", isFromSelf: true, width: 130)
+            FakeCashCard(caption: "You gave", amount: "$60.00", isFromSelf: true, width: 130)
                 .rotationEffect(.degrees(6))
                 .offset(x: 46, y: -22)
             FakeCashCard(caption: "You received", amount: "$25.00", isFromSelf: false, width: 130)

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -22,7 +22,7 @@
 		<string>INSendMessageIntent</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/contact_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/contact_v1_model.pb.swift
@@ -45,12 +45,23 @@ public struct Flipcash_Contact_V1_FlipcashContact: Sendable {
   /// Clears the value of `dmChatID`. Subsequent reads from it will return its default value.
   public mutating func clearDmChatID() {self._dmChatID = nil}
 
+  /// Timestamp the contact joined Flipcash
+  public var joinTs: SwiftProtobuf.Google_Protobuf_Timestamp {
+    get {_joinTs ?? SwiftProtobuf.Google_Protobuf_Timestamp()}
+    set {_joinTs = newValue}
+  }
+  /// Returns true if `joinTs` has been explicitly set.
+  public var hasJoinTs: Bool {self._joinTs != nil}
+  /// Clears the value of `joinTs`. Subsequent reads from it will return its default value.
+  public mutating func clearJoinTs() {self._joinTs = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _phone: Flipcash_Phone_V1_PhoneNumber? = nil
   fileprivate var _dmChatID: Flipcash_Common_V1_ChatId? = nil
+  fileprivate var _joinTs: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -59,7 +70,7 @@ fileprivate let _protobuf_package = "flipcash.contact.v1"
 
 extension Flipcash_Contact_V1_FlipcashContact: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FlipcashContact"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phone\0\u{3}dm_chat_id\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phone\0\u{3}dm_chat_id\0\u{3}join_ts\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -69,6 +80,7 @@ extension Flipcash_Contact_V1_FlipcashContact: SwiftProtobuf.Message, SwiftProto
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._phone) }()
       case 2: try { try decoder.decodeSingularMessageField(value: &self._dmChatID) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._joinTs) }()
       default: break
       }
     }
@@ -85,12 +97,16 @@ extension Flipcash_Contact_V1_FlipcashContact: SwiftProtobuf.Message, SwiftProto
     try { if let v = self._dmChatID {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     } }()
+    try { if let v = self._joinTs {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Flipcash_Contact_V1_FlipcashContact, rhs: Flipcash_Contact_V1_FlipcashContact) -> Bool {
     if lhs._phone != rhs._phone {return false}
     if lhs._dmChatID != rhs._dmChatID {return false}
+    if lhs._joinTs != rhs._joinTs {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/contact/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/contact/v1/model.proto
@@ -4,6 +4,7 @@ package flipcash.contact.v1;
 
 import "common/v1/common.proto";
 import "phone/v1/model.proto";
+import "google/protobuf/timestamp.proto";
 import "validate/validate.proto";
 
 option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/go/contact/v1;contactpb";
@@ -16,4 +17,7 @@ message FlipcashContact {
     // The DM chat ID for the Flipcash contact. If the chat doesn't exist, it needs
     // to be initiated with a cash send to initialize it
     common.v1.ChatId dm_chat_id = 2 [(validate.rules).message.required = true];
+
+    // Timestamp the contact joined Flipcash
+    google.protobuf.Timestamp join_ts = 3 [(validate.rules).timestamp.required = true];
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
@@ -180,16 +180,7 @@ final class ContactListService: CodeService<Flipcash_Contact_V1_ContactListNIOCl
 
         let queue = self.queue
         let stream = service.getFlipcashContacts(request, callOptions: .streaming) { @Sendable response in
-            // Emit raw E.164 strings — server-validated against the proto regex —
-            // rather than routing through `Phone(_:)`. Going through
-            // `PhoneNumberKit` would silently drop any string it can't parse,
-            // decoupling the local matched-set from the server's truth.
-            let contacts = response.contacts.map {
-                MatchedContact(
-                    e164: $0.phone.value,
-                    dmChatID: $0.hasDmChatID && !$0.dmChatID.value.isEmpty ? $0.dmChatID.value : nil
-                )
-            }
+            let contacts = response.contacts.map(MatchedContact.init)
             let batch = FlipcashContactsBatch(
                 result: FlipcashContactsBatch.Result(response.result),
                 contacts: contacts
@@ -246,10 +237,29 @@ public struct MatchedContact: Equatable, Hashable, Sendable {
     /// The server's 32-byte DM ChatId; nil when absent. A chat that doesn't
     /// exist yet is initiated by sending the contact cash.
     public let dmChatID: Data?
+    /// When the contact joined Flipcash. Sorts a chat-less contact into the
+    /// recipient list by recency. `nil` only when the server omits it.
+    public let joinDate: Date?
 
-    public init(e164: String, dmChatID: Data? = nil) {
+    public init(e164: String, dmChatID: Data? = nil, joinDate: Date? = nil) {
         self.e164 = e164
         self.dmChatID = dmChatID
+        self.joinDate = joinDate
+    }
+}
+
+extension MatchedContact {
+    /// Maps a server-matched contact. The e164 is emitted verbatim — it's
+    /// server-validated against the proto regex, and routing it through
+    /// `Phone(_:)`/`PhoneNumberKit` would silently drop anything it can't parse,
+    /// decoupling the local matched-set from the server's truth. An empty
+    /// `dmChatID` and an unset `joinTs` both decode to `nil`.
+    init(_ proto: Flipcash_Contact_V1_FlipcashContact) {
+        self.init(
+            e164: proto.phone.value,
+            dmChatID: proto.hasDmChatID && !proto.dmChatID.value.isEmpty ? proto.dmChatID.value : nil,
+            joinDate: proto.hasJoinTs ? proto.joinTs.date : nil
+        )
     }
 }
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/ContactSyncTypesTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ContactSyncTypesTests.swift
@@ -34,6 +34,37 @@ struct ContactSyncTypesTests {
         #expect(FlipcashContactsBatch.Result(.UNRECOGNIZED(99)) == .unknown)
     }
 
+    // MARK: - MatchedContact proto mapping -
+
+    @Test("MatchedContact maps phone, dm chat id, and join date from the proto")
+    func matchedContact_mapsAllFields() {
+        let chatID = Data(repeating: 0xab, count: 32)
+        let joined = Date(timeIntervalSince1970: 1_700_000_000)
+        let proto = Flipcash_Contact_V1_FlipcashContact.with {
+            $0.phone = .with { $0.value = "+15551234567" }
+            $0.dmChatID = .with { $0.value = chatID }
+            $0.joinTs = .init(date: joined)
+        }
+
+        let contact = MatchedContact(proto)
+
+        #expect(contact.e164 == "+15551234567")
+        #expect(contact.dmChatID == chatID)
+        #expect(contact.joinDate == joined)
+    }
+
+    @Test("MatchedContact decodes an empty dm chat id and unset join ts to nil")
+    func matchedContact_optionalFieldsNil() {
+        let proto = Flipcash_Contact_V1_FlipcashContact.with {
+            $0.phone = .with { $0.value = "+15551234567" }
+        }
+
+        let contact = MatchedContact(proto)
+
+        #expect(contact.dmChatID == nil)
+        #expect(contact.joinDate == nil)
+    }
+
     // MARK: - ErrorContactSync reportability -
 
     @Test(

--- a/FlipcashTests/Database/Database+ContactSyncTests.swift
+++ b/FlipcashTests/Database/Database+ContactSyncTests.swift
@@ -105,6 +105,20 @@ struct DatabaseContactSyncTests {
         #expect(try db.flipcashContacts() == [MatchedContact(e164: "+15551234567", dmChatID: Data(repeating: 0x01, count: 32))])
     }
 
+    @Test("replaceFlipcashContacts round-trips each contact's join date")
+    func contacts_joinDateRoundTrips() throws {
+        let db = Database.mock
+        let joined = Date(timeIntervalSince1970: 1_700_000_000)
+        let contacts = [
+            MatchedContact(e164: "+15551234567", dmChatID: Data(repeating: 0x01, count: 32), joinDate: joined),
+            MatchedContact(e164: "+447700900000", dmChatID: nil, joinDate: nil),
+        ]
+
+        try db.replaceFlipcashContacts(contacts, matchedAt: .now)
+
+        #expect(Set(try db.flipcashContacts()) == Set(contacts))
+    }
+
     // MARK: - Local Snapshot -
 
     @Test("localContactsSnapshot is empty on a fresh database")

--- a/FlipcashTests/RecipientFeedOrderTests.swift
+++ b/FlipcashTests/RecipientFeedOrderTests.swift
@@ -1,0 +1,105 @@
+//
+//  RecipientFeedOrderTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@Suite("Recipient feed order")
+struct RecipientFeedOrderTests {
+
+    private func contact(
+        _ name: String,
+        id: String? = nil,
+        phone: String? = nil,
+        dmChatID: Data? = nil,
+        joinDate: Date? = nil
+    ) -> ResolvedContact {
+        ResolvedContact(
+            contactId: id ?? "contact-\(name)",
+            displayName: name,
+            phoneE164: phone ?? "+1555\(name.count)",
+            nationalPhone: "(555) \(name.count)",
+            imageData: nil,
+            dmChatID: dmChatID,
+            joinDate: joinDate
+        )
+    }
+
+    private func conversation(byte: UInt8, lastActivity: Date) -> Conversation {
+        Conversation(
+            id: ConversationID(data: Data(repeating: byte, count: 32)),
+            members: [],
+            lastMessage: nil,
+            lastActivity: lastActivity
+        )
+    }
+
+    private let order = RecipientFeedOrder()
+
+    @Test("A more recent row precedes an older one")
+    func recencyOrdersMostRecentFirst() {
+        let recent = RecipientListItem.conversation(conversation(byte: 0x01, lastActivity: Date(timeIntervalSince1970: 200)))
+        let older = RecipientListItem.conversation(conversation(byte: 0x02, lastActivity: Date(timeIntervalSince1970: 100)))
+
+        #expect(order.compare(recent, older) == .orderedAscending)
+        #expect(order.compare(older, recent) == .orderedDescending)
+    }
+
+    @Test("Recency is the more recent of conversation activity and join date")
+    func recencyUsesLaterOfActivityAndJoin() {
+        let chat = conversation(byte: 0x01, lastActivity: Date(timeIntervalSince1970: 300))
+        // Matched row ranks by its activity (300), not the contact's earlier join (100).
+        let matched = RecipientListItem.matched(
+            contact("Anna", dmChatID: chat.id.data, joinDate: Date(timeIntervalSince1970: 100)),
+            chat
+        )
+        // Chat-less contact ranks by its join date (200).
+        let newcomer = RecipientListItem.contact(contact("Ben", joinDate: Date(timeIntervalSince1970: 200)))
+
+        #expect(order.compare(matched, newcomer) == .orderedAscending)
+    }
+
+    @Test("Rows sharing a date tie-break by name, ascending")
+    func equalDateTieBreaksByName() {
+        let joined = Date(timeIntervalSince1970: 200)
+        let anna = RecipientListItem.contact(contact("Anna", joinDate: joined))
+        let zoe = RecipientListItem.contact(contact("Zoe", joinDate: joined))
+
+        #expect(order.compare(anna, zoe) == .orderedAscending)
+        #expect(order.compare(zoe, anna) == .orderedDescending)
+    }
+
+    @Test("Rows sharing date and name fall back to the unique id")
+    func equalDateAndNameTieBreakByID() {
+        let joined = Date(timeIntervalSince1970: 200)
+        let first = RecipientListItem.contact(contact("Sam", id: "id-1", phone: "+15550001", joinDate: joined))
+        let second = RecipientListItem.contact(contact("Sam", id: "id-2", phone: "+15550002", joinDate: joined))
+
+        // Same date, same name, distinct ids → ordered by id so the result is total.
+        #expect(order.compare(first, second) == .orderedAscending)
+        #expect(order.compare(second, first) == .orderedDescending)
+    }
+
+    @Test("A row compares equal to itself")
+    func reflexive() {
+        let item = RecipientListItem.contact(contact("Anna", joinDate: Date(timeIntervalSince1970: 200)))
+
+        #expect(order.compare(item, item) == .orderedSame)
+    }
+
+    @Test("Reverse order flips the comparison")
+    func reverseOrderFlips() {
+        let recent = RecipientListItem.conversation(conversation(byte: 0x01, lastActivity: Date(timeIntervalSince1970: 200)))
+        let older = RecipientListItem.conversation(conversation(byte: 0x02, lastActivity: Date(timeIntervalSince1970: 100)))
+        let reversed = RecipientFeedOrder(order: .reverse)
+
+        #expect(reversed.compare(recent, older) == .orderedDescending)
+        #expect(reversed.compare(older, recent) == .orderedAscending)
+    }
+}

--- a/FlipcashTests/RecipientListItemTests.swift
+++ b/FlipcashTests/RecipientListItemTests.swift
@@ -13,14 +13,15 @@ import FlipcashCore
 @Suite("Recipient list items")
 struct RecipientListItemTests {
 
-    private func contact(_ name: String, dmChatID: Data? = nil) -> ResolvedContact {
+    private func contact(_ name: String, dmChatID: Data? = nil, joinDate: Date? = nil) -> ResolvedContact {
         ResolvedContact(
             contactId: "contact-\(name)",
             displayName: name,
             phoneE164: "+1555\(name.count)",
             nationalPhone: "(555) \(name.count)",
             imageData: nil,
-            dmChatID: dmChatID
+            dmChatID: dmChatID,
+            joinDate: joinDate
         )
     }
 
@@ -87,5 +88,38 @@ struct RecipientListItemTests {
         let items = RecipientListItem.items(contacts: [preassigned], conversations: [])
 
         #expect(items == [.contact(preassigned)])
+    }
+
+    @Test("A just-joined chat-less contact sorts above an older conversation")
+    func chatlessContactSortsByJoinDate() {
+        let oldChat = conversation(byte: 0x01, lastActivity: Date(timeIntervalSince1970: 100))
+        let chatContact = contact("Anna", dmChatID: oldChat.id.data)
+        let newcomer = contact("Ben", joinDate: Date(timeIntervalSince1970: 200))
+
+        let items = RecipientListItem.items(contacts: [chatContact, newcomer], conversations: [oldChat])
+
+        #expect(items == [.contact(newcomer), .matched(chatContact, oldChat)])
+    }
+
+    @Test("A matched row sorts by activity even when the contact joined earlier")
+    func matchedRowSortsByActivityOverJoinDate() {
+        let chat = conversation(byte: 0x01, lastActivity: Date(timeIntervalSince1970: 300))
+        let longtime = contact("Anna", dmChatID: chat.id.data, joinDate: Date(timeIntervalSince1970: 100))
+        let newcomer = contact("Ben", joinDate: Date(timeIntervalSince1970: 200))
+
+        let items = RecipientListItem.items(contacts: [longtime, newcomer], conversations: [chat])
+
+        #expect(items == [.matched(longtime, chat), .contact(newcomer)])
+    }
+
+    @Test("Chat-less contacts sharing a join date tie-break by name")
+    func chatlessContactsTieBreakByName() {
+        let joined = Date(timeIntervalSince1970: 200)
+        let zoe = contact("Zoe", joinDate: joined)
+        let anna = contact("Anna", joinDate: joined)
+
+        let items = RecipientListItem.items(contacts: [zoe, anna], conversations: [])
+
+        #expect(items == [.contact(anna), .contact(zoe)])
     }
 }


### PR DESCRIPTION
The server now sends a join timestamp for each Flipcash contact. The Send list now orders each person by the more recent of their last chat activity and when they joined Flipcash, so someone who just joined surfaces alongside active conversations instead of sitting at the bottom in alphabetical order. The "On Flipcash" section header is removed and the "Not on Flipcash Yet" header stays.

Also includes a small "You give" → "You gave" copy fix on the Send promo card.

## Test plan
- [x] Open the Send tab and confirm people appear in one list with no "On Flipcash" header.
- [x] Confirm the "Not on Flipcash Yet" section still appears for contacts who can be invited.
- [x] Confirm a recently active conversation stays near the top of the list.
- [x] Search for a contact and confirm the list filters to matching people.
