### PR TITLE
fix: normalize chat diffing algorithm

### DIFF
--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -622,7 +622,7 @@ private struct RecipientSectionHeader: View {
             .font(.appTextSmall)
             .foregroundStyle(Color.textSecondary)
             .padding(.horizontal, 20)
-            .padding(.vertical, 8)
+            .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.backgroundMain)
             .listRowInsets(EdgeInsets())

--- a/FlipcashTests/Chat/ChatChangesetFlatteningTests.swift
+++ b/FlipcashTests/Chat/ChatChangesetFlatteningTests.swift
@@ -1,0 +1,113 @@
+//
+//  ChatChangesetFlatteningTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import DifferenceKit
+import FlipcashCore
+@testable import FlipcashUI
+
+/// `StagedChangeset.flattenIfPossible` must merge DifferenceKit's staged changesets into a single
+/// changeset whenever no moves are involved, so the transcript applies one `performBatchUpdates`
+/// with one keep-at-bottom compensation. Split stages run as overlapping animated batch updates,
+/// which is what made cells slide in from random directions when a receipt or grouping change
+/// landed together with an insert.
+@MainActor
+@Suite("Chat changeset flattening")
+struct ChatChangesetFlatteningTests {
+
+    private func message(
+        _ id: String,
+        sender: ChatMessage.Sender = .me,
+        continuedByNext: Bool = false,
+        continuationFromPrevious: Bool = false,
+        receipt: String? = nil
+    ) -> ChatItem {
+        .message(ChatMessage(
+            id: id,
+            text: "text-\(id)",
+            sender: sender,
+            isContinuationFromPrevious: continuationFromPrevious,
+            isContinuedByNext: continuedByNext,
+            receipt: receipt
+        ))
+    }
+
+    @Test("A send (previous-row update + insert) flattens to a single changeset")
+    func updateAndInsert_flattensToOne() {
+        // A new own message migrates the receipt off the previous row and flips its grouping —
+        // an update — while the new row is an insert. DifferenceKit stages these separately.
+        let before = [message("a", receipt: "Delivered")]
+        let after = [
+            message("a", continuedByNext: true),
+            message("b", continuationFromPrevious: true, receipt: "Delivered"),
+        ]
+
+        let staged = StagedChangeset(source: before, target: after)
+        #expect(staged.count == 2, "premise: DifferenceKit stages [updates]+[inserts] separately")
+
+        let flattened = staged.flattenIfPossible()
+        #expect(flattened.count == 1)
+        guard let merged = flattened.first else { return }
+        #expect(merged.elementUpdated == [ElementPath(element: 0, section: 0)])
+        #expect(merged.elementInserted == [ElementPath(element: 1, section: 0)])
+        #expect(merged.elementDeleted.isEmpty)
+        #expect(merged.elementMoved.isEmpty)
+        #expect(merged.data == after)
+    }
+
+    @Test("An arrival while typing (update + delete + insert) flattens to a single changeset")
+    func updateDeleteAndInsert_flattensToOne() {
+        // The typing indicator clears (delete), the reply lands (insert), and the previous row's
+        // grouping flips (update) — three DifferenceKit stages in one push.
+        let before = [message("a", sender: .other), .typingIndicator]
+        let after = [
+            message("a", sender: .other, continuedByNext: true),
+            message("b", sender: .other, continuationFromPrevious: true),
+        ]
+
+        let staged = StagedChangeset(source: before, target: after)
+        #expect(staged.count == 3, "premise: DifferenceKit stages [updates]+[deletes]+[inserts] separately")
+
+        let flattened = staged.flattenIfPossible()
+        #expect(flattened.count == 1)
+        guard let merged = flattened.first else { return }
+        #expect(merged.elementUpdated == [ElementPath(element: 0, section: 0)])
+        #expect(merged.elementDeleted == [ElementPath(element: 1, section: 0)])
+        #expect(merged.elementInserted == [ElementPath(element: 1, section: 0)])
+        #expect(merged.elementMoved.isEmpty)
+        #expect(merged.data == after)
+    }
+
+    @Test("A pure delete + insert pair still flattens to a single changeset")
+    func deleteAndInsert_stillFlattensToOne() {
+        // The pre-existing behavior (typing indicator swaps for a message with no other change).
+        let before = [message("a", sender: .other), .typingIndicator]
+        let after = [message("a", sender: .other), message("b", sender: .other)]
+
+        let flattened = StagedChangeset(source: before, target: after).flattenIfPossible()
+        #expect(flattened.count == 1)
+        guard let merged = flattened.first else { return }
+        #expect(merged.elementDeleted == [ElementPath(element: 1, section: 0)])
+        #expect(merged.elementInserted == [ElementPath(element: 1, section: 0)])
+        #expect(merged.data == after)
+    }
+
+    @Test("Stages containing moves are left un-flattened")
+    func moves_areNotFlattened() {
+        // A move's source index is relative to the post-delete stage, not the original source, so
+        // merging would corrupt indices. Reorders never happen in a transcript; keep them staged.
+        let before = [message("a"), message("b")]
+        let after = [message("b"), .message(ChatMessage(id: "a", text: "edited", sender: .me))]
+
+        let staged = StagedChangeset(source: before, target: after)
+        #expect(staged.contains { !$0.elementMoved.isEmpty }, "premise: a reorder diffs to a move")
+
+        let flattened = staged.flattenIfPossible()
+        #expect(flattened.count == staged.count)
+        #expect(flattened.contains { !$0.elementMoved.isEmpty })
+    }
+}

--- a/FlipcashTests/Chat/ChatViewControllerTests.swift
+++ b/FlipcashTests/Chat/ChatViewControllerTests.swift
@@ -65,6 +65,60 @@ struct ChatViewControllerTests {
         #expect(controller.collectionView.numberOfItems(inSection: 0) == 11)
     }
 
+    @Test("A send's receipt migration + grouping flip + insert applies as one batch")
+    func update_receiptMigrationWithInsert_appliesInOneBatch() async {
+        // A new own message updates the previous row (receipt migrates off it, isContinuedByNext
+        // flips) in the same push that inserts the new row. On a live window this must apply as a
+        // single batch update — reconfigure + insert together — without throwing or dropping rows.
+        let controller = ChatViewController()
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+
+        let before = (0..<8).map { item($0, $0.isMultiple(of: 2) ? .me : .other) } + [
+            .message(ChatMessage(id: "sent-1", text: "first send", sender: .me, receipt: "Delivered")),
+        ]
+        controller.update(items: before)
+        for _ in 0..<3 {
+            controller.view.layoutIfNeeded()
+            try? await Task.sleep(for: .milliseconds(40))
+        }
+
+        let after = (0..<8).map { item($0, $0.isMultiple(of: 2) ? .me : .other) } + [
+            .message(ChatMessage(id: "sent-1", text: "first send", sender: .me, isContinuedByNext: true)),
+            .message(ChatMessage(id: "sent-2", text: "second send", sender: .me, isContinuationFromPrevious: true, receipt: "Delivered")),
+        ]
+        controller.update(items: after)
+        #expect(controller.collectionView.numberOfItems(inSection: 0) == after.count)
+    }
+
+    @Test("An arrival while typing (update + delete + insert) applies as one batch")
+    func update_arrivalWhileTyping_appliesInOneBatch() async {
+        // The riskiest merged shape: the typing indicator deletes, the reply inserts at the same
+        // position, and the previous row reconfigures — all in one batch on a live window.
+        let controller = ChatViewController()
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+
+        let before: [ChatItem] = (0..<8).map { item($0, $0.isMultiple(of: 2) ? .me : .other) } + [
+            .message(ChatMessage(id: "them-1", text: "typing next", sender: .other)),
+            .typingIndicator,
+        ]
+        controller.update(items: before)
+        for _ in 0..<3 {
+            controller.view.layoutIfNeeded()
+            try? await Task.sleep(for: .milliseconds(40))
+        }
+
+        let after: [ChatItem] = (0..<8).map { item($0, $0.isMultiple(of: 2) ? .me : .other) } + [
+            .message(ChatMessage(id: "them-1", text: "typing next", sender: .other, isContinuedByNext: true)),
+            .message(ChatMessage(id: "them-2", text: "the reply", sender: .other, isContinuationFromPrevious: true)),
+        ]
+        controller.update(items: after)
+        #expect(controller.collectionView.numberOfItems(inSection: 0) == after.count)
+    }
+
     @Test("Opens at the bottom (newest message) on first layout")
     func opensAtBottom() async {
         let controller = ChatViewController()

--- a/FlipcashUI/Sources/FlipcashUI/Chat/UICollectionView+Reload.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/UICollectionView+Reload.swift
@@ -78,18 +78,27 @@ extension UICollectionView {
 
 extension StagedChangeset {
 
-    /// DifferenceKit splits actions into separate changesets to work around `UICollectionView`
-    /// limitations, which can leave the layout unable to see that an insert and delete happen
-    /// together. Deletions and insertions can be processed together, so flatten that case.
+    /// DifferenceKit packages one diff into up to three stages — `[updates]`, `[deletes]`,
+    /// `[inserts+moves]` — applied as separate batch updates. Applied that way, a receipt or
+    /// grouping change landing with an insert runs 2–3 overlapping animated batch updates, and
+    /// `CollectionViewChatLayout` computes its keep-at-bottom compensation per batch — the overlap
+    /// is what slid transcript cells in from random directions.
+    ///
+    /// Merging is index-safe whenever no stage carries moves or section changes: updated and
+    /// deleted indices come out of the single underlying diff in *source* coordinates and inserted
+    /// indices in *target* coordinates — exactly the before/after semantics of one
+    /// `performBatchUpdates`. A move's source index is relative to the post-delete stage instead,
+    /// so any stage with moves keeps the staged application.
     func flattenIfPossible() -> StagedChangeset {
-        if count == 2,
-           self[0].sectionChangeCount == 0,
-           self[1].sectionChangeCount == 0,
-           self[0].elementDeleted.count == self[0].elementChangeCount,
-           self[1].elementInserted.count == self[1].elementChangeCount {
-            return StagedChangeset(arrayLiteral: Changeset(data: self[1].data, elementDeleted: self[0].elementDeleted, elementInserted: self[1].elementInserted))
-        }
-        return self
+        guard count > 1,
+              let target = last?.data,
+              allSatisfy({ $0.sectionChangeCount == 0 && $0.elementMoved.isEmpty }) else { return self }
+        return StagedChangeset(arrayLiteral: Changeset(
+            data: target,
+            elementDeleted: flatMap(\.elementDeleted),
+            elementInserted: flatMap(\.elementInserted),
+            elementUpdated: flatMap(\.elementUpdated)
+        ))
     }
 }
 #endif


### PR DESCRIPTION
Chat bubbles slid in from the top or bottom at random whenever a new message landed together with a receipt or grouping change — which is nearly every send and reply. DifferenceKit stages updates, deletes, and inserts as separate changesets, so one push ran two or three overlapping animated batch updates, each computing its own bottom-anchoring compensation mid-flight of the previous one.

The staged changesets are now merged into a single batch update whenever no moves are involved (updated/deleted indices are source-space and inserted indices target-space, which is exactly one batch's semantics), so the whole change animates as one transaction with one compensation. Reorders keep the staged path.

## Test plan

- [x] Changeset flattening unit tests cover update+insert, update+delete+insert, the legacy delete+insert pair, and the move fallback
- [x] Windowed transcript tests apply the merged shapes against a live collection view
- [x] FlipcashTests + FlipcashCoreTests pass
- [x] Manual: send and receive with the typing indicator up and receipts migrating — bubbles animate coherently instead of sliding from random edges