### PR TITLE
fix: rebuild the Flip transport when the event stream wedges on a ready connection

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient.swift
@@ -16,27 +16,33 @@ public class FlipClient: ObservableObject {
 
     public let network: Network
 
-    private let grpcClient: GRPCClient<AppTransport>
+    private var grpcClient: GRPCClient<AppTransport>
 
     /// The long-running connection loop. Must be retained for the client's
     /// lifetime — dropping this task makes the client inert and every RPC hangs.
-    private let connectionTask: Task<Void, Never>
+    private var connectionTask: Task<Void, Never>
 
-    internal let accountService: AccountService
-    internal let activityService: ActivityService
-    internal let pushService: PushService
-    internal let thirdPartyService: ThirdPartyService
-    internal let phoneService: PhoneService
-    internal let emailService: EmailService
-    internal let profileService: ProfileService
-    internal let settingsService: SettingsService
-    internal let moderationService: ModerationService
-    internal let contactListService: ContactListService
-    internal let resolverService: ResolverService
-    internal let chatService: ChatService
-    internal let chatMessagingService: ChatMessagingService
+    /// Guards against overlapping `rebuildTransport()` calls — the event stream
+    /// can request a rebuild repeatedly while it's already in flight.
+    private var isRebuildingTransport = false
+
+    internal private(set) var accountService: AccountService
+    internal private(set) var activityService: ActivityService
+    internal private(set) var pushService: PushService
+    internal private(set) var thirdPartyService: ThirdPartyService
+    internal private(set) var phoneService: PhoneService
+    internal private(set) var emailService: EmailService
+    internal private(set) var profileService: ProfileService
+    internal private(set) var settingsService: SettingsService
+    internal private(set) var moderationService: ModerationService
+    internal private(set) var contactListService: ContactListService
+    internal private(set) var resolverService: ResolverService
+    internal private(set) var chatService: ChatService
+    internal private(set) var chatMessagingService: ChatMessagingService
 
     /// The single per-user event stream. Started on login, stopped on logout.
+    /// Retained across a transport rebuild — only its underlying service is
+    /// re-pointed (`adoptRebuiltService`) so consumers keep their reference.
     public let eventStreamer: EventStreamer
 
     // MARK: - Init -
@@ -44,21 +50,9 @@ public class FlipClient: ObservableObject {
     public init(network: Network) throws {
         self.network = network
 
-        let transport = try GRPCTransport.makeTransportServices(
-            host: network.hostForCore,
-            port: network.port
-        )
-        let client = GRPCClient(transport: transport, interceptors: [UserAgentClientInterceptor()])
+        let client = try Self.makeClient(network: network)
         self.grpcClient = client
-        self.connectionTask = Task {
-            do {
-                try await client.runConnections()
-            } catch {
-                // Only reachable on a fatal transport error (graceful shutdown
-                // returns normally) — every RPC after this point will fail.
-                logger.error("Flip connection loop terminated", metadata: ["error": "\(error)"])
-            }
-        }
+        self.connectionTask = Self.runConnections(client)
 
         self.accountService     = AccountService(client: client)
         self.activityService    = ActivityService(client: client)
@@ -74,6 +68,16 @@ public class FlipClient: ObservableObject {
         self.chatService        = ChatService(client: client)
         self.chatMessagingService = ChatMessagingService(client: client)
         self.eventStreamer      = EventStreamer(service: EventStreamingService(client: client))
+
+        // The event stream is the Flip channel's liveness probe. When it can't
+        // recover after repeated reopens despite the transport reporting itself
+        // connected (the "wedged-ready" failure mode), it asks us to rebuild the
+        // whole transport — the only recovery grpc-swift's own machinery can't
+        // perform for a connection that never closes.
+        let streamer = eventStreamer
+        Task { await streamer.setOnWedged { [weak self] in
+            Task { @MainActor in self?.rebuildTransport() }
+        } }
     }
 
     deinit {
@@ -81,7 +85,73 @@ public class FlipClient: ObservableObject {
         connectionTask.cancel()
     }
 
-    // MARK: - Channel Lifecycle -
+    // MARK: - Transport Lifecycle -
+
+    private static func makeClient(network: Network) throws -> GRPCClient<AppTransport> {
+        let transport = try GRPCTransport.makeTransportServices(
+            host: network.hostForCore,
+            port: network.port
+        )
+        return GRPCClient(transport: transport, interceptors: [UserAgentClientInterceptor()])
+    }
+
+    private static func runConnections(_ client: GRPCClient<AppTransport>) -> Task<Void, Never> {
+        Task {
+            do {
+                try await client.runConnections()
+            } catch {
+                // Only reachable on a fatal transport error (graceful shutdown
+                // returns normally) — every RPC after this point will fail.
+                logger.error("Flip connection loop terminated", metadata: ["error": "\(error)"])
+            }
+        }
+    }
+
+    /// Tear down the current transport and stand up a fresh one, re-pointing
+    /// every service at the new client. Triggered by `EventStreamer` when the
+    /// connection is wedged in a ready-but-dead state that no stream-level retry
+    /// can recover. Idempotent while a rebuild is in flight.
+    public func rebuildTransport() {
+        guard !isRebuildingTransport else { return }
+        isRebuildingTransport = true
+        logger.warning("Rebuilding Flip transport — connection wedged while reporting ready")
+
+        connectionTask.cancel()
+        grpcClient.beginGracefulShutdown()
+
+        let client: GRPCClient<AppTransport>
+        do {
+            client = try Self.makeClient(network: network)
+        } catch {
+            logger.error("Failed to rebuild Flip transport", metadata: ["error": "\(error)"])
+            isRebuildingTransport = false
+            return
+        }
+
+        grpcClient = client
+        connectionTask = Self.runConnections(client)
+
+        accountService     = AccountService(client: client)
+        activityService    = ActivityService(client: client)
+        pushService        = PushService(client: client)
+        thirdPartyService  = ThirdPartyService(client: client)
+        phoneService       = PhoneService(client: client)
+        emailService       = EmailService(client: client)
+        profileService     = ProfileService(client: client)
+        settingsService    = SettingsService(client: client)
+        moderationService  = ModerationService(client: client)
+        contactListService = ContactListService(client: client)
+        resolverService    = ResolverService(client: client)
+        chatService        = ChatService(client: client)
+        chatMessagingService = ChatMessagingService(client: client)
+
+        let newEventService = EventStreamingService(client: client)
+        let streamer = eventStreamer
+        Task {
+            await streamer.adoptRebuiltService(newEventService)
+            await MainActor.run { self.isRebuildingTransport = false }
+        }
+    }
 
     /// Pre-warm the connection by issuing a lightweight unauthenticated call.
     /// The response is irrelevant — we only need the transport to start connecting.

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
@@ -45,7 +45,7 @@ public actor EventStreamer {
     public nonisolated let connectionState: AsyncStream<EventStreamConnectionState>
     private let connectionStateContinuation: AsyncStream<EventStreamConnectionState>.Continuation
 
-    private let service: EventStreamingService
+    private var service: EventStreamingService
     private var owner: KeyPair?
 
     private var streamReference: StreamReference?
@@ -62,6 +62,18 @@ public actor EventStreamer {
     /// per-ping liveness proof into a single `.live` per connection, and gates
     /// the matching `.disconnected` on teardown.
     private var isConnectionLive = false
+
+    /// Called when the stream can't recover after `transportRebuildThreshold`
+    /// consecutive reopens despite the transport reporting itself connected —
+    /// the wedged-ready failure mode that no stream-level retry can fix. The
+    /// owner (`FlipClient`) rebuilds the whole transport in response.
+    private var onWedged: (@Sendable () -> Void)?
+    /// Set once per wedge so exactly one rebuild is requested per dead
+    /// connection; cleared on a healthy ping or after adopting a rebuilt service.
+    private var hasRequestedRebuild = false
+    /// Consecutive failed reopens (no ping since) after which a stream-level
+    /// retry is treated as a wedged transport rather than a transient drop.
+    private static let transportRebuildThreshold: UInt = 3
 
     init(service: EventStreamingService) {
         self.service = service
@@ -106,9 +118,27 @@ public actor EventStreamer {
         streamReference != nil && pingTracker.hasRecentPing
     }
 
+    /// Wire the wedge handler. Called once by the owner after construction.
+    func setOnWedged(_ handler: @escaping @Sendable () -> Void) {
+        onWedged = handler
+    }
+
+    /// Adopt a fresh streaming service after the owner rebuilt the transport,
+    /// then reconnect on it. Clears wedge state so detection can re-arm.
+    func adoptRebuiltService(_ service: EventStreamingService) {
+        self.service = service
+        hasRequestedRebuild = false
+        backoff.reset()
+        guard isStreaming else { return }
+        logger.info("Adopting rebuilt transport, reopening event stream")
+        resetAndTeardown()
+        openStream()
+    }
+
     public func stop() {
         isStreaming = false
         isReconnecting = false
+        hasRequestedRebuild = false
         reportConnection(live: false)
         backoff.reset()
         owner = nil
@@ -196,6 +226,8 @@ public actor EventStreamer {
         // clear the reconnect backoff, so a stream that dies before its first ping
         // keeps escalating the delay instead of hammering reconnect.
         backoff.reset()
+        // Proof of life also re-arms wedge detection for any future dead connection.
+        hasRequestedRebuild = false
 
         // The same proof of life marks the connection delivering — once per
         // connection — so the consumer can refetch the window a drop left.
@@ -297,6 +329,18 @@ public actor EventStreamer {
             "delaySeconds": "\(delay)",
             "attempt": "\(backoff.attempts)",
         ])
+
+        // Repeated reopens with no ping in between mean the connection is wedged
+        // (ready but not delivering), not a transient drop — ask the owner to
+        // rebuild the transport. The scheduled reopen below still runs; the
+        // rebuild's `adoptRebuiltService` supersedes it on the fresh connection.
+        if backoff.attempts >= Self.transportRebuildThreshold, !hasRequestedRebuild {
+            hasRequestedRebuild = true
+            logger.warning("Event stream wedged — requesting transport rebuild", metadata: [
+                "attempts": "\(backoff.attempts)",
+            ])
+            onWedged?()
+        }
 
         reconnectTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(delay))


### PR DESCRIPTION
grpc-swift keeps a connection in `.ready` when the socket still answers keepalive pings but its streams stall — e.g. an L7 proxy whose upstream is gone — so no stream-level retry recovers and chat stays dead until the app is relaunched. This adds wedge detection: when the event stream can't get a ping after repeated reopens, the client rebuilds the gRPC client and transport and the stream reconnects on the fresh connection.

Stacked on the grpc-swift v2 upgrade (#370) — it's v2-API code and can't sit on main.

## Test plan
- [x] FlipcashCoreTests + FlipcashTests pass
- [ ] FlipcashUITests pass
- [ ] App connects and chat works on the simulator
- [ ] Recovery confirmed when the Flip connection wedges in a ready-but-dead state