### PR TITLE
fix: retry the chat opening load so push-deeplinked chats aren't empty

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -63,6 +63,7 @@ final class ConversationController {
     @ObservationIgnored private let contactNaming: any DMContactNaming
     @ObservationIgnored private let database: Database
     @ObservationIgnored private let owner: KeyPair
+    @ObservationIgnored private let openingLoadRetryDelay: Duration
     @ObservationIgnored private var startTask: Task<Void, Never>?
     @ObservationIgnored private var streamTask: Task<Void, Never>?
     @ObservationIgnored private var connectionStateTask: Task<Void, Never>?
@@ -82,7 +83,8 @@ final class ConversationController {
         contactNaming: any DMContactNaming,
         database: Database,
         owner: KeyPair,
-        selfUserID: UserID
+        selfUserID: UserID,
+        openingLoadRetryDelay: Duration = .seconds(1.5)
     ) {
         self.fetching = fetching
         self.messaging = messaging
@@ -91,6 +93,7 @@ final class ConversationController {
         self.database = database
         self.owner = owner
         self.selfUserID = selfUserID
+        self.openingLoadRetryDelay = openingLoadRetryDelay
     }
 
     /// Seeds the store from the local cache so the feed, unread state, and
@@ -345,17 +348,33 @@ final class ConversationController {
         store.hasMessages(for: conversationID)
     }
 
-    func loadMessages(for conversationID: ConversationID) async {
+    @discardableResult
+    func loadMessages(for conversationID: ConversationID) async -> Bool {
         do {
             let messages = try await messaging.getMessages(owner: owner, conversationID: conversationID, before: nil)
+            guard !messages.isEmpty else { return true }
             store.mergeMessages(messages, into: conversationID)
             persist(operation: "load-messages") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
+            return true
         } catch {
             logger.error("Failed to load conversation messages", metadata: [
                 "conversationID": "\(conversationID)",
                 "error": "\(error)",
             ])
             ErrorReporting.captureError(error, reason: "Failed to load conversation messages")
+            return false
+        }
+    }
+
+    /// The opening load for a chat reached by deeplink/push or the Chats list,
+    /// retried until a message lands or the attempt budget is spent. Such a chat
+    /// always holds at least one message, so an empty first fetch is a cold-start
+    /// read-after-write race, not a genuinely empty chat.
+    func loadOpeningMessages(for conversationID: ConversationID) async {
+        await Task.retryUntil(maxAttempts: 4, delay: openingLoadRetryDelay) {
+            let loaded = await self.loadMessages(for: conversationID)
+            let landed = await self.hasMessages(for: conversationID)
+            return !loaded || landed
         }
     }
 

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -220,7 +220,7 @@ struct ConversationScreen: View {
         // created yet error-reports. Fires when the chat materializes.
         .task(id: chatExists ? conversationID : nil) {
             guard chatExists, let conversationID else { return }
-            await conversationController.loadMessages(for: conversationID)
+            await conversationController.loadOpeningMessages(for: conversationID)
             await conversationController.markRead(conversationID: conversationID)
             didInitialRead = true
         }

--- a/FlipcashCore/Sources/FlipcashCore/Extensions/Task+Retry.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Extensions/Task+Retry.swift
@@ -44,4 +44,34 @@ extension Task where Success == Never, Failure == Never {
             }
         }
     }
+
+    /// Runs `operation` up to `maxAttempts` times, stopping the moment it returns
+    /// `true`, sleeping `delay` between attempts. Returns `true` once it did, or
+    /// `false` if every attempt returned `false`. Stops promptly on cancellation,
+    /// returning `false`.
+    ///
+    /// Where `retry(maxAttempts:delay:…)` repeats on a thrown *error*, this repeats
+    /// on an unsatisfied *result* — for polling a value that becomes available after
+    /// a short delay (e.g. a record not yet queryable the instant it is created).
+    ///
+    /// - Parameters:
+    ///   - maxAttempts: Total number of tries, including the first. Must be at least 1.
+    ///   - delay: Time to sleep between attempts.
+    ///   - operation: The async work to run each attempt; return `true` to stop.
+    @discardableResult
+    public static func retryUntil(
+        maxAttempts: Int,
+        delay: Duration,
+        operation: sending () async -> Bool
+    ) async -> Bool {
+        precondition(maxAttempts >= 1, "maxAttempts must be at least 1")
+        for attempt in 0..<maxAttempts {
+            if attempt > 0 {
+                try? await Task.sleep(for: delay)
+                if Task.isCancelled { return false }
+            }
+            if await operation() { return true }
+        }
+        return false
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/TaskRetryTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TaskRetryTests.swift
@@ -113,3 +113,71 @@ struct TaskRetryTests {
         #expect(shouldRetryCalled == false)
     }
 }
+
+@Suite("Task.retryUntil")
+struct TaskRetryUntilTests {
+
+    private actor Counter {
+        private(set) var count = 0
+        func increment() { count += 1 }
+    }
+
+    @Test("Returns true and runs once when the first attempt is satisfied")
+    func satisfiedFirstTry() async {
+        var attempts = 0
+        let satisfied = await Task.retryUntil(maxAttempts: 3, delay: .nanoseconds(1)) {
+            attempts += 1
+            return true
+        }
+        #expect(satisfied)
+        #expect(attempts == 1)
+    }
+
+    @Test("Repeats until the operation is satisfied")
+    func repeatsUntilSatisfied() async {
+        var attempts = 0
+        let satisfied = await Task.retryUntil(maxAttempts: 5, delay: .nanoseconds(1)) {
+            attempts += 1
+            return attempts == 3
+        }
+        #expect(satisfied)
+        #expect(attempts == 3)
+    }
+
+    @Test("Returns false after maxAttempts when never satisfied")
+    func exhaustsMaxAttempts() async {
+        var attempts = 0
+        let satisfied = await Task.retryUntil(maxAttempts: 4, delay: .nanoseconds(1)) {
+            attempts += 1
+            return false
+        }
+        #expect(!satisfied)
+        #expect(attempts == 4)
+    }
+
+    @Test("maxAttempts of 1 runs the operation exactly once")
+    func maxAttemptsOneRunsOnce() async {
+        var attempts = 0
+        let satisfied = await Task.retryUntil(maxAttempts: 1, delay: .nanoseconds(1)) {
+            attempts += 1
+            return false
+        }
+        #expect(!satisfied)
+        #expect(attempts == 1)
+    }
+
+    @Test("Stops at the next attempt boundary once cancelled, returning false")
+    func stopsOnCancellation() async {
+        let counter = Counter()
+        let task = Task {
+            await Task.retryUntil(maxAttempts: 5, delay: .seconds(60)) {
+                await counter.increment()
+                return false
+            }
+        }
+        task.cancel()
+        let satisfied = await task.value
+        #expect(!satisfied)
+        #expect(await counter.count == 1)
+    }
+}

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -25,13 +25,15 @@ struct ConversationControllerTests {
         _ mock: MockConversations,
         selfUserID: UserID = UUID(),
         naming: MockDMContactNaming = MockDMContactNaming(),
-        database: Database? = nil
+        database: Database? = nil,
+        openingLoadRetryDelay: Duration = .zero
     ) -> ConversationController {
         ConversationController(
             fetching: mock, messaging: mock, streaming: mock,
             contactNaming: naming,
             database: database ?? (try! Database.makeTemp().database),
-            owner: .generate()!, selfUserID: selfUserID
+            owner: .generate()!, selfUserID: selfUserID,
+            openingLoadRetryDelay: openingLoadRetryDelay
         )
     }
 
@@ -535,5 +537,48 @@ struct ConversationControllerTests {
         #expect(rehydrated.messages(for: ConversationID.test(1)).map(\.id.value) == [1, 2])
         let pointer = rehydrated.conversations.first?.selfReadPointer(for: selfUserID)
         #expect(pointer == MessageID(value: 2))
+    }
+
+    // MARK: - Opening load (deeplink/push cold-start retry)
+
+    private func message(_ id: UInt64) -> ConversationMessage {
+        ConversationMessage(id: MessageID(value: id), senderID: nil, content: .text("hi"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
+    }
+
+    @Test("loadOpeningMessages retries an empty first fetch until the message lands")
+    func loadOpeningMessages_retriesWhileEmpty() async {
+        let mock = MockConversations()
+        // The cold-start race: the first fetch is empty, the second sees the message.
+        mock.messagesScript = [[], [message(1)]]
+        let controller = makeController(mock)
+
+        await controller.loadOpeningMessages(for: ConversationID.test(1))
+
+        #expect(mock.openingQueryCount == 2)
+        #expect(controller.messages(for: ConversationID.test(1)).map(\.id) == [MessageID(value: 1)])
+    }
+
+    @Test("loadOpeningMessages fetches once when the first page already has messages")
+    func loadOpeningMessages_noRetryWhenPopulated() async {
+        let mock = MockConversations()
+        mock.messages = [message(1)]
+        let controller = makeController(mock)
+
+        await controller.loadOpeningMessages(for: ConversationID.test(1))
+
+        #expect(mock.openingQueryCount == 1)
+        #expect(controller.hasMessages(for: ConversationID.test(1)))
+    }
+
+    @Test("loadOpeningMessages stops on a fetch error rather than hammering it")
+    func loadOpeningMessages_stopsOnError() async {
+        let mock = MockConversations()
+        mock.messagesError = CancellationError()
+        let controller = makeController(mock)
+
+        await controller.loadOpeningMessages(for: ConversationID.test(1))
+
+        #expect(mock.openingQueryCount == 1)
+        #expect(!controller.hasMessages(for: ConversationID.test(1)))
     }
 }

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -17,6 +17,9 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
 
     private var _feed: [Conversation] = []
     private var _messages: [ConversationMessage] = []
+    private var _messagesScript: [[ConversationMessage]]?
+    private var _messagesError: Error?
+    private var _openingQueryCount = 0
     private var _olderMessages: [ConversationMessage] = []
     private var _olderQueries: [MessageID] = []
     private var _latestPageQueries: [ConversationID] = []
@@ -38,6 +41,19 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
         get { lock.withLock { _messages } }
         set { lock.withLock { _messages = newValue } }
     }
+    /// Successive responses for the opening `getMessages` (`before == nil`),
+    /// consumed front-to-back; falls back to `messages` once exhausted.
+    var messagesScript: [[ConversationMessage]]? {
+        get { lock.withLock { _messagesScript } }
+        set { lock.withLock { _messagesScript = newValue } }
+    }
+    /// When set, the opening `getMessages` throws this.
+    var messagesError: Error? {
+        get { lock.withLock { _messagesError } }
+        set { lock.withLock { _messagesError = newValue } }
+    }
+    /// Number of opening `getMessages` calls (`before == nil`).
+    var openingQueryCount: Int { lock.withLock { _openingQueryCount } }
     /// Scripted older page returned when `getMessages` is called with `before != nil`.
     var olderMessages: [ConversationMessage] {
         get { lock.withLock { _olderMessages } }
@@ -95,8 +111,15 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
 
     func getMessages(owner: KeyPair, conversationID: ConversationID, before: MessageID?) async throws -> [ConversationMessage] {
         guard let before else {
-            lock.withLock { _latestPageQueries.append(conversationID) }
-            return messages
+            return try lock.withLock {
+                _latestPageQueries.append(conversationID)
+                _openingQueryCount += 1
+                if let error = _messagesError { throw error }
+                guard var script = _messagesScript, !script.isEmpty else { return _messages }
+                let next = script.removeFirst()
+                _messagesScript = script
+                return next
+            }
         }
         lock.withLock { _olderQueries.append(before) }
         return olderMessages


### PR DESCRIPTION
Opening a chat from a push notification or deep link could show an empty conversation even though the messages were there — backing out and reopening the same chat showed them fine. The deep-linked open fetched the messages only once, so if that first fetch landed in the brief window after a new message arrived but before it was queryable, nothing ever refilled the transcript. The open now retries the fetch while it keeps coming back empty, stopping as soon as a message arrives, on an error, or when the chat is closed.

## Test plan
- [x] Tap a new-message push notification from a cold start and confirm the chat shows its messages.
- [x] Open a chat that already has messages and confirm it loads immediately with no delay.
- [x] Open a brand-new empty conversation and confirm it doesn't hang or keep retrying.
