### PR TITLE
refactor: use iOS 26 default search placement (bottom field)

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
@@ -66,7 +66,6 @@ struct CurrencySelectionScreen: View {
             }
             .searchable(
                 text: $viewModel.searchText,
-                placement: .navigationBarDrawer(displayMode: .always),
                 prompt: "Search Regions"
             )
             .foregroundStyle(Color.textMain)

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -39,10 +39,7 @@ struct RecipientPickerScreen: View {
     /// the list footer (limited → "Add More Contacts", denied → CTA card).
     let contactAccess: RecipientContactAccess
 
-    /// Injected from `SendRootScreen`, which owns the `.searchable`. The search
-    /// field has to be present from the moment the Send sheet mounts — a
-    /// `.searchable` added later (when the recipient list appears) gets placed by
-    /// iOS 26 as a floating bottom field instead of the nav-bar drawer.
+    /// Injected from `SendRootScreen`, which owns the `.searchable`.
     let searchText: String
 
     @Environment(ContactSyncController.self) private var contactSyncController

--- a/Flipcash/Core/Screens/Send/SendRootScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendRootScreen.swift
@@ -29,11 +29,9 @@ struct SendRootScreen: View {
         return Group {
             switch step {
             case .ready(let access):
-                // The ready state gets its own stack so `.searchable` is present
-                // from the stack's mount — that's what makes iOS 26 render the
-                // nav-bar drawer. A `.searchable` added later (gated to a step, or
-                // toggled within a shared stack) is placed as a floating bottom
-                // field instead.
+                // The ready state gets its own stack so the search field is
+                // scoped to it — the phone/contacts gating states below use a
+                // separate stack with no `.searchable`.
                 NavigationStack(path: $router[.send]) {
                     Background(color: .backgroundMain) {
                         RecipientPickerScreen(
@@ -51,7 +49,6 @@ struct SendRootScreen: View {
                     }
                     .searchable(
                         text: $searchText,
-                        placement: .navigationBarDrawer(displayMode: .always),
                         prompt: "Search Contacts"
                     )
                 }


### PR DESCRIPTION
Both searchable fields — the Send recipient picker and the Select Region sheet — were forcing the legacy top nav-bar drawer. This drops the explicit placement so they use the iOS 26 default: a floating search field at the bottom, within one-handed reach. The Send screen keeps its split-stack setup, which still scopes search to the recipient list and off the phone/contacts gating states.

## Test plan
- [x] Send → recipient picker shows search at the bottom and filters as you type
- [x] Select Region sheet shows search at the bottom
- [x] Send gating states (no phone / no contacts permission) show no search bar