### PR TITLE
fix: parse Send amounts with the locale-aware keypad parser

### DIFF
--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -46,7 +46,7 @@ final class SendAmountViewModel {
     }
 
     private var enteredFiat: ExchangedFiat? {
-        guard let amount = Decimal(string: enteredAmount),
+        guard let amount = KeyPadView.amount(from: enteredAmount),
               let selectedBalance else { return nil }
         return selectedBalance.enteredFiat(
             for: amount,
@@ -206,7 +206,7 @@ final class SendAmountViewModel {
         ) else { return nil }
 
         guard !enteredAmount.isEmpty,
-              let entered = Decimal(string: enteredAmount),
+              let entered = KeyPadView.amount(from: enteredAmount),
               entered > 0 else { return nil }
 
         let nativeEntered = FiatAmount(value: entered, currency: pin.rate.currency)

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Testing
+import FlipcashUI
 @testable import FlipcashCore
 @testable import Flipcash
 
@@ -159,6 +160,36 @@ struct SendAmountViewModelTests {
         // No resolve has happened — canSend reflects amount validity only, so a
         // red subtitle in EnterAmountView would mean over-limit, not unresolved.
         #expect(viewModel.canSend == true)
+    }
+
+    // MARK: - Locale amount parsing
+
+    // Inputs are built with `Metrics.localizedDecimalSeparator`, exactly what the
+    // keypad's decimal key inserts. On dot-decimal runners these pass trivially;
+    // only on a comma-decimal runner (simulator/device region) can they catch a
+    // parse that stops at the comma and drops the fraction.
+
+    @Test("canSend accepts a sub-unit amount typed with the locale decimal separator")
+    func canSend_localeSeparatorFraction_isTrue() {
+        let viewModel = Self.createViewModel()
+        viewModel.selectCurrencyAction(exchangedBalance: ExchangedBalance.makeTest())
+        viewModel.enteredAmount = "0\(Metrics.localizedDecimalSeparator)50"
+        #expect(viewModel.canSend == true)
+    }
+
+    @Test("prepareSubmission keeps the fraction of an amount typed with the locale decimal separator")
+    func prepareSubmission_localeSeparatorFraction_keepsFraction() async throws {
+        let container = try await Self.makeReadyToSendContainer()
+        let viewModel = SendAmountViewModel(
+            sessionContainer: container,
+            contact: Self.makeContact(),
+            mint: .usdf
+        )
+        viewModel.enteredAmount = "1\(Metrics.localizedDecimalSeparator)50"
+
+        let submission = try #require(await viewModel.prepareSubmission())
+
+        #expect(submission.amount.nativeAmount.value == Decimal(string: "1.5"))
     }
 
     // MARK: - selectCurrencyAction


### PR DESCRIPTION
On comma-decimal locales, the Send flow parsed keypad amounts with an API that stops at the comma and silently drops the fraction — typing 1,50 would send 1,00, and sub-unit amounts couldn't be sent at all. Both parse sites now use the locale-aware keypad parser, matching every sibling amount-entry flow. Two regression tests cover the affected paths, verified failing against the unfixed code with comma keypad input.

## Test plan
- [x] FlipcashTests (843) + FlipcashCoreTests (571) pass locally
- [ ] Full AllTargets suite before merge