### PR TITLE
feat: typing indicator for chats

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -36,6 +36,12 @@ final class ConversationController {
     /// cross-fade onto a settled bubble; the transcript mapping suppresses that row's receipt while set.
     var settlingSendID: String? { receiptSettle.settlingID }
 
+    /// Per-conversation set of OTHER members currently typing, maintained from the live stream.
+    /// Ephemeral — never persisted (the proto marks typing transient/best-effort). Cleared when a
+    /// member sends a stopped/timed-out notification; no client-side expiry (server-driven, mirroring
+    /// Android). `Set<UserID>` is Equatable, so the @Observable setter skips no-op re-inserts.
+    private var typingUserIDs: [ConversationID: Set<UserID>] = [:]
+
     /// The conversation with this ID, if the feed currently holds it.
     func conversation(withID id: ConversationID) -> Conversation? {
         conversations.first { $0.id == id }
@@ -74,6 +80,13 @@ final class ConversationController {
     @ObservationIgnored private var hydratingConversationIDs: Set<ConversationID> = []
     @ObservationIgnored private var markReadTasks: [ConversationID: Task<Void, Never>] = [:]
     @ObservationIgnored private let receiptSettle = ReceiptSettleGate()
+
+    /// Re-send STILL no more often than this while the user keeps typing, and send STOPPED after this
+    /// long idle (matches the Android client so all clients agree on the cadence).
+    private static let typingHeartbeatInterval: Duration = .seconds(3)
+    private static let typingTimeout: Duration = .seconds(5)
+    @ObservationIgnored private var isSelfTyping = false
+    @ObservationIgnored private var selfTypingTask: Task<Void, Never>?
 
     init(
         fetching: any ConversationFetching,
@@ -139,6 +152,7 @@ final class ConversationController {
                 self.persist(event: event)
                 self.hydrateIfUnknown(event)
                 self.logCounterpartRead(event)
+                self.applyTyping(event)
             }
         }
     }
@@ -186,6 +200,28 @@ final class ConversationController {
         }
     }
 
+    /// Updates the ephemeral typing set from a live event. Self is excluded — the server may echo our
+    /// own typing and we never show ourselves typing.
+    private func applyTyping(_ event: ConversationStreamEvent) {
+        guard case .typingChanged(let conversationID, let notifications) = event else { return }
+        for notification in notifications where notification.userID != selfUserID {
+            switch notification.isActive {
+            case true:
+                typingUserIDs[conversationID, default: []].insert(notification.userID)
+            case false:
+                typingUserIDs[conversationID]?.remove(notification.userID)
+                if typingUserIDs[conversationID]?.isEmpty == true {
+                    typingUserIDs[conversationID] = nil
+                }
+            }
+        }
+    }
+
+    /// Whether any OTHER member is currently typing in this conversation.
+    func isCounterpartTyping(in conversationID: ConversationID) -> Bool {
+        !(typingUserIDs[conversationID]?.isEmpty ?? true)
+    }
+
     func stop() {
         startTask?.cancel()
         startTask = nil
@@ -195,6 +231,10 @@ final class ConversationController {
         connectionStateTask = nil
         markReadTasks.values.forEach { $0.cancel() }
         markReadTasks.removeAll()
+        typingUserIDs.removeAll()
+        selfTypingTask?.cancel()
+        selfTypingTask = nil
+        isSelfTyping = false
         receiptSettle.cancel()
         streaming.closeConversationStream()
     }
@@ -213,6 +253,9 @@ final class ConversationController {
         case .newMessages(let id, _), .lastActivityChanged(let id, _), .readPointersChanged(let id, _):
             conversationID = id
         case .metadataRefresh:
+            return
+        case .typingChanged:
+            // A typing event for an unknown conversation isn't worth a metadata fetch — it's transient.
             return
         }
         guard !store.conversations.contains(where: { $0.id == conversationID }),
@@ -265,6 +308,8 @@ final class ConversationController {
         case .lastActivityChanged(let conversationID, _),
              .readPointersChanged(let conversationID, _):
             persistConversation(conversationID)
+        case .typingChanged:
+            break
         }
     }
 
@@ -495,6 +540,62 @@ final class ConversationController {
                 "error": "\(error)",
             ])
             ErrorReporting.captureError(error, reason: "Failed to mark conversation read")
+        }
+    }
+
+    // MARK: - Outgoing typing
+
+    /// Drives outgoing typing from the composer's draft. STARTED on the first non-empty change, STILL
+    /// after a `typingHeartbeatInterval` pause, STOPPED at `typingTimeout` idle or when the draft empties.
+    /// Each change replaces the previous run, mirroring Android's `transformLatest` driver.
+    func draftDidChange(_ text: String, in conversationID: ConversationID) {
+        selfTypingTask?.cancel()
+        guard !text.isEmpty else {
+            stopSelfTyping(in: conversationID)
+            return
+        }
+        selfTypingTask = Task { [weak self] in
+            // A task cancelled before its body runs (a fast type-then-clear) must send nothing — otherwise
+            // it would emit a STARTED with no matching STOPPED and wedge `isSelfTyping`.
+            guard let self, !Task.isCancelled else { return }
+            if !self.isSelfTyping {
+                self.isSelfTyping = true
+                self.sendTyping(.started, in: conversationID)
+            }
+            var elapsed: Duration = .zero
+            while elapsed < Self.typingTimeout {
+                let wait = min(Self.typingHeartbeatInterval, Self.typingTimeout - elapsed)
+                try? await Task.sleep(for: wait)
+                if Task.isCancelled { return }
+                elapsed += wait
+                if elapsed < Self.typingTimeout {
+                    self.sendTyping(.still, in: conversationID)
+                }
+            }
+            self.isSelfTyping = false
+            self.sendTyping(.stopped, in: conversationID)
+        }
+    }
+
+    /// Force-stop outgoing typing (draft cleared, message sent, or the composer lost focus).
+    func stopSelfTyping(in conversationID: ConversationID) {
+        selfTypingTask?.cancel()
+        selfTypingTask = nil
+        guard isSelfTyping else { return }
+        isSelfTyping = false
+        sendTyping(.stopped, in: conversationID)
+    }
+
+    /// Fire-and-forget. Deliberately not logged per-failure — typing fires every few seconds, so an
+    /// offline burst would flood the log — but errors still route through `captureError`: transient ones
+    /// classify as non-reportable and are filtered, while a genuine server error surfaces.
+    private func sendTyping(_ state: TypingState, in conversationID: ConversationID) {
+        Task { [messaging, owner] in
+            do {
+                try await messaging.notifyIsTyping(owner: owner, conversationID: conversationID, state: state)
+            } catch {
+                ErrorReporting.captureError(error, reason: "Failed to notify typing")
+            }
         }
     }
 }

--- a/Flipcash/Core/Controllers/FlipClient+Protocols.swift
+++ b/Flipcash/Core/Controllers/FlipClient+Protocols.swift
@@ -73,6 +73,7 @@ protocol ConversationMessaging: AnyObject, Sendable {
     func getMessages(owner: KeyPair, conversationID: ConversationID, before: MessageID?) async throws -> [ConversationMessage]
     func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID) async throws -> ConversationMessage
     func markRead(owner: KeyPair, conversationID: ConversationID, messageID: MessageID) async throws
+    func notifyIsTyping(owner: KeyPair, conversationID: ConversationID, state: TypingState) async throws
 }
 
 /// The single per-user event stream surface used by `ConversationController`. Wraps the

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -129,7 +129,16 @@ struct ConversationComposer: View {
         // `.onAppear` would raise the keyboard on screen entry. Losing focus (keyboard
         // swiped down) ends composing.
         .onChange(of: model.isComposing) { _, composing in isFocused = composing }
-        .onChange(of: isFocused) { _, focused in if !focused { withAnimation(barSwapSpring) { model.isComposing = false } } }
+        .onChange(of: isFocused) { _, focused in
+            if !focused {
+                withAnimation(barSwapSpring) { model.isComposing = false }
+                if let conversationID { conversationController.stopSelfTyping(in: conversationID) }
+            }
+        }
+        .onChange(of: model.draft) { _, text in
+            guard let conversationID else { return }
+            conversationController.draftDidChange(text, in: conversationID)
+        }
     }
 
     private func send() {

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -144,7 +144,7 @@ struct ConversationScreen: View {
     /// separators). Cash branding mirrors the SwiftUI bubble: USDF reads as "Cash"; a launchpad
     /// currency uses its cached name + icon.
     private var mappedItems: [ChatItem] {
-        ChatItem.from(
+        var items = ChatItem.from(
             messages,
             selfUserID: conversationController.selfUserID,
             counterpartRead: counterpartRead.map { (pointer: $0.pointer, date: $0.date) },
@@ -154,6 +154,10 @@ struct ConversationScreen: View {
                 return (balance.name, balance.imageURL)
             }
         )
+        if let conversationID, conversationController.isCounterpartTyping(in: conversationID) {
+            items.append(.typingIndicator)
+        }
+        return items
     }
 
     /// The counterpart's read watermark + time, read live from the observable

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -439,8 +439,13 @@ private struct RecipientRowBody<Trailing: View>: View {
                         .font(.appTextSmall)
                         .foregroundStyle(Color.textSecondary)
                         .lineLimit(1)
+                        .contentTransition(.opacity)
+                        .transition(.opacity)
                 }
             }
+            // Cross-fade the subtitle when it changes — notably the "Typing…" ⇄ last-message swap, but
+            // also a fresh message preview replacing the previous one.
+            .animation(.easeInOut(duration: 0.2), value: subtitle)
             Spacer(minLength: 12)
             trailing
         }
@@ -490,6 +495,9 @@ private struct RecipientListItemRow: View {
         case .contact:
             return nil
         case .conversation(let conversation), .matched(_, let conversation):
+            if conversationController.isCounterpartTyping(in: conversation.id) {
+                return "Typing…"
+            }
             guard let message = conversation.lastMessage else { return nil }
             switch message.content {
             case .text(let text):

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
@@ -53,6 +53,12 @@ extension FlipClient {
         }
     }
 
+    public func notifyIsTyping(owner: KeyPair, conversationID: ConversationID, state: TypingState) async throws {
+        try await withCheckedThrowingContinuation { c in
+            chatMessagingService.notifyIsTyping(owner: owner, conversationID: conversationID, state: state) { c.resume(with: $0) }
+        }
+    }
+
     // MARK: - Event stream
 
     /// Start the single per-user event stream and return its decoded events.

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
@@ -105,6 +105,26 @@ final class ChatMessagingService: Sendable {
             }
         }
     }
+
+    func notifyIsTyping(owner: KeyPair, conversationID: ConversationID, state: TypingState, completion: @Sendable @escaping (Result<Void, ErrorNotifyIsTyping>) -> Void) {
+        let request = Flipcash_Messaging_V1_NotifyIsTypingRequest.with {
+            $0.chatID = conversationID.proto
+            $0.state = state.proto
+            $0.auth = owner.authFor(message: $0)
+        }
+
+        Task {
+            do {
+                let response = try await service.notifyIsTyping(request, options: .unaryDefault)
+                let error = ErrorNotifyIsTyping(rawValue: response.result.rawValue) ?? .unknown
+                await MainActor.run { completion(error == .ok ? .success(()) : .failure(error)) }
+            } catch let error as RPCError {
+                await MainActor.run { completion(.failure(.from(transportError: error))) }
+            } catch {
+                await MainActor.run { completion(.failure(.unknown)) }
+            }
+        }
+    }
 }
 
 // MARK: - Errors -
@@ -132,6 +152,13 @@ public enum ErrorAdvancePointer: Int, Error {
     case transportFailure = -2
 }
 
+public enum ErrorNotifyIsTyping: Int, Error {
+    case ok
+    case denied
+    case unknown          = -1
+    case transportFailure = -2
+}
+
 extension ErrorGetMessages: ServerError, TransportClassifiableError {
     public var isReportable: Bool {
         switch self {
@@ -154,6 +181,15 @@ extension ErrorAdvancePointer: ServerError, TransportClassifiableError {
     public var isReportable: Bool {
         switch self {
         case .ok, .denied, .messageNotFound, .transportFailure: false
+        case .unknown: true
+        }
+    }
+}
+
+extension ErrorNotifyIsTyping: ServerError, TransportClassifiableError {
+    public var isReportable: Bool {
+        switch self {
+        case .ok, .denied, .transportFailure: false
         case .unknown: true
         }
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -250,6 +250,9 @@ public struct ConversationStore: Sendable {
             for pointer in pointers {
                 advanceReadPointer(to: pointer.value, for: pointer.userID, at: pointer.date, in: conversationID)
             }
+        case .typingChanged:
+            // Typing is ephemeral UI state held by the controller, never the persisted message store.
+            break
         }
     }
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStreamEvent.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStreamEvent.swift
@@ -10,7 +10,7 @@ import FlipcashAPI
 
 /// A decoded update delivered over the single per-user event stream. The
 /// streamer demultiplexes raw `ChatUpdate`s into these so the controller can
-/// apply them without touching proto types. Typing notifications are not consumed.
+/// apply them without touching proto types.
 public enum ConversationStreamEvent: Sendable {
 
     /// New messages arrived in a conversation.
@@ -24,6 +24,11 @@ public enum ConversationStreamEvent: Sendable {
 
     /// One or more members' READ watermarks advanced.
     case readPointersChanged(conversationID: ConversationID, pointers: [MemberReadPointer])
+
+    /// One or more members started or stopped typing. Ephemeral — never persisted or part of the
+    /// event log; the controller holds it as transient UI state and the server clears it with a
+    /// stopped/timed-out notification.
+    case typingChanged(conversationID: ConversationID, notifications: [TypingNotification])
 }
 
 /// A member's READ watermark from a live pointer update: everything at or before
@@ -79,6 +84,11 @@ extension ConversationStreamEvent {
         }
         if !readPointers.isEmpty {
             events.append(.readPointersChanged(conversationID: conversationID, pointers: readPointers))
+        }
+
+        let typing = update.isTypingNotifications.isTypingNotifications.compactMap(TypingNotification.init)
+        if !typing.isEmpty {
+            events.append(.typingChanged(conversationID: conversationID, notifications: typing))
         }
 
         return events

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Typing.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Typing.swift
@@ -1,0 +1,49 @@
+//
+//  Typing.swift
+//  FlipcashCore
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+import FlipcashAPI
+
+/// A typing state the signed-in user broadcasts. The server infers the sender from auth, so only
+/// the state crosses the wire. `timedOut` is server→client only and never sent.
+public enum TypingState: Sendable, Equatable {
+    case started
+    case still
+    case stopped
+
+    var proto: Flipcash_Messaging_V1_IsTypingNotification.State {
+        switch self {
+        case .started: .startedTyping
+        case .still: .stillTyping
+        case .stopped: .stoppedTyping
+        }
+    }
+}
+
+/// A decoded typing notification for one member: `isActive` collapses the wire state to add-or-remove
+/// (started/still → add the typist, stopped/timed-out → remove). Unknown states decode to `nil`.
+public struct TypingNotification: Sendable, Hashable {
+    public let userID: UserID
+    public let isActive: Bool
+
+    public init(userID: UserID, isActive: Bool) {
+        self.userID = userID
+        self.isActive = isActive
+    }
+
+    init?(_ proto: Flipcash_Messaging_V1_IsTypingNotification) {
+        guard let userID = try? UUID(data: proto.userID.value) else { return nil }
+        switch proto.state {
+        case .startedTyping, .stillTyping:
+            self.init(userID: userID, isActive: true)
+        case .stoppedTyping, .typingTimedOut:
+            self.init(userID: userID, isActive: false)
+        case .unknownTypingState, .UNRECOGNIZED:
+            return nil
+        }
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStreamEventDecodeTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStreamEventDecodeTests.swift
@@ -139,4 +139,59 @@ struct ConversationStreamEventDecodeTests {
         #expect(ConversationStreamEvent.decode(Flipcash_Event_V1_Event.with { $0.test = .init() }).isEmpty)
         #expect(ConversationStreamEvent.decode(Flipcash_Event_V1_Event()).isEmpty)
     }
+
+    private func typing(_ user: Data, _ state: Flipcash_Messaging_V1_IsTypingNotification.State) -> Flipcash_Messaging_V1_IsTypingNotification {
+        .with { $0.userID = .with { $0.value = user }; $0.state = state }
+    }
+
+    @Test("started/still typing decodes to active notifications; stopped/timed-out to inactive; unknown is dropped")
+    func typingNotifications() throws {
+        let u1 = Data((0..<16).map { UInt8($0) })
+        let u2 = Data((16..<32).map { UInt8($0) })
+        let event = Flipcash_Event_V1_Event.with {
+            $0.chatUpdate = .with {
+                $0.chat = .with { $0.value = conversationBytes }
+                $0.isTypingNotifications = .with {
+                    $0.isTypingNotifications = [
+                        typing(u1, .startedTyping),
+                        typing(u2, .stoppedTyping),
+                        typing(u1, .unknownTypingState),
+                    ]
+                }
+            }
+        }
+
+        let decoded = ConversationStreamEvent.decode(event)
+        guard case .typingChanged(let conversationID, let notifications) = decoded.first else {
+            Issue.record("expected .typingChanged"); return
+        }
+        #expect(conversationID == ConversationID(data: conversationBytes))
+        #expect(notifications.count == 2) // unknown dropped
+        #expect(notifications.contains(TypingNotification(userID: try UUID(data: u1), isActive: true)))
+        #expect(notifications.contains(TypingNotification(userID: try UUID(data: u2), isActive: false)))
+    }
+
+    @Test("an empty typing batch produces no typing event")
+    func typingEmpty() {
+        let event = Flipcash_Event_V1_Event.with {
+            $0.chatUpdate = .with { $0.chat = .with { $0.value = conversationBytes } }
+        }
+        #expect(!ConversationStreamEvent.decode(event).contains { if case .typingChanged = $0 { true } else { false } })
+    }
+
+    @Test("messages and typing in one update decode to both events")
+    func messagesAndTyping() {
+        let u1 = Data((0..<16).map { UInt8($0) })
+        let event = Flipcash_Event_V1_Event.with {
+            $0.chatUpdate = .with {
+                $0.chat = .with { $0.value = conversationBytes }
+                $0.newMessages = .with { $0.messages = [textMessage(1, "hi")] }
+                $0.isTypingNotifications = .with { $0.isTypingNotifications = [typing(u1, .startedTyping)] }
+            }
+        }
+        let decoded = ConversationStreamEvent.decode(event)
+        #expect(decoded.count == 2)
+        #expect(decoded.contains { if case .newMessages = $0 { true } else { false } })
+        #expect(decoded.contains { if case .typingChanged = $0 { true } else { false } })
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
@@ -53,6 +53,7 @@ struct TransportClassificationTests {
     @Test func errorGetMessages() { assertClassifies(ErrorGetMessages.self) }
     @Test func errorSendMessage() { assertClassifies(ErrorSendMessage.self) }
     @Test func errorAdvancePointer() { assertClassifies(ErrorAdvancePointer.self) }
+    @Test func errorNotifyIsTyping() { assertClassifies(ErrorNotifyIsTyping.self) }
     @Test func errorGetDmChatFeed() { assertClassifies(ErrorGetDmChatFeed.self) }
     @Test func errorGetChat() { assertClassifies(ErrorGetChat.self) }
 

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -35,6 +35,85 @@ struct ConversationControllerTests {
         )
     }
 
+    @Test("a received typing notification marks the counterpart typing; self is ignored")
+    func receivesTyping() async throws {
+        let me = UUID(), them = UUID()
+        let mock = MockConversations()
+        let controller = makeController(mock, selfUserID: me)
+        controller.start()
+        try await waitUntil { mock.streamOpened }
+
+        mock.emit(.typingChanged(conversationID: .test(1), notifications: [
+            TypingNotification(userID: them, isActive: true),
+            TypingNotification(userID: me, isActive: true),
+        ]))
+        try await waitUntil { controller.isCounterpartTyping(in: .test(1)) }
+        #expect(controller.isCounterpartTyping(in: .test(1)))
+    }
+
+    @Test("a stopped notification clears the typing state")
+    func stopsTyping() async throws {
+        let them = UUID()
+        let mock = MockConversations()
+        let controller = makeController(mock)
+        controller.start()
+        try await waitUntil { mock.streamOpened }
+
+        mock.emit(.typingChanged(conversationID: .test(1), notifications: [TypingNotification(userID: them, isActive: true)]))
+        try await waitUntil { controller.isCounterpartTyping(in: .test(1)) }
+        mock.emit(.typingChanged(conversationID: .test(1), notifications: [TypingNotification(userID: them, isActive: false)]))
+        try await waitUntil { !controller.isCounterpartTyping(in: .test(1)) }
+        #expect(!controller.isCounterpartTyping(in: .test(1)))
+    }
+
+    @Test("a non-empty draft sends STARTED once; clearing it sends STOPPED")
+    func sendsTypingOnDraft() async throws {
+        let mock = MockConversations()
+        let controller = makeController(mock)
+
+        controller.draftDidChange("h", in: .test(1))
+        try await waitUntil { mock.typingCalls.contains { $0.state == .started } }
+        controller.draftDidChange("", in: .test(1))
+        try await waitUntil { mock.typingCalls.contains { $0.state == .stopped } }
+
+        let states = mock.typingCalls.map(\.state)
+        #expect(states.filter { $0 == .started }.count == 1)
+        #expect(states.last == .stopped)
+    }
+
+    @Test("stopSelfTyping sends STOPPED only when currently typing")
+    func stopSelfTypingGuarded() async throws {
+        let mock = MockConversations()
+        let controller = makeController(mock)
+
+        controller.stopSelfTyping(in: .test(1))
+        #expect(mock.typingCalls.isEmpty)
+
+        controller.draftDidChange("hey", in: .test(1))
+        try await waitUntil { mock.typingCalls.contains { $0.state == .started } }
+        controller.stopSelfTyping(in: .test(1))
+        try await waitUntil { mock.typingCalls.contains { $0.state == .stopped } }
+        #expect(mock.typingCalls.last?.state == .stopped)
+    }
+
+    @Test("clearing the draft before the typing task starts sends nothing and doesn't wedge typing")
+    func draftClearedBeforeTaskStarts() async throws {
+        let mock = MockConversations()
+        let controller = makeController(mock)
+
+        // Both calls run synchronously before the scheduled task body can take the MainActor, so the
+        // clear cancels the typing task before it ever runs — the exact fast type-then-clear race.
+        controller.draftDidChange("h", in: .test(1))
+        controller.draftDidChange("", in: .test(1))
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(mock.typingCalls.isEmpty) // no orphaned STARTED
+
+        // Typing must still work afterward (state not wedged true).
+        controller.draftDidChange("hi", in: .test(1))
+        try await waitUntil { mock.typingCalls.contains { $0.state == .started } }
+        #expect(mock.typingCalls.contains { $0.state == .started })
+    }
+
 
     @Test("loadFeed populates conversations sorted by activity")
     func loadFeed() async {

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -12,6 +12,7 @@ import FlipcashCore
 final class MockConversations: ConversationFetching, ConversationMessaging, ConversationEventStreaming, @unchecked Sendable {
 
     struct Sent: Sendable { let conversationID: ConversationID; let text: String }
+    struct TypingCall: Sendable { let conversationID: ConversationID; let state: TypingState }
 
     private let lock = NSLock()
 
@@ -25,6 +26,7 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     private var _sentClientIDs: [UUID] = []
     private var _sent: [Sent] = []
     private var _markedRead: [MessageID] = []
+    private var _typingCalls: [TypingCall] = []
     private var _didEnsure = false
     private var _didClose = false
     private var _streamContinuation: AsyncStream<ConversationStreamEvent>.Continuation?
@@ -60,6 +62,7 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     var sentClientIDs: [UUID] { lock.withLock { _sentClientIDs } }
     var sent: [Sent] { lock.withLock { _sent } }
     var markedRead: [MessageID] { lock.withLock { _markedRead } }
+    var typingCalls: [TypingCall] { lock.withLock { _typingCalls } }
     var didEnsure: Bool { lock.withLock { _didEnsure } }
     var didClose: Bool { lock.withLock { _didClose } }
     /// Whether `openConversationStream` has been called — events emitted
@@ -116,6 +119,10 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
 
     func markRead(owner: KeyPair, conversationID: ConversationID, messageID: MessageID) async throws {
         lock.withLock { _markedRead.append(messageID) }
+    }
+
+    func notifyIsTyping(owner: KeyPair, conversationID: ConversationID, state: TypingState) async throws {
+        lock.withLock { _typingCalls.append(TypingCall(conversationID: conversationID, state: state)) }
     }
 
     // MARK: - ConversationEventStreaming

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem.swift
@@ -16,11 +16,14 @@ public enum ChatItem: Hashable, Sendable, Identifiable {
     case message(ChatMessage)
     /// A centered day + time header, e.g. "Today 12:13 PM". `text` is already formatted.
     case dateSeparator(id: String, text: String)
+    /// A leading-aligned typing bubble pinned at the transcript tail while the counterpart types.
+    case typingIndicator
 
     public var id: String {
         switch self {
         case .message(let message): message.id
         case .dateSeparator(let id, _): id
+        case .typingIndicator: "typing-indicator"
         }
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatTypingIndicatorCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatTypingIndicatorCell.swift
@@ -1,0 +1,124 @@
+//
+//  ChatTypingIndicatorCell.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+
+/// Three dots in a leading incoming bubble, shown while the counterpart is typing. The bubble reuses
+/// the shared `BubbleBackgroundView` chrome (incoming fill + hairline + 12pt radius), and the dots run
+/// a repeating iMessage-style opacity wave — each brightens to `peakOpacity` in turn and settles back.
+public final class ChatTypingIndicatorCell: UICollectionViewCell {
+
+    public static let reuseIdentifier = "ChatTypingIndicatorCell"
+
+    // ── tuning knobs ──────────────────────────────────────────────────
+    /// Resting dot opacity (the design's static state: white @ 30%).
+    private static let baseOpacity: Double = 0.3
+    /// Opacity a dot rises to as the wave passes through it.
+    private static let peakOpacity: Double = 0.85
+    /// One full wave cycle, including the rest before it repeats.
+    private static let wavePeriod: Double = 1.3
+    /// Gap between neighbouring dots' rises — the wave's left-to-right speed.
+    private static let waveStagger: Double = 0.16
+    /// How long a dot takes to brighten, and to settle back down.
+    private static let dotRise: Double = 0.20
+    private static let dotFall: Double = 0.30
+    /// Beat after the cycle starts before the first dot rises.
+    private static let waveLeadIn: Double = 0.20
+    // ──────────────────────────────────────────────────────────────────
+
+    private static let dotSize: CGFloat = 7
+
+    private let bubble = BubbleBackgroundView()
+    private let dotsRow = UIStackView()
+    private var dots: [UIView] = []
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        bubble.apply(
+            fill: BubbleBackgroundView.fill(isFromSelf: false),
+            radii: BubbleBackgroundView.radii(isFromSelf: false, groupedAbove: false, groupedBelow: false)
+        )
+        bubble.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(bubble)
+
+        dotsRow.axis = .horizontal
+        dotsRow.spacing = 4
+        dotsRow.alignment = .center
+        dotsRow.translatesAutoresizingMaskIntoConstraints = false
+        bubble.addSubview(dotsRow)
+        dots = (0..<3).map { _ in
+            let dot = UIView()
+            dot.backgroundColor = .white
+            dot.layer.cornerRadius = Self.dotSize / 2
+            dot.layer.opacity = Float(Self.baseOpacity)
+            dot.translatesAutoresizingMaskIntoConstraints = false
+            dot.widthAnchor.constraint(equalToConstant: Self.dotSize).isActive = true
+            dot.heightAnchor.constraint(equalToConstant: Self.dotSize).isActive = true
+            dotsRow.addArrangedSubview(dot)
+            return dot
+        }
+
+        let trailing = bubble.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -12)
+        trailing.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            bubble.topAnchor.constraint(equalTo: contentView.topAnchor),
+            bubble.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            bubble.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
+            trailing,
+            // The bubble's own padding matches a text bubble's 12/9, plus the dot row's inner 6 vertical.
+            dotsRow.leadingAnchor.constraint(equalTo: bubble.leadingAnchor, constant: 12),
+            dotsRow.trailingAnchor.constraint(equalTo: bubble.trailingAnchor, constant: -12),
+            dotsRow.topAnchor.constraint(equalTo: bubble.topAnchor, constant: 15),
+            dotsRow.bottomAnchor.constraint(equalTo: bubble.bottomAnchor, constant: -15),
+        ])
+
+        // Returning from background strips a layer's animations; restart the wave on foreground.
+        NotificationCenter.default.addObserver(self, selector: #selector(restartAnimationIfVisible), name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    @objc private func restartAnimationIfVisible() {
+        if window != nil { startAnimating() }
+    }
+
+    /// Start the dot wave. Driven by the collection view's `willDisplay` (not the cell's
+    /// `didMoveToWindow`, which doesn't reliably re-fire across reuse): a recycled cell loses its
+    /// `CAAnimation`s, so the wave must restart on every (re)display. Idempotent — re-adding under the
+    /// same key replaces any prior copy. Each dot holds at base opacity until the wave reaches it,
+    /// brightens, settles back, then rests until the cycle repeats; all three share `wavePeriod`, so
+    /// the wave stays in phase across the row.
+    public func startAnimating() {
+        for (index, dot) in dots.enumerated() {
+            let delay = Self.waveLeadIn + Double(index) * Self.waveStagger
+            let peak = delay + Self.dotRise
+            let settle = peak + Self.dotFall
+
+            let wave = CAKeyframeAnimation(keyPath: "opacity")
+            wave.values = [Self.baseOpacity, Self.baseOpacity, Self.peakOpacity, Self.baseOpacity, Self.baseOpacity]
+            wave.keyTimes = [0, delay / Self.wavePeriod, peak / Self.wavePeriod, settle / Self.wavePeriod, 1].map { NSNumber(value: $0) }
+            wave.timingFunctions = [
+                CAMediaTimingFunction(name: .linear),
+                CAMediaTimingFunction(name: .easeInEaseOut),
+                CAMediaTimingFunction(name: .easeInEaseOut),
+                CAMediaTimingFunction(name: .linear),
+            ]
+            wave.duration = Self.wavePeriod
+            wave.repeatCount = .infinity
+            dot.layer.add(wave, forKey: "typingWave")
+        }
+    }
+
+    /// Stop the dot wave — the cell is leaving the screen.
+    public func stopAnimating() {
+        dots.forEach { $0.layer.removeAnimation(forKey: "typingWave") }
+    }
+}
+#endif

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -109,6 +109,7 @@ public final class ChatViewController: UICollectionViewController {
         collectionView.register(ChatMessageCell.self, forCellWithReuseIdentifier: ChatMessageCell.reuseIdentifier)
         collectionView.register(ChatCashCardCell.self, forCellWithReuseIdentifier: ChatCashCardCell.reuseIdentifier)
         collectionView.register(ChatDateSeparatorCell.self, forCellWithReuseIdentifier: ChatDateSeparatorCell.reuseIdentifier)
+        collectionView.register(ChatTypingIndicatorCell.self, forCellWithReuseIdentifier: ChatTypingIndicatorCell.reuseIdentifier)
         collectionView.reloadData()
     }
 
@@ -200,6 +201,11 @@ public final class ChatViewController: UICollectionViewController {
 
     public override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch items[indexPath.item] {
+        case .typingIndicator:
+            return collectionView.dequeueReusableCell(
+                withReuseIdentifier: ChatTypingIndicatorCell.reuseIdentifier,
+                for: indexPath
+            ) as! ChatTypingIndicatorCell
         case .dateSeparator(_, let text):
             let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: ChatDateSeparatorCell.reuseIdentifier,
@@ -254,6 +260,17 @@ public final class ChatViewController: UICollectionViewController {
         guard items.indices.contains(indexPath.item),
               case .message(let message) = items[indexPath.item], case .cash = message.content else { return nil }
         return message.id
+    }
+
+    /// The typing indicator's dot wave is driven here, not from the cell's `didMoveToWindow`: a recycled
+    /// cell loses its `CAAnimation`s, and `willDisplay`/`didEndDisplaying` are the reliable per-appearance
+    /// hooks, so the wave restarts every time the row is (re)inserted.
+    public override func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        (cell as? ChatTypingIndicatorCell)?.startAnimating()
+    }
+
+    public override func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        (cell as? ChatTypingIndicatorCell)?.stopAnimating()
     }
 
     // MARK: - Scrolling
@@ -400,6 +417,8 @@ extension ChatViewController {
                 return nil
             }
         case .dateSeparator:
+            return nil
+        case .typingIndicator:
             return nil
         }
 


### PR DESCRIPTION
Adds a typing indicator to chats. The signed-in user broadcasts typing while composing (started/still/stopped, matching the Android cadence), and incoming typing shows as an animated three-dot bubble in the transcript and as a fading "Typing…" in the chats list. It's ephemeral — it rides the existing event stream and is never persisted, so no schema change.

## Test plan
- [x] In a DM, have the other side type — the dots bubble appears at the bottom and clears on stop/send
- [x] The dots animate on every re-appearance (and after backgrounding the app)
- [x] Type locally — the other side sees the indicator; it stops on send, clear, or keyboard dismiss
- [x] In the chats list, a conversation with someone typing shows "Typing…" and fades back to the last message when they stop
