### PR TITLE
feat: open a chat by contact phone number from a deeplink

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -97,6 +97,9 @@ final class DeepLinkController {
         case .chat(let conversationID):
             return actionForChat(conversationID: conversationID)
 
+        case .chatContact(let phone):
+            return actionForChatContact(phone: phone)
+
         case .give:
             return actionForOpenSheet(.give)
 
@@ -153,6 +156,13 @@ final class DeepLinkController {
     private func actionForChat(conversationID: ConversationID) -> DeepLinkAction {
         DeepLinkAction(
             kind: .chat(conversationID),
+            sessionAuthenticator: sessionAuthenticator
+        )
+    }
+
+    private func actionForChatContact(phone: Phone) -> DeepLinkAction {
+        DeepLinkAction(
+            kind: .chatContact(phone),
             sessionAuthenticator: sessionAuthenticator
         )
     }
@@ -223,6 +233,22 @@ struct DeepLinkAction {
                 container.appRouter.present(.conversation(.existing(conversationID)))
             }
 
+        case .chatContact(let phone):
+            if case .loggedIn(let container) = sessionAuthenticator.state {
+                Analytics.deeplinkRouted(kind: kind)
+                // Resolve the phone against the synced directory. No match (not a
+                // contact, or contact sync hasn't settled yet) is a silent no-op,
+                // like any other unresolvable deeplink. The `.contact` context
+                // resolves the `dmChatID` live and opens whether or not the chat
+                // exists yet.
+                guard let contact = container.contactSyncController.resolvedContacts.onFlipcash
+                    .first(where: { $0.phoneE164 == phone.e164 }) else {
+                    logger.info("No synced contact for chat deeplink phone — ignoring")
+                    return
+                }
+                container.appRouter.present(.conversation(.contact(contact)))
+            }
+
         case .openSheet(let sheet):
             if case .loggedIn(let container) = sessionAuthenticator.state {
                 Analytics.deeplinkRouted(kind: kind)
@@ -253,6 +279,7 @@ extension DeepLinkAction {
         case verifyEmail(VerificationDescription)
         case currencyInfo(PublicKey)
         case chat(ConversationID)
+        case chatContact(Phone)
         case openSheet(AppRouter.SheetPresentation)
     }
 }
@@ -265,6 +292,7 @@ extension DeepLinkAction.Kind {
         case .verifyEmail:      "EmailVerification"
         case .currencyInfo:     "TokenInfo"
         case .chat:             "Chat"
+        case .chatContact:      "ChatContact"
         case .openSheet(let sheet): "Sheet:\(sheet)"
         }
     }

--- a/Flipcash/Core/Controllers/Deep Links/Route.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Route.swift
@@ -86,6 +86,7 @@ nonisolated extension Route {
         case verifyEmail
         case token(PublicKey)
         case chat(ConversationID)
+        case chatContact(Phone)
         case give
         case balance
         case discover
@@ -117,10 +118,22 @@ nonisolated extension Route {
                 }
                 return .token(mint)
             case "chat":
-                guard components.count > 1, let id = ConversationID(base64URLEncoded: components[1]) else {
+                guard components.count > 1 else {
                     return nil
                 }
-                return .chat(id)
+                // Existing chat-by-ID deeplink wins; the server's contact-chat
+                // variant is `/chat/{E.164}` (it percent-encodes the leading "+"
+                // as "%2B", already decoded back to "+" by here). The two are
+                // disjoint — a 32-byte base64url ChatId never starts with "+".
+                // Require the "+" so a bare national number can't misparse against
+                // PhoneNumberKit's implicit US region.
+                if let id = ConversationID(base64URLEncoded: components[1]) {
+                    return .chat(id)
+                }
+                if components[1].hasPrefix("+"), let phone = Phone(components[1]) {
+                    return .chatContact(phone)
+                }
+                return nil
             case "give":
                 return .give
             case "balance":

--- a/Flipcash/Core/Screens/Main/ScanViewModel.swift
+++ b/Flipcash/Core/Screens/Main/ScanViewModel.swift
@@ -106,7 +106,8 @@ class ScanViewModel {
     // MARK: - QR Scanning -
 
     /// Returns whether a URL is eligible for QR code scanning.
-    /// Only `.cash` and `.token` routes are allowed; `.login` and `.verifyEmail` are blocked for security.
+    /// Allowlist: only `.cash` and `.token` may be scanned. Every other route —
+    /// including security-sensitive ones like `.login` and `.verifyEmail` — is blocked.
     nonisolated static func canScanQR(url: URL) -> Bool {
         guard let route = Route(url: url) else {
             return false
@@ -115,7 +116,7 @@ class ScanViewModel {
         switch route.path {
         case .cash, .token:
             return true
-        case .login, .verifyEmail, .chat, .give, .balance, .discover, .send, .unknown:
+        case .login, .verifyEmail, .chat, .chatContact, .give, .balance, .discover, .send, .unknown:
             return false
         }
     }

--- a/FlipcashTests/RouteTests.swift
+++ b/FlipcashTests/RouteTests.swift
@@ -167,6 +167,44 @@ struct RouteTests {
         #expect(Route(url: URL(string: "https://app.flipcash.com/chat")!) == nil)
     }
 
+    @Test("Chat route parses a contact phone number (the /chat/{phone} variant)")
+    func chatContactRoute() {
+        // The server emits https://app.flipcash.com/chat/{phone} for a
+        // contact-chat push, URL-encoding the leading "+" as "%2B".
+        let e164 = "+14155550100"
+
+        let deepLink = URL(string: "flipcash://chat/\(e164)")!
+        let universalLink = URL(string: "https://app.flipcash.com/chat/\(e164)")!
+        // The exact form the server sends, with the "+" percent-encoded.
+        let encodedUniversalLink = URL(string: "https://app.flipcash.com/chat/%2B14155550100")!
+
+        for url in [deepLink, universalLink, encodedUniversalLink] {
+            if case .chatContact(let phone) = Route(url: url)?.path {
+                #expect(phone.e164 == e164)
+            } else {
+                Issue.record("\(url) should parse as .chatContact with the phone number")
+            }
+        }
+
+        // A base64url ChatId must still win over the phone fallback.
+        let idData = Data((0..<32).map { UInt8($0) })
+        let encodedID = idData.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+        if case .chat = Route(url: URL(string: "https://app.flipcash.com/chat/\(encodedID)")!)?.path {} else {
+            Issue.record("A base64url ChatId must still parse as .chat, not .chatContact")
+        }
+
+        // Neither a ChatId nor a phone — still nil.
+        #expect(Route(url: URL(string: "https://app.flipcash.com/chat/notaphone")!) == nil)
+
+        // E.164 only: the server always sends the leading "+". A bare national
+        // number must NOT parse, otherwise PhoneNumberKit's implicit US region
+        // would silently accept it (10-digit US) or mis-region it (intl without "+").
+        #expect(Route(url: URL(string: "https://app.flipcash.com/chat/4155550100")!) == nil)
+        #expect(Route(url: URL(string: "https://app.flipcash.com/chat/441632960000")!) == nil)
+    }
+
     // MARK: - Sheet Routes -
     //
     // The home-screen quick actions open sheets via these routes. The

--- a/FlipcashTests/RouteTests.swift
+++ b/FlipcashTests/RouteTests.swift
@@ -177,8 +177,10 @@ struct RouteTests {
         let universalLink = URL(string: "https://app.flipcash.com/chat/\(e164)")!
         // The exact form the server sends, with the "+" percent-encoded.
         let encodedUniversalLink = URL(string: "https://app.flipcash.com/chat/%2B14155550100")!
+        // The same percent-encoding over the custom scheme, for symmetry.
+        let encodedDeepLink = URL(string: "flipcash://chat/%2B14155550100")!
 
-        for url in [deepLink, universalLink, encodedUniversalLink] {
+        for url in [deepLink, universalLink, encodedUniversalLink, encodedDeepLink] {
             if case .chatContact(let phone) = Route(url: url)?.path {
                 #expect(phone.e164 == e164)
             } else {


### PR DESCRIPTION
The backend can now send a `/chat/{phone}` deeplink in addition to the existing `/chat/{chat-id}` one. The phone is parsed as strict E.164, resolved against the synced contact directory, and opens that contact's conversation. An unknown number is a silent no-op, like any other unresolvable deeplink, and the existing chat-id deeplink is unchanged.

## Test plan
- [x] `/chat/{+e164}` of a synced contact opens that conversation
- [x] `/chat/{base64url chat-id}` still opens the conversation (unchanged)
- [x] `/chat/{+e164}` of an unknown number does nothing (no crash, no navigation)
- [x] A bare national number like `/chat/4155550100` (no "+") does nothing