### PR TITLE
feat: redesign the Send connect-phone empty state

### DIFF
--- a/Flipcash/Core/Screens/Send/ConnectPhoneEmptyState.swift
+++ b/Flipcash/Core/Screens/Send/ConnectPhoneEmptyState.swift
@@ -7,26 +7,34 @@ import SwiftUI
 import FlipcashUI
 
 /// Empty state shown when the user opens the Send sheet without a verified
-/// phone number. Primary CTA launches the standalone phone verification flow.
+/// phone number. A ghosted cash-card-and-chat illustration sells the feature and
+/// the primary CTA launches the standalone phone verification flow. Rendered in
+/// the non-searchable stack; the "Send" title and close button come from the
+/// hosting `NavigationStack`.
 struct ConnectPhoneEmptyState: View {
 
     let onConnect: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
-            Spacer()
-            VStack(spacing: 12) {
-                Text("Connect Phone To Send")
+            Spacer(minLength: 0)
+
+            SendConversationHero()
+
+            VStack(spacing: 8) {
+                Text("Send Money To Your Friends")
                     .font(.appTextLarge)
                     .foregroundStyle(Color.textMain)
-                    .multilineTextAlignment(.center)
-                Text("Connect your phone number to send cash")
-                    .font(.appTextMedium)
+                Text("Send money to friends as easily as a text. Connect your phone number to get started.")
+                    .font(.appTextSmall)
                     .foregroundStyle(Color.textSecondary)
-                    .multilineTextAlignment(.center)
             }
-            Spacer()
-            Button("Connect Your Phone Number", action: onConnect)
+            .multilineTextAlignment(.center)
+            .padding(.top, 28)
+
+            Spacer(minLength: 0)
+
+            Button("Next", action: onConnect)
                 .buttonStyle(.filled)
         }
         .padding(20)
@@ -36,5 +44,12 @@ struct ConnectPhoneEmptyState: View {
 // MARK: - Previews -
 
 #Preview {
-    ConnectPhoneEmptyState(onConnect: {})
+    NavigationStack {
+        ConnectPhoneEmptyState(onConnect: {})
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.backgroundMain)
+            .navigationTitle("Send")
+            .toolbarTitleDisplayMode(.inline)
+    }
+    .preferredColorScheme(.dark)
 }

--- a/Flipcash/Core/Screens/Send/DeniedAccessEmptyState.swift
+++ b/Flipcash/Core/Screens/Send/DeniedAccessEmptyState.swift
@@ -18,7 +18,7 @@ struct DeniedAccessEmptyState: View {
         VStack(spacing: 0) {
             Spacer(minLength: 0)
 
-            DeniedAccessHero()
+            SendConversationHero()
 
             VStack(spacing: 8) {
                 Text("Send Money to Your Friends")
@@ -49,52 +49,6 @@ struct DeniedAccessEmptyState: View {
             .buttonStyle(.filled)
         }
         .padding(20)
-    }
-}
-
-/// The hero: a cash card and two chat bubbles framed inside a faint "chat
-/// preview" panel whose bottom fades into the background via a `mask`. The
-/// cards and bubbles carry their real sender/recipient fills, so the muted look
-/// comes from those subtle fills plus the fade — not a global opacity. Hidden
-/// from VoiceOver so the placeholder amounts aren't read as real money.
-private struct DeniedAccessHero: View {
-    var body: some View {
-        // Laid out like a real conversation: the self messages (the sent card
-        // and "Thanks for dinner!") hug the trailing edge, the other person's
-        // reply hugs the leading edge.
-        VStack(spacing: 6) {
-            FakeCashCard(caption: "You sent", amount: "$60.00", isFromSelf: true, width: 180)
-                .frame(maxWidth: .infinity, alignment: .trailing)
-            FakeChatBubble(text: "Thanks for dinner!", isFromSelf: true)
-                .frame(maxWidth: .infinity, alignment: .trailing)
-            FakeChatBubble(
-                text: "That's very kind of you. I had a great time last night",
-                isFromSelf: false,
-                maxTextWidth: 200
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 22)
-        .background {
-            RoundedRectangle(cornerRadius: 26, style: .continuous)
-                .fill(Color.white.opacity(0.035))
-        }
-        .frame(maxWidth: 300)
-        .mask {
-            // Solid at the top edge of the panel, fading out toward the bottom
-            // so it melts into the background above the headline.
-            LinearGradient(
-                stops: [
-                    .init(color: .black, location: 0),
-                    .init(color: .black, location: 0.72),
-                    .init(color: .clear, location: 1),
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        }
-        .accessibilityHidden(true)
     }
 }
 

--- a/Flipcash/Core/Screens/Send/SendConversationHero.swift
+++ b/Flipcash/Core/Screens/Send/SendConversationHero.swift
@@ -1,0 +1,64 @@
+//
+//  SendConversationHero.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+
+/// A cash card and two chat bubbles framed inside a faint "chat preview" panel
+/// whose bottom fades into the background via a `mask`. Sells the Send feature
+/// across the sheet's onboarding empty states (`ConnectPhoneEmptyState`,
+/// `DeniedAccessEmptyState`).
+///
+/// The cards and bubbles carry their real sender/recipient fills, so the muted
+/// look comes from those subtle fills plus the fade — not a global opacity.
+/// Hidden from VoiceOver so the placeholder amounts aren't read as real money.
+struct SendConversationHero: View {
+    var body: some View {
+        // Laid out like a real conversation: the self messages (the sent card
+        // and "Thanks for dinner!") hug the trailing edge, the other person's
+        // reply hugs the leading edge.
+        VStack(spacing: 6) {
+            FakeCashCard(caption: "You sent", amount: "$60.00", isFromSelf: true, width: 180)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            FakeChatBubble(text: "Thanks for dinner!", isFromSelf: true)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            FakeChatBubble(
+                text: "That's very kind of you. I had a great time last night",
+                isFromSelf: false,
+                maxTextWidth: 200
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 22)
+        .background {
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .fill(Color.white.opacity(0.035))
+        }
+        .frame(maxWidth: 300)
+        .mask {
+            // Solid at the top edge of the panel, fading out toward the bottom
+            // so it melts into the background above the headline.
+            LinearGradient(
+                stops: [
+                    .init(color: .black, location: 0),
+                    .init(color: .black, location: 0.72),
+                    .init(color: .clear, location: 1),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Preview -
+
+#Preview {
+    SendConversationHero()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.backgroundMain)
+}

--- a/FlipcashUITests/Smoke/SendSmokeTests.swift
+++ b/FlipcashUITests/Smoke/SendSmokeTests.swift
@@ -17,11 +17,12 @@ final class SendSmokeTests: BaseUITestCase {
         // Send is the 4th LargeButton on ScanBottomBar.
         waitAndTap(app.buttons["Send"])
 
-        // Send gates phone entry behind a "Connect Your Phone Number" CTA;
-        // onboarding drops you on the entry screen directly, so `allowPhone…`
-        // alone can't reach the flow here. Tap through the CTA when the gate
-        // is shown (skipped when the test account already has a verified phone).
-        let connectPhone = app.buttons["Connect Your Phone Number"]
+        // Send gates phone entry behind a "Next" CTA on the connect-phone
+        // pitch; onboarding drops you on the entry screen directly, so
+        // `allowPhone…` alone can't reach the flow here. Tap through the CTA
+        // when the gate is shown (skipped when the test account already has a
+        // verified phone).
+        let connectPhone = app.buttons["Next"]
         if connectPhone.waitForExistence(timeout: 5) {
             connectPhone.tap()
         }


### PR DESCRIPTION
Replaces the placeholder connect-phone screen in Send with the same onboarding pitch as the contacts-denied screen — a sample cash-card conversation, a "Send Money to Your Friends" headline, and a Next button. The shared illustration is extracted into one reusable view so the connect-phone and contacts-denied screens stay in sync.

## Test plan
- [x] Open Send without a verified phone → the new pitch screen appears
- [x] Tap **Next** → the phone verification flow launches
- [x] Deny contacts with no recent chats → the denied screen still renders with the shared hero