### PR TITLE
fix: prevent re-entrant scroll restore from crashing the chat transcript

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -66,9 +66,13 @@ public final class ChatCashCardCell: ChatColumnCell {
 
         installColumn(content: card)
 
+        // Below required so the card height yields to the cell's self-sizing height instead of fighting it.
+        let cardHeight = card.heightAnchor.constraint(equalToConstant: Self.cardSize.height)
+        cardHeight.priority = UILayoutPriority(999)
+
         NSLayoutConstraint.activate([
             card.widthAnchor.constraint(equalToConstant: Self.cardSize.width),
-            card.heightAnchor.constraint(equalToConstant: Self.cardSize.height),
+            cardHeight,
 
             tokenRow.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 11),
             tokenRow.topAnchor.constraint(equalTo: card.topAnchor, constant: 8),

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -51,6 +51,10 @@ public final class ChatViewController: UICollectionViewController {
     private static let bottomContentPadding: CGFloat = 12
     /// True while a batch update animates, so the top trigger doesn't re-fire mid-update.
     private var isUpdating = false
+    /// Set while `setBottomInset` writes the content inset — that write synchronously fires
+    /// `scrollViewDidChangeAdjustedContentInset`, and this stops the delegate re-entering `scrollToBottom`
+    /// → `restoreContentOffset` mid-write, a nested layout pass that crashes ChatLayout.
+    private var isAdjustingBottomInset = false
     /// True while a context menu is lifted from a bubble. Presenting the menu dismisses the keyboard;
     /// without intervention the adjusted inset shrinks and the transcript reflows out from under the
     /// lifted preview. So for the menu's lifetime the inset is taken over and frozen at its keyboard-up
@@ -117,7 +121,7 @@ public final class ChatViewController: UICollectionViewController {
         // While a context menu is up the inset is frozen (`freezeInset`), so this shouldn't fire for the
         // keyboard — but guard anyway, since taking the inset over and handing it back each toggles the
         // adjusted inset, and following those would move the content the freeze is holding in place.
-        guard !isShowingContextMenu, wasAtBottom, !needsInitialScroll, !isUpdating, !items.isEmpty else { return }
+        guard !isAdjustingBottomInset, !isShowingContextMenu, wasAtBottom, !needsInitialScroll, !isUpdating, !items.isEmpty else { return }
         scrollToBottom(animated: false)
     }
 
@@ -295,8 +299,10 @@ public final class ChatViewController: UICollectionViewController {
         let target = inset + Self.bottomContentPadding
         guard isViewLoaded, !isUpdating, abs(collectionView.contentInset.bottom - target) > 0.5 else { return }
         let snapshot = chatLayout.getContentOffsetSnapshot(from: .bottom)
+        isAdjustingBottomInset = true // suppress the delegate re-entry from the inset write below
         collectionView.contentInset.bottom = target
         collectionView.verticalScrollIndicatorInsets.bottom = target
+        isAdjustingBottomInset = false
         if let snapshot {
             chatLayout.restoreContentOffset(with: snapshot)
         }


### PR DESCRIPTION
Opening or switching DM conversations could crash with a UICollectionView "missing final attributes" assertion. The chat's bottom-inset update wrote the collection view's content inset, which synchronously re-entered the scroll-to-bottom path and forced a nested layout pass mid-bounds-change. The inset delegate now ignores that self-inflicted re-entry while still following the keyboard, and the cash card's fixed height yields to the cell's self-sizing height to clear the related Auto Layout warnings.

This assertion only reproduces under a real navigation push's animation timing, so it has no automated test — verify by hand.

## Test plan
- [x] Open a conversation, hold-to-copy a few messages, then tap Send Message — no crash
- [x] Switch between several conversations rapidly — no crash
- [x] Keyboard still follows the newest message when composing
- [x] No "BubbleBackgroundView height == 170" Auto Layout warnings in the console
