### PR TITLE
fix: preserve coreMintFees and createdAt when rebuilding stored mint metadata

### DIFF
--- a/Flipcash/Core/Controllers/Database/Models/StoredMintMetadata.swift
+++ b/Flipcash/Core/Controllers/Database/Models/StoredMintMetadata.swift
@@ -100,7 +100,7 @@ extension StoredMintMetadata {
                 authority: authority,
                 mintVault: mintVault,
                 coreMintVault: coreMintVault,
-                coreMintFees: nil,
+                coreMintFees: coreMintFees,
                 supplyFromBonding: supplyFromBonding,
                 sellFeeBps: sellFeeBps
             )
@@ -126,7 +126,8 @@ extension StoredMintMetadata {
             vmMetadata: vmMetadata,
             launchpadMetadata: launchpadMetadata,
             socialLinks: decodedSocialLinks,
-            billColors: decodedBillColors
+            billColors: decodedBillColors,
+            createdAt: createdAt
         )
     }
 }

--- a/FlipcashTests/Database/Database+MintUpsertTests.swift
+++ b/FlipcashTests/Database/Database+MintUpsertTests.swift
@@ -10,7 +10,7 @@ import Testing
 import FlipcashCore
 @testable import Flipcash
 
-@Suite("Mint upsert preserves supplyFromBonding")
+@Suite("Mint upsert round-trips")
 struct DatabaseMintUpsertTests {
 
     // MARK: - Helpers
@@ -100,6 +100,36 @@ struct DatabaseMintUpsertTests {
         // Live supply must survive the upsert
         let stored = try #require(try db.getMintMetadata(mint: mint))
         #expect(stored.supplyFromBonding == liveSupply)
+    }
+
+    @Test("coreMintFees survives store → read → rebuilt metadata")
+    func coreMintFees_storeAndRead_preservedInRebuiltMetadata() throws {
+        let (db, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let fees = try PublicKey([UInt8](repeating: 7, count: 32))
+
+        let original = MintMetadata.makeLaunchpad(coreMintFees: fees)
+        try db.insert(mints: [original], date: .now)
+
+        let stored = try #require(try db.getMintMetadata(mint: original.address))
+        #expect(stored.coreMintFees == fees)
+
+        let rebuilt = try #require(stored.metadata.launchpadMetadata)
+        #expect(rebuilt.coreMintFees == fees)
+    }
+
+    @Test("createdAt survives store → read → rebuilt metadata")
+    func createdAt_storeAndRead_preservedInRebuiltMetadata() throws {
+        let (db, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let created = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let original = MintMetadata.makeLaunchpad(createdAt: created)
+        try db.insert(mints: [original], date: .now)
+
+        let stored = try #require(try db.getMintMetadata(mint: original.address))
+        #expect(stored.createdAt == created)
+        #expect(stored.metadata.createdAt == created)
     }
 
     @Test("Balance is visible after mint upsert without launchpadMetadata")

--- a/FlipcashTests/TestSupport/MintMetadata+TestSupport.swift
+++ b/FlipcashTests/TestSupport/MintMetadata+TestSupport.swift
@@ -3,12 +3,15 @@
 //  FlipcashTests
 //
 
+import Foundation
 import FlipcashCore
 
 extension MintMetadata {
     static func makeLaunchpad(
         address: PublicKey = .jeffy,
-        supplyFromBonding: UInt64 = 50_000 * 10_000_000_000
+        supplyFromBonding: UInt64 = 50_000 * 10_000_000_000,
+        coreMintFees: PublicKey? = nil,
+        createdAt: Date? = nil
     ) -> MintMetadata {
         MintMetadata(
             address: address,
@@ -29,10 +32,11 @@ extension MintMetadata {
                 authority: .usdcAuthority,
                 mintVault: .usdc,
                 coreMintVault: .usdc,
-                coreMintFees: nil,
+                coreMintFees: coreMintFees,
                 supplyFromBonding: supplyFromBonding,
                 sellFeeBps: 100
-            )
+            ),
+            createdAt: createdAt
         )
     }
 


### PR DESCRIPTION
Rebuilding a mint's metadata from its stored database row hardcoded the core mint fees address to nil and dropped the creation date, while the write path persists both — data the database has was silently lost on read. Both fields now pass through. Nothing user-facing reads either field from the rebuilt copy yet (the currency info screen reads the creation date from the stored row directly, and the fees address stays dormant until the vendored proto picks up the field upstream already marks required), so this is a correctness fix ahead of visibility.

Test plan:
- [x] New round-trip tests: store → read → rebuilt metadata preserves coreMintFees and createdAt (both watched fail before the fix)
- [x] FlipcashTests + FlipcashCoreTests pass