### PR TITLE
fix: reject stale proofs on cash sends and drop the rates stream on background

### DIFF
--- a/Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift
@@ -49,10 +49,6 @@ private let logger = Logger(label: "flipcash.send-cash")
 /// a share sheet to suppress grab-request processing underneath it.
 class SendCashOperation {
 
-    /// Submitting a proof older than this is rejected as stale, so we pre-flight the check
-    /// to fail fast and surface a specific error in logs and Bugsnag.
-    static let maxReserveAge: TimeInterval = 15 * 60
-
     enum FailurePath: String {
         case advertisement
         case stream
@@ -193,13 +189,15 @@ class SendCashOperation {
             throw error
         }
 
-        if let reserveTimestamp = transferState.reserveTimestamp {
-            let reserveAge = Date().timeIntervalSince(reserveTimestamp)
-            if reserveAge >= Self.maxReserveAge {
-                let error = Error.reserveProofStale(ageSeconds: reserveAge)
-                handleFailure(error, path: .transfer, resolution: resolution)
-                throw error
-            }
+        // Reject a proof bundle past the client freshness ceiling. `isStale`
+        // folds in both the rate and reserve protos (the older drives it), so a
+        // proof pinned at bill creation that went stale while the bill sat open
+        // — or while the app was backgrounded — is caught here instead of
+        // failing server-side as `invalidIntent`.
+        if transferState.isStale {
+            let error = Error.verifiedStateStale(ageSeconds: transferState.age)
+            handleFailure(error, path: .transfer, resolution: resolution)
+            throw error
         }
 
         do {
@@ -303,9 +301,10 @@ extension SendCashOperation {
         /// brand-new currencies that haven't been rate-cached yet.
         case missingVerifiedState
 
-        /// The resolved `VerifiedState` has a reserve-state proof older than
-        /// the server tolerates. Submitting it would be rejected — we reject
-        /// client-side to surface a specific error.
-        case reserveProofStale(ageSeconds: TimeInterval)
+        /// The resolved `VerifiedState` is past the client freshness ceiling
+        /// (`VerifiedState.clientMaxAge`) — its rate and/or reserve proof would
+        /// be rejected server-side. We reject client-side to fail fast with a
+        /// specific error instead of a generic `invalidIntent`.
+        case verifiedStateStale(ageSeconds: TimeInterval)
     }
 }

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -404,6 +404,12 @@ class Session {
         if let sendOperation, !sendOperation.ignoresStream {
             dismissCashBill(style: .slide)
         }
+
+        // Drop the live rate/reserve stream — nothing consumes it in the
+        // background and iOS suspends the socket anyway. `didBecomeActive`
+        // re-establishes it on return, keeping the lifecycle symmetric and
+        // avoiding reconnect churn during the grace window.
+        ratesController.stopStreaming()
     }
     
     // MARK: - Balance -
@@ -1312,6 +1318,13 @@ class Session {
     // MARK: - Cash Links -
     
     private func createCashLink(payload: CashCode.Payload, exchangedFiat: ExchangedFiat, verifiedState: VerifiedState) async throws -> GiftCardCluster {
+        try assertFresh(
+            verifiedState,
+            operation: "createCashLink",
+            currency: exchangedFiat.nativeAmount.currency,
+            mint: exchangedFiat.mint
+        )
+
         do {
             var vmAuthority = PublicKey.usdcAuthority
             var owner = owner

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/LiveMintDataStreamer.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/LiveMintDataStreamer.swift
@@ -73,12 +73,21 @@ public actor LiveMintDataStreamer {
         openStream()
     }
 
-    /// Ensure the stream is alive. If it died (e.g. after backgrounding),
-    /// tear it down and reopen immediately — bypassing exponential backoff.
+    /// Ensure the stream is alive on returning to the foreground. Reopens
+    /// whether it was explicitly stopped (`stop()` on background) or merely
+    /// died while the process was suspended — bypassing exponential backoff.
+    /// `subscribedMints` survives `stop()`, so the re-subscription is intact.
     public func ensureConnected() {
-        guard isStreaming, !subscribedMints.isEmpty else { return }
+        guard !subscribedMints.isEmpty else { return }
 
-        // If the stream is alive and has received a recent ping, nothing to do
+        // Stopped on background — bring streaming back up.
+        if !isStreaming {
+            isStreaming = true
+            openStream()
+            return
+        }
+
+        // Alive and recently pinged — nothing to do.
         if isLikelyHealthy, !isReconnecting {
             return
         }

--- a/FlipcashTests/VerifiedStateTests.swift
+++ b/FlipcashTests/VerifiedStateTests.swift
@@ -78,4 +78,17 @@ struct VerifiedStateTests {
     func clientMaxAge_value() {
         #expect(VerifiedState.clientMaxAge == 13 * 60)
     }
+
+    @Test("a fresh reserve proof does not rescue a stale rate proof")
+    func isStale_staleRate_freshReserve() {
+        // The bug `SendCashOperation` had: it checked only the reserve age, so a
+        // bundle with a fresh reserve but a stale rate slipped through and was
+        // rejected server-side as `invalidIntent`. `isStale` must flag it,
+        // because `serverTimestamp` takes the older (rate) proof.
+        let state = VerifiedState.makeForTest(
+            rateTimestamp: Date().addingTimeInterval(-(VerifiedState.clientMaxAge + 1)),
+            reserveTimestamp: Date()
+        )
+        #expect(state.isStale)
+    }
 }


### PR DESCRIPTION
Two small lifecycle fixes around backgrounding the live rate stream.

Face-to-face cash bills and cash links could submit an exchange-rate proof that had gone stale while the bill sat open or the app was backgrounded — the transfer only checked the reserve proof's age, never the rate, so a stale rate slipped through and came back as a server-side reject. Both paths now reject any proof past the client freshness ceiling, matching every other buy/sell/withdraw/send flow. Separately, the live rate/reserve stream is now torn down when the app backgrounds and cleanly re-established on return, instead of being left to die at suspension.

Test plan:
- [x] FlipcashTests + FlipcashCoreTests pass (568 tests), plus a new regression test pinning "fresh reserve must not rescue a stale rate"
- [x] Leave a cash bill open past ~13 min, then grab it — sender gets a clean failure, not a server invalidIntent
- [x] Background and foreground the app — balances/rates refresh and live updates resume