### PR TITLE
refactor: load chat cash card coin icon through Kingfisher

### DIFF
--- a/Flipcash/Keychain/Defaults.swift
+++ b/Flipcash/Keychain/Defaults.swift
@@ -19,8 +19,6 @@ enum DefaultsKey: String {
 
     case storedTokenMint = "com.flipcash.token.storedTokenMint"
 
-    case didClearLegacyImageDiskCache = "com.flipcash.image.didClearLegacyDiskCache"
-
     case betaFlags = "com.flipcash.betaFlags"
 }
 

--- a/FlipcashUI/Package.swift
+++ b/FlipcashUI/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(path: "../FlipcashCore"),
         .package(url: "https://github.com/ekazaev/ChatLayout", from: "2.4.2"),
         .package(url: "https://github.com/ra1028/DifferenceKit", from: "1.3.0"),
+        .package(url: "https://github.com/onevcat/Kingfisher", from: "8.3.0"),
     ],
     targets: [
         .target(
@@ -26,6 +27,7 @@ let package = Package(
                 .product(name: "FlipcashCore", package: "FlipcashCore"),
                 .product(name: "ChatLayout", package: "ChatLayout", condition: .when(platforms: [.iOS])),
                 .product(name: "DifferenceKit", package: "DifferenceKit"),
+                .product(name: "Kingfisher", package: "Kingfisher"),
             ],
             resources: [
                 .process("Assets")

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -8,6 +8,7 @@
 #if canImport(UIKit)
 import UIKit
 import FlipcashCore
+import Kingfisher
 
 /// A recycled cell for a cash payment row: a fixed-size card (shared `BubbleBackgroundView` chrome)
 /// with the token name + optional coin icon in the top-left and a centered "You sent / You received"
@@ -26,7 +27,6 @@ public final class ChatCashCardCell: ChatColumnCell {
     private let flag = UIImageView()
     private let captionLabel = UILabel()
     private let amountLabel = UILabel()
-    private var iconTask: Task<Void, Never>?
 
     /// Dim the card while pressed so the tap-to-open-currency-info affordance reads as a button.
     /// Driven by the collection view's selection machinery (`shouldHighlightItemAt`), not a gesture.
@@ -112,7 +112,7 @@ public final class ChatCashCardCell: ChatColumnCell {
 
     public override func prepareForReuse() {
         super.prepareForReuse()
-        iconTask?.cancel()
+        coinIcon.kf.cancelDownloadTask()
         coinIcon.image = nil
     }
 
@@ -126,16 +126,8 @@ public final class ChatCashCardCell: ChatColumnCell {
         flag.image = flagImage
         flag.isHidden = flagImage == nil
 
-        iconTask?.cancel()
-        coinIcon.image = nil
         coinIcon.isHidden = cash.iconURL == nil
-        if let url = cash.iconURL {
-            iconTask = Task { [weak self] in
-                guard let data = try? await URLSession.shared.data(from: url).0,
-                      let image = UIImage(data: data) else { return }
-                self?.coinIcon.image = image
-            }
-        }
+        coinIcon.kf.setImage(with: cash.iconURL)
 
         card.apply(
             fill: BubbleBackgroundView.fill(isFromSelf: message.sender == .me),

--- a/FlipcashUI/Sources/FlipcashUI/Images/RemoteImage.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Images/RemoteImage.swift
@@ -1,6 +1,6 @@
 //
 //  RemoteImage.swift
-//  Code
+//  FlipcashUI
 //
 //  Created by Dima Bart on 2025-10-24.
 //
@@ -8,15 +8,15 @@
 import Kingfisher
 import SwiftUI
 
-struct RemoteImage: View {
-    
+public struct RemoteImage: View {
+
     let url: URL?
 
-    init(url: URL?) {
+    public init(url: URL?) {
         self.url = url
     }
-    
-    var body: some View {
+
+    public var body: some View {
         KFImage(url)
             .placeholder { Circle().fill(Color.black.opacity(0.5)) }
             .resizable()

--- a/FlipcashUI/Sources/FlipcashUI/Images/RemoteImageCache.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Images/RemoteImageCache.swift
@@ -1,17 +1,19 @@
 //
 //  RemoteImageCache.swift
-//  Code
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
 //
 
 import Foundation
 import Kingfisher
 
-enum RemoteImageCache {
+public enum RemoteImageCache {
 
     /// Configures remote-image caching so an image's lifetime follows the server's HTTP
     /// headers — `Cache-Control`/`Expires` for freshness, `ETag` for revalidation —
     /// instead of being cached indefinitely. Call once at launch.
-    static func install() {
+    public static func install() {
         // The system URLCache is the persistent, revalidating layer: it stores responses
         // on disk and issues conditional GETs (`If-None-Match`) so a changed image is
         // refetched rather than served forever. Kingfisher's downloader defaults to an
@@ -45,17 +47,27 @@ enum RemoteImageCache {
     /// prior build still serves from Kingfisher's disk and masks the URLCache. Purge it
     /// once so existing installs pick up the current server image.
     private static func clearLegacyDiskCacheIfNeeded() {
-        guard UserDefaults.didClearLegacyImageDiskCache != true else { return }
+        guard !didClearLegacyDiskCache else { return }
         ImageCache.default.clearDiskCache {
-            Task { @MainActor in UserDefaults.didClearLegacyImageDiskCache = true }
+            Task { @MainActor in didClearLegacyDiskCache = true }
         }
     }
-}
 
-// MARK: - UserDefaults -
+    // MARK: - Purge flag -
 
-extension UserDefaults {
+    private static let didClearLegacyDiskCacheKey = "com.flipcash.image.didClearLegacyDiskCache"
 
-    @Defaults(.didClearLegacyImageDiskCache)
-    fileprivate static var didClearLegacyImageDiskCache: Bool?
+    /// Stored as JSON-encoded `Data` — the format existing installs already have under this
+    /// key; reading it as a plain bool would re-run the purge.
+    private static var didClearLegacyDiskCache: Bool {
+        get {
+            UserDefaults.standard.data(forKey: didClearLegacyDiskCacheKey)
+                .flatMap { try? JSONDecoder().decode(Bool.self, from: $0) } ?? false
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue) {
+                UserDefaults.standard.set(data, forKey: didClearLegacyDiskCacheKey)
+            }
+        }
+    }
 }

--- a/NotificationContent/NotificationTranscriptView.swift
+++ b/NotificationContent/NotificationTranscriptView.swift
@@ -204,8 +204,9 @@ private struct NotificationCashCenter: View {
     }
 }
 
-/// Asynchronously loads a circular 13pt coin icon for a launchpad token, mirroring
-/// `ChatCashCardCell`'s lightweight `URLSession` fetch.
+/// Asynchronously loads a circular 13pt coin icon for a launchpad token via a bare
+/// `URLSession` fetch — the extension deliberately skips Kingfisher's cache stack
+/// (which `ChatCashCardCell` uses) to keep its memory footprint minimal.
 private struct NotificationCoinIcon: View {
 
     let url: URL


### PR DESCRIPTION
The chat cash card cell loaded its coin icon with a hand-rolled URLSession task, bypassing the shared Kingfisher stack the rest of the app uses — every cell recycle refetched the icon, and a slow response could land a stale icon on a reused cell. FlipcashUI now depends on the workspace's existing Kingfisher pin and the cell loads through it, picking up the app-wide HTTP cache policy, in-flight request dedupe, and reuse-safe cancellation. With the dependency in the package, RemoteImage and the cache configuration moved from the app target into FlipcashUI so the policy and all its consumers live in one module; the one-time purge flag keeps its existing storage key and format. The notification extension deliberately keeps its bare URLSession loader for memory-budget reasons.

## Test plan
- [x] Open a chat with launchpad-token cash cards and confirm coin icons render correctly while scrolling
- [x] Currency discovery, select-currency, withdraw summary, and cash-received modal still show remote icons
- [x] AllTargets suite passes