### PR TITLE
chore: remove icon from Send phone-verification empty state

### DIFF
--- a/Flipcash/Core/Screens/Send/ConnectPhoneEmptyState.swift
+++ b/Flipcash/Core/Screens/Send/ConnectPhoneEmptyState.swift
@@ -16,8 +16,6 @@ struct ConnectPhoneEmptyState: View {
         VStack(spacing: 0) {
             Spacer()
             VStack(spacing: 12) {
-                Image(.Icons.send)
-                    .foregroundStyle(Color.textSecondary)
                 Text("Connect Phone To Send")
                     .font(.appTextLarge)
                     .foregroundStyle(Color.textMain)


### PR DESCRIPTION
The "Connect Phone To Send" empty state in the Send sheet showed a send icon above the text. Removed the icon so the screen is just the title, subtitle, and CTA.

## Test plan
- [x] Open the Send sheet without a verified phone number
- [x] Confirm the empty state shows only text (no icon) above the "Connect Your Phone Number" button