### PR TITLE
feat: optimistic chat send with retry

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -32,6 +32,12 @@ final class ConversationController {
     var conversations: [Conversation] { store.conversations }
     private(set) var isLoadingFeed = false
 
+    /// The `stableID` of a just-sent optimistic message whose Delivered/Read receipt is held back until
+    /// its bubble has settled in place — so the receipt cross-fades onto a stationary row rather than
+    /// popping in during the insert animation. Cleared shortly after insert; the mapping suppresses the
+    /// receipt for this id while set.
+    private(set) var settlingSendID: String?
+
     /// The conversation with this ID, if the feed currently holds it.
     func conversation(withID id: ConversationID) -> Conversation? {
         conversations.first { $0.id == id }
@@ -63,6 +69,11 @@ final class ConversationController {
     @ObservationIgnored private var streamTask: Task<Void, Never>?
     @ObservationIgnored private var hydratingConversationIDs: Set<ConversationID> = []
     @ObservationIgnored private var markReadTasks: [ConversationID: Task<Void, Never>] = [:]
+    @ObservationIgnored private var settleTask: Task<Void, Never>?
+
+    /// How long a freshly-sent bubble's receipt is held back, ~matching the insert animation so
+    /// "Delivered" lands after the row settles instead of mid-animation.
+    private static let receiptSettleDelay: Duration = .milliseconds(350)
 
     init(
         fetching: any ConversationFetching,
@@ -151,6 +162,9 @@ final class ConversationController {
         streamTask = nil
         markReadTasks.values.forEach { $0.cancel() }
         markReadTasks.removeAll()
+        settleTask?.cancel()
+        settleTask = nil
+        settlingSendID = nil
         streaming.closeConversationStream()
     }
 
@@ -381,7 +395,21 @@ final class ConversationController {
             clientMessageID: clientMessageID
         )
         store.insertPending(pending, into: conversationID)
+        holdReceiptUntilSettled(for: clientMessageID.uuidString)
         return await deliver(clientMessageID: clientMessageID, text: text, to: conversationID)
+    }
+
+    /// Suppress the new row's receipt until its insert animation settles, then clear it so the receipt
+    /// (Delivered/Read, once the message confirms) cross-fades onto a stationary bubble. Only the
+    /// latest send shows a receipt, so a newer send simply replaces the held id.
+    private func holdReceiptUntilSettled(for stableID: String) {
+        settlingSendID = stableID
+        settleTask?.cancel()
+        settleTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.receiptSettleDelay)
+            guard !Task.isCancelled, let self, self.settlingSendID == stableID else { return }
+            self.settlingSendID = nil
+        }
     }
 
     /// Re-send a failed optimistic message, reusing its client id so the server (idempotent on it)

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -73,7 +73,7 @@ final class ConversationController {
 
     /// How long a freshly-sent bubble's receipt is held back, ~matching the insert animation so
     /// "Delivered" lands after the row settles instead of mid-animation.
-    private static let receiptSettleDelay: Duration = .milliseconds(350)
+    private static let receiptSettleDelay: Duration = .milliseconds(500)
 
     init(
         fetching: any ConversationFetching,

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -71,8 +71,9 @@ final class ConversationController {
     @ObservationIgnored private var markReadTasks: [ConversationID: Task<Void, Never>] = [:]
     @ObservationIgnored private var settleTask: Task<Void, Never>?
 
-    /// How long a freshly-sent bubble's receipt is held back, ~matching the insert animation so
-    /// "Delivered" lands after the row settles instead of mid-animation.
+    /// How long a freshly-sent bubble's receipt is held back so "Delivered" lands after the row has
+    /// settled rather than mid-insert. A deliberate, generous beat tuned by feel that sits past the
+    /// insert animation — not pinned to its exact duration, so the two need not stay in lockstep.
     private static let receiptSettleDelay: Duration = .milliseconds(500)
 
     init(
@@ -386,7 +387,7 @@ final class ConversationController {
     func send(_ text: String, to conversationID: ConversationID) async -> Bool {
         let clientMessageID = UUID()
         let pending = ConversationMessage(
-            id: MessageID(value: .max),
+            id: .unassigned,
             senderID: selfUserID,
             content: .text(text),
             date: .now,

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -32,11 +32,9 @@ final class ConversationController {
     var conversations: [Conversation] { store.conversations }
     private(set) var isLoadingFeed = false
 
-    /// The `stableID` of a just-sent optimistic message whose Delivered/Read receipt is held back until
-    /// its bubble has settled in place — so the receipt cross-fades onto a stationary row rather than
-    /// popping in during the insert animation. Cleared shortly after insert; the mapping suppresses the
-    /// receipt for this id while set.
-    private(set) var settlingSendID: String?
+    /// The `stableID` of a just-sent optimistic message whose receipt is currently held back so it can
+    /// cross-fade onto a settled bubble; the transcript mapping suppresses that row's receipt while set.
+    var settlingSendID: String? { receiptSettle.settlingID }
 
     /// The conversation with this ID, if the feed currently holds it.
     func conversation(withID id: ConversationID) -> Conversation? {
@@ -69,12 +67,7 @@ final class ConversationController {
     @ObservationIgnored private var streamTask: Task<Void, Never>?
     @ObservationIgnored private var hydratingConversationIDs: Set<ConversationID> = []
     @ObservationIgnored private var markReadTasks: [ConversationID: Task<Void, Never>] = [:]
-    @ObservationIgnored private var settleTask: Task<Void, Never>?
-
-    /// How long a freshly-sent bubble's receipt is held back so "Delivered" lands after the row has
-    /// settled rather than mid-insert. A deliberate, generous beat tuned by feel that sits past the
-    /// insert animation — not pinned to its exact duration, so the two need not stay in lockstep.
-    private static let receiptSettleDelay: Duration = .milliseconds(500)
+    @ObservationIgnored private let receiptSettle = ReceiptSettleGate()
 
     init(
         fetching: any ConversationFetching,
@@ -163,9 +156,7 @@ final class ConversationController {
         streamTask = nil
         markReadTasks.values.forEach { $0.cancel() }
         markReadTasks.removeAll()
-        settleTask?.cancel()
-        settleTask = nil
-        settlingSendID = nil
+        receiptSettle.cancel()
         streaming.closeConversationStream()
     }
 
@@ -396,21 +387,8 @@ final class ConversationController {
             clientMessageID: clientMessageID
         )
         store.insertPending(pending, into: conversationID)
-        holdReceiptUntilSettled(for: clientMessageID.uuidString)
+        receiptSettle.hold(clientMessageID.uuidString)
         return await deliver(clientMessageID: clientMessageID, text: text, to: conversationID)
-    }
-
-    /// Suppress the new row's receipt until its insert animation settles, then clear it so the receipt
-    /// (Delivered/Read, once the message confirms) cross-fades onto a stationary bubble. Only the
-    /// latest send shows a receipt, so a newer send simply replaces the held id.
-    private func holdReceiptUntilSettled(for stableID: String) {
-        settlingSendID = stableID
-        settleTask?.cancel()
-        settleTask = Task { [weak self] in
-            try? await Task.sleep(for: Self.receiptSettleDelay)
-            guard !Task.isCancelled, let self, self.settlingSendID == stableID else { return }
-            self.settlingSendID = nil
-        }
     }
 
     /// Re-send a failed optimistic message, reusing its client id so the server (idempotent on it)

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -295,6 +295,11 @@ final class ConversationController {
         store.lastConfirmedMessage(for: conversationID)
     }
 
+    /// Whether the conversation holds any message, without building the merged transcript.
+    func hasMessages(for conversationID: ConversationID) -> Bool {
+        store.hasMessages(for: conversationID)
+    }
+
     func loadMessages(for conversationID: ConversationID) async {
         do {
             let messages = try await messaging.getMessages(owner: owner, conversationID: conversationID, before: nil)
@@ -380,9 +385,11 @@ final class ConversationController {
     }
 
     /// Re-send a failed optimistic message, reusing its client id so the server (idempotent on it)
-    /// returns the original message rather than creating a duplicate.
+    /// returns the original message rather than creating a duplicate. Only a `.failed` row is retried,
+    /// so a double-tap (or a tap during a slow in-flight retry) can't fire concurrent sends.
     func retry(clientMessageID: UUID, in conversationID: ConversationID) async {
         guard let pending = store.pendingMessage(clientMessageID: clientMessageID, in: conversationID),
+              pending.status == .failed,
               case .text(let text) = pending.content else { return }
         store.markPending(clientMessageID: clientMessageID, status: .sending, in: conversationID)
         _ = await deliver(clientMessageID: clientMessageID, text: text, to: conversationID)

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -289,6 +289,12 @@ final class ConversationController {
         store.displayedMessages(for: conversationID)
     }
 
+    /// The newest server-confirmed message — what the screen's receive buzz and mark-read track, so an
+    /// unresolved optimistic send (which renders after the confirmed run) never masks an incoming one.
+    func lastConfirmedMessage(for conversationID: ConversationID) -> ConversationMessage? {
+        store.lastConfirmedMessage(for: conversationID)
+    }
+
     func loadMessages(for conversationID: ConversationID) async {
         do {
             let messages = try await messaging.getMessages(owner: owner, conversationID: conversationID, before: nil)
@@ -382,7 +388,6 @@ final class ConversationController {
         _ = await deliver(clientMessageID: clientMessageID, text: text, to: conversationID)
     }
 
-    @discardableResult
     private func deliver(clientMessageID: UUID, text: String, to conversationID: ConversationID) async -> Bool {
         do {
             let message = try await messaging.sendMessage(owner: owner, conversationID: conversationID, text: text, clientMessageID: clientMessageID)

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -286,7 +286,7 @@ final class ConversationController {
     // MARK: - Conversation
 
     func messages(for conversationID: ConversationID) -> [ConversationMessage] {
-        store.messages(for: conversationID)
+        store.displayedMessages(for: conversationID)
     }
 
     func loadMessages(for conversationID: ConversationID) async {
@@ -354,16 +354,45 @@ final class ConversationController {
         }
     }
 
+    /// Optimistically inserts the message so it appears instantly as `.sending`, then awaits the
+    /// server: on success it reconciles to the confirmed message, on failure it stays in the
+    /// transcript as `.failed` (never silently dropped).
     @discardableResult
     func send(_ text: String, to conversationID: ConversationID) async -> Bool {
+        let clientMessageID = UUID()
+        let pending = ConversationMessage(
+            id: MessageID(value: .max),
+            senderID: selfUserID,
+            content: .text(text),
+            date: .now,
+            unreadSeq: 0,
+            status: .sending,
+            clientMessageID: clientMessageID
+        )
+        store.insertPending(pending, into: conversationID)
+        return await deliver(clientMessageID: clientMessageID, text: text, to: conversationID)
+    }
+
+    /// Re-send a failed optimistic message, reusing its client id so the server (idempotent on it)
+    /// returns the original message rather than creating a duplicate.
+    func retry(clientMessageID: UUID, in conversationID: ConversationID) async {
+        guard let pending = store.pendingMessage(clientMessageID: clientMessageID, in: conversationID),
+              case .text(let text) = pending.content else { return }
+        store.markPending(clientMessageID: clientMessageID, status: .sending, in: conversationID)
+        _ = await deliver(clientMessageID: clientMessageID, text: text, to: conversationID)
+    }
+
+    @discardableResult
+    private func deliver(clientMessageID: UUID, text: String, to conversationID: ConversationID) async -> Bool {
         do {
-            let message = try await messaging.sendMessage(owner: owner, conversationID: conversationID, text: text)
-            store.mergeMessages([message], into: conversationID)
+            let message = try await messaging.sendMessage(owner: owner, conversationID: conversationID, text: text, clientMessageID: clientMessageID)
+            store.reconcile(clientMessageID: clientMessageID, with: message, in: conversationID)
             store.setLastMessage(message, in: conversationID)
             persist(operation: "send-message") { try database.upsertConversationMessages([message], conversationID: conversationID) }
             persistConversation(conversationID)
             return true
         } catch {
+            store.markPending(clientMessageID: clientMessageID, status: .failed, in: conversationID)
             logger.error("Failed to send conversation message", metadata: [
                 "conversationID": "\(conversationID)",
                 "error": "\(error)",

--- a/Flipcash/Core/Controllers/FlipClient+Protocols.swift
+++ b/Flipcash/Core/Controllers/FlipClient+Protocols.swift
@@ -71,7 +71,7 @@ protocol ConversationMessaging: AnyObject, Sendable {
     /// Fetches a page of messages. `before == nil` returns the newest page;
     /// pass the oldest currently-loaded id to page strictly older (history).
     func getMessages(owner: KeyPair, conversationID: ConversationID, before: MessageID?) async throws -> [ConversationMessage]
-    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String) async throws -> ConversationMessage
+    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID) async throws -> ConversationMessage
     func markRead(owner: KeyPair, conversationID: ConversationID, messageID: MessageID) async throws
 }
 

--- a/Flipcash/Core/Controllers/ReceiptSettleGate.swift
+++ b/Flipcash/Core/Controllers/ReceiptSettleGate.swift
@@ -1,0 +1,49 @@
+//
+//  ReceiptSettleGate.swift
+//  Flipcash
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Holds a just-sent message's delivery receipt for a short beat after its bubble is inserted, so
+/// "Delivered" cross-fades onto a settled row instead of popping in mid-insert. Owns the held id, the
+/// timer, and the delay as one unit; the transcript mapping reads `settlingID` to suppress that row's
+/// receipt while it's held.
+///
+/// Main-actor isolated (not an `actor`) because the state is UI-bound: the SwiftUI mapping reads
+/// `settlingID` synchronously, which actor isolation would force behind `await`, and it's only ever
+/// mutated on the main actor — there's no second concurrency domain to protect.
+@MainActor @Observable
+final class ReceiptSettleGate {
+
+    /// The `stableID` of the row whose receipt is currently held back, or nil when nothing is settling.
+    private(set) var settlingID: String?
+
+    @ObservationIgnored private var task: Task<Void, Never>?
+    @ObservationIgnored private let delay: Duration
+
+    init(delay: Duration = .milliseconds(500)) {
+        self.delay = delay
+    }
+
+    /// Begin holding `id`'s receipt; it clears on its own after the settle delay. A newer hold replaces
+    /// the current one — only the latest send shows a receipt.
+    func hold(_ id: String) {
+        settlingID = id
+        task?.cancel()
+        task = Task { [weak self] in
+            try? await Task.sleep(for: self?.delay ?? .zero)
+            guard !Task.isCancelled, self?.settlingID == id else { return }
+            self?.settlingID = nil
+        }
+    }
+
+    /// Stop holding and cancel the timer (e.g. when the conversation tears down).
+    func cancel() {
+        task?.cancel()
+        task = nil
+        settlingID = nil
+    }
+}

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -72,7 +72,8 @@ extension ChatItem {
             case .sent:
                 // "Delivered"/"Read" rides only the latest confirmed self message — preserved even when
                 // a later send is in flight or failed, and held back while the row is still settling in.
-                receipt = isFromSelf && message.stableID == latestSentFromSelfID && message.stableID != suppressReceiptFor
+                // `latestSentFromSelfID` is already a self+sent row, so matching it implies both.
+                receipt = message.stableID == latestSentFromSelfID && message.stableID != suppressReceiptFor
                     ? Self.receiptText(for: message.id, counterpartRead: counterpartRead)
                     : nil
             case .sending:

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -78,8 +78,8 @@ extension ChatItem {
                     : nil
                 deliveryState = .normal
             case .sending:
-                // No status line while in flight — the bubble just sits there until it resolves to
-                // "Delivered" or the failed state (matches iMessage).
+                // No status line while in flight — the bubble sits there until it resolves to
+                // "Delivered" or the failed state.
                 receipt = nil
                 deliveryState = .sending
             case .failed:

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -22,6 +22,7 @@ extension ChatItem {
         selfUserID: UserID,
         gap: TimeInterval = 15 * 60,
         counterpartRead: (pointer: MessageID, date: Date?)? = nil,
+        suppressReceiptFor: String? = nil,
         cashBranding: (ExchangedFiat) -> (token: String, iconURL: URL?) = { _ in ("Cash", nil) }
     ) -> [ChatItem] {
         // "Delivered"/"Read" rides the latest *confirmed* self message, so an in-flight or failed send
@@ -71,8 +72,8 @@ extension ChatItem {
             switch message.status {
             case .sent:
                 // "Delivered"/"Read" rides only the latest confirmed self message — preserved even when
-                // a later send is in flight or failed.
-                receipt = isFromSelf && message.stableID == latestSentFromSelfID
+                // a later send is in flight or failed, and held back while the row is still settling in.
+                receipt = isFromSelf && message.stableID == latestSentFromSelfID && message.stableID != suppressReceiptFor
                     ? Self.receiptText(for: message.id, counterpartRead: counterpartRead)
                     : nil
                 deliveryState = .normal

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -24,8 +24,11 @@ extension ChatItem {
         counterpartRead: (pointer: MessageID, date: Date?)? = nil,
         cashBranding: (ExchangedFiat) -> (token: String, iconURL: URL?) = { _ in ("Cash", nil) }
     ) -> [ChatItem] {
-        // Only the user's latest sent message carries a receipt.
-        let latestFromSelfID = messages.last { $0.isFromSelf(selfUserID) }?.id
+        // The status line rides only the LAST message from self (iMessage-style): "Delivered"/"Read"
+        // when it's confirmed, else that message shows its own sending/failed state. A newer in-flight
+        // send moves the line off the prior delivered bubble. Per-message sending/failed still renders
+        // below (so every failed message stays independently retryable) — only the receipt is last-only.
+        let latestFromSelfID = messages.last { $0.isFromSelf(selfUserID) }?.stableID
         var items: [ChatItem] = []
         for (index, message) in messages.enumerated() {
             let isFromSelf = message.isFromSelf(selfUserID)
@@ -35,7 +38,7 @@ extension ChatItem {
             // A separator opens the transcript and breaks any run longer than the gap.
             let showsSeparator = previous.map { message.date.timeIntervalSince($0.date) > gap } ?? true
             if showsSeparator {
-                items.append(.dateSeparator(id: "sep-\(message.id.value)", text: Self.separatorText(for: message.date)))
+                items.append(.dateSeparator(id: "sep-\(message.stableID)", text: Self.separatorText(for: message.date)))
             }
 
             let groupedAbove = previous.map {
@@ -63,17 +66,24 @@ extension ChatItem {
 
             // The delivery line rides on the latest sent message itself, not a separate row, so a
             // send diffs to a clean insert instead of tearing a receipt row down and rebuilding it.
-            let receipt: String? = isFromSelf && message.id == latestFromSelfID
+            let receipt: String? = isFromSelf && message.stableID == latestFromSelfID && message.status == .sent
                 ? Self.receiptText(for: message.id, counterpartRead: counterpartRead)
                 : nil
 
+            let deliveryState: ChatMessage.DeliveryState = switch message.status {
+            case .sent: .normal
+            case .sending: .sending
+            case .failed: .failed
+            }
+
             items.append(.message(ChatMessage(
-                id: "\(message.id.value)",
+                id: message.stableID,
                 content: content,
                 sender: isFromSelf ? .me : .other,
                 isContinuationFromPrevious: groupedAbove,
                 isContinuedByNext: groupedBelow,
-                receipt: receipt
+                receipt: receipt,
+                deliveryState: deliveryState
             )))
         }
         return items

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -64,16 +64,25 @@ extension ChatItem {
                 ))
             }
 
-            // The delivery line rides on the latest sent message itself, not a separate row, so a
-            // send diffs to a clean insert instead of tearing a receipt row down and rebuilding it.
-            let receipt: String? = isFromSelf && message.stableID == latestFromSelfID && message.status == .sent
-                ? Self.receiptText(for: message.id, counterpartRead: counterpartRead)
-                : nil
-
-            let deliveryState: ChatMessage.DeliveryState = switch message.status {
-            case .sent: .normal
-            case .sending: .sending
-            case .failed: .failed
+            // The status line rides on the bubble itself (not a separate row, so a send is a clean
+            // insert). All of its copy is produced here, in one layer; the cell only styles it
+            // (resting vs. red + tappable) off `deliveryState`.
+            let receipt: String?
+            let deliveryState: ChatMessage.DeliveryState
+            switch message.status {
+            case .sent:
+                // "Delivered"/"Read" rides only the latest message from self; a newer in-flight send
+                // moves it off the prior delivered bubble.
+                receipt = isFromSelf && message.stableID == latestFromSelfID
+                    ? Self.receiptText(for: message.id, counterpartRead: counterpartRead)
+                    : nil
+                deliveryState = .normal
+            case .sending:
+                receipt = "Sending…"
+                deliveryState = .sending
+            case .failed:
+                receipt = "Not Delivered. Tap to retry"
+                deliveryState = .failed
             }
 
             items.append(.message(ChatMessage(

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -66,9 +66,8 @@ extension ChatItem {
 
             // The status line rides on the bubble itself (not a separate row, so a send is a clean
             // insert). All of its copy is produced here, in one layer; the cell only styles it
-            // (resting vs. red + tappable) off `deliveryState`.
+            // (resting vs. red + tappable) off `isFailed`.
             let receipt: String?
-            let deliveryState: ChatMessage.DeliveryState
             switch message.status {
             case .sent:
                 // "Delivered"/"Read" rides only the latest confirmed self message — preserved even when
@@ -76,15 +75,12 @@ extension ChatItem {
                 receipt = isFromSelf && message.stableID == latestSentFromSelfID && message.stableID != suppressReceiptFor
                     ? Self.receiptText(for: message.id, counterpartRead: counterpartRead)
                     : nil
-                deliveryState = .normal
             case .sending:
                 // No status line while in flight — the bubble sits there until it resolves to
                 // "Delivered" or the failed state.
                 receipt = nil
-                deliveryState = .sending
             case .failed:
                 receipt = "Not Delivered. Tap to retry"
-                deliveryState = .failed
             }
 
             items.append(.message(ChatMessage(
@@ -94,7 +90,7 @@ extension ChatItem {
                 isContinuationFromPrevious: groupedAbove,
                 isContinuedByNext: groupedBelow,
                 receipt: receipt,
-                deliveryState: deliveryState
+                isFailed: message.status == .failed
             )))
         }
         return items

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -24,11 +24,10 @@ extension ChatItem {
         counterpartRead: (pointer: MessageID, date: Date?)? = nil,
         cashBranding: (ExchangedFiat) -> (token: String, iconURL: URL?) = { _ in ("Cash", nil) }
     ) -> [ChatItem] {
-        // The status line rides only the LAST message from self (iMessage-style): "Delivered"/"Read"
-        // when it's confirmed, else that message shows its own sending/failed state. A newer in-flight
-        // send moves the line off the prior delivered bubble. Per-message sending/failed still renders
-        // below (so every failed message stays independently retryable) — only the receipt is last-only.
-        let latestFromSelfID = messages.last { $0.isFromSelf(selfUserID) }?.stableID
+        // "Delivered"/"Read" rides the latest *confirmed* self message, so an in-flight or failed send
+        // trailing it doesn't strip the receipt off the last delivered bubble. A sending row shows
+        // nothing; a failed row shows its own "Not Delivered" line (each independently retryable).
+        let latestSentFromSelfID = messages.last { $0.isFromSelf(selfUserID) && $0.status == .sent }?.stableID
         var items: [ChatItem] = []
         for (index, message) in messages.enumerated() {
             let isFromSelf = message.isFromSelf(selfUserID)
@@ -71,9 +70,9 @@ extension ChatItem {
             let deliveryState: ChatMessage.DeliveryState
             switch message.status {
             case .sent:
-                // "Delivered"/"Read" rides only the latest message from self; a newer in-flight send
-                // moves it off the prior delivered bubble.
-                receipt = isFromSelf && message.stableID == latestFromSelfID
+                // "Delivered"/"Read" rides only the latest confirmed self message — preserved even when
+                // a later send is in flight or failed.
+                receipt = isFromSelf && message.stableID == latestSentFromSelfID
                     ? Self.receiptText(for: message.id, counterpartRead: counterpartRead)
                     : nil
                 deliveryState = .normal

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -78,7 +78,9 @@ extension ChatItem {
                     : nil
                 deliveryState = .normal
             case .sending:
-                receipt = "Sending…"
+                // No status line while in flight — the bubble just sits there until it resolves to
+                // "Delivered" or the failed state (matches iMessage).
+                receipt = nil
                 deliveryState = .sending
             case .failed:
                 receipt = "Not Delivered. Tap to retry"

--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -22,6 +22,9 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     /// transcript preserves scroll offset across the prepend). This is the incremental
     /// reverse-infinite paging that the UIKit rebuild exists to enable.
     let onReachTop: () -> Void
+    /// Fired when the user taps a failed outgoing row; the argument is the message's stable id (its
+    /// client message id). The owner re-sends it.
+    let onRetry: (String) -> Void
     let showsSendCash: Bool
     let showsSendMessage: Bool
     let conversationID: ConversationID?
@@ -41,6 +44,7 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
             keyboardBarController: keyboardHost
         )
         screen.onReachTop = onReachTop
+        screen.onRetry = onRetry
         screen.update(items: items)
         screen.setComposing(barModel.isComposing)
         context.coordinator.restingHost = restingHost
@@ -56,6 +60,7 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         context.coordinator.restingHost?.rootView = restingBar(coordinator: context.coordinator)
         context.coordinator.keyboardHost?.rootView = keyboardBar(coordinator: context.coordinator)
         screen.onReachTop = onReachTop
+        screen.onRetry = onRetry
         screen.setComposing(barModel.isComposing)
 
         // Scroll only when the user's *own* message was just appended — a new trailing message id

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -15,10 +15,9 @@ import FlipcashUI
 @MainActor @Observable final class ConversationBarModel {
     var isComposing = false
     var draft = ""
-    var isSending = false
 
     var canSend: Bool {
-        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending
+        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 
@@ -135,14 +134,13 @@ struct ConversationComposer: View {
     private func send() {
         guard let conversationID else { return }
         let text = model.draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, !model.isSending else { return }
-        model.isSending = true
+        guard !text.isEmpty else { return }
         model.draft = ""
         isFocused = true
-        Task {
-            await conversationController.send(text, to: conversationID)
-            model.isSending = false
-        }
+        // Fire-and-forget: the message inserts optimistically and resolves on its own, so the composer
+        // stays ready immediately — the user can keep sending (especially offline) without waiting for
+        // each round-trip. Clearing the draft up front makes a double-tap a no-op (empty text).
+        Task { await conversationController.send(text, to: conversationID) }
     }
 }
 

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -97,7 +97,7 @@ struct ConversationScreen: View {
             return true
         case .contact:
             return conversationController.conversation(withID: conversationID) != nil
-                || !conversationController.messages(for: conversationID).isEmpty
+                || conversationController.hasMessages(for: conversationID)
         }
     }
 

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -200,9 +200,13 @@ struct ConversationScreen: View {
             didInitialRead = true
         }
         .onChange(of: latestConfirmedMessage?.stableID) {
-            // The initial load flips this from nil, which would double-fire
-            // markRead alongside the .task above; only mark live arrivals.
-            guard didInitialRead, let conversationID else { return }
+            // Mark read only when the counterpart's message is the latest — our own send reconciling
+            // shouldn't fire a markRead round-trip for a message we sent. didInitialRead skips the
+            // opening load (the .task already marked read).
+            guard didInitialRead, let conversationID,
+                  let last = latestConfirmedMessage,
+                  !last.isFromSelf(conversationController.selfUserID)
+            else { return }
             conversationController.scheduleMarkRead(conversationID: conversationID)
         }
         // Buzz on a live message from the other side while this conversation is on screen. `old != nil`

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -129,6 +129,7 @@ struct ConversationScreen: View {
             messages,
             selfUserID: conversationController.selfUserID,
             counterpartRead: counterpartRead.map { (pointer: $0.pointer, date: $0.date) },
+            suppressReceiptFor: conversationController.settlingSendID,
             cashBranding: { fiat in
                 guard fiat.mint != .usdf, let balance = session.balance(for: fiat.mint) else { return ("Cash", nil) }
                 return (balance.name, balance.imageURL)

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -113,6 +113,13 @@ struct ConversationScreen: View {
         return conversationController.messages(for: conversationID)
     }
 
+    /// The newest server-confirmed message — what the receive buzz and mark-read track. Optimistic
+    /// pending sends render after the confirmed run, so they must not drive these signals (an unresolved
+    /// send would otherwise sit at `.last` forever and mask incoming messages).
+    private var latestConfirmedMessage: ConversationMessage? {
+        messages.last { $0.status == .sent }
+    }
+
     /// The transcript's messages mapped to the UIKit chat's display items (messages + date
     /// separators). Cash branding mirrors the SwiftUI bubble: USDF reads as "Cash"; a launchpad
     /// currency uses its cached name + icon.
@@ -142,6 +149,7 @@ struct ConversationScreen: View {
         ChatScreenRepresentable(
             items: mappedItems,
             onReachTop: loadOlderMessages,
+            onRetry: retry,
             showsSendCash: sendTarget != nil,
             showsSendMessage: chatExists,
             conversationID: conversationID,
@@ -190,7 +198,7 @@ struct ConversationScreen: View {
             await conversationController.markRead(conversationID: conversationID)
             didInitialRead = true
         }
-        .onChange(of: messages.last?.id) {
+        .onChange(of: latestConfirmedMessage?.stableID) {
             // The initial load flips this from nil, which would double-fire
             // markRead alongside the .task above; only mark live arrivals.
             guard didInitialRead, let conversationID else { return }
@@ -199,9 +207,9 @@ struct ConversationScreen: View {
         // Buzz on a live message from the other side while this conversation is on screen. `old != nil`
         // and `didInitialRead` skip the opening history load; the sender and visibility checks skip the
         // user's own sends and arrivals in a chat they've navigated away from.
-        .sensoryFeedback(.impact(weight: .light), trigger: messages.last?.id) { old, _ in
+        .sensoryFeedback(.impact(weight: .light), trigger: latestConfirmedMessage?.stableID) { old, _ in
             guard old != nil, didInitialRead,
-                  let last = messages.last,
+                  let last = latestConfirmedMessage,
                   !last.isFromSelf(conversationController.selfUserID),
                   conversationController.visibleConversationID == conversationID
             else { return false }
@@ -253,6 +261,13 @@ struct ConversationScreen: View {
             return
         }
         router.presentNested(.sendAmount(sendTarget))
+    }
+
+    /// Re-send a failed message tapped in the transcript. The id is the row's stable id, which for a
+    /// failed message is its client message id.
+    private func retry(messageID: String) {
+        guard let conversationID, let clientMessageID = UUID(uuidString: messageID) else { return }
+        Task { await conversationController.retry(clientMessageID: clientMessageID, in: conversationID) }
     }
 
     /// Fetches the next older page when the UIKit transcript nears the top. Guarded so the

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -115,9 +115,10 @@ struct ConversationScreen: View {
 
     /// The newest server-confirmed message — what the receive buzz and mark-read track. Optimistic
     /// pending sends render after the confirmed run, so they must not drive these signals (an unresolved
-    /// send would otherwise sit at `.last` forever and mask incoming messages).
+    /// send would otherwise sit at the transcript's tail and mask incoming messages).
     private var latestConfirmedMessage: ConversationMessage? {
-        messages.last { $0.status == .sent }
+        guard let conversationID else { return nil }
+        return conversationController.lastConfirmedMessage(for: conversationID)
     }
 
     /// The transcript's messages mapped to the UIKit chat's display items (messages + date

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -201,13 +201,11 @@ struct ConversationScreen: View {
             didInitialRead = true
         }
         .onChange(of: latestConfirmedMessage?.stableID) {
-            // Mark read only when the counterpart's message is the latest — our own send reconciling
-            // shouldn't fire a markRead round-trip for a message we sent. didInitialRead skips the
-            // opening load (the .task already marked read).
-            guard didInitialRead, let conversationID,
-                  let last = latestConfirmedMessage,
-                  !last.isFromSelf(conversationController.selfUserID)
-            else { return }
+            // Fires on a live arrival or our own send. Marking read on our own send is intentional: it
+            // advances the self-read watermark past the message we just sent, so the conversation
+            // doesn't show as unread in the feed. didInitialRead skips the opening load (the .task
+            // already marked read), and markRead short-circuits when the watermark already covers it.
+            guard didInitialRead, let conversationID else { return }
             conversationController.scheduleMarkRead(conversationID: conversationID)
         }
         // Buzz on a live message from the other side while this conversation is on screen. `old != nil`

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
@@ -41,9 +41,9 @@ extension FlipClient {
     }
 
     @discardableResult
-    public func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String) async throws -> ConversationMessage {
+    public func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID) async throws -> ConversationMessage {
         try await withCheckedThrowingContinuation { c in
-            chatMessagingService.sendMessage(owner: owner, conversationID: conversationID, text: text) { c.resume(with: $0) }
+            chatMessagingService.sendMessage(owner: owner, conversationID: conversationID, text: text, clientMessageID: clientMessageID) { c.resume(with: $0) }
         }
     }
 

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
@@ -47,11 +47,11 @@ class ChatMessagingService: CodeService<Flipcash_Messaging_V1_MessagingNIOClient
         }
     }
 
-    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, completion: @Sendable @escaping (Result<ConversationMessage, ErrorSendMessage>) -> Void) {
+    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID, completion: @Sendable @escaping (Result<ConversationMessage, ErrorSendMessage>) -> Void) {
         let request = Flipcash_Messaging_V1_SendMessageRequest.with {
             $0.chatID = conversationID.proto
             $0.content = [.with { $0.text = .with { $0.text = text } }]
-            $0.clientMessageID = .with { $0.value = UUID().data }
+            $0.clientMessageID = .with { $0.value = clientMessageID.data }
             $0.auth = owner.authFor(message: $0)
         }
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationIdentifiers.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationIdentifiers.swift
@@ -58,6 +58,11 @@ public struct MessageID: Hashable, Sendable, Comparable, CustomStringConvertible
         self.value = value
     }
 
+    /// Placeholder id for an optimistic message the server hasn't assigned a real id to yet. Never used
+    /// for ordering or lookup — pending rows are keyed by their client id, anchor, and send sequence —
+    /// so it only fills the non-optional `id` field until reconciliation replaces it with the real id.
+    public static let unassigned = MessageID(value: .max)
+
     public init(_ proto: Flipcash_Messaging_V1_MessageId) {
         self.value = proto.value
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
@@ -37,8 +37,9 @@ public struct ConversationMessage: Identifiable, Hashable, Sendable {
     public var status: SendStatus
     /// The id the client minted for this send, reused across retries (the server is idempotent on
     /// it). Set only for messages that originated optimistically on this device; nil for everything
-    /// loaded from the server, the stream, or the cache.
-    public let clientMessageID: UUID?
+    /// loaded from the server, the stream, or the cache. Mutable so the store can carry it onto the
+    /// confirmed server copy during reconciliation without rebuilding the whole value.
+    public var clientMessageID: UUID?
 
     public init(
         id: MessageID,

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
@@ -8,6 +8,15 @@
 import Foundation
 import FlipcashAPI
 
+/// Delivery state of an outgoing message. `.sent` is the only state a message loaded from the
+/// server, the stream, or the local cache can have; `.sending`/`.failed` exist only for an
+/// optimistic message in flight on this device this session.
+public enum SendStatus: Sendable, Hashable {
+    case sent
+    case sending
+    case failed
+}
+
 /// A single message within a conversation.
 public struct ConversationMessage: Identifiable, Hashable, Sendable {
 
@@ -23,13 +32,39 @@ public struct ConversationMessage: Identifiable, Hashable, Sendable {
     public let content: Content
     public let date: Date
     public let unreadSeq: UInt64
+    /// Delivery state. `.sent` for every server/cache message; `.sending`/`.failed` only for an
+    /// in-flight optimistic message.
+    public var status: SendStatus
+    /// The id the client minted for this send, reused across retries (the server is idempotent on
+    /// it). Set only for messages that originated optimistically on this device; nil for everything
+    /// loaded from the server, the stream, or the cache.
+    public let clientMessageID: UUID?
 
-    public init(id: MessageID, senderID: UserID?, content: Content, date: Date, unreadSeq: UInt64) {
+    public init(
+        id: MessageID,
+        senderID: UserID?,
+        content: Content,
+        date: Date,
+        unreadSeq: UInt64,
+        status: SendStatus = .sent,
+        clientMessageID: UUID? = nil
+    ) {
         self.id = id
         self.senderID = senderID
         self.content = content
         self.date = date
         self.unreadSeq = unreadSeq
+        self.status = status
+        self.clientMessageID = clientMessageID
+    }
+}
+
+extension ConversationMessage {
+    /// Identity used by the transcript diff: the client id while the server id is unknown (and
+    /// preserved after reconciliation), so a row keeps its identity across sending → sent and never
+    /// re-inserts. Falls back to the server id.
+    public var stableID: String {
+        clientMessageID?.uuidString ?? "\(id.value)"
     }
 }
 
@@ -60,5 +95,7 @@ extension ConversationMessage {
         self.senderID = try? UUID(data: proto.senderID.value)
         self.date = proto.hasTs ? proto.ts.date : .now
         self.unreadSeq = proto.unreadSeq
+        self.status = .sent
+        self.clientMessageID = nil
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -30,9 +30,16 @@ public struct ConversationStore: Sendable {
         self.conversations = conversations.sorted { $0.lastActivity > $1.lastActivity }
     }
 
-    /// Insert/replace messages keyed by their gapless id, keeping oldest first.
-    /// Dedupes the send-response echo against the same message arriving on the
-    /// stream (both carry the server-assigned id).
+    /// How far apart an incoming server copy and a pending optimistic send may be (in either
+    /// direction, to absorb client/server clock skew) and still be treated as the same message. Wide
+    /// enough for skew, tight enough that an unrelated old history message with identical text never
+    /// reconciles a fresh pending send.
+    private static let pendingReconcileWindow: TimeInterval = 5 * 60
+
+    /// Insert/replace messages keyed by their gapless id, keeping oldest first. Reconciles a server
+    /// copy of one of our own optimistic sends — which carries no client id, because the server never
+    /// echoes it — against the matching pending row, so the echo collapses onto that row instead of
+    /// duplicating it, no matter which path (stream, history load, or the send RPC) delivers it first.
     public mutating func mergeMessages(_ incoming: [ConversationMessage], into conversationID: ConversationID) {
         guard !incoming.isEmpty else { return }
         let current = messagesByConversation[conversationID] ?? []
@@ -42,28 +49,46 @@ public struct ConversationStore: Sendable {
             uniquingKeysWith: { _, new in new }
         )
         for message in incoming {
-            // A re-delivered server copy (the stream echo of a message this device sent) carries no
-            // client id; keep the one the optimistic send reconciled onto this row so the transcript
-            // identity stays stable and the row never re-inserts.
-            if message.clientMessageID == nil, let existing = byID[message.id]?.clientMessageID {
-                byID[message.id] = ConversationMessage(
-                    id: message.id, senderID: message.senderID, content: message.content,
-                    date: message.date, unreadSeq: message.unreadSeq, status: .sent, clientMessageID: existing
-                )
-            } else {
-                byID[message.id] = message
+            var message = message
+            // A server copy with no client id is either the echo of one of our optimistic sends or a
+            // re-delivery of an already-reconciled row. Adopt the matching pending row's client id (and
+            // drop that pending copy) so the row keeps one stable identity across sending → sent and is
+            // never shown twice; otherwise keep the client id already on the confirmed row.
+            if message.clientMessageID == nil {
+                if let clientMessageID = reconcilePendingMatch(for: message, in: conversationID) {
+                    message.clientMessageID = clientMessageID
+                } else if let existing = byID[message.id]?.clientMessageID {
+                    message.clientMessageID = existing
+                }
             }
+            byID[message.id] = message
         }
         messagesByConversation[conversationID] = byID.values.sorted { $0.id < $1.id }
     }
 
+    /// Removes and returns the client id of the oldest pending send that matches `serverCopy` by sender
+    /// and content within the reconcile window — the optimistic row this server copy confirms. Returns
+    /// nil when nothing matches (a counterpart message, or an unrelated history message).
+    private mutating func reconcilePendingMatch(for serverCopy: ConversationMessage, in conversationID: ConversationID) -> UUID? {
+        guard let index = pendingByConversation[conversationID]?.firstIndex(where: {
+            $0.senderID == serverCopy.senderID
+                && $0.content == serverCopy.content
+                && abs($0.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
+        }) else {
+            return nil
+        }
+        return pendingByConversation[conversationID]?.remove(at: index).clientMessageID
+    }
+
     // MARK: - Optimistic (pending) sends
 
-    /// Confirmed messages (oldest first) followed by in-flight optimistic ones (by send time). This is
+    /// Confirmed messages (oldest first) followed by in-flight optimistic ones in send order. This is
     /// the transcript's source of truth; `messages(for:)` stays confirmed-only for mark-read and paging.
+    /// Pending rows are appended in send order (and stay there), so no re-sort is needed — which also
+    /// keeps two same-millisecond sends in the order they were tapped.
     public func displayedMessages(for conversationID: ConversationID) -> [ConversationMessage] {
         let confirmed = messagesByConversation[conversationID] ?? []
-        let pending = (pendingByConversation[conversationID] ?? []).sorted { $0.date < $1.date }
+        let pending = pendingByConversation[conversationID] ?? []
         return confirmed + pending
     }
 
@@ -83,14 +108,14 @@ public struct ConversationStore: Sendable {
         pendingByConversation[conversationID]?[index].status = status
     }
 
-    /// Replace a server-confirmed send: drop the optimistic copy and merge the server message, carrying
-    /// the client id onto it so the row keeps its identity across sending → sent (no delete+insert).
+    /// Replace a server-confirmed send (the send RPC's own response): drop the optimistic copy and merge
+    /// the server message, carrying the client id onto it so the row keeps its identity across
+    /// sending → sent (no delete+insert).
     public mutating func reconcile(clientMessageID: UUID, with serverMessage: ConversationMessage, in conversationID: ConversationID) {
         pendingByConversation[conversationID]?.removeAll { $0.clientMessageID == clientMessageID }
-        let confirmed = ConversationMessage(
-            id: serverMessage.id, senderID: serverMessage.senderID, content: serverMessage.content,
-            date: serverMessage.date, unreadSeq: serverMessage.unreadSeq, status: .sent, clientMessageID: clientMessageID
-        )
+        var confirmed = serverMessage
+        confirmed.status = .sent
+        confirmed.clientMessageID = clientMessageID
         mergeMessages([confirmed], into: conversationID)
     }
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -87,23 +87,19 @@ public struct ConversationStore: Sendable {
 
     // MARK: - Optimistic (pending) sends
 
-    /// The transcript's source of truth: confirmed rows in server order, with each in-flight optimistic
-    /// row positioned by its send time. Positioning by date (rather than always appending) keeps a row
-    /// in place when sends reconcile out of order — e.g. a retried older message that resolves after a
-    /// newer one, or two rapid sends whose responses race. `messages(for:)` stays confirmed-only for
-    /// mark-read and paging.
+    /// The transcript's source of truth: confirmed rows in server order, then in-flight optimistic rows
+    /// in send order. They're appended (not date-merged) so a fresh send always lands at the tail —
+    /// immune to client/server clock skew, and the scroll-to-bottom on send stays reliable.
+    /// `messages(for:)` stays confirmed-only for mark-read and paging.
+    ///
+    /// A caveat we accept: if several sends are in flight at once and their responses reconcile out of
+    /// order, the just-confirmed one briefly sits among the confirmed run while earlier still-pending
+    /// ones trail it — a sub-second shuffle that settles into the server's order. Offline sends (which
+    /// never reconcile) stay in send order throughout.
     public func displayedMessages(for conversationID: ConversationID) -> [ConversationMessage] {
         let confirmed = messagesByConversation[conversationID] ?? []
         let pending = pendingByConversation[conversationID] ?? []
-        guard !pending.isEmpty else { return confirmed }
-        var result = confirmed
-        for message in pending {
-            // Sit before the first row newer than this send; same-date rows (and the common
-            // newest-send case) keep it after them, i.e. at the tail.
-            let index = result.firstIndex { $0.date > message.date } ?? result.endIndex
-            result.insert(message, at: index)
-        }
-        return result
+        return confirmed + pending
     }
 
     /// The newest server-confirmed message, or nil. Confirmed rows are kept sorted oldest-first and are

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -70,14 +70,17 @@ public struct ConversationStore: Sendable {
     /// and content within the reconcile window — the optimistic row this server copy confirms. Returns
     /// nil when nothing matches (a counterpart message, or an unrelated history message).
     private mutating func reconcilePendingMatch(for serverCopy: ConversationMessage, in conversationID: ConversationID) -> UUID? {
-        guard let index = pendingByConversation[conversationID]?.firstIndex(where: {
-            $0.senderID == serverCopy.senderID
-                && $0.content == serverCopy.content
-                && abs($0.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
-        }) else {
+        guard var pending = pendingByConversation[conversationID],
+              let index = pending.firstIndex(where: {
+                  $0.senderID == serverCopy.senderID
+                      && $0.content == serverCopy.content
+                      && abs($0.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
+              }) else {
             return nil
         }
-        return pendingByConversation[conversationID]?.remove(at: index).clientMessageID
+        let clientMessageID = pending.remove(at: index).clientMessageID
+        pendingByConversation[conversationID] = pending
+        return clientMessageID
     }
 
     // MARK: - Optimistic (pending) sends
@@ -90,6 +93,13 @@ public struct ConversationStore: Sendable {
         let confirmed = messagesByConversation[conversationID] ?? []
         let pending = pendingByConversation[conversationID] ?? []
         return confirmed + pending
+    }
+
+    /// The newest server-confirmed message, or nil. Confirmed rows are kept sorted oldest-first and are
+    /// always `.sent` (pending sends live separately), so this is what the receive buzz and mark-read
+    /// track — never a pending row.
+    public func lastConfirmedMessage(for conversationID: ConversationID) -> ConversationMessage? {
+        messagesByConversation[conversationID]?.last
     }
 
     /// Add an optimistic message that the server hasn't confirmed yet.

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -15,6 +15,9 @@ public struct ConversationStore: Sendable {
 
     public private(set) var conversations: [Conversation] = []
     private var messagesByConversation: [ConversationID: [ConversationMessage]] = [:]
+    /// Optimistic messages not yet confirmed by the server, kept separate from the server-mirrored
+    /// `messagesByConversation` so paging, mark-read, and the feed never see them.
+    private var pendingByConversation: [ConversationID: [ConversationMessage]] = [:]
 
     public init() {}
 
@@ -39,9 +42,56 @@ public struct ConversationStore: Sendable {
             uniquingKeysWith: { _, new in new }
         )
         for message in incoming {
-            byID[message.id] = message
+            // A re-delivered server copy (the stream echo of a message this device sent) carries no
+            // client id; keep the one the optimistic send reconciled onto this row so the transcript
+            // identity stays stable and the row never re-inserts.
+            if message.clientMessageID == nil, let existing = byID[message.id]?.clientMessageID {
+                byID[message.id] = ConversationMessage(
+                    id: message.id, senderID: message.senderID, content: message.content,
+                    date: message.date, unreadSeq: message.unreadSeq, status: .sent, clientMessageID: existing
+                )
+            } else {
+                byID[message.id] = message
+            }
         }
         messagesByConversation[conversationID] = byID.values.sorted { $0.id < $1.id }
+    }
+
+    // MARK: - Optimistic (pending) sends
+
+    /// Confirmed messages (oldest first) followed by in-flight optimistic ones (by send time). This is
+    /// the transcript's source of truth; `messages(for:)` stays confirmed-only for mark-read and paging.
+    public func displayedMessages(for conversationID: ConversationID) -> [ConversationMessage] {
+        let confirmed = messagesByConversation[conversationID] ?? []
+        let pending = (pendingByConversation[conversationID] ?? []).sorted { $0.date < $1.date }
+        return confirmed + pending
+    }
+
+    /// Add an optimistic message that the server hasn't confirmed yet.
+    public mutating func insertPending(_ message: ConversationMessage, into conversationID: ConversationID) {
+        pendingByConversation[conversationID, default: []].append(message)
+    }
+
+    /// The in-flight optimistic message for a client id, if still pending.
+    public func pendingMessage(clientMessageID: UUID, in conversationID: ConversationID) -> ConversationMessage? {
+        pendingByConversation[conversationID]?.first { $0.clientMessageID == clientMessageID }
+    }
+
+    /// Move a pending message between sending and failed.
+    public mutating func markPending(clientMessageID: UUID, status: SendStatus, in conversationID: ConversationID) {
+        guard let index = pendingByConversation[conversationID]?.firstIndex(where: { $0.clientMessageID == clientMessageID }) else { return }
+        pendingByConversation[conversationID]?[index].status = status
+    }
+
+    /// Replace a server-confirmed send: drop the optimistic copy and merge the server message, carrying
+    /// the client id onto it so the row keeps its identity across sending → sent (no delete+insert).
+    public mutating func reconcile(clientMessageID: UUID, with serverMessage: ConversationMessage, in conversationID: ConversationID) {
+        pendingByConversation[conversationID]?.removeAll { $0.clientMessageID == clientMessageID }
+        let confirmed = ConversationMessage(
+            id: serverMessage.id, senderID: serverMessage.senderID, content: serverMessage.content,
+            date: serverMessage.date, unreadSeq: serverMessage.unreadSeq, status: .sent, clientMessageID: clientMessageID
+        )
+        mergeMessages([confirmed], into: conversationID)
     }
 
     /// The signed-in user's READ watermark for a conversation, as last reported by

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -16,8 +16,21 @@ public struct ConversationStore: Sendable {
     public private(set) var conversations: [Conversation] = []
     private var messagesByConversation: [ConversationID: [ConversationMessage]] = [:]
     /// Optimistic messages not yet confirmed by the server, kept separate from the server-mirrored
-    /// `messagesByConversation` so paging, mark-read, and the feed never see them.
-    private var pendingByConversation: [ConversationID: [ConversationMessage]] = [:]
+    /// `messagesByConversation` so paging, mark-read, and the feed never see them. Each carries the
+    /// server id it was sent after (its `anchor`) and a monotonic send `sequence`, so the transcript
+    /// orders it relative to confirmed rows without comparing client and server wall-clock times.
+    private var pendingByConversation: [ConversationID: [PendingEntry]] = [:]
+    /// Monotonic counter stamped on each optimistic send, breaking ties among rows that share an anchor
+    /// and keeping send order stable across out-of-order reconciles.
+    private var pendingSequence: UInt64 = 0
+
+    /// An optimistic send plus the keys that place it in the transcript: `anchor` is the newest
+    /// confirmed server id at send time (the row this send sits after), `sequence` is its send order.
+    private struct PendingEntry: Sendable {
+        var message: ConversationMessage
+        let anchor: UInt64
+        let sequence: UInt64
+    }
 
     public init() {}
 
@@ -74,32 +87,48 @@ public struct ConversationStore: Sendable {
     private mutating func reconcilePendingMatch(for serverCopy: ConversationMessage, in conversationID: ConversationID) -> UUID? {
         guard var pending = pendingByConversation[conversationID],
               let index = pending.firstIndex(where: {
-                  $0.senderID == serverCopy.senderID
-                      && $0.content == serverCopy.content
-                      && abs($0.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
+                  $0.message.senderID == serverCopy.senderID
+                      && $0.message.content == serverCopy.content
+                      && abs($0.message.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
               }) else {
             return nil
         }
-        let clientMessageID = pending.remove(at: index).clientMessageID
+        let clientMessageID = pending.remove(at: index).message.clientMessageID
         pendingByConversation[conversationID] = pending
         return clientMessageID
     }
 
     // MARK: - Optimistic (pending) sends
 
-    /// The transcript's source of truth: confirmed rows in server order, then in-flight optimistic rows
-    /// in send order. They're appended (not date-merged) so a fresh send always lands at the tail —
-    /// immune to client/server clock skew, and the scroll-to-bottom on send stays reliable.
+    /// The transcript's source of truth: confirmed rows in server order, with each in-flight optimistic
+    /// row placed right after the confirmed row it was sent after (its anchor), ties broken by send
+    /// sequence. Ordering by the server `MessageId` anchor — not wall-clock dates — means a fresh send
+    /// lands at the tail (immune to clock skew, scroll-to-bottom stays reliable), a failed send keeps
+    /// its place even as newer messages arrive, and out-of-order reconciles never reshuffle (a
+    /// reconciled row's real id is greater than its anchor, so it lands where the pending row was).
     /// `messages(for:)` stays confirmed-only for mark-read and paging.
-    ///
-    /// A caveat we accept: if several sends are in flight at once and their responses reconcile out of
-    /// order, the just-confirmed one briefly sits among the confirmed run while earlier still-pending
-    /// ones trail it — a sub-second shuffle that settles into the server's order. Offline sends (which
-    /// never reconcile) stay in send order throughout.
     public func displayedMessages(for conversationID: ConversationID) -> [ConversationMessage] {
         let confirmed = messagesByConversation[conversationID] ?? []
-        let pending = pendingByConversation[conversationID] ?? []
-        return confirmed + pending
+        guard let pending = pendingByConversation[conversationID], !pending.isEmpty else { return confirmed }
+
+        let ordered = pending.sorted { ($0.anchor, $0.sequence) < ($1.anchor, $1.sequence) }
+        var result: [ConversationMessage] = []
+        result.reserveCapacity(confirmed.count + ordered.count)
+        var p = 0
+        for message in confirmed {
+            result.append(message)
+            while p < ordered.count, ordered[p].anchor == message.id.value {
+                result.append(ordered[p].message)
+                p += 1
+            }
+        }
+        // Anything anchored beyond the last confirmed row (the common fresh-send case, or a send made
+        // when no messages were loaded) trails at the end, in send order.
+        while p < ordered.count {
+            result.append(ordered[p].message)
+            p += 1
+        }
+        return result
     }
 
     /// The newest server-confirmed message, or nil. Confirmed rows are kept sorted oldest-first and are
@@ -115,27 +144,30 @@ public struct ConversationStore: Sendable {
         !(messagesByConversation[conversationID]?.isEmpty ?? true) || !(pendingByConversation[conversationID]?.isEmpty ?? true)
     }
 
-    /// Add an optimistic message that the server hasn't confirmed yet.
+    /// Add an optimistic message that the server hasn't confirmed yet, anchored to the newest confirmed
+    /// id at send time so the transcript can position it without a wall-clock comparison.
     public mutating func insertPending(_ message: ConversationMessage, into conversationID: ConversationID) {
-        pendingByConversation[conversationID, default: []].append(message)
+        let anchor = messagesByConversation[conversationID]?.last?.id.value ?? 0
+        pendingByConversation[conversationID, default: []].append(PendingEntry(message: message, anchor: anchor, sequence: pendingSequence))
+        pendingSequence += 1
     }
 
     /// The in-flight optimistic message for a client id, if still pending.
     public func pendingMessage(clientMessageID: UUID, in conversationID: ConversationID) -> ConversationMessage? {
-        pendingByConversation[conversationID]?.first { $0.clientMessageID == clientMessageID }
+        pendingByConversation[conversationID]?.first { $0.message.clientMessageID == clientMessageID }?.message
     }
 
     /// Move a pending message between sending and failed.
     public mutating func markPending(clientMessageID: UUID, status: SendStatus, in conversationID: ConversationID) {
-        guard let index = pendingByConversation[conversationID]?.firstIndex(where: { $0.clientMessageID == clientMessageID }) else { return }
-        pendingByConversation[conversationID]?[index].status = status
+        guard let index = pendingByConversation[conversationID]?.firstIndex(where: { $0.message.clientMessageID == clientMessageID }) else { return }
+        pendingByConversation[conversationID]?[index].message.status = status
     }
 
     /// Replace a server-confirmed send (the send RPC's own response): drop the optimistic copy and merge
     /// the server message, carrying the client id onto it so the row keeps its identity across
     /// sending → sent (no delete+insert).
     public mutating func reconcile(clientMessageID: UUID, with serverMessage: ConversationMessage, in conversationID: ConversationID) {
-        pendingByConversation[conversationID]?.removeAll { $0.clientMessageID == clientMessageID }
+        pendingByConversation[conversationID]?.removeAll { $0.message.clientMessageID == clientMessageID }
         var confirmed = serverMessage
         confirmed.status = .sent
         confirmed.clientMessageID = clientMessageID

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -87,14 +87,17 @@ public struct ConversationStore: Sendable {
     /// and content within the reconcile window — the optimistic row this server copy confirms. Returns
     /// nil when nothing matches (a counterpart message, or an unrelated history message).
     private mutating func reconcilePendingMatch(for serverCopy: ConversationMessage, in conversationID: ConversationID) -> UUID? {
-        guard var pending = pendingByConversation[conversationID],
-              let index = pending.firstIndex(where: {
-                  $0.message.senderID == serverCopy.senderID
-                      && $0.message.content == serverCopy.content
-                      && abs($0.message.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
-              }) else {
-            return nil
+        guard var pending = pendingByConversation[conversationID] else { return nil }
+        let matches = pending.indices.filter {
+            pending[$0].message.senderID == serverCopy.senderID
+                && pending[$0].message.content == serverCopy.content
+                && abs(pending[$0].message.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
         }
+        // Reconcile only an unambiguous match. Two in-flight sends with identical text can't be told
+        // apart (the server echoes no client id), so leave them for their own send-RPC responses —
+        // which key on the exact client id — rather than cross-wiring one send's id onto the other's
+        // row (which would briefly give two rows the same stableID).
+        guard matches.count == 1, let index = matches.first else { return nil }
         let matched = pending.remove(at: index)
         pendingByConversation[conversationID] = pending
         reanchorLaterSends(after: matched.sequence, toAtLeast: serverCopy.id.value, in: conversationID)

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -51,11 +51,13 @@ public struct ConversationStore: Sendable {
         for message in incoming {
             var message = message
             // A server copy with no client id is either the echo of one of our optimistic sends or a
-            // re-delivery of an already-reconciled row. Adopt the matching pending row's client id (and
-            // drop that pending copy) so the row keeps one stable identity across sending → sent and is
-            // never shown twice; otherwise keep the client id already on the confirmed row.
+            // re-delivery of an already-known row. Only a brand-new id (not already confirmed) can be a
+            // fresh send's echo, so only then do we content-match a pending row — this keeps a
+            // re-delivery of an OLD identical message from stealing a fresh pending send. Adopting the
+            // pending row's client id (and dropping that pending copy) keeps one stable identity across
+            // sending → sent; for an already-known id we just keep the client id already on the row.
             if message.clientMessageID == nil {
-                if let clientMessageID = reconcilePendingMatch(for: message, in: conversationID) {
+                if byID[message.id] == nil, let clientMessageID = reconcilePendingMatch(for: message, in: conversationID) {
                     message.clientMessageID = clientMessageID
                 } else if let existing = byID[message.id]?.clientMessageID {
                     message.clientMessageID = existing
@@ -85,14 +87,23 @@ public struct ConversationStore: Sendable {
 
     // MARK: - Optimistic (pending) sends
 
-    /// Confirmed messages (oldest first) followed by in-flight optimistic ones in send order. This is
-    /// the transcript's source of truth; `messages(for:)` stays confirmed-only for mark-read and paging.
-    /// Pending rows are appended in send order (and stay there), so no re-sort is needed — which also
-    /// keeps two same-millisecond sends in the order they were tapped.
+    /// The transcript's source of truth: confirmed rows in server order, with each in-flight optimistic
+    /// row positioned by its send time. Positioning by date (rather than always appending) keeps a row
+    /// in place when sends reconcile out of order — e.g. a retried older message that resolves after a
+    /// newer one, or two rapid sends whose responses race. `messages(for:)` stays confirmed-only for
+    /// mark-read and paging.
     public func displayedMessages(for conversationID: ConversationID) -> [ConversationMessage] {
         let confirmed = messagesByConversation[conversationID] ?? []
         let pending = pendingByConversation[conversationID] ?? []
-        return confirmed + pending
+        guard !pending.isEmpty else { return confirmed }
+        var result = confirmed
+        for message in pending {
+            // Sit before the first row newer than this send; same-date rows (and the common
+            // newest-send case) keep it after them, i.e. at the tail.
+            let index = result.firstIndex { $0.date > message.date } ?? result.endIndex
+            result.insert(message, at: index)
+        }
+        return result
     }
 
     /// The newest server-confirmed message, or nil. Confirmed rows are kept sorted oldest-first and are
@@ -100,6 +111,12 @@ public struct ConversationStore: Sendable {
     /// track — never a pending row.
     public func lastConfirmedMessage(for conversationID: ConversationID) -> ConversationMessage? {
         messagesByConversation[conversationID]?.last
+    }
+
+    /// Whether the conversation has any message (confirmed or in-flight) — checked without building the
+    /// merged transcript, so an emptiness test doesn't allocate the whole array.
+    public func hasMessages(for conversationID: ConversationID) -> Bool {
+        !(messagesByConversation[conversationID]?.isEmpty ?? true) || !(pendingByConversation[conversationID]?.isEmpty ?? true)
     }
 
     /// Add an optimistic message that the server hasn't confirmed yet.

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -28,7 +28,9 @@ public struct ConversationStore: Sendable {
     /// confirmed server id at send time (the row this send sits after), `sequence` is its send order.
     private struct PendingEntry: Sendable {
         var message: ConversationMessage
-        let anchor: UInt64
+        /// Re-anchored upward when an earlier-but-later-confirming sibling reconciles, so send order
+        /// holds regardless of which concurrent send the server confirms first.
+        var anchor: UInt64
         let sequence: UInt64
     }
 
@@ -93,9 +95,21 @@ public struct ConversationStore: Sendable {
               }) else {
             return nil
         }
-        let clientMessageID = pending.remove(at: index).message.clientMessageID
+        let matched = pending.remove(at: index)
         pendingByConversation[conversationID] = pending
-        return clientMessageID
+        reanchorLaterSends(after: matched.sequence, toAtLeast: serverCopy.id.value, in: conversationID)
+        return matched.message.clientMessageID
+    }
+
+    /// After an optimistic send (`sequence`) confirms at `confirmedID`, any still-pending send made
+    /// after it (higher sequence) was sent after that now-confirmed row, so re-anchor it to at least
+    /// `confirmedID`. This keeps send order even when an earlier send reconciles before a later one.
+    private mutating func reanchorLaterSends(after sequence: UInt64, toAtLeast confirmedID: UInt64, in conversationID: ConversationID) {
+        guard var pending = pendingByConversation[conversationID] else { return }
+        for i in pending.indices where pending[i].sequence > sequence && pending[i].anchor < confirmedID {
+            pending[i].anchor = confirmedID
+        }
+        pendingByConversation[conversationID] = pending
     }
 
     // MARK: - Optimistic (pending) sends
@@ -167,11 +181,15 @@ public struct ConversationStore: Sendable {
     /// the server message, carrying the client id onto it so the row keeps its identity across
     /// sending → sent (no delete+insert).
     public mutating func reconcile(clientMessageID: UUID, with serverMessage: ConversationMessage, in conversationID: ConversationID) {
+        let reconciledSequence = pendingByConversation[conversationID]?.first { $0.message.clientMessageID == clientMessageID }?.sequence
         pendingByConversation[conversationID]?.removeAll { $0.message.clientMessageID == clientMessageID }
         var confirmed = serverMessage
         confirmed.status = .sent
         confirmed.clientMessageID = clientMessageID
         mergeMessages([confirmed], into: conversationID)
+        if let reconciledSequence {
+            reanchorLaterSends(after: reconciledSequence, toAtLeast: serverMessage.id.value, in: conversationID)
+        }
     }
 
     /// The signed-in user's READ watermark for a conversation, as last reported by

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -410,4 +410,34 @@ struct ConversationStoreTests {
         store.reconcile(clientMessageID: clientA, with: message(4, "A"), in: conversationID(1))
         #expect(displayedTexts(store, conversationID(1)) == ["x", "A", "B"])
     }
+
+    @Test("An ambiguous echo of two identical-text in-flight sends is not cross-wired")
+    func ambiguousIdenticalSendsAreNotCrossWired() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientA = UUID(), clientB = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientA),
+            into: conversationID(1)
+        )
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientB),
+            into: conversationID(1)
+        )
+        // An echo of "hi" can't be told apart from either pending send — it must NOT reconcile.
+        store.mergeMessages(
+            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"),
+                                 date: Date(timeIntervalSince1970: 0), unreadSeq: 0)],
+            into: conversationID(1)
+        )
+        #expect(store.pendingMessage(clientMessageID: clientA, in: conversationID(1)) != nil)
+        #expect(store.pendingMessage(clientMessageID: clientB, in: conversationID(1)) != nil)
+        // No two displayed rows share a stableID — no diff-corrupting duplicate identity.
+        let ids = store.displayedMessages(for: conversationID(1)).map(\.stableID)
+        #expect(Set(ids).count == ids.count)
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -311,38 +311,6 @@ struct ConversationStoreTests {
         #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
     }
 
-    @Test("Out-of-order reconcile keeps messages in send-time order")
-    func outOfOrderReconcileKeepsOrder() {
-        let me = UUID()
-        var store = ConversationStore()
-        let clientA = UUID(), clientB = UUID()
-        // A sent first (t=10), B sent second (t=20).
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("A"),
-                                date: Date(timeIntervalSince1970: 10), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientA),
-            into: conversationID(1)
-        )
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("B"),
-                                date: Date(timeIntervalSince1970: 20), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientB),
-            into: conversationID(1)
-        )
-        // B confirms first (its RPC/echo wins the race).
-        store.reconcile(
-            clientMessageID: clientB,
-            with: ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("B"),
-                                      date: Date(timeIntervalSince1970: 20), unreadSeq: 0),
-            in: conversationID(1)
-        )
-        // A is still pending but was sent first, so it stays ABOVE the just-confirmed B.
-        let texts = store.displayedMessages(for: conversationID(1)).map {
-            if case .text(let t) = $0.content { t } else { "" }
-        }
-        #expect(texts == ["A", "B"])
-    }
-
     @Test("A re-delivered already-confirmed identical message does not absorb a fresh pending send")
     func redeliveredConfirmedDoesNotAbsorbPending() {
         let me = UUID()

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -339,4 +339,52 @@ struct ConversationStoreTests {
         #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
         #expect(store.displayedMessages(for: conversationID(1)).count == 2)   // old confirmed + fresh pending
     }
+
+    private func displayedTexts(_ store: ConversationStore, _ id: ConversationID) -> [String] {
+        store.displayedMessages(for: id).map { if case .text(let t) = $0.content { t } else { "" } }
+    }
+
+    @Test("A failed send keeps its chronological place when newer messages arrive")
+    func failedMessageHoldsChronologicalPosition() {
+        let me = UUID()
+        var store = ConversationStore()
+        store.mergeMessages([message(1, "a"), message(2, "b"), message(3, "c")], into: conversationID(1))
+        // Sent after seeing id 3, then it fails.
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("mine"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        store.markPending(clientMessageID: clientID, status: .failed, in: conversationID(1))
+        // A newer message arrives.
+        store.mergeMessages([message(4, "later")], into: conversationID(1))
+        // "mine" stays after id 3 (where it was sent), before the newer "later" — not dumped at the tail.
+        #expect(displayedTexts(store, conversationID(1)) == ["a", "b", "c", "mine", "later"])
+    }
+
+    @Test("Out-of-order reconcile keeps optimistic sends in send order")
+    func outOfOrderReconcileKeepsSendOrder() {
+        let me = UUID()
+        var store = ConversationStore()
+        store.mergeMessages([message(3, "x")], into: conversationID(1))
+        let clientA = UUID(), clientB = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("A"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientA),
+            into: conversationID(1)
+        )
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("B"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientB),
+            into: conversationID(1)
+        )
+        // B (sent second) reconciles first.
+        store.reconcile(clientMessageID: clientB, with: message(4, "B"), in: conversationID(1))
+        // A (sent first, still pending) stays above the just-confirmed B.
+        #expect(displayedTexts(store, conversationID(1)) == ["x", "A", "B"])
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -310,4 +310,65 @@ struct ConversationStoreTests {
         #expect(displayed.count == 2)                               // counterpart's "hi" + my pending "hi"
         #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
     }
+
+    @Test("Out-of-order reconcile keeps messages in send-time order")
+    func outOfOrderReconcileKeepsOrder() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientA = UUID(), clientB = UUID()
+        // A sent first (t=10), B sent second (t=20).
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("A"),
+                                date: Date(timeIntervalSince1970: 10), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientA),
+            into: conversationID(1)
+        )
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("B"),
+                                date: Date(timeIntervalSince1970: 20), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientB),
+            into: conversationID(1)
+        )
+        // B confirms first (its RPC/echo wins the race).
+        store.reconcile(
+            clientMessageID: clientB,
+            with: ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("B"),
+                                      date: Date(timeIntervalSince1970: 20), unreadSeq: 0),
+            in: conversationID(1)
+        )
+        // A is still pending but was sent first, so it stays ABOVE the just-confirmed B.
+        let texts = store.displayedMessages(for: conversationID(1)).map {
+            if case .text(let t) = $0.content { t } else { "" }
+        }
+        #expect(texts == ["A", "B"])
+    }
+
+    @Test("A re-delivered already-confirmed identical message does not absorb a fresh pending send")
+    func redeliveredConfirmedDoesNotAbsorbPending() {
+        let me = UUID()
+        var store = ConversationStore()
+        // An identical "hi" was sent earlier and confirmed at id 5.
+        store.mergeMessages(
+            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"),
+                                 date: Date(timeIntervalSince1970: 100), unreadSeq: 0)],
+            into: conversationID(1)
+        )
+        // A fresh "hi" is now in flight, within the reconcile window of the old one.
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
+                                date: Date(timeIntervalSince1970: 120), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        // The stream re-delivers the OLD confirmed "hi" (id 5, already known) — it must not steal the
+        // fresh pending row.
+        store.mergeMessages(
+            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"),
+                                 date: Date(timeIntervalSince1970: 100), unreadSeq: 0)],
+            into: conversationID(1)
+        )
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
+        #expect(store.displayedMessages(for: conversationID(1)).count == 2)   // old confirmed + fresh pending
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -387,4 +387,27 @@ struct ConversationStoreTests {
         // A (sent first, still pending) stays above the just-confirmed B.
         #expect(displayedTexts(store, conversationID(1)) == ["x", "A", "B"])
     }
+
+    @Test("Out-of-order reconcile: the earlier send confirming first keeps send order")
+    func earlierSendReconcilingFirstKeepsSendOrder() {
+        let me = UUID()
+        var store = ConversationStore()
+        store.mergeMessages([message(3, "x")], into: conversationID(1))
+        let clientA = UUID(), clientB = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("A"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientA),
+            into: conversationID(1)
+        )
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("B"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientB),
+            into: conversationID(1)
+        )
+        // A (sent first) reconciles first — B must NOT jump above it.
+        store.reconcile(clientMessageID: clientA, with: message(4, "A"), in: conversationID(1))
+        #expect(displayedTexts(store, conversationID(1)) == ["x", "A", "B"])
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -128,4 +128,94 @@ struct ConversationStoreTests {
         store.apply(.readPointersChanged(conversationID: conversationID(1), pointers: [MemberReadPointer(userID: me, value: MessageID(value: 3), date: Date(timeIntervalSince1970: 0))]))
         #expect(store.conversations.first?.members.first?.readPointerTimestamp == readAt)
     }
+
+    // MARK: - Optimistic send
+
+    @Test("A server-built message defaults to .sent with no client id; stableID is the server id")
+    func messageDefaultsAreSent() {
+        let m = message(7)
+        #expect(m.status == .sent)
+        #expect(m.clientMessageID == nil)
+        #expect(m.stableID == "7")
+    }
+
+    @Test("A pending message carries its client id as the stable identity")
+    func pendingMessageStableID() {
+        let id = UUID()
+        let m = ConversationMessage(
+            id: MessageID(value: .max), senderID: nil, content: .text("hi"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+            status: .sending, clientMessageID: id
+        )
+        #expect(m.status == .sending)
+        #expect(m.stableID == id.uuidString)
+    }
+
+    @Test("insertPending shows the optimistic message after the confirmed ones; messages() ignores it")
+    func insertPendingDisplaysAfterConfirmed() {
+        var store = ConversationStore()
+        store.mergeMessages([message(1), message(2)], into: conversationID(1))
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
+                                date: Date(timeIntervalSince1970: 99), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        #expect(store.displayedMessages(for: conversationID(1)).map(\.stableID) == ["1", "2", clientID.uuidString])
+        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [1, 2]) // confirmed-only, unchanged
+    }
+
+    @Test("markPending flips a pending message to failed")
+    func markPendingFailed() {
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        store.markPending(clientMessageID: clientID, status: .failed, in: conversationID(1))
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1))?.status == .failed)
+    }
+
+    @Test("reconcile drops the pending copy and keeps the client id on the confirmed message")
+    func reconcileKeepsIdentity() {
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        store.reconcile(clientMessageID: clientID, with: message(5, "c"), in: conversationID(1))
+
+        let displayed = store.displayedMessages(for: conversationID(1))
+        #expect(displayed.count == 1)
+        #expect(displayed.first?.id.value == 5)
+        #expect(displayed.first?.status == .sent)
+        #expect(displayed.first?.stableID == clientID.uuidString)   // identity preserved → no re-insert
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) == nil)
+    }
+
+    @Test("a stream echo of a reconciled message does not strip its client id")
+    func mergePreservesClientID() {
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        store.reconcile(clientMessageID: clientID, with: message(5, "c"), in: conversationID(1))
+        // The event stream re-delivers the same server message with no client id.
+        store.mergeMessages([message(5, "c")], into: conversationID(1))
+
+        let displayed = store.displayedMessages(for: conversationID(1))
+        #expect(displayed.count == 1)
+        #expect(displayed.first?.stableID == clientID.uuidString)
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -218,4 +218,96 @@ struct ConversationStoreTests {
         #expect(displayed.count == 1)
         #expect(displayed.first?.stableID == clientID.uuidString)
     }
+
+    @Test("An echo arriving before reconcile collapses onto the pending row (no duplicate, stable id)")
+    func echoBeforeReconcileCollapses() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("c"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        // The stream echo (server id, no client id, same sender+content+time) lands before the RPC.
+        store.mergeMessages(
+            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("c"),
+                                 date: Date(timeIntervalSince1970: 1), unreadSeq: 0)],
+            into: conversationID(1)
+        )
+        let displayed = store.displayedMessages(for: conversationID(1))
+        #expect(displayed.count == 1)                               // collapsed, not duplicated
+        #expect(displayed.first?.id.value == 5)
+        #expect(displayed.first?.status == .sent)
+        #expect(displayed.first?.stableID == clientID.uuidString)   // identity preserved across the echo
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) == nil)
+    }
+
+    @Test("An echo reconciles a failed pending send, clearing the phantom (timed-out-but-persisted)")
+    func echoReconcilesFailedPending() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("c"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        store.markPending(clientMessageID: clientID, status: .failed, in: conversationID(1))
+        // The send RPC timed out, but the server persisted + echoed the message.
+        store.mergeMessages(
+            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("c"),
+                                 date: Date(timeIntervalSince1970: 1), unreadSeq: 0)],
+            into: conversationID(1)
+        )
+        let displayed = store.displayedMessages(for: conversationID(1))
+        #expect(displayed.count == 1)                               // no permanent duplicate
+        #expect(displayed.first?.status == .sent)                   // no false "Not Delivered" phantom
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) == nil)
+    }
+
+    @Test("An unrelated old message with identical text does not reconcile a fresh pending send")
+    func oldHistoryDoesNotReconcile() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
+                                date: Date(timeIntervalSince1970: 100_000), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        // A history page carries an old "hi" from the same sender, far outside the reconcile window.
+        store.mergeMessages(
+            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"),
+                                 date: Date(timeIntervalSince1970: 0), unreadSeq: 0)],
+            into: conversationID(1)
+        )
+        let displayed = store.displayedMessages(for: conversationID(1))
+        #expect(displayed.count == 2)                               // distinct messages, not collapsed
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
+    }
+
+    @Test("A counterpart message with identical text does not reconcile a pending self-send")
+    func counterpartMessageDoesNotReconcile() {
+        let me = UUID(), them = UUID()
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        store.mergeMessages(
+            [ConversationMessage(id: MessageID(value: 5), senderID: them, content: .text("hi"),
+                                 date: Date(timeIntervalSince1970: 0), unreadSeq: 0)],
+            into: conversationID(1)
+        )
+        let displayed = store.displayedMessages(for: conversationID(1))
+        #expect(displayed.count == 2)                               // counterpart's "hi" + my pending "hi"
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
+    }
 }

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -50,8 +50,8 @@ struct ChatMessageMappingTests {
         )
     }
 
-    private func deliveryStates(_ items: [ChatItem]) -> [ChatMessage.DeliveryState] {
-        messageRows(items).map(\.deliveryState)
+    private func failedFlags(_ items: [ChatItem]) -> [Bool] {
+        messageRows(items).map(\.isFailed)
     }
 
     @Test("Same-sender run within the gap groups; a sender change breaks it; gaps add separators")
@@ -188,7 +188,7 @@ struct ChatMessageMappingTests {
             selfUserID: me,
             counterpartRead: (pointer: MessageID(value: 0), date: nil)
         )
-        #expect(deliveryStates(items) == [.normal, .sending])
+        #expect(failedFlags(items) == [false, false])
         // "b" (sending) shows nothing; the prior delivered "a" keeps its "Delivered" line.
         let rows = messageRows(items)
         #expect(rows.first?.receipt == "Delivered")
@@ -206,7 +206,7 @@ struct ChatMessageMappingTests {
             selfUserID: me,
             counterpartRead: (pointer: MessageID(value: 0), date: nil)
         )
-        #expect(deliveryStates(items) == [.normal, .failed])
+        #expect(failedFlags(items) == [false, true])
         let rows = messageRows(items)
         #expect(rows.first?.receipt == "Delivered")                     // prior delivered receipt preserved
         #expect(rows.last?.receipt == "Not Delivered. Tap to retry")    // failed row shows its own line

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -211,4 +211,15 @@ struct ChatMessageMappingTests {
         #expect(rows.first?.receipt == "Delivered")                     // prior delivered receipt preserved
         #expect(rows.last?.receipt == "Not Delivered. Tap to retry")    // failed row shows its own line
     }
+
+    @Test("A settling send's Delivered receipt is held back, then shows once the gate clears")
+    func suppressedReceiptWhileSettling() {
+        let read = (pointer: MessageID(value: 0), date: Date?.none)
+        // While the row is still settling (its id is suppressed), no receipt shows.
+        let settling = ChatItem.from([text(1, me, "hi", after: 0)], selfUserID: me, counterpartRead: read, suppressReceiptFor: "1")
+        #expect(receiptText(settling) == nil)
+        // Once the gate clears, "Delivered" appears.
+        let settled = ChatItem.from([text(1, me, "hi", after: 0)], selfUserID: me, counterpartRead: read)
+        #expect(receiptText(settled) == "Delivered")
+    }
 }

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -180,7 +180,7 @@ struct ChatMessageMappingTests {
         #expect(receiptText(items) == "Read \(weekday)")
     }
 
-    @Test("A sending message shows no status line until it resolves")
+    @Test("A sending row shows no status line and keeps the prior delivered receipt")
     func sendingMapsToState() {
         let clientID = UUID()
         let items = ChatItem.from(
@@ -189,19 +189,26 @@ struct ChatMessageMappingTests {
             counterpartRead: (pointer: MessageID(value: 0), date: nil)
         )
         #expect(deliveryStates(items) == [.normal, .sending])
-        // Nothing renders while "b" is in flight, and the older "a" isn't the latest self row, so the
-        // transcript shows no status line at all until "b" resolves to Delivered or failed.
-        #expect(receiptText(items) == nil)
-        // The sending row's stable identity is its client id.
-        #expect(messageRows(items).last?.id == clientID.uuidString)
+        // "b" (sending) shows nothing; the prior delivered "a" keeps its "Delivered" line.
+        let rows = messageRows(items)
+        #expect(rows.first?.receipt == "Delivered")
+        #expect(rows.last?.id == clientID.uuidString)
+        #expect(rows.last?.receipt == nil)
     }
 
-    @Test("A failed message maps to .failed")
+    @Test("A failed row shows its own line without stripping the prior delivered receipt")
     func failedMapsToState() {
         let clientID = UUID()
         var msg = sending(clientID, "b", after: 60)
         msg.status = .failed
-        let items = ChatItem.from([text(1, me, "a", after: 0), msg], selfUserID: me)
+        let items = ChatItem.from(
+            [text(1, me, "a", after: 0), msg],
+            selfUserID: me,
+            counterpartRead: (pointer: MessageID(value: 0), date: nil)
+        )
         #expect(deliveryStates(items) == [.normal, .failed])
+        let rows = messageRows(items)
+        #expect(rows.first?.receipt == "Delivered")                     // prior delivered receipt preserved
+        #expect(rows.last?.receipt == "Not Delivered. Tap to retry")    // failed row shows its own line
     }
 }

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -190,8 +190,8 @@ struct ChatMessageMappingTests {
         )
         #expect(deliveryStates(items) == [.normal, .sending])
         // The status line rides the LAST self message (iMessage-style); while "b" is sending it shows
-        // its own state and the older delivered "a" shows nothing — so there's no "Delivered" anywhere.
-        #expect(receiptText(items) == nil)
+        // "Sending…" and the older delivered "a" shows nothing — so no "Delivered" anywhere.
+        #expect(receiptText(items) == "Sending…")
         // The sending row's stable identity is its client id.
         #expect(messageRows(items).last?.id == clientID.uuidString)
     }

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -180,7 +180,7 @@ struct ChatMessageMappingTests {
         #expect(receiptText(items) == "Read \(weekday)")
     }
 
-    @Test("A sending message maps to .sending; the status line follows it, so no Delivered shows")
+    @Test("A sending message shows no status line until it resolves")
     func sendingMapsToState() {
         let clientID = UUID()
         let items = ChatItem.from(
@@ -189,9 +189,9 @@ struct ChatMessageMappingTests {
             counterpartRead: (pointer: MessageID(value: 0), date: nil)
         )
         #expect(deliveryStates(items) == [.normal, .sending])
-        // The status line rides the LAST self message (iMessage-style); while "b" is sending it shows
-        // "Sending…" and the older delivered "a" shows nothing — so no "Delivered" anywhere.
-        #expect(receiptText(items) == "Sending…")
+        // Nothing renders while "b" is in flight, and the older "a" isn't the latest self row, so the
+        // transcript shows no status line at all until "b" resolves to Delivered or failed.
+        #expect(receiptText(items) == nil)
         // The sending row's stable identity is its client id.
         #expect(messageRows(items).last?.id == clientID.uuidString)
     }

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -42,6 +42,18 @@ struct ChatMessageMappingTests {
         items.compactMap { if case .message(let message) = $0 { message.receipt } else { nil } }.last
     }
 
+    private func sending(_ clientID: UUID, _ body: String, after offset: TimeInterval) -> ConversationMessage {
+        ConversationMessage(
+            id: MessageID(value: .max), senderID: me, content: .text(body),
+            date: base.addingTimeInterval(offset), unreadSeq: 0,
+            status: .sending, clientMessageID: clientID
+        )
+    }
+
+    private func deliveryStates(_ items: [ChatItem]) -> [ChatMessage.DeliveryState] {
+        messageRows(items).map(\.deliveryState)
+    }
+
     @Test("Same-sender run within the gap groups; a sender change breaks it; gaps add separators")
     func grouping() {
         let messages = [
@@ -166,5 +178,30 @@ struct ChatMessageMappingTests {
             counterpartRead: (pointer: MessageID(value: 1), date: threeDaysAgo)
         )
         #expect(receiptText(items) == "Read \(weekday)")
+    }
+
+    @Test("A sending message maps to .sending; the status line follows it, so no Delivered shows")
+    func sendingMapsToState() {
+        let clientID = UUID()
+        let items = ChatItem.from(
+            [text(1, me, "a", after: 0), sending(clientID, "b", after: 60)],
+            selfUserID: me,
+            counterpartRead: (pointer: MessageID(value: 0), date: nil)
+        )
+        #expect(deliveryStates(items) == [.normal, .sending])
+        // The status line rides the LAST self message (iMessage-style); while "b" is sending it shows
+        // its own state and the older delivered "a" shows nothing — so there's no "Delivered" anywhere.
+        #expect(receiptText(items) == nil)
+        // The sending row's stable identity is its client id.
+        #expect(messageRows(items).last?.id == clientID.uuidString)
+    }
+
+    @Test("A failed message maps to .failed")
+    func failedMapsToState() {
+        let clientID = UUID()
+        var msg = sending(clientID, "b", after: 60)
+        msg.status = .failed
+        let items = ChatItem.from([text(1, me, "a", after: 0), msg], selfUserID: me)
+        #expect(deliveryStates(items) == [.normal, .failed])
     }
 }

--- a/FlipcashTests/Chat/ReceiptSettleGateTests.swift
+++ b/FlipcashTests/Chat/ReceiptSettleGateTests.swift
@@ -1,0 +1,47 @@
+//
+//  ReceiptSettleGateTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Flipcash
+
+@MainActor
+@Suite("ReceiptSettleGate")
+struct ReceiptSettleGateTests {
+
+    @Test("Holding sets the settling id")
+    func holdSetsID() {
+        let gate = ReceiptSettleGate(delay: .seconds(60))
+        gate.hold("a")
+        #expect(gate.settlingID == "a")
+    }
+
+    @Test("A newer hold replaces the current one")
+    func newerHoldReplaces() {
+        let gate = ReceiptSettleGate(delay: .seconds(60))
+        gate.hold("a")
+        gate.hold("b")
+        #expect(gate.settlingID == "b")
+    }
+
+    @Test("Cancel clears the held id immediately")
+    func cancelClears() {
+        let gate = ReceiptSettleGate(delay: .seconds(60))
+        gate.hold("a")
+        gate.cancel()
+        #expect(gate.settlingID == nil)
+    }
+
+    @Test("The held id clears on its own after the delay")
+    func clearsAfterDelay() async throws {
+        let gate = ReceiptSettleGate(delay: .milliseconds(20))
+        gate.hold("a")
+        #expect(gate.settlingID == "a")
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(gate.settlingID == nil)
+    }
+}

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -99,6 +99,59 @@ struct ConversationControllerTests {
         #expect(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [7])
     }
 
+    @Test("send shows the message immediately as sending, then sent on success")
+    func sendOptimisticSuccess() async {
+        let me = UUID()
+        let mock = MockConversations()
+        mock.sendResult = ConversationMessage(id: MessageID(value: 7), senderID: me, content: .text("hello"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
+        let controller = makeController(mock, selfUserID: me)
+
+        let ok = await controller.send("hello", to: ConversationID.test(1))
+        #expect(ok)
+        let messages = controller.messages(for: ConversationID.test(1))
+        #expect(messages.count == 1)
+        #expect(messages.first?.id.value == 7)
+        #expect(messages.first?.status == .sent)
+    }
+
+    @Test("a failed send leaves the message in the transcript as failed")
+    func sendOptimisticFailureKeepsMessage() async {
+        let me = UUID()
+        let mock = MockConversations()
+        mock.sendError = ErrorSendMessage.transportFailure
+        let controller = makeController(mock, selfUserID: me)
+
+        let ok = await controller.send("hello", to: ConversationID.test(1))
+        #expect(!ok)
+        let messages = controller.messages(for: ConversationID.test(1))
+        #expect(messages.count == 1)
+        #expect(messages.first?.status == .failed)
+        #expect(messages.first?.content == .text("hello"))
+    }
+
+    @Test("retry re-sends the failed message reusing its client id")
+    func retryReusesClientID() async throws {
+        let me = UUID()
+        let mock = MockConversations()
+        mock.sendError = ErrorSendMessage.transportFailure
+        let controller = makeController(mock, selfUserID: me)
+        _ = await controller.send("hello", to: ConversationID.test(1))
+
+        let failed = try #require(controller.messages(for: ConversationID.test(1)).first)
+        let clientID = try #require(failed.clientMessageID)
+
+        // Second attempt succeeds.
+        mock.sendError = nil
+        mock.sendResult = ConversationMessage(id: MessageID(value: 9), senderID: me, content: .text("hello"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
+        await controller.retry(clientMessageID: clientID, in: ConversationID.test(1))
+
+        #expect(mock.sentClientIDs == [clientID, clientID])   // same id both attempts → server-idempotent
+        let messages = controller.messages(for: ConversationID.test(1))
+        #expect(messages.count == 1)
+        #expect(messages.first?.status == .sent)
+        #expect(messages.first?.id.value == 9)
+    }
+
     @Test("markRead advances to the latest loaded message")
     func markRead() async {
         let mock = MockConversations()

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -20,6 +20,8 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     private var _olderMessages: [ConversationMessage] = []
     private var _olderQueries: [MessageID] = []
     private var _sendResult: ConversationMessage?
+    private var _sendError: Error?
+    private var _sentClientIDs: [UUID] = []
     private var _sent: [Sent] = []
     private var _markedRead: [MessageID] = []
     private var _didEnsure = false
@@ -45,6 +47,13 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
         get { lock.withLock { _sendResult } }
         set { lock.withLock { _sendResult = newValue } }
     }
+    /// When set, `sendMessage` throws this instead of returning a message.
+    var sendError: Error? {
+        get { lock.withLock { _sendError } }
+        set { lock.withLock { _sendError = newValue } }
+    }
+    /// The client message ids `sendMessage` was called with, in order.
+    var sentClientIDs: [UUID] { lock.withLock { _sentClientIDs } }
     var sent: [Sent] { lock.withLock { _sent } }
     var markedRead: [MessageID] { lock.withLock { _markedRead } }
     var didEnsure: Bool { lock.withLock { _didEnsure } }
@@ -77,8 +86,12 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
         return olderMessages
     }
 
-    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String) async throws -> ConversationMessage {
-        lock.withLock { _sent.append(Sent(conversationID: conversationID, text: text)) }
+    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID) async throws -> ConversationMessage {
+        lock.withLock {
+            _sent.append(Sent(conversationID: conversationID, text: text))
+            _sentClientIDs.append(clientMessageID)
+        }
+        if let error = sendError { throw error }
         return sendResult ?? ConversationMessage(
             id: MessageID(value: 1), senderID: nil, content: .text(text),
             date: Date(timeIntervalSince1970: 0), unreadSeq: 0

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -100,9 +100,7 @@ public final class ChatCashCardCell: ChatColumnCell {
         coinIcon.image = nil
     }
 
-    /// - Parameter revealsReceiptAfterSettling: set only for a just-sent message's inserting cell, so
-    ///   the delivery line fades in after the card settles instead of popping in with it.
-    public func configure(with message: ChatMessage, revealsReceiptAfterSettling: Bool = false) {
+    public func configure(with message: ChatMessage) {
         guard case .cash(let cash) = message.content else { return }
         tokenLabel.text = cash.token
         captionLabel.text = message.sender == .me ? "You sent" : "You received"
@@ -131,7 +129,7 @@ public final class ChatCashCardCell: ChatColumnCell {
                 groupedBelow: message.isContinuedByNext
             )
         )
-        updateColumn(for: message, revealsReceiptAfterSettling: revealsReceiptAfterSettling)
+        updateColumn(for: message)
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -65,14 +65,10 @@ public class ChatColumnCell: UICollectionViewCell {
     /// is supplied by the mapping (`message.receipt`); this only styles it — a failed row turns red and
     /// becomes tappable to retry.
     func updateColumn(for message: ChatMessage) {
-        if message.isFailed {
-            retryID = message.id
-            receipt.textColor = ChatReceiptLabel.failedColor
-        } else {
-            retryID = nil
-            receipt.textColor = ChatReceiptLabel.defaultColor
-        }
-        retryTap?.isEnabled = retryID != nil
+        // A failed row is the only interactive/red one — every signal keys off that single condition.
+        retryID = message.isFailed ? message.id : nil
+        receipt.textColor = message.isFailed ? ChatReceiptLabel.failedColor : ChatReceiptLabel.defaultColor
+        retryTap?.isEnabled = message.isFailed
         // A cell already in the window is being reconfigured in place (Delivered→Read, sending→
         // delivered, the line clearing as a newer sent message takes it over), so cross-fade the
         // change. A freshly dequeued cell isn't in the window yet, so it's set without animation — a

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -65,13 +65,12 @@ public class ChatColumnCell: UICollectionViewCell {
     /// is supplied by the mapping (`message.receipt`); this only styles it — a failed row turns red and
     /// becomes tappable to retry.
     func updateColumn(for message: ChatMessage) {
-        switch message.deliveryState {
-        case .normal, .sending:
-            retryID = nil
-            receipt.textColor = ChatReceiptLabel.defaultColor
-        case .failed:
+        if message.isFailed {
             retryID = message.id
             receipt.textColor = ChatReceiptLabel.failedColor
+        } else {
+            retryID = nil
+            receipt.textColor = ChatReceiptLabel.defaultColor
         }
         retryTap?.isEnabled = retryID != nil
         // A cell already in the window is being reconfigured in place (Delivered→Read, sending→

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -26,6 +26,10 @@ public class ChatColumnCell: UICollectionViewCell {
     /// Tap-to-retry recognizer, enabled only while this row is failed so non-failed bubbles don't
     /// consume taps (and a future single-tap affordance isn't pre-empted).
     private var retryTap: UITapGestureRecognizer?
+    /// The id of the message this cell currently renders. The receipt is cross-faded only when the
+    /// *same* row changes in place; a recycled cell reconfigured for a different id sets its line
+    /// directly, so it never replays this cell's prior line (a reused failed cell flashing red).
+    private var currentMessageID: String?
 
     /// Stacks `content` above the receipt and pins the column into the contentView, pinning top and
     /// bottom so the cell self-sizes to the content plus the receipt line. Call once, from the
@@ -57,23 +61,30 @@ public class ChatColumnCell: UICollectionViewCell {
 
     public override func prepareForReuse() {
         super.prepareForReuse()
+        currentMessageID = nil
         retryID = nil
         retryTap?.isEnabled = false
+        // Clear the line so a recycled cell never carries its prior row's text/color into the next use.
+        receipt.text = nil
+        receipt.isHidden = true
+        receipt.textColor = ChatReceiptLabel.defaultColor
     }
 
     /// Sets the status line and hugs the column to the sender's edge. Call from `configure`. The text
     /// is supplied by the mapping (`message.receipt`); this only styles it — a failed row turns red and
     /// becomes tappable to retry.
     func updateColumn(for message: ChatMessage) {
+        // Cross-fade the receipt only when the *same* row changes in place (Delivered→Read, the settling
+        // line revealing). A recycled or freshly dequeued cell renders a different row, so its line is set
+        // directly — otherwise the cross-fade would replay this cell's prior line (a reused failed cell
+        // flashing red "Not Delivered" before resolving to the real line).
+        let isInPlaceUpdate = currentMessageID == message.id
+        currentMessageID = message.id
         // A failed row is the only interactive/red one — every signal keys off that single condition.
         retryID = message.isFailed ? message.id : nil
         receipt.textColor = message.isFailed ? ChatReceiptLabel.failedColor : ChatReceiptLabel.defaultColor
         retryTap?.isEnabled = message.isFailed
-        // A cell already in the window is being reconfigured in place (Delivered→Read, sending→
-        // delivered, the line clearing as a newer sent message takes it over), so cross-fade the
-        // change. A freshly dequeued cell isn't in the window yet, so it's set without animation — a
-        // scroll-in or a send shouldn't flash the line.
-        setReceipt(message.receipt, animated: window != nil)
+        setReceipt(message.receipt, animated: isInPlaceUpdate && window != nil)
         column.alignment = message.sender == .me ? .trailing : .leading
         applyAlignment(isFromSelf: message.sender == .me)
     }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -23,6 +23,9 @@ public class ChatColumnCell: UICollectionViewCell {
     var onRetry: ((String) -> Void)?
     /// The message's stable id while this row is failed and tappable; nil otherwise.
     private var retryID: String?
+    /// Tap-to-retry recognizer, enabled only while this row is failed so non-failed bubbles don't
+    /// consume taps (and a future single-tap affordance isn't pre-empted).
+    private var retryTap: UITapGestureRecognizer?
 
     /// Stacks `content` above the receipt and pins the column into the contentView, pinning top and
     /// bottom so the cell self-sizes to the content plus the receipt line. Call once, from the
@@ -35,10 +38,13 @@ public class ChatColumnCell: UICollectionViewCell {
         column.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(column)
 
-        // The whole bubble + status line is the retry target (a generous hit area vs. the thin
-        // receipt line), but a tap only fires onRetry when this row is failed — `retryTapped` checks
-        // retryID, so non-failed rows ignore taps and keep their long-press copy menu.
-        column.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(retryTapped)))
+        // The whole bubble + status line is the retry target (a generous hit area vs. the thin receipt
+        // line). The recognizer is enabled only for a failed row (see updateColumn), so non-failed
+        // bubbles don't consume taps and keep their long-press copy menu.
+        let tap = UITapGestureRecognizer(target: self, action: #selector(retryTapped))
+        tap.isEnabled = false
+        column.addGestureRecognizer(tap)
+        retryTap = tap
 
         leadingConstraint = column.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12)
         trailingConstraint = column.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12)
@@ -52,6 +58,7 @@ public class ChatColumnCell: UICollectionViewCell {
     public override func prepareForReuse() {
         super.prepareForReuse()
         retryID = nil
+        retryTap?.isEnabled = false
     }
 
     /// Sets the status line and hugs the column to the sender's edge. Call from `configure`. The text
@@ -66,6 +73,7 @@ public class ChatColumnCell: UICollectionViewCell {
             retryID = message.id
             receipt.textColor = ChatReceiptLabel.failedColor
         }
+        retryTap?.isEnabled = retryID != nil
         // A cell already in the window is being reconfigured in place (Delivered→Read, sending→
         // delivered, the line clearing as a newer sent message takes it over), so cross-fade the
         // change. A freshly dequeued cell isn't in the window yet, so it's set without animation — a

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -19,6 +19,11 @@ public class ChatColumnCell: UICollectionViewCell {
     private var leadingConstraint: NSLayoutConstraint!
     private var trailingConstraint: NSLayoutConstraint!
 
+    /// Fired when the user taps a failed row to retry; the argument is the message's stable id.
+    var onRetry: ((String) -> Void)?
+    /// The message's stable id while this row is failed and tappable; nil otherwise.
+    private var retryID: String?
+
     /// Stacks `content` above the receipt and pins the column into the contentView, pinning top and
     /// bottom so the cell self-sizes to the content plus the receipt line. Call once, from the
     /// subclass's `init`, after the content view exists.
@@ -30,6 +35,11 @@ public class ChatColumnCell: UICollectionViewCell {
         column.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(column)
 
+        // The failed-state receipt ("Not Delivered. Tap to retry") is the only interactive part of the
+        // column; a tap fires onRetry when retryID is set.
+        receipt.isUserInteractionEnabled = true
+        receipt.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(receiptTapped)))
+
         leadingConstraint = column.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12)
         trailingConstraint = column.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12)
 
@@ -39,15 +49,38 @@ public class ChatColumnCell: UICollectionViewCell {
         ])
     }
 
-    /// Sets the receipt line and hugs the column to the sender's edge. Call from `configure`.
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        retryID = nil
+    }
+
+    /// Sets the receipt/status line and hugs the column to the sender's edge. Call from `configure`.
     func updateColumn(for message: ChatMessage) {
-        // A cell already in the window is being reconfigured in place (Delivered→Read, or the line
-        // clearing as a newer sent message takes it over), so cross-fade the change. A freshly
-        // dequeued cell isn't in the window yet, so it's set without animation — a scroll-in or a
-        // send shouldn't flash the line.
-        setReceipt(message.receipt, animated: window != nil)
+        // A cell already in the window is being reconfigured in place (Delivered→Read, sending→
+        // delivered, or the line clearing as a newer sent message takes it over), so cross-fade the
+        // change. A freshly dequeued cell isn't in the window yet, so it's set without animation — a
+        // scroll-in or a send shouldn't flash the line.
+        switch message.deliveryState {
+        case .normal:
+            retryID = nil
+            receipt.textColor = ChatReceiptLabel.defaultColor
+            setReceipt(message.receipt, animated: window != nil)
+        case .sending:
+            retryID = nil
+            receipt.textColor = ChatReceiptLabel.defaultColor
+            setReceipt("Sending\u{2026}", animated: window != nil)
+        case .failed:
+            retryID = message.id
+            receipt.textColor = .systemRed
+            setReceipt("Not Delivered. Tap to retry", animated: window != nil)
+        }
         column.alignment = message.sender == .me ? .trailing : .leading
         applyAlignment(isFromSelf: message.sender == .me)
+    }
+
+    @objc private func receiptTapped() {
+        guard let retryID else { return }
+        onRetry?(retryID)
     }
 
     private func setReceipt(_ text: String?, animated: Bool) {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -54,26 +54,23 @@ public class ChatColumnCell: UICollectionViewCell {
         retryID = nil
     }
 
-    /// Sets the receipt/status line and hugs the column to the sender's edge. Call from `configure`.
+    /// Sets the status line and hugs the column to the sender's edge. Call from `configure`. The text
+    /// is supplied by the mapping (`message.receipt`); this only styles it — a failed row turns red and
+    /// becomes tappable to retry.
     func updateColumn(for message: ChatMessage) {
-        // A cell already in the window is being reconfigured in place (Delivered→Read, sending→
-        // delivered, or the line clearing as a newer sent message takes it over), so cross-fade the
-        // change. A freshly dequeued cell isn't in the window yet, so it's set without animation — a
-        // scroll-in or a send shouldn't flash the line.
         switch message.deliveryState {
-        case .normal:
+        case .normal, .sending:
             retryID = nil
             receipt.textColor = ChatReceiptLabel.defaultColor
-            setReceipt(message.receipt, animated: window != nil)
-        case .sending:
-            retryID = nil
-            receipt.textColor = ChatReceiptLabel.defaultColor
-            setReceipt("Sending\u{2026}", animated: window != nil)
         case .failed:
             retryID = message.id
             receipt.textColor = .systemRed
-            setReceipt("Not Delivered. Tap to retry", animated: window != nil)
         }
+        // A cell already in the window is being reconfigured in place (Delivered→Read, sending→
+        // delivered, the line clearing as a newer sent message takes it over), so cross-fade the
+        // change. A freshly dequeued cell isn't in the window yet, so it's set without animation — a
+        // scroll-in or a send shouldn't flash the line.
+        setReceipt(message.receipt, animated: window != nil)
         column.alignment = message.sender == .me ? .trailing : .leading
         applyAlignment(isFromSelf: message.sender == .me)
     }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -64,7 +64,7 @@ public class ChatColumnCell: UICollectionViewCell {
             receipt.textColor = ChatReceiptLabel.defaultColor
         case .failed:
             retryID = message.id
-            receipt.textColor = .systemRed
+            receipt.textColor = ChatReceiptLabel.failedColor
         }
         // A cell already in the window is being reconfigured in place (Delivered→Read, sending→
         // delivered, the line clearing as a newer sent message takes it over), so cross-fade the

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -18,8 +18,6 @@ public class ChatColumnCell: UICollectionViewCell {
     private let column = UIStackView()
     private var leadingConstraint: NSLayoutConstraint!
     private var trailingConstraint: NSLayoutConstraint!
-    /// Duration of the receipt fade-in and the in-place Delivered→Read cross-fade.
-    private static let receiptFadeDuration: TimeInterval = 0.25
 
     /// Stacks `content` above the receipt and pins the column into the contentView, pinning top and
     /// bottom so the cell self-sizes to the content plus the receipt line. Call once, from the
@@ -42,64 +40,31 @@ public class ChatColumnCell: UICollectionViewCell {
     }
 
     /// Sets the receipt line and hugs the column to the sender's edge. Call from `configure`.
-    /// `revealsReceiptAfterSettling` is set only for a just-sent message's inserting cell: the line is
-    /// held hidden and faded in by `revealHeldReceipt()` once the controller reports the insert has
-    /// settled, instead of popping in with the bubble.
-    func updateColumn(for message: ChatMessage, revealsReceiptAfterSettling: Bool = false) {
-        setReceipt(message.receipt, animated: window != nil, held: revealsReceiptAfterSettling)
+    func updateColumn(for message: ChatMessage) {
+        // A cell already in the window is being reconfigured in place (Delivered→Read, or the line
+        // clearing as a newer sent message takes it over), so cross-fade the change. A freshly
+        // dequeued cell isn't in the window yet, so it's set without animation — a scroll-in or a
+        // send shouldn't flash the line.
+        setReceipt(message.receipt, animated: window != nil)
         column.alignment = message.sender == .me ? .trailing : .leading
         applyAlignment(isFromSelf: message.sender == .me)
     }
 
-    private func setReceipt(_ text: String?, animated: Bool, held: Bool) {
+    private func setReceipt(_ text: String?, animated: Bool) {
         guard receipt.text != text else { return }
-        if let text, held {
-            // A just-sent message's inserting cell: reserve the line's space so the bubble lands in its
-            // final spot, but hold it hidden. `revealHeldReceipt()` fades it in once the controller
-            // reports the insert has settled — the delivery state shouldn't pop in with the bubble.
+        // Cross-fade the line in (nil→text) and across the Delivered→Read swap; let it snap away when
+        // it clears so the row collapses in step with the batch update rather than after the fade. The
+        // visibility change is applied synchronously, outside the transition, so the cell's self-sized
+        // height never lags the cross-fade.
+        if animated, text != nil {
             receipt.isHidden = false
-            receipt.text = text
-            receipt.alpha = 0
-        } else if let text, receipt.alpha < 1 {
-            // A swap arrived while the line was still held (the read pointer advanced before the insert
-            // settled): update the text but stay held, so the pending `revealHeldReceipt()` fades the
-            // new text in once the insert settles — rather than colliding a cross-dissolve with the reveal.
-            receipt.text = text
-        } else if animated, text != nil {
-            // A cell already in the window is being reconfigured in place (Delivered→Read), so
-            // cross-fade the swap. alpha is restored first in case the cell was mid-hold. The
-            // visibility change is applied synchronously, outside the transition, so the cell's
-            // self-sized height never lags the cross-fade.
-            receipt.alpha = 1
-            receipt.isHidden = false
-            UIView.transition(with: receipt, duration: Self.receiptFadeDuration, options: .transitionCrossDissolve) {
+            UIView.transition(with: receipt, duration: 0.25, options: .transitionCrossDissolve) {
                 self.receipt.text = text
             }
         } else {
-            // Set without animation: a first open or a scroll-in shows the line already in place; a
-            // newer sent message clearing the line lets it snap away so the row collapses in step with
-            // the batch update rather than after a fade.
-            receipt.alpha = 1
             receipt.text = text
             receipt.isHidden = text == nil
         }
-    }
-
-    /// Fade in a receipt that was held hidden for its inserting cell, now that the insert has settled.
-    /// A no-op for any cell not currently holding one, so the controller can call it on every visible
-    /// cell after a batch update without tracking which cell inserted.
-    func revealHeldReceipt() {
-        guard receipt.alpha < 1 else { return }
-        UIView.animate(withDuration: Self.receiptFadeDuration) { self.receipt.alpha = 1 }
-    }
-
-    public override func prepareForReuse() {
-        super.prepareForReuse()
-        // Clear the receipt fully: a stale text would let `setReceipt`'s `text != text` guard skip the
-        // hold for a recycled cell whose previous occupant ended on the same string ("Delivered").
-        receipt.text = nil
-        receipt.isHidden = true
-        receipt.alpha = 1
     }
 
     /// Exactly one horizontal edge is pinned, so the column hugs its sender's side and the opposite

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -35,10 +35,10 @@ public class ChatColumnCell: UICollectionViewCell {
         column.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(column)
 
-        // The failed-state receipt ("Not Delivered. Tap to retry") is the only interactive part of the
-        // column; a tap fires onRetry when retryID is set.
-        receipt.isUserInteractionEnabled = true
-        receipt.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(receiptTapped)))
+        // The whole bubble + status line is the retry target (a generous hit area vs. the thin
+        // receipt line), but a tap only fires onRetry when this row is failed — `retryTapped` checks
+        // retryID, so non-failed rows ignore taps and keep their long-press copy menu.
+        column.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(retryTapped)))
 
         leadingConstraint = column.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12)
         trailingConstraint = column.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12)
@@ -75,7 +75,7 @@ public class ChatColumnCell: UICollectionViewCell {
         applyAlignment(isFromSelf: message.sender == .me)
     }
 
-    @objc private func receiptTapped() {
+    @objc private func retryTapped() {
         guard let retryID else { return }
         onRetry?(retryID)
     }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem.swift
@@ -23,14 +23,6 @@ public enum ChatItem: Hashable, Sendable, Identifiable {
         case .dateSeparator(let id, _): id
         }
     }
-
-    /// The message this row carries, or nil for a date separator.
-    public var message: ChatMessage? {
-        switch self {
-        case .message(let message): message
-        case .dateSeparator: nil
-        }
-    }
 }
 
 /// Drives ChatLayout's canonical `reload(using:)` diffing: identity by `id` (stable across a

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessage.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessage.swift
@@ -25,14 +25,6 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
         case cash(ChatCashContent)
     }
 
-    /// Outgoing delivery state shown beneath the bubble. `.normal` renders the receipt line (or
-    /// nothing); `.sending`/`.failed` render their own status in the receipt slot.
-    public enum DeliveryState: Hashable, Sendable {
-        case normal
-        case sending
-        case failed
-    }
-
     public let id: String
     public let content: Content
     public let sender: Sender
@@ -45,9 +37,9 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
     /// retry"), or nil when the row carries none. Carried on the message — not a separate transcript
     /// row — so a send stays a clean insert instead of tearing the line down and rebuilding it.
     public let receipt: String?
-    /// How the status line is styled: `.normal`/`.sending` use the resting color, `.failed` turns it
-    /// red and makes the row tappable to retry. The text itself comes from `receipt`.
-    public let deliveryState: DeliveryState
+    /// Whether this row failed to send: turns the status line red and makes the row tappable to retry.
+    /// Other states (sending, delivered, received) render the same — the text comes from `receipt`.
+    public let isFailed: Bool
 
     public init(
         id: String,
@@ -56,7 +48,7 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
         isContinuationFromPrevious: Bool = false,
         isContinuedByNext: Bool = false,
         receipt: String? = nil,
-        deliveryState: DeliveryState = .normal
+        isFailed: Bool = false
     ) {
         self.id = id
         self.content = content
@@ -64,7 +56,7 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
         self.isContinuationFromPrevious = isContinuationFromPrevious
         self.isContinuedByNext = isContinuedByNext
         self.receipt = receipt
-        self.deliveryState = deliveryState
+        self.isFailed = isFailed
     }
 
     /// Convenience for text rows.
@@ -75,7 +67,7 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
         isContinuationFromPrevious: Bool = false,
         isContinuedByNext: Bool = false,
         receipt: String? = nil,
-        deliveryState: DeliveryState = .normal
+        isFailed: Bool = false
     ) {
         self.init(
             id: id,
@@ -84,7 +76,7 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
             isContinuationFromPrevious: isContinuationFromPrevious,
             isContinuedByNext: isContinuedByNext,
             receipt: receipt,
-            deliveryState: deliveryState
+            isFailed: isFailed
         )
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessage.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessage.swift
@@ -41,12 +41,13 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
     public let isContinuationFromPrevious: Bool
     /// The row below is the same sender — flatten the inner bottom corner.
     public let isContinuedByNext: Bool
-    /// The delivery line shown under this bubble ("Delivered" / "Read 3:42 PM"), or nil for every
-    /// message except the user's latest sent one. Carried on the message — not a separate transcript
-    /// row — so a send stays a clean insert instead of tearing the line down and rebuilding it.
+    /// The status line shown under this bubble ("Delivered" / "Read 3:42 PM" / "Sending…" / "Not
+    /// Delivered. Tap to retry"), or nil when the row carries none. Carried on the message — not a
+    /// separate transcript row — so a send stays a clean insert instead of tearing the line down and
+    /// rebuilding it.
     public let receipt: String?
-    /// Whether this outgoing row is in flight or failed; drives the sending/failed indicator in the
-    /// receipt slot. `.normal` for received messages and confirmed sends.
+    /// How the status line is styled: `.normal`/`.sending` use the resting color, `.failed` turns it
+    /// red and makes the row tappable to retry. The text itself comes from `receipt`.
     public let deliveryState: DeliveryState
 
     public init(

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessage.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessage.swift
@@ -41,10 +41,9 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
     public let isContinuationFromPrevious: Bool
     /// The row below is the same sender — flatten the inner bottom corner.
     public let isContinuedByNext: Bool
-    /// The status line shown under this bubble ("Delivered" / "Read 3:42 PM" / "Sending…" / "Not
-    /// Delivered. Tap to retry"), or nil when the row carries none. Carried on the message — not a
-    /// separate transcript row — so a send stays a clean insert instead of tearing the line down and
-    /// rebuilding it.
+    /// The status line shown under this bubble ("Delivered" / "Read 3:42 PM" / "Not Delivered. Tap to
+    /// retry"), or nil when the row carries none. Carried on the message — not a separate transcript
+    /// row — so a send stays a clean insert instead of tearing the line down and rebuilding it.
     public let receipt: String?
     /// How the status line is styled: `.normal`/`.sending` use the resting color, `.failed` turns it
     /// red and makes the row tappable to retry. The text itself comes from `receipt`.

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessage.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessage.swift
@@ -25,6 +25,14 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
         case cash(ChatCashContent)
     }
 
+    /// Outgoing delivery state shown beneath the bubble. `.normal` renders the receipt line (or
+    /// nothing); `.sending`/`.failed` render their own status in the receipt slot.
+    public enum DeliveryState: Hashable, Sendable {
+        case normal
+        case sending
+        case failed
+    }
+
     public let id: String
     public let content: Content
     public let sender: Sender
@@ -37,6 +45,9 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
     /// message except the user's latest sent one. Carried on the message — not a separate transcript
     /// row — so a send stays a clean insert instead of tearing the line down and rebuilding it.
     public let receipt: String?
+    /// Whether this outgoing row is in flight or failed; drives the sending/failed indicator in the
+    /// receipt slot. `.normal` for received messages and confirmed sends.
+    public let deliveryState: DeliveryState
 
     public init(
         id: String,
@@ -44,7 +55,8 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
         sender: Sender,
         isContinuationFromPrevious: Bool = false,
         isContinuedByNext: Bool = false,
-        receipt: String? = nil
+        receipt: String? = nil,
+        deliveryState: DeliveryState = .normal
     ) {
         self.id = id
         self.content = content
@@ -52,6 +64,7 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
         self.isContinuationFromPrevious = isContinuationFromPrevious
         self.isContinuedByNext = isContinuedByNext
         self.receipt = receipt
+        self.deliveryState = deliveryState
     }
 
     /// Convenience for text rows.
@@ -61,7 +74,8 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
         sender: Sender,
         isContinuationFromPrevious: Bool = false,
         isContinuedByNext: Bool = false,
-        receipt: String? = nil
+        receipt: String? = nil,
+        deliveryState: DeliveryState = .normal
     ) {
         self.init(
             id: id,
@@ -69,7 +83,8 @@ public struct ChatMessage: Hashable, Sendable, Identifiable {
             sender: sender,
             isContinuationFromPrevious: isContinuationFromPrevious,
             isContinuedByNext: isContinuedByNext,
-            receipt: receipt
+            receipt: receipt,
+            deliveryState: deliveryState
         )
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
@@ -34,15 +34,12 @@ public final class ChatMessageCell: ChatColumnCell {
     @available(*, unavailable)
     public required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    /// - Parameters:
-    ///   - maxWidth: the widest the bubble may grow before its text wraps, in points. The owner
-    ///     derives it from the collection view's width.
-    ///   - revealsReceiptAfterSettling: set only for a just-sent message's inserting cell, so the
-    ///     delivery line fades in after the bubble settles instead of popping in with it.
-    public func configure(with message: ChatMessage, maxWidth: CGFloat, revealsReceiptAfterSettling: Bool = false) {
+    /// - Parameter maxWidth: the widest the bubble may grow before its text wraps, in points.
+    ///   The owner derives it from the collection view's width.
+    public func configure(with message: ChatMessage, maxWidth: CGFloat) {
         bubble.configure(with: message)
         maxWidthConstraint.constant = maxWidth
-        updateColumn(for: message, revealsReceiptAfterSettling: revealsReceiptAfterSettling)
+        updateColumn(for: message)
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatReceiptLabel.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatReceiptLabel.swift
@@ -17,10 +17,13 @@ public final class ChatReceiptLabel: UILabel {
     /// against the column's right side.
     private static let textInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
 
+    /// Resting color of the receipt line (Delivered/Read/Sending); the failed state overrides it red.
+    public static let defaultColor = UIColor.white.withAlphaComponent(0.5)
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         font = .default(size: 12, weight: .medium)
-        textColor = UIColor.white.withAlphaComponent(0.5)
+        textColor = Self.defaultColor
         textAlignment = .right
         numberOfLines = 1
     }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatReceiptLabel.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatReceiptLabel.swift
@@ -18,10 +18,9 @@ public final class ChatReceiptLabel: UILabel {
     /// against the column's right side.
     private static let textInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
 
-    /// Resting color of the receipt line (Delivered/Read/Sending).
+    /// Resting color of the receipt line (Delivered/Read).
     public static let defaultColor = UIColor.white.withAlphaComponent(0.5)
-    /// Color of the failed status line — the theme's error-text token, so it matches error text
-    /// elsewhere and tracks theme changes (rather than the system red).
+    /// Color of the failed status line: the theme's error-text token, which tracks appearance changes.
     public static let failedColor = UIColor(Color.textError)
 
     public override init(frame: CGRect) {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatReceiptLabel.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatReceiptLabel.swift
@@ -7,6 +7,7 @@
 
 #if canImport(UIKit)
 import UIKit
+import SwiftUI
 
 /// The "Delivered" / "Read 3:42 PM" line under the user's latest sent bubble. A styled label the
 /// message cell embeds below its content — not a standalone transcript row — so it sizes and
@@ -17,8 +18,11 @@ public final class ChatReceiptLabel: UILabel {
     /// against the column's right side.
     private static let textInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
 
-    /// Resting color of the receipt line (Delivered/Read/Sending); the failed state overrides it red.
+    /// Resting color of the receipt line (Delivered/Read/Sending).
     public static let defaultColor = UIColor.white.withAlphaComponent(0.5)
+    /// Color of the failed status line — the theme's error-text token, so it matches error text
+    /// elsewhere and tracks theme changes (rather than the system red).
+    public static let failedColor = UIColor(Color.textError)
 
     public override init(frame: CGRect) {
         super.init(frame: frame)

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -61,6 +61,11 @@ public final class ChatScreenViewController: UIViewController {
         set { transcript.onReachTop = newValue }
     }
 
+    public var onRetry: ((String) -> Void)? {
+        get { transcript.onRetry }
+        set { transcript.onRetry = newValue }
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor(Color.backgroundMain)

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -48,10 +48,6 @@ public final class ChatViewController: UICollectionViewController {
     private static let bottomContentPadding: CGFloat = 12
     /// True while a batch update animates, so the top trigger doesn't re-fire mid-update.
     private var isUpdating = false
-    /// The id of a just-sent message whose receipt should fade in only after its inserting cell
-    /// settles, set across the batch that inserts it. Lets `cellForItemAt` tell that one cell apart
-    /// from a first open or a scroll-in (which show the line immediately).
-    private var pendingReceiptRevealID: String?
     /// True while a context menu is lifted from a bubble. Presenting the menu dismisses the keyboard;
     /// without intervention the adjusted inset shrinks and the transcript reflows out from under the
     /// lifted preview. So for the menu's lifetime the inset is taken over and frozen at its keyboard-up
@@ -162,8 +158,6 @@ public final class ChatViewController: UICollectionViewController {
             items = newItems
             return
         }
-        let revealID = freshlyInsertedReceiptID(from: items, to: newItems)
-        pendingReceiptRevealID = revealID
         isUpdating = true
         collectionView.reload(
             using: changeset,
@@ -179,32 +173,12 @@ public final class ChatViewController: UICollectionViewController {
                 }
             },
             completion: { [weak self] _ in
-                guard let self else { return }
-                isUpdating = false
-                // Clear only if a later update hasn't already claimed it for its own insert.
-                if pendingReceiptRevealID == revealID { pendingReceiptRevealID = nil }
-                // The batch has settled — fade in any receipt held back for an insert. revealHeldReceipt
-                // is a no-op on every cell that isn't currently holding one.
-                for case let cell as ChatColumnCell in collectionView.visibleCells {
-                    cell.revealHeldReceipt()
-                }
+                self?.isUpdating = false
             },
             setData: { [weak self] data in
                 self?.items = data
             }
         )
-    }
-
-    /// The id of a just-sent message — the trailing message, new to the transcript and carrying a
-    /// receipt. Its cell delays the delivery line so it fades in once the bubble has settled. nil for
-    /// every other update: a receipt swap on an existing message, a received message, or paged-in
-    /// history, all of which show their line immediately.
-    private func freshlyInsertedReceiptID(from old: [ChatItem], to new: [ChatItem]) -> String? {
-        guard let last = new.last(where: { $0.message != nil })?.message,
-              last.receipt != nil,
-              !old.contains(where: { $0.id == last.id })
-        else { return nil }
-        return last.id
     }
 
     // MARK: - Data source
@@ -223,7 +197,6 @@ public final class ChatViewController: UICollectionViewController {
             cell.configure(text: text)
             return cell
         case .message(let message):
-            let revealsReceipt = message.id == pendingReceiptRevealID
             switch message.content {
             case .text:
                 let cell = collectionView.dequeueReusableCell(
@@ -231,14 +204,14 @@ public final class ChatViewController: UICollectionViewController {
                     for: indexPath
                 ) as! ChatMessageCell
                 let width = collectionView.bounds.width > 0 ? collectionView.bounds.width : UIScreen.main.bounds.width
-                cell.configure(with: message, maxWidth: width * Self.maxBubbleWidthFraction, revealsReceiptAfterSettling: revealsReceipt)
+                cell.configure(with: message, maxWidth: width * Self.maxBubbleWidthFraction)
                 return cell
             case .cash:
                 let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: ChatCashCardCell.reuseIdentifier,
                     for: indexPath
                 ) as! ChatCashCardCell
-                cell.configure(with: message, revealsReceiptAfterSettling: revealsReceipt)
+                cell.configure(with: message)
                 return cell
             }
         }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -208,6 +208,8 @@ public final class ChatViewController: UICollectionViewController {
                 ) as! ChatMessageCell
                 let width = collectionView.bounds.width > 0 ? collectionView.bounds.width : UIScreen.main.bounds.width
                 cell.configure(with: message, maxWidth: width * Self.maxBubbleWidthFraction)
+                // Only text messages are sent optimistically, so only they can reach the failed
+                // state that arms retry. Cash messages are always server-confirmed.
                 cell.onRetry = { [weak self] id in self?.onRetry?(id) }
                 return cell
             case .cash:
@@ -216,7 +218,6 @@ public final class ChatViewController: UICollectionViewController {
                     for: indexPath
                 ) as! ChatCashCardCell
                 cell.configure(with: message)
-                cell.onRetry = { [weak self] id in self?.onRetry?(id) }
                 return cell
             }
         }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -28,6 +28,9 @@ public final class ChatViewController: UICollectionViewController {
     /// what keeps paging from ever getting stuck on a page.
     public var onReachTop: (() -> Void)?
 
+    /// Called when the user taps a failed outgoing row to retry; the argument is the message's stable id.
+    public var onRetry: ((String) -> Void)?
+
     /// The widest a bubble may grow, as a share of the collection view's width.
     private static let maxBubbleWidthFraction: CGFloat = 0.78
 
@@ -205,6 +208,7 @@ public final class ChatViewController: UICollectionViewController {
                 ) as! ChatMessageCell
                 let width = collectionView.bounds.width > 0 ? collectionView.bounds.width : UIScreen.main.bounds.width
                 cell.configure(with: message, maxWidth: width * Self.maxBubbleWidthFraction)
+                cell.onRetry = { [weak self] id in self?.onRetry?(id) }
                 return cell
             case .cash:
                 let cell = collectionView.dequeueReusableCell(
@@ -212,6 +216,7 @@ public final class ChatViewController: UICollectionViewController {
                     for: indexPath
                 ) as! ChatCashCardCell
                 cell.configure(with: message)
+                cell.onRetry = { [weak self] id in self?.onRetry?(id) }
                 return cell
             }
         }


### PR DESCRIPTION
Sending a chat message now adds it to the conversation immediately and shows its delivery state — Delivered, Read, or a tappable "Not Delivered" to retry — instead of only appearing once the server confirms. A message sent with no connection (or any failure) no longer silently disappears; it stays in place and can be retried. The Delivered/Read line is held for a beat so it fades in after the bubble settles, which supersedes and removes the earlier receipt-settle-delay change.

## Test plan
- [x] Send a message and confirm it appears instantly, then shows Delivered.
- [x] Send with no connection and confirm it stays as a tappable "Not Delivered" rather than vanishing.
- [x] Tap a failed message and confirm it sends once the connection returns.
- [x] Confirm the Read receipt appears with its time when the other person reads.
- [x] Confirm Delivered fades in after the bubble settles, not mid-animation.
