### PR TITLE
chore: instrument chat open-load and event-stream connection state

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -348,6 +348,10 @@ final class ConversationController {
     func loadMessages(for conversationID: ConversationID) async {
         do {
             let messages = try await messaging.getMessages(owner: owner, conversationID: conversationID, before: nil)
+            logger.info("Loaded conversation messages", metadata: [
+                "conversationID": "\(conversationID)",
+                "count": "\(messages.count)",
+            ])
             store.mergeMessages(messages, into: conversationID)
             persist(operation: "load-messages") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
         } catch {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
@@ -268,6 +268,11 @@ public actor EventStreamer {
     private func reportConnection(live: Bool) {
         guard isConnectionLive != live else { return }
         isConnectionLive = live
+        if live {
+            // Mark when the stream starts delivering (first ping) — the edge that gates the
+            // missed-window refetch, and the one transition no other log captures.
+            logger.info("Event stream went live", metadata: ["generation": "\(streamGeneration)"])
+        }
         connectionStateContinuation.yield(live ? .live : .disconnected)
     }
 


### PR DESCRIPTION
Adds two diagnostic log lines (no behavior change) to pin down why a chat opened from a push can render empty. One records the message-load result count; the other records event-stream connection-state transitions. Together they tell an empty read-after-write result apart from a load that never completed, and reveal whether the reconnect-refetch recovery ever triggers.

## Test plan
- [x] FlipcashTests + FlipcashCoreTests pass
- [x] `Loaded conversation messages` and `Event stream connection state changed` appear in a device log capture