### PR TITLE
fix: link phone for payment on cold launch and number change

### DIFF
--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -286,6 +286,12 @@ class Session {
             try await flipClient.fetchProfile(userID: userID, owner: ownerKeyPair)
         }
 
+        // A changed or removed phone number must be re-linked for payment, so drop
+        // the per-session claim whenever the number differs from the one we linked.
+        if profile?.phone?.e164 != fetched.phone?.e164 {
+            hasLinkedPhoneForPayment = false
+        }
+
         profile = fetched
         try? database.insertProfile(fetched)
         Task { await linkPhoneForPaymentIfNeeded() }
@@ -327,8 +333,7 @@ class Session {
 
     /// Links an already-verified phone for payment once per session. Best-effort; server-idempotent.
     private func linkPhoneForPaymentIfNeeded() async {
-        guard canSend,
-              let phone = profile?.phone,
+        guard let phone = profile?.phone,
               !hasLinkedPhoneForPayment else { return }
         // Claim before the await so two concurrent callers can't double-fire; released on failure below.
         hasLinkedPhoneForPayment = true


### PR DESCRIPTION
Contact payments were being denied server-side ("source phone number is not linked for payment") because the client only linked a phone for payment when the Send feature flag was on, and only once per session — so a user who reached Send via chat without the flag, or who changed their number mid-session, was never linked. This decouples payment-linking from the Send feature flag and resets the per-session claim when the number changes, so any verified phone is linked on cold launch and on every update.

## Test plan
- [x] Build passes
- [x] Cold launch with a verified phone links it for payment (Send flag on or off)
- [x] Changing / re-verifying a number mid-session re-links the new number
- [x] A contact (chat) payment from a freshly-verified user is no longer denied