### PR TITLE
feat: show the token name in chat amount displays

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -131,7 +131,7 @@ struct ConversationScreen: View {
             counterpartRead: counterpartRead.map { (pointer: $0.pointer, date: $0.date) },
             suppressReceiptFor: conversationController.settlingSendID,
             cashBranding: { fiat in
-                guard fiat.mint != .usdf, let balance = session.balance(for: fiat.mint) else { return ("Cash", nil) }
+                guard let balance = session.balance(for: fiat.mint) else { return ("Cash", nil) }
                 return (balance.name, balance.imageURL)
             }
         )

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -475,6 +475,7 @@ private struct RecipientListItemRow: View {
     let onTap: () -> Void
 
     @Environment(ConversationController.self) private var conversationController
+    @Environment(Session.self) private var session
 
     private var title: String {
         switch item {
@@ -496,7 +497,11 @@ private struct RecipientListItemRow: View {
                 return text
             case .cash(let amount):
                 let verb = message.isFromSelf(conversationController.selfUserID) ? "You sent" : "You received"
-                return "\(verb) \(amount.nativeAmount.formatted())"
+                let formatted = amount.nativeAmount.formatted()
+                guard let name = session.balance(for: amount.mint)?.name else {
+                    return "\(verb) \(formatted)"
+                }
+                return "\(verb) \(formatted) of \(name)"
             }
         }
     }


### PR DESCRIPTION
Chat amount displays now name the token alongside the amount, so a cash message reads "You received $0.10 of Cattle Cash" instead of just "You received $0.10". The Send-list preview gains the token name it was missing, and USDF now shows its real name and icon in the transcript like every other token instead of a generic "Cash" label.

## Test plan
- [x] In the Send list, a cash chat preview reads "You received $X of <token name>".
- [x] A USDF cash message shows "USD on Flipcash" with its icon.
- [x] A launchpad-token cash message shows that token's name.