### PR TITLE
feat: enlarge the unread badge on the Send icon

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
@@ -48,9 +48,8 @@ private struct LargeButtonIcon: View {
     let image: Image
     let badgeCount: Int
 
-    /// Resting size of the pill (a touch smaller than its natural size) and the
-    /// transparent gap punched around it.
-    private let badgeScale: CGFloat = 0.85
+    /// Resting scale of the pill and the transparent gap punched around it.
+    private let badgeScale: CGFloat = 1.275
     private let ring: CGFloat = 3
     private let offset = CGSize(width: 14, height: -10)
 


### PR DESCRIPTION
Makes the unread count badge on the Send button 50% larger so it's easier to notice at a glance. The badge scales uniformly from its center, so its anchor position and the surrounding icon stay put.

## Test plan
- [x] With unread conversations, the Send badge is noticeably larger
- [x] Badge still animates in/out cleanly and stays pinned to the icon's top-right corner
