### PR TITLE
refactor: replace ServerError.isReportable with three-way reportingLevel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,12 +156,15 @@ logger.info("Requested swap", metadata: [
 
 ### Error Reporting: Always Call `captureError` Unconditionally
 
-**Call `ErrorReporting.captureError(error, reason: ...)` directly — never gate it on `isReportable` at the call site.** The reporter handles that internally in `ErrorReporting.capture(_:)`:
+**Call `ErrorReporting.captureError(error, reason: ...)` directly — never gate it on `reportingLevel` at the call site.** The reporter handles that internally in `ErrorReporting.capture(_:)`, mapping the level onto Bugsnag severity (or dropping the event):
 
 ```swift
 // Inside ErrorReporting (Flipcash/Utilities/ErrorReporting.swift)
-if let serverError = error as? ServerError, !serverError.isReportable {
-    return
+let level = (error as? ServerError)?.reportingLevel ?? .error  // non-ServerError → real bug
+switch level {
+case .suppressed: return            // dropped — never sent
+case .info:       severity = .info  // visible, low-priority
+case .error:      severity = .error
 }
 ```
 
@@ -169,8 +172,7 @@ Duplicating the check at the call site is dead code and drifts from every other 
 
 ```swift
 // ❌ BAD: rechecks what ErrorReporting already filters
-let shouldReport = (error as? ServerError)?.isReportable ?? true
-if shouldReport {
+if (error as? ServerError)?.reportingLevel != .suppressed {
     ErrorReporting.captureError(error, reason: "...")
 }
 
@@ -178,7 +180,7 @@ if shouldReport {
 ErrorReporting.captureError(error, reason: "...")
 ```
 
-To suppress reporting for a specific error type, conform it to `ServerError` (in `FlipcashCore/Sources/FlipcashCore/Models/ServerError.swift`) and return `false` from `isReportable` for the non-actionable cases. That's the single source of truth — call sites stay uniform.
+To change how a specific error type surfaces, conform it to `ServerError` (in `FlipcashCore/Sources/FlipcashCore/Models/ServerError.swift`) and return the right `ErrorReportingLevel` per case — `.suppressed` for network weather / success sentinels, `.info` for expected business outcomes (denied, not-found, rate-limited), `.error` for client/proto defects (`.unknown`, parse failures). There is deliberately no protocol default — the compiler forces every new conformer to classify its cases explicitly. That's the single source of truth — call sites stay uniform.
 
 ### Form Input Validation: Use the `Validator` Family
 
@@ -277,9 +279,9 @@ Streaming RPCs run through the `BidirectionalGRPCStream` / `ServerGRPCStream` ad
 
 A gRPC transport failure (request timeout / unavailable channel) is a network condition, not a code defect — it must never reach Bugsnag. The `TransportClassifiableError` protocol carries this guarantee.
 
-- **Typed error enums:** conform the enum to `TransportClassifiableError` (give it a `.transportFailure` case — `isReportable == false` — alongside `.unknown`), then in the call's `catch` map via `ErrorX.from(transportError: rpcError)`. The single shared `from(transportError: RPCError)` default does the mapping — you don't write one per enum. Never map a timeout to a reportable `.unknown`.
-- **Associated-value error enums** (cases like `.grpcStatus(RPCError)` / `.network(Error)`): make `isReportable` return `false` when the captured error is transient (`rpcError.code.isTransientNetworkError`, or `(error as? ServerError)?.isReportable ?? true`), mirroring `ErrorSubmitIntent` / `ErrorSwap` / `ErrorStatelessSwap` / `ErrorModeration`.
-- **Unary RPCs whose failure type is the existential `Error`:** `RPCError` itself conforms to `ServerError` with `isReportable == !code.isTransientNetworkError`, so shipping the raw error via `completion(.failure(error))` classifies transient transport failures automatically — no per-call-site mapping needed.
+- **Typed error enums:** conform the enum to `TransportClassifiableError` (give it a `.transportFailure` case — which `reportingLevel` maps to `.suppressed` — alongside `.unknown`), then in the call's `catch` map via `ErrorX.from(transportError: rpcError)`. The single shared `from(transportError: RPCError)` default does the mapping — you don't write one per enum. Never map a timeout to an `.error`-level `.unknown`.
+- **Associated-value error enums** (cases like `.grpcStatus(RPCError)` / `.network(Error)`): return `.suppressed` from `reportingLevel` when the captured error is transient (`rpcError.code.isTransientNetworkError`), and forward `.grpcStatus(s)` / `.network(e)` to the inner value's `reportingLevel` (`(error as? ServerError)?.reportingLevel ?? .error`), mirroring `ErrorSubmitIntent` / `ErrorSwap` / `ErrorStatelessSwap` / `ErrorModeration`.
+- **Unary RPCs whose failure type is the existential `Error`:** `RPCError` itself conforms to `ServerError`, mapping transient codes (`isTransientNetworkError`) to `.suppressed`, `.cancelled` to `.info` (app-initiated teardown, not a defect), and all other codes to `.error`, so shipping the raw error via `completion(.failure(error))` classifies transient transport failures automatically — no per-call-site mapping needed.
 - `FlipcashCoreTests/TransportClassificationTests` asserts every conformer is wired — add a line when you add a classifiable error.
 
 ### Navigation: AppRouter

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -500,7 +500,6 @@ final class ContactSyncController {
             logger.info("Sync deferred — checksum drift (will retry on next trigger)")
         case .checksumMismatch:
             logger.error("Sync failed — checksumMismatch (algorithm divergence)")
-            await reportError(error, reason: "Contact sync checksum mismatch")
         case .denied:
             logger.warning("Sync stopped — user not registered as Flipcash")
         case .tooManyContacts:
@@ -509,8 +508,10 @@ final class ContactSyncController {
             logger.info("Sync completed with no matched contacts")
         case .unknown:
             logger.error("Sync failed — unknown error")
-            await reportError(error, reason: "Contact sync unknown error")
         }
+        // Unconditional — ErrorContactSync.reportingLevel classifies:
+        // transportFailure suppressed, business outcomes info, defects error.
+        await reportError(error, reason: "Contact sync failed")
     }
 
     nonisolated private func reportError(_ error: Error, reason: String) async {

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -588,7 +588,8 @@ final class ConversationController {
 
     /// Fire-and-forget. Deliberately not logged per-failure — typing fires every few seconds, so an
     /// offline burst would flood the log — but errors still route through `captureError`: transient ones
-    /// classify as non-reportable and are filtered, while a genuine server error surfaces.
+    /// classify as `.suppressed` and are dropped, denied surfaces at `.info`, and a genuine server
+    /// error reports at `.error`.
     private func sendTyping(_ state: TypingState, in conversationID: ConversationID) {
         Task { [messaging, owner] in
             do {

--- a/Flipcash/Core/Screens/Main/Operations/FundingOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/FundingOperation.swift
@@ -87,6 +87,10 @@ nonisolated enum FundingOperationError: Error, Equatable, Sendable {
     /// via the catch-all and falls through to Bugsnag — if this fires it's
     /// a bug or an API contract change worth investigating.
     case unexpectedFailure(reason: String)
+    /// The on-chain submit of a funding transaction failed. Deliberately
+    /// reported to Bugsnag at error severity even when the underlying cause
+    /// is a network blip — at this point money is in flight and the user's
+    /// funds may be in limbo, so every occurrence is worth investigating.
     case chainSubmitFailed(String)
 }
 

--- a/Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift
@@ -308,3 +308,12 @@ extension SendCashOperation {
         case verifiedStateStale(ageSeconds: TimeInterval)
     }
 }
+
+extension SendCashOperation.Error: ServerError {
+    var reportingLevel: ErrorReportingLevel {
+        switch self {
+        case .verifiedStateStale: .info
+        case .invalidPaymentDestinationSignature, .missingMintMetadata, .missingVerifiedState: .error
+        }
+    }
+}

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -1646,6 +1646,17 @@ extension Session {
     }
 }
 
+extension Session.Error: ServerError {
+    var reportingLevel: ErrorReportingLevel {
+        switch self {
+        // Expected outcome: a bill/share left open past VerifiedState.clientMaxAge
+        // is rejected client-side by assertFresh. Visible for triage, not a defect.
+        case .verifiedStateStale: .info
+        case .cashLinkCreationFailed, .vmMetadataMissing, .mintNotFound, .insufficientBalance, .missingSupply: .error
+        }
+    }
+}
+
 // MARK: - SufficientFundsResult -
 
 extension Session {

--- a/Flipcash/Utilities/ErrorReporting.swift
+++ b/Flipcash/Utilities/ErrorReporting.swift
@@ -68,8 +68,16 @@ enum ErrorReporting {
     private static func capture(_ error: Swift.Error, reason: String? = nil, id: String? = nil, file: String = #file, function: String = #function, line: Int = #line, buildUserInfo: (inout [String: Any]) -> Void) {
         guard isEnabled else { return }
 
-        if let serverError = error as? ServerError, !serverError.isReportable {
+        // A non-ServerError reaching the reporter is unclassified — treat as a real bug.
+        let level = (error as? ServerError)?.reportingLevel ?? .error
+        let severity: BSGSeverity
+        switch level {
+        case .suppressed:
             return
+        case .info:
+            severity = .info
+        case .error:
+            severity = .error
         }
 
         let swiftError = error as NSError
@@ -99,6 +107,8 @@ enum ErrorReporting {
         )
 
         Bugsnag.notifyError(customError) { event in
+            event.severity = severity
+
             if !event.errors.isEmpty {
                 event.errors[0].errorClass = reason ?? "\(error)"
                 event.errors[0].errorMessage = "\(error)"

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/AccountService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/AccountService.swift
@@ -182,37 +182,40 @@ public enum ErrorFetchUnauthenticatedUserFlags: Int, Error {
 }
 
 extension ErrorRegisterAccount: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .invalidSignature, .denied, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .invalidSignature, .denied: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorLoginAccount: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .invalidTimestamp, .denied, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .invalidTimestamp, .denied: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorFetchUserFlags: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorFetchUnauthenticatedUserFlags: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ActivityService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ActivityService.swift
@@ -119,19 +119,21 @@ public enum ErrorFetchTransactionHistoryItemsByID: Int, Error {
 }
 
 extension ErrorFetchTransactionHistory: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorFetchTransactionHistoryItemsByID: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .notFound, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .notFound: .info
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
@@ -160,37 +160,41 @@ public enum ErrorNotifyIsTyping: Int, Error {
 }
 
 extension ErrorGetMessages: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .notFound, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .notFound: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorSendMessage: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorAdvancePointer: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .messageNotFound, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .messageNotFound: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorNotifyIsTyping: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied: .info
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatService.swift
@@ -103,19 +103,21 @@ public enum ErrorGetChat: Int, Error {
 }
 
 extension ErrorGetDmChatFeed: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .notFound, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .notFound: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorGetChat: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .notFound, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .notFound: .info
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
@@ -322,10 +322,11 @@ public enum ErrorContactSync: Int, Error, Equatable, Sendable {
 }
 
 extension ErrorContactSync: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .tooManyContacts, .checksumDrift, .transportFailure, .notFound: false
-        case .checksumMismatch, .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .tooManyContacts, .checksumDrift, .notFound: .info
+        case .checksumMismatch, .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EmailService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EmailService.swift
@@ -148,28 +148,31 @@ public enum ErrorUnlinkEmail: Int, Error {
 }
 
 extension ErrorSendEmailCode: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .rateLimited, .invalidEmailAddress, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .rateLimited, .invalidEmailAddress: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorCheckEmailCode: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .rateLimited, .invalidCode, .noVerification, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .rateLimited, .invalidCode, .noVerification: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorUnlinkEmail: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied: .info
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ModerationService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ModerationService.swift
@@ -117,11 +117,11 @@ public enum ErrorModeration: Error, Sendable {
 }
 
 extension ErrorModeration: ServerError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .denied, .unsupportedFormat, .unsupportedLanguage: false
-        case .unknown: true
-        case .network(let error): (error as? ServerError)?.isReportable ?? true
+        case .denied, .unsupportedFormat, .unsupportedLanguage: .info
+        case .unknown: .error
+        case .network(let error): (error as? ServerError)?.reportingLevel ?? .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PhoneService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PhoneService.swift
@@ -183,37 +183,41 @@ public enum ErrorLinkForPayment: Int, Error, Equatable, Sendable {
 }
 
 extension ErrorSendVerificationCode: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .rateLimited, .invalidPhoneNumber, .unsupportedPhoneType, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .rateLimited, .invalidPhoneNumber, .unsupportedPhoneType: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorCheckVerificationCode: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .rateLimited, .invalidCode, .noVerification, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .rateLimited, .invalidCode, .noVerification: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorUnlinkPhone: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorLinkForPayment: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .notAssociated, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .notAssociated: .info
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
@@ -69,10 +69,11 @@ public enum ErrorFetchProfile: Int, Error {
 }
 
 extension ErrorFetchProfile: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .notFound, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .notFound: .info
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PushService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PushService.swift
@@ -94,19 +94,20 @@ public enum ErrorDeleteToken: Int, Error {
 }
 
 extension ErrorAddToken: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .invalidPushToken, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .invalidPushToken: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorDeleteToken: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ResolverService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ResolverService.swift
@@ -77,10 +77,11 @@ public enum ErrorResolve: Int, Error, Equatable, Sendable {
 }
 
 extension ErrorResolve: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .notFound, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .notFound: .info
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/SettingsService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/SettingsService.swift
@@ -65,10 +65,11 @@ public enum ErrorUpdateSettings: Int, Error {
 }
 
 extension ErrorUpdateSettings: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .invalidLocale, .invalidRegion, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .invalidLocale, .invalidRegion: .info
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ThirdPartyService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ThirdPartyService.swift
@@ -71,10 +71,11 @@ public enum ErrorFetchJWT: Int, Error {
 }
 
 extension ErrorFetchJWT: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .unsupportedProvider, .invalidApiKey, .phoneVerificationRequired, .emailVerificationRequired, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .unsupportedProvider, .invalidApiKey, .phoneVerificationRequired, .emailVerificationRequired: .info
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
@@ -188,10 +188,11 @@ public enum ErrorFetchBalance: Int, Error, Equatable, Sendable {
 }
 
 extension ErrorFetchBalance: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .notFound, .accountNotInList, .transportFailure: false
-        case .unknown, .parseFailed: true
+        case .ok, .transportFailure: .suppressed
+        case .notFound, .accountNotInList: .info
+        case .unknown, .parseFailed: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/CurrencyService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/CurrencyService.swift
@@ -268,20 +268,21 @@ public enum ErrorLaunchCurrency: Error, Sendable {
 }
 
 extension ErrorRateHistory: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .notFound, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .notFound: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorLaunchCurrency: ServerError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .denied, .nameExists, .invalidIcon: false
-        case .unknown: true
-        case .network(let error): (error as? ServerError)?.isReportable ?? true
+        case .denied, .nameExists, .invalidIcon: .info
+        case .unknown: .error
+        case .network(let error): (error as? ServerError)?.reportingLevel ?? .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
@@ -658,21 +658,22 @@ public enum ErrorGetSwap: Int, Error {
 }
 
 extension ErrorSwap: ServerError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .denied, .invalidSwap: false
-        case .signatureError, .unknown, .grpcError: true
-        case .grpcStatus(let status): status.isReportable
-        case .fundingIntent(let inner): inner.isReportable
+        case .denied, .invalidSwap: .info
+        case .signatureError, .unknown, .grpcError: .error
+        case .grpcStatus(let status): status.reportingLevel
+        case .fundingIntent(let inner): inner.reportingLevel
         }
     }
 }
 
 extension ErrorGetSwap: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .notFound, .denied, .transportFailure: false
-        case .unknown, .failedToParse: true
+        case .ok, .transportFailure: .suppressed
+        case .notFound, .denied: .info
+        case .unknown, .failedToParse: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -1053,11 +1053,11 @@ public enum ErrorFetchLimits: Int, Error {
 }
 
 extension ErrorSubmitIntent: ServerError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .denied, .invalidIntent, .staleState: false
-        case .signatureError, .unknown, .deviceTokenUnavailable, .grpcError: true
-        case .grpcStatus: !isTransientNetworkError
+        case .denied, .invalidIntent, .staleState: .info
+        case .signatureError, .unknown, .deviceTokenUnavailable, .grpcError: .error
+        case .grpcStatus: isTransientNetworkError ? .suppressed : .error
         }
     }
 
@@ -1072,28 +1072,30 @@ extension ErrorSubmitIntent: ServerError {
 }
 
 extension ErrorVoidGiftCard: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .denied, .claimed, .notFound, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .denied, .claimed, .notFound: .info
+        case .unknown: .error
         }
     }
 }
 
 extension ErrorFetchIntentMetadata: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .notFound, .denied, .transportFailure: false
-        case .unknown, .failedToParse: true
+        case .ok, .transportFailure: .suppressed
+        case .notFound, .denied: .info
+        case .unknown, .failedToParse: .error
         }
     }
 }
 
 extension ErrorFetchLimits: ServerError, TransportClassifiableError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
-        case .ok, .transportFailure: false
-        case .unknown: true
+        case .ok, .transportFailure: .suppressed
+        case .unknown: .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Extensions/RPCError+Extensions.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Extensions/RPCError+Extensions.swift
@@ -9,9 +9,10 @@ extension RPCError.Code {
 
     /// Whether the code represents a transient network condition (deadline
     /// expired or channel unavailable). Excludes `.cancelled`, `.aborted`,
-    /// and `.unknown` by design — those stay reportable so app cancellations
-    /// and server aborts remain visible in error tracking. Mirrors the v1
-    /// `GRPCStatus.Code.isTransientNetworkError` semantics exactly.
+    /// and `.unknown` by design — those stay visible in error tracking
+    /// (`.cancelled` at `.info` since it's app-initiated teardown, the rest
+    /// at `.error`). Mirrors the v1 `GRPCStatus.Code.isTransientNetworkError`
+    /// semantics exactly.
     public var isTransientNetworkError: Bool {
         self == .deadlineExceeded || self == .unavailable
     }
@@ -19,12 +20,20 @@ extension RPCError.Code {
 
 extension RPCError: ServerError {
 
-    /// A raw transport error is non-reportable only for transient network
-    /// conditions (`RPCError.Code.isTransientNetworkError`); every other code
-    /// stays reportable. This lets unary RPCs whose failure type is the
-    /// existential `Error` ship the error directly and still classify
-    /// correctly, without a dedicated `TransportClassifiableError` enum.
-    public var isReportable: Bool {
-        !code.isTransientNetworkError
+    /// Transient transport conditions (`RPCError.Code.isTransientNetworkError`)
+    /// are suppressed; `.cancelled` is app/user-initiated teardown (a dismissed
+    /// screen cancelling its in-flight call) so it stays visible at `.info`;
+    /// every other code is an unexpected transport/server state and reports at
+    /// `.error`. This lets unary RPCs whose failure type is the existential
+    /// `Error` ship the error directly and still classify correctly, without a
+    /// dedicated `TransportClassifiableError` enum.
+    public var reportingLevel: ErrorReportingLevel {
+        if code.isTransientNetworkError {
+            .suppressed
+        } else if code == .cancelled {
+            .info
+        } else {
+            .error
+        }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/ServerError.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/ServerError.swift
@@ -5,17 +5,26 @@
 
 import Foundation
 
-/// Marker for errors carrying a server-returned result code (denied, not-found,
-/// invalid-input, etc.). Filtered out of error reporting by default — they
-/// represent user-driven outcomes, not iOS bugs.
-///
-/// Override `isReportable` per enum to surface specific cases that *should*
-/// reach the reporter — typically `.unknown` (raw value the client doesn't
-/// recognize → proto/client drift) and wrapped non-business causes.
-public protocol ServerError: Error {
-    var isReportable: Bool { get }
+/// How an error should surface in error reporting.
+public enum ErrorReportingLevel: Sendable, Equatable {
+    /// Never sent. Network weather (transport failures) and success sentinels.
+    case suppressed
+    /// Sent at info severity. Expected, user-driven server outcomes (denied,
+    /// not-found, rate-limited) — visible for triage but not a defect.
+    case info
+    /// Sent at error severity. Client/proto defects: unrecognized codes,
+    /// parse failures, signature errors.
+    case error
 }
 
-public extension ServerError {
-    var isReportable: Bool { false }
+/// Marker for errors carrying a server-returned result code (denied, not-found,
+/// invalid-input, etc.) or an otherwise classifiable failure.
+///
+/// There is deliberately no default implementation: every conformer must place
+/// each case explicitly — `.suppressed` for network weather / success sentinels,
+/// `.info` for expected business outcomes, `.error` for client/proto defects
+/// (typically `.unknown`). A defaulted level would let a forgotten or drifted
+/// conformance compile while silently muting its errors.
+public protocol ServerError: Error {
+    var reportingLevel: ErrorReportingLevel { get }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/StatelessSwapModels.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/StatelessSwapModels.swift
@@ -109,14 +109,14 @@ public enum ErrorStatelessSwap: Error, Sendable {
 }
 
 extension ErrorStatelessSwap: ServerError {
-    public var isReportable: Bool {
+    public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .signatureError, .invalidSwap, .unknown, .grpcError:
-            return true
+            return .error
         case .denied, .transactionFailed:
-            return false
+            return .info
         case .grpcStatus(let status):
-            return status.isReportable
+            return status.reportingLevel
         }
     }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ContactSyncTypesTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ContactSyncTypesTests.swift
@@ -68,36 +68,36 @@ struct ContactSyncTypesTests {
     // MARK: - ErrorContactSync reportability -
 
     @Test(
-        "transient/recoverable cases non-reportable; only .checksumMismatch / .unknown bugsnag",
+        "ok/transport suppressed; business outcomes info; .checksumMismatch / .unknown error",
         arguments: [
-            (ErrorContactSync.ok,              false),
-            (.denied,            false),
-            (.tooManyContacts,   false),
-            (.checksumDrift,     false),
-            (.transportFailure,  false),
-            (.notFound,          false),
-            (.checksumMismatch,  true),
-            (.unknown,           true),
+            (ErrorContactSync.ok,              ErrorReportingLevel.suppressed),
+            (.denied,            .info),
+            (.tooManyContacts,   .info),
+            (.checksumDrift,     .info),
+            (.transportFailure,  .suppressed),
+            (.notFound,          .info),
+            (.checksumMismatch,  .error),
+            (.unknown,           .error),
         ]
     )
-    func contactSync_isReportable(error: ErrorContactSync, expected: Bool) {
-        #expect(error.isReportable == expected)
+    func contactSync_reportingLevel(error: ErrorContactSync, expected: ErrorReportingLevel) {
+        #expect(error.reportingLevel == expected)
     }
 
     // MARK: - ErrorResolve reportability -
 
     @Test(
-        "Resolve transient/denied/not-found cases are non-reportable; only .unknown bugsnags",
+        "Resolve ok/transport suppressed; denied/not-found info; .unknown error",
         arguments: [
-            (ErrorResolve.ok,           false),
-            (.denied,       false),
-            (.notFound,     false),
-            (.transportFailure, false),
-            (.unknown,      true),
+            (ErrorResolve.ok,           ErrorReportingLevel.suppressed),
+            (.denied,       .info),
+            (.notFound,     .info),
+            (.transportFailure, .suppressed),
+            (.unknown,      .error),
         ]
     )
-    func resolve_isReportable(error: ErrorResolve, expected: Bool) {
-        #expect(error.isReportable == expected)
+    func resolve_reportingLevel(error: ErrorResolve, expected: ErrorReportingLevel) {
+        #expect(error.reportingLevel == expected)
     }
 
     // MARK: - CheckSyncResult equality -

--- a/FlipcashCore/Tests/FlipcashCoreTests/ErrorLinkForPaymentTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ErrorLinkForPaymentTests.swift
@@ -18,13 +18,13 @@ struct ErrorLinkForPaymentTests {
         #expect(ErrorLinkForPayment(rawValue: result.rawValue) == expected)
     }
 
-    @Test("Only the unknown case is reportable")
-    func reportability() {
-        #expect(ErrorLinkForPayment.ok.isReportable == false)
-        #expect(ErrorLinkForPayment.denied.isReportable == false)
-        #expect(ErrorLinkForPayment.notAssociated.isReportable == false)
-        #expect(ErrorLinkForPayment.transportFailure.isReportable == false)
-        #expect(ErrorLinkForPayment.unknown.isReportable == true)
+    @Test("ok/transport suppressed; denied/not-associated info; only unknown errors")
+    func reportingLevel() {
+        #expect(ErrorLinkForPayment.ok.reportingLevel == .suppressed)
+        #expect(ErrorLinkForPayment.denied.reportingLevel == .info)
+        #expect(ErrorLinkForPayment.notAssociated.reportingLevel == .info)
+        #expect(ErrorLinkForPayment.transportFailure.reportingLevel == .suppressed)
+        #expect(ErrorLinkForPayment.unknown.reportingLevel == .error)
     }
 
     @Test("A result code the client doesn't model maps to nil, which the caller coalesces to .unknown")

--- a/FlipcashCore/Tests/FlipcashCoreTests/ErrorStatelessSwapTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ErrorStatelessSwapTests.swift
@@ -69,10 +69,10 @@ struct ErrorStatelessSwapTests {
         #expect(error.isUnknown)
     }
 
-    @Test("isReportable returns true for .invalidSwap regardless of reasons")
-    func isReportable_invalidSwap() {
-        #expect(ErrorStatelessSwap.invalidSwap(reasons: []).isReportable)
-        #expect(ErrorStatelessSwap.invalidSwap(reasons: ["anything"]).isReportable)
+    @Test("reportingLevel is .error for .invalidSwap regardless of reasons")
+    func reportingLevel_invalidSwap() {
+        #expect(ErrorStatelessSwap.invalidSwap(reasons: []).reportingLevel == .error)
+        #expect(ErrorStatelessSwap.invalidSwap(reasons: ["anything"]).reportingLevel == .error)
     }
 
     // MARK: - Fixture helpers

--- a/FlipcashCore/Tests/FlipcashCoreTests/ErrorSubmitIntentTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ErrorSubmitIntentTests.swift
@@ -135,7 +135,7 @@ struct ErrorSubmitIntentTests {
         }
     }
 
-    // MARK: - isTransientNetworkError / isReportable
+    // MARK: - isTransientNetworkError / reportingLevel
 
     @Test(
         "grpcStatus(.deadlineExceeded) and grpcStatus(.unavailable) are transient network errors",
@@ -145,7 +145,7 @@ struct ErrorSubmitIntentTests {
         let error = ErrorSubmitIntent.grpcStatus(RPCError(code: code, message: ""))
 
         #expect(error.isTransientNetworkError)
-        #expect(!error.isReportable)
+        #expect(error.reportingLevel == .suppressed)
     }
 
     // `.cancelled`/`.aborted`/`.unknown` are retryable per gRPC semantics
@@ -166,7 +166,7 @@ struct ErrorSubmitIntentTests {
         let error = ErrorSubmitIntent.grpcStatus(RPCError(code: code, message: ""))
 
         #expect(!error.isTransientNetworkError)
-        #expect(error.isReportable)
+        #expect(error.reportingLevel == .error)
     }
 
     @Test(

--- a/FlipcashCore/Tests/FlipcashCoreTests/ServerErrorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ServerErrorTests.swift
@@ -2,50 +2,45 @@ import Foundation
 import Testing
 @testable import FlipcashCore
 
-@Suite("ServerError reportability")
+@Suite("ServerError reporting level")
 struct ServerErrorTests {
 
-    @Test("ErrorLoginAccount reportability", arguments: [
-        (ErrorLoginAccount.denied, false),
-        (ErrorLoginAccount.invalidTimestamp, false),
-        (ErrorLoginAccount.unknown, true),
+    @Test("ErrorLoginAccount reporting level", arguments: [
+        (ErrorLoginAccount.denied, ErrorReportingLevel.info),
+        (ErrorLoginAccount.invalidTimestamp, .info),
+        (ErrorLoginAccount.unknown, .error),
     ])
-    func loginAccount_isReportable(error: ErrorLoginAccount, expected: Bool) {
-        #expect(error.isReportable == expected)
+    func loginAccount_reportingLevel(error: ErrorLoginAccount, expected: ErrorReportingLevel) {
+        #expect(error.reportingLevel == expected)
     }
 
-    @Test("ErrorRegisterAccount reportability", arguments: [
-        (ErrorRegisterAccount.denied, false),
-        (ErrorRegisterAccount.invalidSignature, false),
-        (ErrorRegisterAccount.unknown, true),
+    @Test("ErrorRegisterAccount reporting level", arguments: [
+        (ErrorRegisterAccount.denied, ErrorReportingLevel.info),
+        (ErrorRegisterAccount.invalidSignature, .info),
+        (ErrorRegisterAccount.unknown, .error),
     ])
-    func registerAccount_isReportable(error: ErrorRegisterAccount, expected: Bool) {
-        #expect(error.isReportable == expected)
+    func registerAccount_reportingLevel(error: ErrorRegisterAccount, expected: ErrorReportingLevel) {
+        #expect(error.reportingLevel == expected)
     }
 
-    @Test("ErrorSubmitIntent reportability", arguments: [
-        (ErrorSubmitIntent.denied([], messages: []), false),
-        (ErrorSubmitIntent.invalidIntent([]), false),
-        (ErrorSubmitIntent.staleState([], kinds: []), false),
-        (ErrorSubmitIntent.signatureError, true),
-        (ErrorSubmitIntent.unknown, true),
-        (ErrorSubmitIntent.deviceTokenUnavailable, true),
+    @Test("ErrorSubmitIntent reporting level", arguments: [
+        (ErrorSubmitIntent.denied([], messages: []), ErrorReportingLevel.info),
+        (ErrorSubmitIntent.invalidIntent([]), .info),
+        (ErrorSubmitIntent.staleState([], kinds: []), .info),
+        (ErrorSubmitIntent.signatureError, .error),
+        (ErrorSubmitIntent.unknown, .error),
+        (ErrorSubmitIntent.deviceTokenUnavailable, .error),
     ])
-    func submitIntent_isReportable(error: ErrorSubmitIntent, expected: Bool) {
-        #expect(error.isReportable == expected)
+    func submitIntent_reportingLevel(error: ErrorSubmitIntent, expected: ErrorReportingLevel) {
+        #expect(error.reportingLevel == expected)
     }
 
     @Test("ErrorSwap.fundingIntent delegates to wrapped ErrorSubmitIntent", arguments: [
-        (ErrorSubmitIntent.denied([], messages: []), false),
-        (ErrorSubmitIntent.signatureError, true),
+        (ErrorSubmitIntent.denied([], messages: []), ErrorReportingLevel.info),
+        (ErrorSubmitIntent.signatureError, .error),
     ])
-    func errorSwap_fundingIntentDelegates(inner: ErrorSubmitIntent, expected: Bool) {
-        #expect(ErrorSwap.fundingIntent(inner).isReportable == expected)
+    func errorSwap_fundingIntentDelegates(inner: ErrorSubmitIntent, expected: ErrorReportingLevel) {
+        #expect(ErrorSwap.fundingIntent(inner).reportingLevel == expected)
     }
 
-    @Test("Default protocol implementation returns false")
-    func defaultIsReportable_returnsFalse() {
-        struct Sample: ServerError {}
-        #expect(Sample().isReportable == false)
-    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
@@ -16,9 +16,9 @@ struct TransportClassificationTests {
     /// a generic over the concrete type (not a list of erased closures) keeps
     /// arguments `Sendable`-free and the call type-safe.
     private func assertClassifies<E: TransportClassifiableError>(_ type: E.Type) {
-        #expect(E.from(transportError: RPCError(code: .deadlineExceeded, message: "")).isReportable == false)
-        #expect(E.from(transportError: RPCError(code: .unavailable, message: "")).isReportable == false)
-        #expect(E.from(transportError: RPCError(code: .internalError, message: "")).isReportable == true)
+        #expect(E.from(transportError: RPCError(code: .deadlineExceeded, message: "")).reportingLevel == .suppressed)
+        #expect(E.from(transportError: RPCError(code: .unavailable, message: "")).reportingLevel == .suppressed)
+        #expect(E.from(transportError: RPCError(code: .internalError, message: "")).reportingLevel == .error)
     }
 
     // MARK: - Registry (one line per TransportClassifiableError conformer) -
@@ -59,39 +59,39 @@ struct TransportClassificationTests {
 
     // MARK: - Tier 2: associated-value errors that capture the transport error -
     // These don't conform to TransportClassifiableError (they carry the error in a
-    // case rather than mapping to a dedicated one), so their `isReportable` is
+    // case rather than mapping to a dedicated one), so their `reportingLevel` is
     // asserted directly.
 
     @Test("ErrorModeration.network is reportable only for non-transient errors")
     func errorModerationNetwork() {
-        #expect(ErrorModeration.network(RPCError(code: .deadlineExceeded, message: "")).isReportable == false)
-        #expect(ErrorModeration.network(RPCError(code: .internalError, message: "")).isReportable == true)
-        #expect(ErrorModeration.unknown.isReportable == true)
+        #expect(ErrorModeration.network(RPCError(code: .deadlineExceeded, message: "")).reportingLevel == .suppressed)
+        #expect(ErrorModeration.network(RPCError(code: .internalError, message: "")).reportingLevel == .error)
+        #expect(ErrorModeration.unknown.reportingLevel == .error)
     }
 
     @Test("ErrorLaunchCurrency.network is reportable only for non-transient errors")
     func errorLaunchCurrencyNetwork() {
-        #expect(ErrorLaunchCurrency.network(RPCError(code: .deadlineExceeded, message: "")).isReportable == false)
-        #expect(ErrorLaunchCurrency.network(RPCError(code: .internalError, message: "")).isReportable == true)
-        #expect(ErrorLaunchCurrency.unknown.isReportable == true)
+        #expect(ErrorLaunchCurrency.network(RPCError(code: .deadlineExceeded, message: "")).reportingLevel == .suppressed)
+        #expect(ErrorLaunchCurrency.network(RPCError(code: .internalError, message: "")).reportingLevel == .error)
+        #expect(ErrorLaunchCurrency.unknown.reportingLevel == .error)
     }
 
     @Test("ErrorSwap classifies grpcStatus by transience; grpcError always reports")
     func errorSwapClassification() {
-        #expect(ErrorSwap.grpcStatus(RPCError(code: .deadlineExceeded, message: "")).isReportable == false)
-        #expect(ErrorSwap.grpcStatus(RPCError(code: .internalError, message: "")).isReportable == true)
-        // .grpcError is the un-typed failure — deliberately reportable even for a
+        #expect(ErrorSwap.grpcStatus(RPCError(code: .deadlineExceeded, message: "")).reportingLevel == .suppressed)
+        #expect(ErrorSwap.grpcStatus(RPCError(code: .internalError, message: "")).reportingLevel == .error)
+        // .grpcError is the un-typed failure — deliberately reported even for a
         // transient-looking code, unlike the typed .grpcStatus case.
-        #expect(ErrorSwap.grpcError(RPCError(code: .unavailable, message: "")).isReportable == true)
-        #expect(ErrorSwap.unknown.isReportable == true)
+        #expect(ErrorSwap.grpcError(RPCError(code: .unavailable, message: "")).reportingLevel == .error)
+        #expect(ErrorSwap.unknown.reportingLevel == .error)
     }
 
     @Test("ErrorStatelessSwap classifies grpcStatus by transience; grpcError always reports")
     func errorStatelessSwapClassification() {
-        #expect(ErrorStatelessSwap.grpcStatus(RPCError(code: .deadlineExceeded, message: "")).isReportable == false)
-        #expect(ErrorStatelessSwap.grpcStatus(RPCError(code: .internalError, message: "")).isReportable == true)
-        #expect(ErrorStatelessSwap.grpcError(RPCError(code: .unavailable, message: "")).isReportable == true)
-        #expect(ErrorStatelessSwap.unknown.isReportable == true)
+        #expect(ErrorStatelessSwap.grpcStatus(RPCError(code: .deadlineExceeded, message: "")).reportingLevel == .suppressed)
+        #expect(ErrorStatelessSwap.grpcStatus(RPCError(code: .internalError, message: "")).reportingLevel == .error)
+        #expect(ErrorStatelessSwap.grpcError(RPCError(code: .unavailable, message: "")).reportingLevel == .error)
+        #expect(ErrorStatelessSwap.unknown.reportingLevel == .error)
     }
 
     // MARK: - Raw RPCError self-classification -
@@ -99,12 +99,13 @@ struct TransportClassificationTests {
     // directly; its `ServerError` conformance classifies transient transport
     // failures as non-reportable without a dedicated error enum.
 
-    @Test("RPCError is reportable only for non-transient codes")
+    @Test("RPCError suppresses transient codes, softens cancellation, errors the rest")
     func rpcErrorReportability() {
-        #expect(RPCError(code: .deadlineExceeded, message: "").isReportable == false)
-        #expect(RPCError(code: .unavailable, message: "").isReportable == false)
-        #expect(RPCError(code: .internalError, message: "").isReportable == true)
-        #expect(RPCError(code: .cancelled, message: "").isReportable == true)
+        #expect(RPCError(code: .deadlineExceeded, message: "").reportingLevel == .suppressed)
+        #expect(RPCError(code: .unavailable, message: "").reportingLevel == .suppressed)
+        #expect(RPCError(code: .internalError, message: "").reportingLevel == .error)
+        // App/user-initiated teardown — visible, but not a defect.
+        #expect(RPCError(code: .cancelled, message: "").reportingLevel == .info)
     }
 
     // MARK: - Real transport errors -
@@ -147,7 +148,7 @@ struct TransportClassificationTests {
 
             let rpcError = try #require(caught)
             #expect(rpcError.code == .deadlineExceeded)
-            #expect(rpcError.isReportable == false)
+            #expect(rpcError.reportingLevel == .suppressed)
 
             client.beginGracefulShutdown()
             server.beginGracefulShutdown()

--- a/FlipcashTests/Regressions/Regression_6a10ebf.swift
+++ b/FlipcashTests/Regressions/Regression_6a10ebf.swift
@@ -9,11 +9,11 @@
 //            which is reportable. Result: a Bugsnag report per cold resume
 //            that misrepresents a transport timeout as a server "unknown".
 //
-//  Fix:      Add ErrorFetchBalance.transportFailure (isReportable: false) and
-//            a static `from(transportError:)` helper that classifies gRPC
+//  Fix:      Add ErrorFetchBalance.transportFailure (reportingLevel: .suppressed)
+//            and a static `from(transportError:)` helper that classifies gRPC
 //            timeout / unavailable into it. AccountInfoService's failure paths
 //            route through the helper. ErrorReporting already honors
-//            ServerError.isReportable, so the sweep catch suppresses these
+//            ServerError.reportingLevel, so the sweep catch suppresses these
 //            reports automatically.
 //
 
@@ -25,16 +25,16 @@ import FlipcashCore
 @Suite("Regression: 6a10ebf – USDC sweep no longer reports cold-resume RPC timeouts", .bug("6a10ebfc8c3285d1a545d656"))
 struct Regression_6a10ebf {
 
-    @Test("ErrorFetchBalance reportability is correct for every case", arguments: [
-        (ErrorFetchBalance.ok,               false),
-        (ErrorFetchBalance.notFound,         false),
-        (ErrorFetchBalance.accountNotInList, false),
-        (ErrorFetchBalance.unknown,          true),
-        (ErrorFetchBalance.parseFailed,      true),
-        (ErrorFetchBalance.transportFailure, false),
+    @Test("ErrorFetchBalance reporting level is correct for every case", arguments: [
+        (ErrorFetchBalance.ok,               ErrorReportingLevel.suppressed),
+        (ErrorFetchBalance.notFound,         .info),
+        (ErrorFetchBalance.accountNotInList, .info),
+        (ErrorFetchBalance.unknown,          .error),
+        (ErrorFetchBalance.parseFailed,      .error),
+        (ErrorFetchBalance.transportFailure, .suppressed),
     ])
-    func reportability(error: ErrorFetchBalance, expected: Bool) {
-        #expect(error.isReportable == expected)
+    func reportingLevel(error: ErrorFetchBalance, expected: ErrorReportingLevel) {
+        #expect(error.reportingLevel == expected)
     }
 
     @Test("gRPC transport errors map to the right ErrorFetchBalance case", arguments: [
@@ -56,6 +56,6 @@ struct Regression_6a10ebf {
         let mapped = ErrorFetchBalance.from(transportError: error)
 
         #expect(mapped == .transportFailure)
-        #expect(mapped.isReportable == false)
+        #expect(mapped.reportingLevel == .suppressed)
     }
 }


### PR DESCRIPTION
Since the reportability boolean landed, expected server outcomes (denied, not-found, rate-limited) have been invisible in Bugsnag — dropped entirely alongside network noise. This replaces the boolean with a three-way reporting level: business outcomes now surface at Info severity, client and proto defects report at Error, and transient transport failures stay suppressed. The protocol deliberately has no default level, so a new error enum fails to compile until every case is explicitly classified — a forgotten conformance is now a build error instead of silently muted reports. Cancellations of in-flight calls soften from Error to Info, and error types introduced by the recent chat and stale-proof work are classified under the same taxonomy.

Test plan:
- [x] FlipcashCoreTests + FlipcashTests pass
- [x] AllTargets suite