### PR TITLE
feat: gate Send on server UserFlags, retire temporary beta toggle

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -236,7 +236,7 @@ struct DeepLinkAction {
                     }
                 }
                 if sheet == .send {
-                    guard container.session.userFlags?.enablePhoneNumberSend == true else { return }
+                    guard container.session.canSend else { return }
                 }
                 container.appRouter.present(sheet)
             }

--- a/Flipcash/Core/Controllers/QuickActionsController.swift
+++ b/Flipcash/Core/Controllers/QuickActionsController.swift
@@ -9,7 +9,7 @@ import FlipcashCore
 /// Owns the Home Screen quick actions (long-press the app icon).
 ///
 /// Actions are installed on login and cleared on logout. The Send action is
-/// included only for users with `enablePhoneNumberSend`. Taps reuse the existing
+/// included only when ``Session/canSend`` is true. Taps reuse the existing
 /// deep-link pipeline via each action's `url` userInfo (see ``SceneDelegate``).
 @MainActor
 final class QuickActionsController {
@@ -22,7 +22,7 @@ final class QuickActionsController {
 
     func configure() {
         UIApplication.shared.shortcutItems = Self.shortcutItems(
-            includeSend: session.userFlags?.enablePhoneNumberSend == true
+            includeSend: session.canSend
         )
     }
 

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -11,9 +11,7 @@ import FlipcashCore
 
 struct ScanScreen: View {
     
-    @Environment(SessionAuthenticator.self) private var sessionAuthenticator
     @Environment(Preferences.self) private var preferences
-    @Environment(BetaFlags.self) private var betaFlags
     @Environment(AppRouter.self) private var router
 
     @Bindable private var session: Session

--- a/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import UserNotifications
 import FlipcashUI
 import FlipcashCore
 
@@ -123,15 +122,38 @@ class OnboardingViewModel {
         accessKeyButtonState = .success
         try await Task.delay(milliseconds: 500)
 
-        // Phone verification only exists to power Send; show it when the Send
-        // beta flag is on, otherwise advance straight to the next step.
-        if BetaFlags.shared.hasEnabled(.enableSend) {
+        // Phone verification only exists to power Send; show it when Send is
+        // available for this account, otherwise advance straight to the next step.
+        if await shouldOfferPhoneVerification() {
             navigateToPhoneVerification()
         } else {
             await advanceFromPhoneVerificationStep()
         }
 
         try await Task.delay(milliseconds: 500) // Delay deferred state change
+    }
+
+    /// Whether to collect a phone number during onboarding. The local beta flag
+    /// forces it on; otherwise the server's `enablePhoneNumberSend` decides.
+    /// The flags fetch is time-boxed so a slow connection can't stall onboarding;
+    /// the step is skipped if the account isn't known yet, the fetch times out, or
+    /// it fails — a phone can still be connected later from the Send sheet.
+    private func shouldOfferPhoneVerification() async -> Bool {
+        if BetaFlags.shared.hasEnabled(.enableSend) {
+            return true
+        }
+
+        guard let userID = initializedAccount?.userID else {
+            return false
+        }
+
+        let flags = try? await container.flipClient.fetchUserFlags(
+            userID: userID,
+            owner: inflightMnemonic.solanaKeyPair(),
+            timeout: 5
+        )
+
+        return flags?.enablePhoneNumberSend == true
     }
 
     /// Advances past the phone step: requests push permission when undetermined,

--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedBetaFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedBetaFeaturesScreen.swift
@@ -6,34 +6,32 @@
 //
 
 import SwiftUI
-import FlipcashCore
 import FlipcashUI
 
 struct SettingsAdvancedBetaFeaturesScreen: View {
 
-    @Environment(BetaFlags.self) private var betaFlags
-
-    private let insets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
-
     var body: some View {
         Background(color: .backgroundMain) {
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: 12) {
-                        Image(systemName: "paperplane")
-                            .frame(minWidth: 45)
-                        Toggle("Send Cash", isOn: betaFlags.bindingFor(option: .enableSend))
-                            .tint(.textSuccess)
-                    }
-                    .padding(insets)
-                    .vSeparator(color: .rowSeparator, position: .bottom)
-                }
-                .font(.appDisplayXS)
-                .foregroundStyle(.textMain)
-                .padding(.horizontal, 20)
+            ContentUnavailableView {
+                Text("No Beta Features")
+                    .font(.appTextLarge)
+                    .foregroundStyle(Color.textMain)
+            } description: {
+                Text("There are no beta features available right now.")
+                    .font(.appTextMedium)
+                    .foregroundStyle(Color.textSecondary)
             }
         }
         .navigationTitle("Beta Features")
         .toolbarTitleDisplayMode(.inline)
     }
+}
+
+// MARK: - Previews -
+
+#Preview {
+    NavigationStack {
+        SettingsAdvancedBetaFeaturesScreen()
+    }
+    .preferredColorScheme(.dark)
 }

--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedFeaturesScreen.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import FlipcashCore
 import FlipcashUI
 
 struct SettingsAdvancedFeaturesScreen: View {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Account.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Account.swift
@@ -22,9 +22,9 @@ extension FlipClient {
         }
     }
     
-    public func fetchUserFlags(userID: UserID, owner: KeyPair) async throws -> UserFlags {
+    public func fetchUserFlags(userID: UserID, owner: KeyPair, timeout: TimeInterval? = nil) async throws -> UserFlags {
         try await withCheckedThrowingContinuation { c in
-            accountService.fetchUserFlags(userID: userID, owner: owner) { c.resume(with: $0) }
+            accountService.fetchUserFlags(userID: userID, owner: owner, timeout: timeout) { c.resume(with: $0) }
         }
     }
 

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/AccountService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/AccountService.swift
@@ -84,7 +84,7 @@ final class AccountService: Sendable {
         }
     }
 
-    func fetchUserFlags(userID: UserID, owner: KeyPair, completion: @Sendable @escaping (Result<UserFlags, ErrorFetchUserFlags>) -> Void) {
+    func fetchUserFlags(userID: UserID, owner: KeyPair, timeout: TimeInterval? = nil, completion: @Sendable @escaping (Result<UserFlags, ErrorFetchUserFlags>) -> Void) {
         logger.info("Fetching user flags", metadata: ["userId": "\(userID)"])
 
         let request = Flipcash_Account_V1_GetUserFlagsRequest.with {
@@ -98,9 +98,14 @@ final class AccountService: Sendable {
             $0.auth = owner.authFor(message: $0)
         }
 
+        var options = CallOptions.unaryDefault
+        if let timeout {
+            options.timeout = .seconds(timeout)
+        }
+
         Task {
             do {
-                let response = try await service.getUserFlags(request, options: .unaryDefault)
+                let response = try await service.getUserFlags(request, options: options)
                 let error = ErrorFetchUserFlags(rawValue: response.result.rawValue) ?? .unknown
                 guard error == .ok else {
                     logger.error("Failed to fetch user flags", metadata: ["owner": "\(owner.publicKey.base58)"])


### PR DESCRIPTION
Send is shipping, so it now gates on the server-backed user flag (`enablePhoneNumberSend`) through the single `canSend` check — the same way Coinbase is gated — instead of the temporary local beta flag. The hidden Beta Flags screen keeps the flag as a manual override, the public Advanced → Beta Features screen becomes an empty state, and the deep-link and quick-action send paths route through that same gate. Onboarding's phone-verification step reads the server flag via a time-boxed fetch so a slow connection can't stall onboarding.

## Test plan
- [ ] Advanced → Beta Features shows the empty state
- [ ] Hidden (9-tap) Beta Flags still lists "Send Cash"; toggling it on enables Send everywhere
- [ ] With both flags off, Send stays hidden: scan-screen button, `flipcash://send` deep link, and app-icon quick action
- [ ] Onboarding skips the phone step when neither flag is set, and doesn't stall on a slow/offline connection
