### PR TITLE
test: add Send cash + message UI test for an on-Flipcash contact

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -101,6 +101,7 @@ struct ConversationComposer: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Send")
+                .accessibilityIdentifier("send-message-button")
                 // Pop from 60% + fade, so the opacity ramp actually reads
                 // (scaling from 0 hides the fade behind a tiny speck).
                 .transition(.scale(scale: 0.6).combined(with: .opacity))

--- a/FlipcashUITests/Smoke/SendSmokeTests.swift
+++ b/FlipcashUITests/Smoke/SendSmokeTests.swift
@@ -84,4 +84,38 @@ final class SendSmokeTests: BaseUITestCase {
             "Expected `RecipientPickerScreen` to remain visible after dismissing the share sheet"
         )
     }
+
+    /// Sends cash to an on-Flipcash recipient (Raul Riera), then a message in the
+    /// same chat, asserting each is marked "Delivered" in turn (the receipt rides
+    /// only the latest message, so never both at once).
+    ///
+    /// **Prerequisites:** the `FLIPCASH_UI_TEST_ACCESS_KEY` account needs a
+    /// verified phone, a giveable balance, and "Raul Riera" reachable in the
+    /// recipient picker.
+    func testSendFlow_onFlipcashContact_sendsCashThenMessage() {
+        let picker = RecipientPickerUIScreen(app: app)
+        let amountEntry = AmountEntryScreen(app: app)
+        let sendAmount = SendAmountUIScreen(app: app)
+        let conversation = ConversationUIScreen(app: app)
+
+        assertMainScreenReached()
+
+        // Main → Send → recipient picker → Raul Riera's conversation.
+        picker.open(from: self)
+        picker.passEntryGates(from: self)
+        picker.selectRecipient(named: "Raul Riera")
+
+        // Send cash (the default currency is fine).
+        conversation.tapSendCash(from: self)
+        amountEntry.enterMinimumAmount()
+        sendAmount.commit()
+        conversation.assertCashDelivered()
+
+        // Send a message; the receipt moves off the cash and onto the message.
+        // Unique per run — prior runs' messages persist in the chat, so a fixed
+        // string would make the bubble query match multiple elements.
+        let message = "UI test \(UUID().uuidString.prefix(8))"
+        conversation.sendMessage(message, from: self)
+        conversation.assertMessageDelivered(message)
+    }
 }

--- a/FlipcashUITests/Support/Screens/ConversationUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/ConversationUIScreen.swift
@@ -1,0 +1,91 @@
+//
+//  ConversationUIScreen.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+/// Page object for a DM conversation. Drives Send Cash, the message composer,
+/// and the delivery receipts.
+@MainActor
+struct ConversationUIScreen {
+
+    private let app: XCUIApplication
+
+    init(app: XCUIApplication) {
+        self.app = app
+    }
+
+    // MARK: - Elements
+
+    var sendCashButton: XCUIElement { app.buttons["Send Cash"] }
+    var sendMessageButton: XCUIElement { app.buttons["Send Message"] }
+    var messageField: XCUIElement { app.textFields["Message"] }
+
+    /// The composer's send arrow. A dedicated identifier avoids the same-labelled
+    /// back button and ScanBottomBar "Send".
+    var composerSendButton: XCUIElement { app.buttons["send-message-button"] }
+
+    var deliveredReceipt: XCUIElement { app.staticTexts["Delivered"] }
+
+    func messageBubble(_ text: String) -> XCUIElement { app.staticTexts[text] }
+
+    // MARK: - Actions
+
+    /// Opens the Send amount sheet on top of the conversation.
+    func tapSendCash(from testCase: BaseUITestCase) {
+        testCase.waitAndTap(sendCashButton)
+    }
+
+    /// Opens the composer, types `text`, and sends it.
+    func sendMessage(_ text: String, from testCase: BaseUITestCase) {
+        testCase.waitAndTap(sendMessageButton)
+        testCase.waitUntilHittableAndTap(messageField)
+        messageField.typeText(text)
+        testCase.waitAndTap(composerSendButton)
+    }
+
+    // MARK: - Assertions
+
+    /// Asserts the cash payment is marked "Delivered".
+    func assertCashDelivered(timeout: TimeInterval = 40) {
+        XCTAssertTrue(
+            deliveredReceipt.waitForExistence(timeout: timeout),
+            "Expected the cash payment to be marked 'Delivered'"
+        )
+    }
+
+    /// Asserts `text`'s bubble appears and is marked "Delivered". The receipt
+    /// rides the latest sent message, so one at/below the bubble is the message's,
+    /// not the cash's.
+    func assertMessageDelivered(_ text: String, timeout: TimeInterval = 30) {
+        let bubble = messageBubble(text)
+        XCTAssertTrue(
+            bubble.waitForExistence(timeout: 15),
+            "Expected the sent message to appear as a bubble in the transcript"
+        )
+        XCTAssertTrue(
+            waitForReceipt(atOrBelow: bubble, timeout: timeout),
+            "Expected the message to be marked 'Delivered'"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Polls until a "Delivered" receipt sits at or below `reference`'s top edge.
+    /// Two "Delivered" labels can briefly coexist during the cash→message receipt
+    /// hand-off (the transcript cross-fades), so scan all matches rather than
+    /// resolving a single element — which raises "multiple matching elements".
+    private func waitForReceipt(atOrBelow reference: XCUIElement, timeout: TimeInterval) -> Bool {
+        let receipts = app.staticTexts.matching(NSPredicate(format: "label == %@", "Delivered"))
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let top = reference.frame.minY
+            if receipts.allElementsBoundByIndex.contains(where: { $0.frame.minY >= top }) {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        return false
+    }
+}

--- a/FlipcashUITests/Support/Screens/RecipientPickerUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/RecipientPickerUIScreen.swift
@@ -1,0 +1,68 @@
+//
+//  RecipientPickerUIScreen.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+/// Page object for the Send flow's recipient picker. Opens Send, clears the
+/// entry gates, and selects an on-Flipcash recipient.
+@MainActor
+struct RecipientPickerUIScreen {
+
+    private let app: XCUIApplication
+
+    init(app: XCUIApplication) {
+        self.app = app
+    }
+
+    // MARK: - Elements
+
+    /// The Send button on the ScanBottomBar (gated by the `enableSend` flag).
+    var sendButton: XCUIElement { app.buttons["scan-send-button"] }
+
+    /// A recipient row whose accessibility label starts with `name`.
+    func recipientRow(named name: String) -> XCUIElement {
+        app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", name)).firstMatch
+    }
+
+    // MARK: - Actions
+
+    /// Opens the Send sheet from the main screen.
+    func open(from testCase: BaseUITestCase) {
+        testCase.waitAndTap(sendButton)
+    }
+
+    /// Clears the connect-phone CTA, the phone + contacts gates, and the
+    /// on-Flipcash nudge. Each step no-ops when already satisfied.
+    func passEntryGates(from testCase: BaseUITestCase) {
+        let connectPhone = app.buttons["Next"]
+        if connectPhone.waitForExistence(timeout: 5) {
+            connectPhone.tap()
+        }
+        testCase.allowPhoneVerificationIfNeeded()
+        testCase.allowContactsIfNeeded()
+
+        // The nudge sits in its own window over the picker, so dismiss it first.
+        let nudge = app.buttons["OK"]
+        if nudge.waitForExistence(timeout: 5) {
+            nudge.tap()
+        }
+    }
+
+    /// Selects the recipient row for `name`, opening their conversation. Scrolls
+    /// as insurance when it isn't already near the top of the feed.
+    func selectRecipient(named name: String) {
+        let row = recipientRow(named: name)
+        if !row.waitForExistence(timeout: 20) {
+            for _ in 0..<6 where !row.exists {
+                app.swipeUp()
+            }
+        }
+        XCTAssertTrue(
+            row.exists,
+            "Expected '\(name)' in the Send recipient picker — the test account must reach them as an on-Flipcash contact or chat"
+        )
+        row.tap()
+    }
+}

--- a/FlipcashUITests/Support/Screens/SendAmountUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/SendAmountUIScreen.swift
@@ -1,0 +1,34 @@
+//
+//  SendAmountUIScreen.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+/// Page object for the Send amount sheet's slide-to-send control. Digit entry
+/// uses the shared `AmountEntryScreen`.
+@MainActor
+struct SendAmountUIScreen {
+
+    private let app: XCUIApplication
+
+    init(app: XCUIApplication) {
+        self.app = app
+    }
+
+    // MARK: - Elements
+
+    /// The "Swipe to Send" slider.
+    var swipeToSend: XCUIElement { app.buttons["Swipe to Send"] }
+
+    // MARK: - Actions
+
+    /// Commits the send by dragging the knob across the track — a tap lands on
+    /// the track and never moves it.
+    func commit() {
+        XCTAssertTrue(swipeToSend.waitForExistence(timeout: 15), "Expected the 'Swipe to Send' control")
+        let knob = swipeToSend.coordinate(withNormalizedOffset: CGVector(dx: 0.08, dy: 0.5))
+        let end = swipeToSend.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5))
+        knob.press(forDuration: 0.1, thenDragTo: end)
+    }
+}


### PR DESCRIPTION
Adds a UI test covering the full Send flow to an on-Flipcash contact: pick the recipient, send cash via the slide-to-send control, then send a chat message — asserting the cash and the message each reach "Delivered" (the receipt only ever rides the latest message, so the two are never Delivered at the same time). Also gives the chat composer's send button an accessibility identifier so the test can target it unambiguously past the same-labeled back and bottom-bar buttons.

## Test plan
- [x] Send-flow UI test passes on the iPhone 17 simulator (cash + message sent to an on-Flipcash contact, each shown as Delivered)