### PR TITLE
test: rebuild ImageEncoder downsize fixture from a pixel buffer

### DIFF
--- a/FlipcashTests/ImageEncoderTests.swift
+++ b/FlipcashTests/ImageEncoderTests.swift
@@ -26,23 +26,56 @@ struct ImageEncoderTests {
 
     @Test("encode downsizes a large image to stay under budget")
     func encode_largeImage_downsizesUnderBudget() async throws {
-        // 4000x4000 image filled with noise is typically >1MB as JPEG
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 4000, height: 4000))
-        let image = renderer.image { context in
-            for y in stride(from: 0, to: 4000, by: 4) {
-                for x in stride(from: 0, to: 4000, by: 4) {
-                    UIColor(red: .random(in: 0...1),
-                            green: .random(in: 0...1),
-                            blue: .random(in: 0...1),
-                            alpha: 1).setFill()
-                    context.fill(CGRect(x: x, y: y, width: 4, height: 4))
-                }
-            }
-        }
+        let image = try makeNoiseImage(side: 2560)
+
+        // 0.3 mirrors the encoder's lowest full-size quality step: when even
+        // that encode exceeds the budget, encodeForUpload can't satisfy
+        // maxBytes without downsizing. Guards against a fixture too cheap to
+        // exercise the downsize path.
+        let smallestFullSizeEncode = try #require(image.jpegData(compressionQuality: 0.3))
+        #expect(smallestFullSizeEncode.count > 1_048_576)
 
         let data = try await ImageEncoder.encodeForUpload(image, maxBytes: 1_048_576)
 
         #expect(data.count <= 1_048_576)
         #expect(UIImage(data: data) != nil)
+    }
+
+    /// Deterministic per-pixel noise built directly from a pixel buffer.
+    /// Noise defeats JPEG compression, so a modest canvas encodes well over
+    /// the upload budget — and skipping CoreGraphics drawing keeps the
+    /// fixture cheap under Thread Sanitizer, which the test scheme enables.
+    private func makeNoiseImage(side: Int) throws -> UIImage {
+        var state: UInt64 = 0x9E3779B97F4A7C15
+        func next() -> UInt64 {
+            state &+= 0x9E3779B97F4A7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+            z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+            return z ^ (z >> 31)
+        }
+
+        var words = [UInt64](repeating: 0, count: side * side * 4 / 8)
+        for i in words.indices {
+            words[i] = next()
+        }
+
+        let data = words.withUnsafeBytes { Data($0) }
+        let provider = try #require(CGDataProvider(data: data as CFData))
+        let cgImage = try #require(CGImage(
+            width: side,
+            height: side,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: side * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            // RGBX — .noneSkipLast ignores the random fourth byte.
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        ))
+        return UIImage(cgImage: cgImage)
     }
 }


### PR DESCRIPTION
The large-image encoder test rendered a 4000×4000 canvas by filling a million random rects, which took ~43 seconds under Thread Sanitizer and got killed by the 120-second test allowance whenever the machine was busy. The fixture is now deterministic per-pixel noise built directly from a pixel buffer: it still encodes to ~2 MiB at the encoder's lowest full-size quality, so the downsize path is genuinely exercised, but the whole test finishes in under 2 seconds. A new guard assertion pins the fixture above the byte budget so a future too-cheap fixture can't silently stop testing the downsize path.

## Test plan

- [x] ImageEncoderTests passes on the iPhone 17 simulator (8 consecutive clean runs at 1.7–1.8s)
- [x] FlipcashTests and FlipcashCoreTests pass