### PR TITLE
feat: track chat analytics events

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -448,6 +448,7 @@ final class ConversationController {
             store.setLastMessage(message, in: conversationID)
             persist(operation: "send-message") { try database.upsertConversationMessages([message], conversationID: conversationID) }
             persistConversation(conversationID)
+            Analytics.track(event: Analytics.ConversationEvent.sentMessage)
             return true
         } catch {
             store.markPending(clientMessageID: clientMessageID, status: .failed, in: conversationID)
@@ -456,6 +457,7 @@ final class ConversationController {
                 "error": "\(error)",
             ])
             ErrorReporting.captureError(error, reason: "Failed to send conversation message")
+            Analytics.track(event: Analytics.ConversationEvent.sentMessage, error: error)
             return false
         }
     }

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -96,7 +96,6 @@ struct RecipientPickerScreen: View {
     // MARK: - Tap -
 
     private func selectRecipient(_ contact: ResolvedContact) {
-        Analytics.track(event: Analytics.SendEvent.tapRecipient)
         router.push(.dmConversation(.contact(contact)))
     }
 

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -136,10 +136,10 @@ final class SendAmountViewModel {
                     to: recipient,
                     chat: chatPaymentMetadata()
                 )
-                Analytics.track(event: Analytics.SendEvent.sendSuccess)
+                Analytics.transfer(event: .sentCash, exchangedFiat: amountToSend, grabTime: nil, successful: true, error: nil)
                 return .success
             } catch {
-                Analytics.track(event: Analytics.SendEvent.sendFailure)
+                Analytics.transfer(event: .sentCash, exchangedFiat: amountToSend, grabTime: nil, successful: false, error: error)
                 showSendError()
                 return .failed
             }
@@ -169,9 +169,8 @@ final class SendAmountViewModel {
         case failed
     }
 
-    /// Resolves the recipient, retrying once on a transient network error, and
-    /// records resolve telemetry. A successful resolution is cached so a
-    /// retried send skips the round-trip (and isn't re-counted).
+    /// Resolves the recipient, retrying once on a transient network error. A
+    /// successful resolution is cached so a retried send skips the round-trip.
     private func resolveRecipient() async -> RecipientResolution {
         if let resolvedRecipient {
             return .resolved(resolvedRecipient)
@@ -179,17 +178,14 @@ final class SendAmountViewModel {
         for attempt in 0..<2 {
             do {
                 let owner = try await resolver.resolveContact(e164: contact.phoneE164)
-                Analytics.track(event: Analytics.SendEvent.resolveSuccess)
                 resolvedRecipient = owner
                 return .resolved(owner)
             } catch ErrorResolve.notFound {
-                Analytics.track(event: Analytics.SendEvent.resolveNotFound)
                 logger.info("Recipient not on Flipcash", metadata: ["contactId": "\(contact.contactId)"])
                 return .notFound
             } catch ErrorResolve.transportFailure where attempt == 0 {
                 continue
             } catch {
-                Analytics.track(event: Analytics.SendEvent.resolveError)
                 logger.error("Recipient resolve failed", metadata: ["contactId": "\(contact.contactId)", "error": "\(error)"])
                 ErrorReporting.captureError(error, reason: "Contact resolve failed")
                 return .failed

--- a/Flipcash/Utilities/Events.swift
+++ b/Flipcash/Utilities/Events.swift
@@ -38,6 +38,7 @@ extension Analytics {
 
     enum TransferEvent: String, AnalyticsEvent {
         case withdrawal      = "Withdrawal"
+        case sentCash        = "Sent Cash"
         case sendCashLink    = "Send Cash Link"
         case receiveCashLink = "Receive Cash Link"
         case grabBill        = "Grab Bill"
@@ -59,12 +60,10 @@ extension Analytics {
     enum SendEvent: String, AnalyticsEvent {
         case showEnterPhone   = "Send: Show Enter Phone"
         case showConfirmPhone = "Send: Show Confirm Phone"
-        case tapRecipient     = "Send: Tap Recipient"
-        case resolveSuccess   = "Send: Resolve Success"
-        case resolveNotFound  = "Send: Resolve NotFound"
-        case resolveError     = "Send: Resolve Error"
-        case sendSuccess      = "Send: Send Success"
-        case sendFailure      = "Send: Send Failure"
+    }
+
+    enum ConversationEvent: String, AnalyticsEvent {
+        case sentMessage = "Sent Message"
     }
 
     enum OnboardingEvent: String, AnalyticsEvent {


### PR DESCRIPTION
Aligns the chat analytics events with the Android app. The cash-send success event becomes "Sent Cash" on TransferEvent and now carries the full transfer payload (amount, currency, state, error); a new "Sent Message" event fires on the message delivery outcome, with an error property on failure. The recipient-tap and recipient-resolve/send-failure events, which have no Android counterpart, are removed.

## Test plan
- [x] Send cash to a contact from a chat → "Sent Cash" fires with amount + state
- [x] Send a chat message → "Sent Message" fires on success
- [x] Force a message send failure (offline) → "Sent Message" fires with an Error property