### PR TITLE
feat: exclude your own contact from the recipient list

### DIFF
--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -154,6 +154,17 @@ enum RecipientLoader {
         return candidateNamed && candidate.contactId != existing.contactId
     }
 
+    /// Drops the user's own contact: you can't send to yourself, so your own
+    /// number never belongs in the recipient list even when it's saved in your
+    /// address book. A `nil`/empty self phone leaves the list untouched.
+    nonisolated static func excludingSelf(
+        _ contacts: [ResolvedContact],
+        selfPhone: String?,
+    ) -> [ResolvedContact] {
+        guard let selfPhone, !selfPhone.isEmpty else { return contacts }
+        return contacts.filter { $0.phoneE164 != selfPhone }
+    }
+
     static func load(database: Database) async -> ResolvedContacts {
         await Task.detached(priority: .userInitiated) {
             let snapshot: [Database.LocalContact]
@@ -167,6 +178,8 @@ enum RecipientLoader {
                 ])
                 return ResolvedContacts.empty
             }
+            // Best-effort: a missing profile just leaves the list unfiltered.
+            let selfPhone = try? database.getProfile()?.phone?.e164
             let flipcashSet = Set(matched.map(\.e164))
             let dmChatIDByPhone = Dictionary(
                 matched.compactMap { contact in contact.dmChatID.map { (contact.e164, $0) } },
@@ -235,7 +248,10 @@ enum RecipientLoader {
 
             // Collapse `(displayName, nationalPhone)` collisions so the same
             // display name + national number is never shown twice.
-            let unique = deduplicatedForDisplay(resolvedByPlacement, flipcashSet: flipcashSet)
+            let unique = deduplicatedForDisplay(
+                excludingSelf(resolvedByPlacement, selfPhone: selfPhone),
+                flipcashSet: flipcashSet,
+            )
 
             var onFlipcash: [ResolvedContact] = []
             var invite: [ResolvedContact] = []

--- a/FlipcashTests/RecipientLoaderPlacementsTests.swift
+++ b/FlipcashTests/RecipientLoaderPlacementsTests.swift
@@ -138,3 +138,49 @@ struct RecipientLoaderDeduplicatedForDisplayTests {
         #expect(Set(unique.map(\.displayName)) == ["Alice|Smith", "Alice"])
     }
 }
+
+@Suite("RecipientLoader.excludingSelf(_:selfPhone:)")
+struct RecipientLoaderExcludingSelfTests {
+
+    private func makeContact(e164: String) -> ResolvedContact {
+        ResolvedContact(
+            contactId: e164,
+            displayName: "Name \(e164)",
+            phoneE164: e164,
+            nationalPhone: e164,
+            imageData: nil,
+        )
+    }
+
+    @Test("Drops the contact matching the user's own number")
+    func dropsSelf() {
+        let contacts = [makeContact(e164: "+14085551111"), makeContact(e164: "+14085552222")]
+        let result = RecipientLoader.excludingSelf(contacts, selfPhone: "+14085551111")
+        #expect(result.map(\.phoneE164) == ["+14085552222"])
+    }
+
+    @Test("Drops every row sharing the user's number")
+    func dropsAllSelfRows() {
+        let contacts = [
+            makeContact(e164: "+14085551111"),
+            makeContact(e164: "+14085551111"),
+            makeContact(e164: "+14085552222"),
+        ]
+        let result = RecipientLoader.excludingSelf(contacts, selfPhone: "+14085551111")
+        #expect(result.map(\.phoneE164) == ["+14085552222"])
+    }
+
+    @Test("Leaves the list untouched when self phone is nil")
+    func nilSelfPhoneKeepsAll() {
+        let contacts = [makeContact(e164: "+14085551111"), makeContact(e164: "+14085552222")]
+        let result = RecipientLoader.excludingSelf(contacts, selfPhone: nil)
+        #expect(result.count == 2)
+    }
+
+    @Test("Leaves the list untouched when self phone is empty")
+    func emptySelfPhoneKeepsAll() {
+        let contacts = [makeContact(e164: "+14085551111")]
+        let result = RecipientLoader.excludingSelf(contacts, selfPhone: "")
+        #expect(result.count == 1)
+    }
+}


### PR DESCRIPTION
The Send / conversations list showed your own contact whenever your number was saved in your address book, even though you can't send a payment to yourself. Your own number is now filtered out where the directory is loaded, so it never appears in the recipient picker or the conversation directory.

## Test plan
- [x] Save your own verified number in Contacts → it no longer appears in the Send recipient list
- [x] A contact whose number isn't yours still appears normally
- [x] With no profile phone on file, the list renders unchanged