### PR TITLE
feat: honor server cache headers for remote images

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -57,6 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         FontBook.registerApplicationFonts()
         setupAppearance()
+        RemoteImageCache.install()
 
         if Container.isRunningUITests {
             UIView.setAnimationsEnabled(false)

--- a/Flipcash/Keychain/Defaults.swift
+++ b/Flipcash/Keychain/Defaults.swift
@@ -19,6 +19,8 @@ enum DefaultsKey: String {
 
     case storedTokenMint = "com.flipcash.token.storedTokenMint"
 
+    case didClearLegacyImageDiskCache = "com.flipcash.image.didClearLegacyDiskCache"
+
     case betaFlags = "com.flipcash.betaFlags"
 }
 

--- a/Flipcash/UI/RemoteImage.swift
+++ b/Flipcash/UI/RemoteImage.swift
@@ -10,10 +10,10 @@ import SwiftUI
 
 struct RemoteImage: View {
     
-    let url: URL
-    
+    let url: URL?
+
     init(url: URL?) {
-        self.url = url ?? URL(string: "https://example.com")!
+        self.url = url
     }
     
     var body: some View {

--- a/Flipcash/UI/RemoteImageCache.swift
+++ b/Flipcash/UI/RemoteImageCache.swift
@@ -8,8 +8,6 @@ import Kingfisher
 
 enum RemoteImageCache {
 
-    private static let didClearLegacyDiskCacheKey = "RemoteImageCache.didClearLegacyKingfisherDiskCache"
-
     /// Configures remote-image caching so an image's lifetime follows the server's HTTP
     /// headers — `Cache-Control`/`Expires` for freshness, `ETag` for revalidation —
     /// instead of being cached indefinitely. Call once at launch.
@@ -23,7 +21,6 @@ enum RemoteImageCache {
             memoryCapacity: 20 * 1024 * 1024,
             diskCapacity: 300 * 1024 * 1024
         )
-        configuration.requestCachePolicy = .useProtocolCachePolicy
         ImageDownloader.default.sessionConfiguration = configuration
 
         KingfisherManager.shared.defaultOptions += [
@@ -48,10 +45,17 @@ enum RemoteImageCache {
     /// prior build still serves from Kingfisher's disk and masks the URLCache. Purge it
     /// once so existing installs pick up the current server image.
     private static func clearLegacyDiskCacheIfNeeded() {
-        let key = didClearLegacyDiskCacheKey
-        guard !UserDefaults.standard.bool(forKey: key) else { return }
+        guard UserDefaults.didClearLegacyImageDiskCache != true else { return }
         ImageCache.default.clearDiskCache {
-            UserDefaults.standard.set(true, forKey: key)
+            Task { @MainActor in UserDefaults.didClearLegacyImageDiskCache = true }
         }
     }
+}
+
+// MARK: - UserDefaults -
+
+extension UserDefaults {
+
+    @Defaults(.didClearLegacyImageDiskCache)
+    fileprivate static var didClearLegacyImageDiskCache: Bool?
 }

--- a/Flipcash/UI/RemoteImageCache.swift
+++ b/Flipcash/UI/RemoteImageCache.swift
@@ -1,0 +1,57 @@
+//
+//  RemoteImageCache.swift
+//  Code
+//
+
+import Foundation
+import Kingfisher
+
+enum RemoteImageCache {
+
+    private static let didClearLegacyDiskCacheKey = "RemoteImageCache.didClearLegacyKingfisherDiskCache"
+
+    /// Configures remote-image caching so an image's lifetime follows the server's HTTP
+    /// headers — `Cache-Control`/`Expires` for freshness, `ETag` for revalidation —
+    /// instead of being cached indefinitely. Call once at launch.
+    static func install() {
+        // The system URLCache is the persistent, revalidating layer: it stores responses
+        // on disk and issues conditional GETs (`If-None-Match`) so a changed image is
+        // refetched rather than served forever. Kingfisher's downloader defaults to an
+        // `.ephemeral` session with no URLCache, so give it one.
+        let configuration = URLSessionConfiguration.default
+        configuration.urlCache = URLCache(
+            memoryCapacity: 20 * 1024 * 1024,
+            diskCapacity: 300 * 1024 * 1024
+        )
+        configuration.requestCachePolicy = .useProtocolCachePolicy
+        ImageDownloader.default.sessionConfiguration = configuration
+
+        KingfisherManager.shared.defaultOptions += [
+            // Kingfisher builds every request with `.reloadIgnoringLocalCacheData`, which
+            // bypasses the URLCache. Restore protocol cache policy so the URLCache and its
+            // ETag revalidation are actually consulted.
+            .requestModifier(AnyModifier { request in
+                var request = request
+                request.cachePolicy = .useProtocolCachePolicy
+                return request
+            }),
+            // Keep Kingfisher's in-memory decoded cache (smooth, flicker-free scrolling)
+            // but not its disk cache: a second persistent layer would shadow the URLCache
+            // and pin stale images. Persistence lives in the URLCache above.
+            .cacheMemoryOnly,
+        ]
+
+        clearLegacyDiskCacheIfNeeded()
+    }
+
+    /// `.cacheMemoryOnly` stops future disk writes but not reads, so an image cached by a
+    /// prior build still serves from Kingfisher's disk and masks the URLCache. Purge it
+    /// once so existing installs pick up the current server image.
+    private static func clearLegacyDiskCacheIfNeeded() {
+        let key = didClearLegacyDiskCacheKey
+        guard !UserDefaults.standard.bool(forKey: key) else { return }
+        ImageCache.default.clearDiskCache {
+            UserDefaults.standard.set(true, forKey: key)
+        }
+    }
+}


### PR DESCRIPTION
Remote currency logos were cached indefinitely, so an updated logo on the server never reached anyone who had already loaded the old one. This routes image caching through the system's HTTP cache, which respects the server's validators and refetches an image only when it actually changes, while keeping scrolling smooth. Existing installs get a one-time cache reset so already-stale logos refresh.

## Test plan
- [x] Currency logos still load and display correctly.
- [x] The USD on Flipcash logo shows in gold instead of the old placeholder.
- [x] Logos persist across a cold relaunch instead of reloading every time.