### PR TITLE
feat: open Currency Info when tapping a cash card in a chat

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -135,7 +135,10 @@ struct DestinationView: View {
         case .withdrawCurrency(let mint):
             PreselectedWithdrawRoot(
                 mint: mint,
-                onComplete: { sessionContainer.appRouter.popToRoot(on: .balance) }
+                // Reachable from the Wallet (.balance) and — since cash cards open currency info — from
+                // a chat (.conversation / .send). Reset the host stack, not a hardcoded one, so the
+                // user isn't stranded on the finished withdraw screen when it ran over a chat.
+                onComplete: { sessionContainer.appRouter.popToRoot() }
             )
 
         case .usdcDepositEducation:

--- a/Flipcash/Core/Navigation/AppRouter+SheetPresentation.swift
+++ b/Flipcash/Core/Navigation/AppRouter+SheetPresentation.swift
@@ -49,6 +49,17 @@ extension AppRouter {
             }
         }
 
+        /// Whether presenting this sheet should reset its stack to root first. A conversation is
+        /// always re-entered fresh — a deeplink/push should land on the chat, never on a leaf pushed
+        /// onto its stack (a cash card's currency info). Every other root preserves its path so a
+        /// swap-back or tab re-tap restores where the user was.
+        var resetsStackOnPresent: Bool {
+            switch self {
+            case .conversation: true
+            case .balance, .settings, .give, .discover, .buy, .downloadApp, .send, .sendAmount: false
+            }
+        }
+
         /// Payload-free case discriminator. Used by `presentNested` to detect
         /// "same case, different payload" (e.g. `.buy(A)` → `.buy(B)`) without
         /// comparing the stringly-typed `description`.

--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -168,6 +168,15 @@ final class AppRouter {
         logger.info("Reset stack", metadata: ["stack": "\(stack)"])
     }
 
+    /// Resets whichever stack the currently-presented sheet hosts to its root — the stack-agnostic
+    /// counterpart to `popToRoot(on:)`, mirroring `popTopmost()`. Used by completion handlers that
+    /// must unwind to the host stack's root without hand-stamping which stack they're on (e.g. the
+    /// withdraw flow, reachable from the Wallet, a deeplinked chat, or the recipient picker).
+    func popToRoot() {
+        guard let stack = presentedSheet?.stack else { return }
+        popToRoot(on: stack)
+    }
+
     /// Pops up to `count` items from the top of `stack`. Used by sub-flows
     /// (e.g., `WithdrawViewModel.popToEnterAmount`) that need to unwind a
     /// known number of substeps.
@@ -225,6 +234,13 @@ final class AppRouter {
     /// different sheet without going through `dismissSheet` first) leaves
     /// both paths intact, preserving the original "swap-and-return" behaviour.
     func present(_ sheet: SheetPresentation) {
+        // Roots that are re-entered fresh (the conversation root — see `resetsStackOnPresent`) clear
+        // their stack up front, before any branch below. One rule covers every re-entry: idempotent
+        // re-present, chat→chat swap, swap-away-then-return, and a re-present with a nested sheet above.
+        if sheet.resetsStackOnPresent {
+            popToRoot(on: sheet.stack)
+        }
+
         if presentedSheets == [sheet] { return }
 
         let previousTop = presentedSheet

--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -25,6 +25,9 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     /// Fired when the user taps a failed outgoing row; the argument is the message's stable id (its
     /// client message id). The owner re-sends it.
     let onRetry: (String) -> Void
+    /// Fired when the user taps a cash card; the argument is the message's stable id. The owner opens
+    /// that token's currency info.
+    let onCashCardTap: (String) -> Void
     let showsSendCash: Bool
     let showsSendMessage: Bool
     let conversationID: ConversationID?
@@ -45,6 +48,7 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         )
         screen.onReachTop = onReachTop
         screen.onRetry = onRetry
+        screen.onCashCardTap = onCashCardTap
         screen.update(items: items)
         screen.setComposing(barModel.isComposing)
         context.coordinator.restingHost = restingHost
@@ -61,6 +65,7 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         context.coordinator.keyboardHost?.rootView = keyboardBar(coordinator: context.coordinator)
         screen.onReachTop = onReachTop
         screen.onRetry = onRetry
+        screen.onCashCardTap = onCashCardTap
         screen.setComposing(barModel.isComposing)
 
         // Scroll only when the user's *own* message was just appended — a new trailing message id

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -171,6 +171,7 @@ struct ConversationScreen: View {
             items: mappedItems,
             onReachTop: loadOlderMessages,
             onRetry: retry,
+            onCashCardTap: openCurrencyInfo,
             showsSendCash: sendTarget != nil,
             showsSendMessage: chatExists,
             conversationID: conversationID,
@@ -331,6 +332,18 @@ struct ConversationScreen: View {
     private func retry(messageID: String) {
         guard let conversationID, let clientMessageID = UUID(uuidString: messageID) else { return }
         Task { await conversationController.retry(clientMessageID: clientMessageID, in: conversationID) }
+    }
+
+    /// Push the tapped cash card's token currency info onto the current chat stack (so back returns
+    /// here). The id is the row's stable id; resolve it to the cash message's mint.
+    private func openCurrencyInfo(messageID: String) {
+        guard let message = messages.first(where: { $0.stableID == messageID }) else { return }
+        switch message.content {
+        case .cash(let fiat):
+            router.push(.currencyInfo(fiat.mint))
+        case .text:
+            break
+        }
     }
 
     /// Fetches the next older page when the UIKit transcript nears the top. Guarded so the

--- a/Flipcash/Core/Screens/Conversation/ConversationSheetRoot.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationSheetRoot.swift
@@ -7,10 +7,12 @@ import SwiftUI
 import FlipcashUI
 
 /// Root view for the `.conversation` sheet — a chat entered as the bottom view
-/// via deeplink / push notification. The `NavigationStack` is unbound: nothing
-/// pushes onto this stack, so it exists only to render the toolbar. The trailing
-/// close button is the root-sheet counterpart to the back button the pushed
-/// `.dmConversation` entry gets (push → back, root sheet → close).
+/// via deeplink / push notification. The `NavigationStack` is bound to the
+/// `.conversation` stack so in-chat pushes (e.g. tapping a cash card to open its
+/// currency info) land here, and `.appRouterDestinations` registers the map those
+/// pushes resolve through. The trailing close button is the root-sheet counterpart
+/// to the back button the pushed `.dmConversation` entry gets (push → back, root
+/// sheet → close).
 struct ConversationSheetRoot: View {
 
     let context: ConversationContext
@@ -18,8 +20,10 @@ struct ConversationSheetRoot: View {
     @Environment(AppRouter.self) private var router
 
     var body: some View {
-        NavigationStack {
+        @Bindable var router = router
+        NavigationStack(path: $router[.conversation]) {
             ConversationScreen(context: context)
+                .appRouterDestinations()
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
                         CloseButton(action: router.dismissSheet)

--- a/FlipcashTests/Navigation/AppRouterConversationSendTests.swift
+++ b/FlipcashTests/Navigation/AppRouterConversationSendTests.swift
@@ -142,4 +142,105 @@ struct AppRouterConversationSendTests {
         #expect(router.presentedSheets == [.balance])
         #expect(router[.balance] == AppRouter.navigationPath(.currencyInfoForDeposit(.usdc)))
     }
+
+    // MARK: - In-chat currency info pushed on the conversation stack (cash card tap)
+
+    @Test("Swapping to a different chat clears the previous chat's pushed currency info")
+    func conversationSwap_clearsPushedLeaf() {
+        // A cash card tapped in chat A pushes currency info onto the shared .conversation stack; a
+        // deeplink/push for chat B must not inherit chat A's leaf.
+        let router = AppRouter()
+        let chatA = ConversationContext.existing(.test(0x01))
+        let chatB = ConversationContext.existing(.test(0x02))
+        router.present(.conversation(chatA))
+        router.push(.currencyInfo(.usdc))
+        #expect(router[.conversation] == AppRouter.navigationPath(.currencyInfo(.usdc)))
+
+        router.present(.conversation(chatB))
+
+        #expect(router.presentedSheets == [.conversation(chatB)])
+        #expect(router[.conversation].isEmpty)
+    }
+
+    @Test("Re-presenting the same chat with currency info pushed lands back on the chat")
+    func conversationRePresent_popsPushedLeaf() {
+        let router = AppRouter()
+        router.present(.conversation(Self.existingContext))
+        router.push(.currencyInfo(.usdc))
+
+        router.present(.conversation(Self.existingContext))  // same-chat deeplink/push re-arrival
+
+        #expect(router.presentedSheets == [.conversation(Self.existingContext)])
+        #expect(router[.conversation].isEmpty)
+    }
+
+    @Test("A cross-stack swap still preserves the swapped-out stack's path (swap-back)")
+    func crossStackSwap_preservesPath() {
+        // The conversation-leaf clearing must be scoped to same-stack swaps — a .balance → .settings
+        // swap must still keep .balance's path so swapping back restores it.
+        let router = AppRouter()
+        router.present(.balance)
+        router.push(.currencyInfo(.usdc))
+
+        router.present(.settings)
+
+        #expect(router.presentedSheets == [.settings])
+        #expect(router[.balance] == AppRouter.navigationPath(.currencyInfo(.usdc)))
+    }
+
+    @Test("popToRoot() resets the host stack so a chat-launched withdraw doesn't strand the user")
+    func popToRoot_resetsHostStack() {
+        // The withdraw flow's completion uses the stack-agnostic popToRoot(); reached from a chat it
+        // must reset the conversation stack (not a hardcoded .balance) and leave the chat presented.
+        let router = AppRouter()
+        router.present(.conversation(Self.existingContext))
+        router.push(.currencyInfo(.usdc))
+        router.push(.withdrawCurrency(.usdc))
+
+        router.popToRoot()
+
+        #expect(router.presentedSheets == [.conversation(Self.existingContext)])
+        #expect(router[.conversation].isEmpty)
+    }
+
+    @Test("popToRoot() from the Wallet stack still resets .balance, unchanged from the hardcoded path")
+    func popToRoot_walletStackUnchanged() {
+        let router = AppRouter()
+        router.present(.balance)
+        router.push(.currencyInfo(.usdc))
+        router.push(.withdrawCurrency(.usdc))
+
+        router.popToRoot()
+
+        #expect(router.presentedSheets == [.balance])
+        #expect(router[.balance].isEmpty)
+    }
+
+    @Test("Swapping away to another root then back to the chat lands on the chat, not the stale leaf")
+    func conversationSwapAwayAndBack_clearsLeaf() {
+        // Re-present after a cross-stack detour: the leaf left dangling on the swapped-away
+        // .conversation stack must clear when the chat is re-entered.
+        let router = AppRouter()
+        router.present(.conversation(Self.existingContext))
+        router.push(.currencyInfo(.usdc))
+        router.present(.balance)                              // swap away to a different root
+
+        router.present(.conversation(Self.existingContext))   // deeplink/push back to the chat
+
+        #expect(router.presentedSheets == [.conversation(Self.existingContext)])
+        #expect(router[.conversation].isEmpty)
+    }
+
+    @Test("Re-presenting the chat with a nested sheet above still clears the pushed leaf")
+    func conversationRePresent_withNestedAbove_clearsLeaf() {
+        let router = AppRouter()
+        router.present(.conversation(Self.existingContext))
+        router.push(.currencyInfo(.usdc))
+        router.presentNested(.sendAmount(Self.contact))       // nested sheet stacks above the chat
+
+        router.present(.conversation(Self.existingContext))   // same-chat deeplink/push re-arrival
+
+        #expect(router.presentedSheets == [.conversation(Self.existingContext)])
+        #expect(router[.conversation].isEmpty)
+    }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -27,6 +27,17 @@ public final class ChatCashCardCell: ChatColumnCell {
     private let amountLabel = UILabel()
     private var iconTask: Task<Void, Never>?
 
+    /// Dim the card while pressed so the tap-to-open-currency-info affordance reads as a button.
+    /// Driven by the collection view's selection machinery (`shouldHighlightItemAt`), not a gesture.
+    public override var isHighlighted: Bool {
+        didSet {
+            guard isHighlighted != oldValue else { return }
+            UIView.animate(withDuration: 0.15) {
+                self.card.alpha = self.isHighlighted ? 0.6 : 1
+            }
+        }
+    }
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -134,6 +145,11 @@ public final class ChatCashCardCell: ChatColumnCell {
             )
         )
         updateColumn(for: message)
+
+        // Resting alpha lives here, not just in prepareForReuse: an in-place reconfigure (a new
+        // message flipping this row's grouping) re-runs configure without prepareForReuse, so this is
+        // the single place that restores the press dim to match the current highlight state.
+        card.alpha = isHighlighted ? 0.6 : 1
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -66,6 +66,11 @@ public final class ChatScreenViewController: UIViewController {
         set { transcript.onRetry = newValue }
     }
 
+    public var onCashCardTap: ((String) -> Void)? {
+        get { transcript.onCashCardTap }
+        set { transcript.onCashCardTap = newValue }
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor(Color.backgroundMain)

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -31,6 +31,10 @@ public final class ChatViewController: UICollectionViewController {
     /// Called when the user taps a failed outgoing row to retry; the argument is the message's stable id.
     public var onRetry: ((String) -> Void)?
 
+    /// Called when the user taps a cash card; the argument is the message's stable id. The owner opens
+    /// that token's currency info. Only cash rows are selectable (see `shouldHighlightItemAt`).
+    public var onCashCardTap: ((String) -> Void)?
+
     /// The widest a bubble may grow, as a share of the collection view's width.
     private static let maxBubbleWidthFraction: CGFloat = 0.78
 
@@ -225,6 +229,31 @@ public final class ChatViewController: UICollectionViewController {
                 return cell
             }
         }
+    }
+
+    // MARK: - Selection
+
+    /// Only cash cards are tappable — they open the token's currency info. Text bubbles and date
+    /// separators opt out (a text row's only tap is retry, handled by its own recognizer). Gating
+    /// highlight is enough to gate selection too: UIKit won't select a row it didn't highlight, and
+    /// `didSelectItemAt` re-checks for cash as a backstop.
+    public override func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
+        cashMessageID(at: indexPath) != nil
+    }
+
+    public override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // Selection here is a momentary tap action, not a persisted state — clear it immediately.
+        collectionView.deselectItem(at: indexPath, animated: false)
+        guard let id = cashMessageID(at: indexPath) else { return }
+        onCashCardTap?(id)
+    }
+
+    /// The stable id of the cash message at `indexPath`, or nil if that row isn't a cash card. The
+    /// index is bounds-checked: a tap can race a batch update, where the index may outrun `items`.
+    private func cashMessageID(at indexPath: IndexPath) -> String? {
+        guard items.indices.contains(indexPath.item),
+              case .message(let message) = items[indexPath.item], case .cash = message.content else { return nil }
+        return message.id
     }
 
     // MARK: - Scrolling


### PR DESCRIPTION
Tapping a cash card in a conversation now opens that token's Currency Info, pushed onto the chat's own stack so the back button returns to the chat. It works whether the chat was opened from the recipient picker or from a deeplink/push. Binding the deeplink-opened chat for in-chat pushes surfaced a few latent navigation edges — a stale pushed screen surviving a chat re-entry, and a withdraw completion that reset a hardcoded stack — which are fixed and covered by regression tests.

## Test plan
- [x] Tap a cash card in a chat → its token's Currency Info opens; back returns to the chat
- [x] Works from both a picker-opened chat and a deeplink/push-opened chat
- [x] After viewing a card's Currency Info, re-opening the same or a different chat lands on the chat, not the stale screen
- [ ] VoiceOver reads the cash card as a button and a double-tap opens Currency Info