### PR TITLE
feat: delay chat receipts until the sent message settles

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -100,7 +100,9 @@ public final class ChatCashCardCell: ChatColumnCell {
         coinIcon.image = nil
     }
 
-    public func configure(with message: ChatMessage) {
+    /// - Parameter revealsReceiptAfterSettling: set only for a just-sent message's inserting cell, so
+    ///   the delivery line fades in after the card settles instead of popping in with it.
+    public func configure(with message: ChatMessage, revealsReceiptAfterSettling: Bool = false) {
         guard case .cash(let cash) = message.content else { return }
         tokenLabel.text = cash.token
         captionLabel.text = message.sender == .me ? "You sent" : "You received"
@@ -129,7 +131,7 @@ public final class ChatCashCardCell: ChatColumnCell {
                 groupedBelow: message.isContinuedByNext
             )
         )
-        updateColumn(for: message)
+        updateColumn(for: message, revealsReceiptAfterSettling: revealsReceiptAfterSettling)
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -18,6 +18,8 @@ public class ChatColumnCell: UICollectionViewCell {
     private let column = UIStackView()
     private var leadingConstraint: NSLayoutConstraint!
     private var trailingConstraint: NSLayoutConstraint!
+    /// Duration of the receipt fade-in and the in-place Delivered→Read cross-fade.
+    private static let receiptFadeDuration: TimeInterval = 0.25
 
     /// Stacks `content` above the receipt and pins the column into the contentView, pinning top and
     /// bottom so the cell self-sizes to the content plus the receipt line. Call once, from the
@@ -40,31 +42,64 @@ public class ChatColumnCell: UICollectionViewCell {
     }
 
     /// Sets the receipt line and hugs the column to the sender's edge. Call from `configure`.
-    func updateColumn(for message: ChatMessage) {
-        // A cell already in the window is being reconfigured in place (Delivered→Read, or the line
-        // clearing as a newer sent message takes it over), so cross-fade the change. A freshly
-        // dequeued cell isn't in the window yet, so it's set without animation — a scroll-in or a
-        // send shouldn't flash the line.
-        setReceipt(message.receipt, animated: window != nil)
+    /// `revealsReceiptAfterSettling` is set only for a just-sent message's inserting cell: the line is
+    /// held hidden and faded in by `revealHeldReceipt()` once the controller reports the insert has
+    /// settled, instead of popping in with the bubble.
+    func updateColumn(for message: ChatMessage, revealsReceiptAfterSettling: Bool = false) {
+        setReceipt(message.receipt, animated: window != nil, held: revealsReceiptAfterSettling)
         column.alignment = message.sender == .me ? .trailing : .leading
         applyAlignment(isFromSelf: message.sender == .me)
     }
 
-    private func setReceipt(_ text: String?, animated: Bool) {
+    private func setReceipt(_ text: String?, animated: Bool, held: Bool) {
         guard receipt.text != text else { return }
-        // Cross-fade the line in (nil→text) and across the Delivered→Read swap; let it snap away when
-        // it clears so the row collapses in step with the batch update rather than after the fade. The
-        // visibility change is applied synchronously, outside the transition, so the cell's self-sized
-        // height never lags the cross-fade.
-        if animated, text != nil {
+        if let text, held {
+            // A just-sent message's inserting cell: reserve the line's space so the bubble lands in its
+            // final spot, but hold it hidden. `revealHeldReceipt()` fades it in once the controller
+            // reports the insert has settled — the delivery state shouldn't pop in with the bubble.
             receipt.isHidden = false
-            UIView.transition(with: receipt, duration: 0.25, options: .transitionCrossDissolve) {
+            receipt.text = text
+            receipt.alpha = 0
+        } else if let text, receipt.alpha < 1 {
+            // A swap arrived while the line was still held (the read pointer advanced before the insert
+            // settled): update the text but stay held, so the pending `revealHeldReceipt()` fades the
+            // new text in once the insert settles — rather than colliding a cross-dissolve with the reveal.
+            receipt.text = text
+        } else if animated, text != nil {
+            // A cell already in the window is being reconfigured in place (Delivered→Read), so
+            // cross-fade the swap. alpha is restored first in case the cell was mid-hold. The
+            // visibility change is applied synchronously, outside the transition, so the cell's
+            // self-sized height never lags the cross-fade.
+            receipt.alpha = 1
+            receipt.isHidden = false
+            UIView.transition(with: receipt, duration: Self.receiptFadeDuration, options: .transitionCrossDissolve) {
                 self.receipt.text = text
             }
         } else {
+            // Set without animation: a first open or a scroll-in shows the line already in place; a
+            // newer sent message clearing the line lets it snap away so the row collapses in step with
+            // the batch update rather than after a fade.
+            receipt.alpha = 1
             receipt.text = text
             receipt.isHidden = text == nil
         }
+    }
+
+    /// Fade in a receipt that was held hidden for its inserting cell, now that the insert has settled.
+    /// A no-op for any cell not currently holding one, so the controller can call it on every visible
+    /// cell after a batch update without tracking which cell inserted.
+    func revealHeldReceipt() {
+        guard receipt.alpha < 1 else { return }
+        UIView.animate(withDuration: Self.receiptFadeDuration) { self.receipt.alpha = 1 }
+    }
+
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        // Clear the receipt fully: a stale text would let `setReceipt`'s `text != text` guard skip the
+        // hold for a recycled cell whose previous occupant ended on the same string ("Delivered").
+        receipt.text = nil
+        receipt.isHidden = true
+        receipt.alpha = 1
     }
 
     /// Exactly one horizontal edge is pinned, so the column hugs its sender's side and the opposite

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem.swift
@@ -23,6 +23,14 @@ public enum ChatItem: Hashable, Sendable, Identifiable {
         case .dateSeparator(let id, _): id
         }
     }
+
+    /// The message this row carries, or nil for a date separator.
+    public var message: ChatMessage? {
+        switch self {
+        case .message(let message): message
+        case .dateSeparator: nil
+        }
+    }
 }
 
 /// Drives ChatLayout's canonical `reload(using:)` diffing: identity by `id` (stable across a

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
@@ -34,12 +34,15 @@ public final class ChatMessageCell: ChatColumnCell {
     @available(*, unavailable)
     public required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    /// - Parameter maxWidth: the widest the bubble may grow before its text wraps, in points.
-    ///   The owner derives it from the collection view's width.
-    public func configure(with message: ChatMessage, maxWidth: CGFloat) {
+    /// - Parameters:
+    ///   - maxWidth: the widest the bubble may grow before its text wraps, in points. The owner
+    ///     derives it from the collection view's width.
+    ///   - revealsReceiptAfterSettling: set only for a just-sent message's inserting cell, so the
+    ///     delivery line fades in after the bubble settles instead of popping in with it.
+    public func configure(with message: ChatMessage, maxWidth: CGFloat, revealsReceiptAfterSettling: Bool = false) {
         bubble.configure(with: message)
         maxWidthConstraint.constant = maxWidth
-        updateColumn(for: message)
+        updateColumn(for: message, revealsReceiptAfterSettling: revealsReceiptAfterSettling)
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -48,6 +48,10 @@ public final class ChatViewController: UICollectionViewController {
     private static let bottomContentPadding: CGFloat = 12
     /// True while a batch update animates, so the top trigger doesn't re-fire mid-update.
     private var isUpdating = false
+    /// The id of a just-sent message whose receipt should fade in only after its inserting cell
+    /// settles, set across the batch that inserts it. Lets `cellForItemAt` tell that one cell apart
+    /// from a first open or a scroll-in (which show the line immediately).
+    private var pendingReceiptRevealID: String?
     /// True while a context menu is lifted from a bubble. Presenting the menu dismisses the keyboard;
     /// without intervention the adjusted inset shrinks and the transcript reflows out from under the
     /// lifted preview. So for the menu's lifetime the inset is taken over and frozen at its keyboard-up
@@ -158,6 +162,8 @@ public final class ChatViewController: UICollectionViewController {
             items = newItems
             return
         }
+        let revealID = freshlyInsertedReceiptID(from: items, to: newItems)
+        pendingReceiptRevealID = revealID
         isUpdating = true
         collectionView.reload(
             using: changeset,
@@ -173,12 +179,32 @@ public final class ChatViewController: UICollectionViewController {
                 }
             },
             completion: { [weak self] _ in
-                self?.isUpdating = false
+                guard let self else { return }
+                isUpdating = false
+                // Clear only if a later update hasn't already claimed it for its own insert.
+                if pendingReceiptRevealID == revealID { pendingReceiptRevealID = nil }
+                // The batch has settled — fade in any receipt held back for an insert. revealHeldReceipt
+                // is a no-op on every cell that isn't currently holding one.
+                for case let cell as ChatColumnCell in collectionView.visibleCells {
+                    cell.revealHeldReceipt()
+                }
             },
             setData: { [weak self] data in
                 self?.items = data
             }
         )
+    }
+
+    /// The id of a just-sent message — the trailing message, new to the transcript and carrying a
+    /// receipt. Its cell delays the delivery line so it fades in once the bubble has settled. nil for
+    /// every other update: a receipt swap on an existing message, a received message, or paged-in
+    /// history, all of which show their line immediately.
+    private func freshlyInsertedReceiptID(from old: [ChatItem], to new: [ChatItem]) -> String? {
+        guard let last = new.last(where: { $0.message != nil })?.message,
+              last.receipt != nil,
+              !old.contains(where: { $0.id == last.id })
+        else { return nil }
+        return last.id
     }
 
     // MARK: - Data source
@@ -197,6 +223,7 @@ public final class ChatViewController: UICollectionViewController {
             cell.configure(text: text)
             return cell
         case .message(let message):
+            let revealsReceipt = message.id == pendingReceiptRevealID
             switch message.content {
             case .text:
                 let cell = collectionView.dequeueReusableCell(
@@ -204,14 +231,14 @@ public final class ChatViewController: UICollectionViewController {
                     for: indexPath
                 ) as! ChatMessageCell
                 let width = collectionView.bounds.width > 0 ? collectionView.bounds.width : UIScreen.main.bounds.width
-                cell.configure(with: message, maxWidth: width * Self.maxBubbleWidthFraction)
+                cell.configure(with: message, maxWidth: width * Self.maxBubbleWidthFraction, revealsReceiptAfterSettling: revealsReceipt)
                 return cell
             case .cash:
                 let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: ChatCashCardCell.reuseIdentifier,
                     for: indexPath
                 ) as! ChatCashCardCell
-                cell.configure(with: message)
+                cell.configure(with: message, revealsReceiptAfterSettling: revealsReceipt)
                 return cell
             }
         }


### PR DESCRIPTION
The Delivered and Read receipts under a sent message used to pop in at the same instant the bubble appeared. Now the message settles first and the receipt fades in a moment later, so the two no longer arrive together. Only a freshly sent message is delayed — opening a conversation, scrolling, and the switch from Delivered to Read are unchanged, and the receipt's space is reserved up front so the bubble never shifts when the line appears.

## Test plan
- [x] Send a message and confirm the receipt fades in shortly after the bubble settles, not at the same moment.
- [x] Confirm the message still animates in with its normal insert animation and the bubble doesn't shift when the receipt appears.
- [x] Open a conversation and confirm the existing receipt shows immediately, with no delay.
- [x] Have the recipient read a message and confirm Delivered still cross-fades to Read.