### PR TITLE
fix: refetch the open conversation when its chat push is suppressed

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -187,6 +187,22 @@ final class ConversationController {
         }
     }
 
+    /// A foreground chat push arrived for the on-screen conversation and its banner was
+    /// suppressed. The push is positive evidence the message exists server-side, but the
+    /// event stream may not have delivered it: a dropped stream can sit in reconnect backoff
+    /// for tens of seconds (the server rejects re-opens with "stream already exists" while it
+    /// still holds the zombie), or the stream can wedge silently open. The payload carries no
+    /// message id to check against the store, so refetch the newest window unconditionally —
+    /// when the stream already delivered the message, the merge is a no-op.
+    func refetchForSuppressedPush(_ conversationID: ConversationID) {
+        logger.info("Refetching after a suppressed chat push", metadata: [
+            "conversationID": "\(conversationID)",
+        ])
+        Task {
+            await loadMessages(for: conversationID)
+        }
+    }
+
     /// Surfaces a counterpart's READ pointer advance — the signal behind the
     /// "Read 3:42 PM" receipt — so it can be traced in the log stream.
     private func logCounterpartRead(_ event: ConversationStreamEvent) {

--- a/Flipcash/Core/Controllers/PushController.swift
+++ b/Flipcash/Core/Controllers/PushController.swift
@@ -35,6 +35,14 @@ class PushController {
         set { delegate.isViewingConversation = newValue }
     }
 
+    /// Fired after a chat push for the on-screen conversation is suppressed — the cue to
+    /// refetch that conversation: the push proves a message exists server-side that the
+    /// event stream may not have delivered.
+    var didSuppressChatPush: (@MainActor (ConversationID) -> Void)? {
+        get { delegate.didSuppressChatPush }
+        set { delegate.didSuppressChatPush = newValue }
+    }
+
     @ObservationIgnored private let owner: KeyPair
     @ObservationIgnored private let client: FlipClient
     @ObservationIgnored private let center: UNUserNotificationCenter
@@ -230,6 +238,7 @@ private class NotificationDelegate: NSObject, @preconcurrency UNUserNotification
     
     var didReceiveFCMToken: (@MainActor (String?) async throws -> Void)?
     var isViewingConversation: (@MainActor (ConversationID) -> Bool)?
+    var didSuppressChatPush: (@MainActor (ConversationID) -> Void)?
 
     override init() {
         super.init()
@@ -266,6 +275,10 @@ private class NotificationDelegate: NSObject, @preconcurrency UNUserNotification
             logger.info("Suppressing chat push for the open conversation", metadata: [
                 "conversationID": "\(conversationID)",
             ])
+            // The suppressed push is positive evidence of a message the event stream may not
+            // have delivered (down mid-backoff, or wedged silently open) — cue the owner to
+            // refetch the on-screen conversation right away.
+            didSuppressChatPush?(conversationID)
             return []
         }
 

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -546,6 +546,13 @@ final class SessionContainer {
             conversationController?.visibleConversationID == conversationID
         }
 
+        // A suppressed chat push is positive evidence of a message the store may have
+        // missed — refetch the on-screen conversation immediately instead of waiting out
+        // the stream's reconnect backoff (or a silently wedged stream).
+        pushController.didSuppressChatPush = { [weak conversationController] conversationID in
+            conversationController?.refetchForSuppressedPush(conversationID)
+        }
+
         let chatSpotlightIndexer = ChatSpotlightIndexer(
             controller: conversationController,
             contactSyncController: contactSyncController

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -466,6 +466,37 @@ struct ConversationControllerTests {
         controller.stop()
     }
 
+    @Test("a suppressed chat push refetches the on-screen conversation, catching up a message the stream never delivered")
+    func suppressedPushCatchesUpVisibleTranscript() async throws {
+        let mock = MockConversations()
+        mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
+        mock.messages = [ConversationMessage(id: MessageID(value: 1), senderID: nil, content: .text("one"), date: Date(timeIntervalSince1970: 10), unreadSeq: 1)]
+        let controller = makeController(mock)
+
+        controller.start()
+        try await waitUntil { mock.streamOpened }
+
+        // Open the chat: load its first page and mark it visible (as the screen does).
+        await controller.loadMessages(for: ConversationID.test(1))
+        controller.visibleConversationID = ConversationID.test(1)
+        try #require(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [1])
+
+        // A newer message lands server-side but its live event is never delivered — the
+        // stream is down mid-backoff or wedged silently open. Its push still arrives, gets
+        // suppressed for the open conversation, and triggers the refetch.
+        mock.messages = [
+            ConversationMessage(id: MessageID(value: 1), senderID: nil, content: .text("one"), date: Date(timeIntervalSince1970: 10), unreadSeq: 1),
+            ConversationMessage(id: MessageID(value: 2), senderID: nil, content: .text("two"), date: Date(timeIntervalSince1970: 20), unreadSeq: 2),
+        ]
+        controller.refetchForSuppressedPush(ConversationID.test(1))
+
+        // The refetch pulls the newest page and the missed message appears without
+        // waiting for any stream reconnect.
+        try await waitUntil { controller.messages(for: ConversationID.test(1)).map(\.id.value) == [1, 2] }
+        #expect(mock.latestPageQueries == [ConversationID.test(1), ConversationID.test(1)])
+        controller.stop()
+    }
+
     @Test("a reconnect refreshes the feed even with no conversation open")
     func reconnectRefreshesFeed() async throws {
         let mock = MockConversations()


### PR DESCRIPTION
When the chat event stream drops, the server can reject reconnects for tens of seconds, and messages sent in that window reach the device only as push notifications — which we suppress for the conversation on screen, so the transcript silently misses them until the stream recovers. A suppressed push now doubles as a recovery signal: it immediately refetches the open conversation, since the push itself proves a message arrived that the stream may not have delivered.

## Test plan

- [ ] Unit test: a message with no stream event appears after a suppressed push
- [ ] Manually confirm a message sent while the stream is down appears right away
- [x] FlipcashTests + FlipcashCoreTests pass