### PR TITLE
feat: clear a conversation's notifications when you open it

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -120,6 +120,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             sessionContainer?.contactSyncController.didBecomeActive()
             sessionContainer?.conversationController.ensureConnected()
             sessionContainer?.pushController.clearBadgeCount()
+            sessionContainer?.pushController.clearDeliveredNotifications()
         case .inactive:
             break
         @unknown default:

--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -120,7 +120,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             sessionContainer?.contactSyncController.didBecomeActive()
             sessionContainer?.conversationController.ensureConnected()
             sessionContainer?.pushController.clearBadgeCount()
-            sessionContainer?.pushController.clearDeliveredNotifications()
         case .inactive:
             break
         @unknown default:

--- a/Flipcash/Core/Controllers/PushController.swift
+++ b/Flipcash/Core/Controllers/PushController.swift
@@ -122,11 +122,16 @@ class PushController {
         center.setBadgeCount(0)
     }
 
-    /// Removes every notification already delivered to Notification Center. Called
-    /// when the app becomes active so the user isn't left with a stack of pushes
-    /// for content they're about to see in-app.
-    func clearDeliveredNotifications() {
-        center.removeAllDeliveredNotifications()
+    /// Removes delivered notifications for a single conversation from Notification
+    /// Center. Called when the user opens that conversation, so reading a thread
+    /// clears its own pushes without disturbing other chats or non-chat alerts.
+    func clearDeliveredNotifications(for conversationID: ConversationID) async {
+        let identifiers = await center.deliveredNotifications()
+            .filter { NotificationPayload.chatID($0.request.content.userInfo) == conversationID }
+            .map { $0.request.identifier }
+
+        guard !identifiers.isEmpty else { return }
+        center.removeDeliveredNotifications(withIdentifiers: identifiers)
     }
 
     // MARK: - Authorization Status -

--- a/Flipcash/Core/Controllers/PushController.swift
+++ b/Flipcash/Core/Controllers/PushController.swift
@@ -122,6 +122,13 @@ class PushController {
         center.setBadgeCount(0)
     }
 
+    /// Removes every notification already delivered to Notification Center. Called
+    /// when the app becomes active so the user isn't left with a stack of pushes
+    /// for content they're about to see in-app.
+    func clearDeliveredNotifications() {
+        center.removeAllDeliveredNotifications()
+    }
+
     // MARK: - Authorization Status -
 
     /// Re-fetches the notification authorization status from the system.

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -40,6 +40,7 @@ struct ConversationScreen: View {
     @Environment(AppRouter.self) private var router
     @Environment(Session.self) private var session
     @Environment(RatesController.self) private var ratesController
+    @Environment(PushController.self) private var pushController
 
     @State private var didInitialRead = false
     @State private var barModel = ConversationBarModel()
@@ -227,6 +228,8 @@ struct ConversationScreen: View {
             guard chatExists, let conversationID else { return }
             await conversationController.loadMessages(for: conversationID)
             await conversationController.markRead(conversationID: conversationID)
+            // Reading the thread clears its own delivered pushes; other chats keep theirs.
+            await pushController.clearDeliveredNotifications(for: conversationID)
             didInitialRead = true
         }
         .onChange(of: latestConfirmedMessage?.stableID) {


### PR DESCRIPTION
Opening a conversation now clears its own delivered notifications from Notification Center — reading a thread dismisses its pushes, while other chats and non-chat alerts (payments, contact joins) keep theirs. This replaces the earlier blanket clear-everything-on-app-open, which was too aggressive.

## Test plan
- [x] Receive chat pushes in two conversations; open one and confirm only its notifications clear, the other's remain
- [x] Confirm non-chat notifications (e.g. a payment) are untouched when opening a chat
- [x] Tap a chat notification to deep-link in and confirm that chat's notifications clear on open