### PR TITLE
feat: auto-advance phone verification once the number is valid

### DIFF
--- a/Flipcash/Core/Screens/PhoneVerification/EnterPhoneScreen.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/EnterPhoneScreen.swift
@@ -90,6 +90,16 @@ struct EnterPhoneScreen<VM: PhoneVerifying>: View {
             try? await Task.sleep(for: .milliseconds(100))
             isFocused = true
         }
+        .onChange(of: viewModel.enteredPhone) { _, _ in
+            // Advance as soon as the number is valid — a completed or pasted
+            // number submits without a manual "Next" tap, mirroring the code
+            // screen's auto-submit. The button-state guard stops a re-fire while
+            // a request is already in flight.
+            if viewModel.canSendVerificationCode, viewModel.sendCodeButtonState == .normal {
+                isFocused = false
+                viewModel.sendPhoneNumberCodeAction()
+            }
+        }
     }
 
     // MARK: - Actions -

--- a/FlipcashTests/PhoneVerificationViewModelTests.swift
+++ b/FlipcashTests/PhoneVerificationViewModelTests.swift
@@ -21,6 +21,29 @@ struct PhoneVerificationViewModelTests {
         #expect(viewModel.phone?.e164 == "+14155550100")
     }
 
+    @Test("A pasted full +1 number is valid, so auto-advance fires")
+    func pastedInternationalNumber_isValid() {
+        let viewModel = PhoneVerificationViewModel(owner: .mock, flipClient: .mock)
+        viewModel.setRegion(.us)
+
+        // A whole-string binding set is exactly what SwiftUI delivers on paste.
+        viewModel.adjustingPhoneNumberBinding.wrappedValue = "+1 6138096923"
+
+        #expect(viewModel.canSendVerificationCode)
+        #expect(viewModel.phone?.e164 == "+16138096923")
+    }
+
+    @Test("A partial number is not valid, so auto-advance stays gated")
+    func partialNumber_isNotValid() {
+        let viewModel = PhoneVerificationViewModel(owner: .mock, flipClient: .mock)
+        viewModel.setRegion(.us)
+
+        viewModel.adjustingPhoneNumberBinding.wrappedValue = "613809"
+
+        #expect(viewModel.canSendVerificationCode == false)
+        #expect(viewModel.phone == nil)
+    }
+
     @Test("Default isAlreadyVerified is false — onboarding never short-circuits the phone step")
     func isAlreadyVerified_defaultsFalse() {
         let viewModel = PhoneVerificationViewModel(owner: .mock, flipClient: .mock)

--- a/FlipcashUITests/Support/BaseUITestCase.swift
+++ b/FlipcashUITests/Support/BaseUITestCase.swift
@@ -126,11 +126,10 @@ class BaseUITestCase: XCTestCase {
         let phoneField = app.textFields["Phone Number"]
         guard phoneField.waitForExistence(timeout: 2) else { return }
         phoneField.tap()
-        // US-default region, so only the 10 digits get typed; the formatter
-        // prepends "+1".
-        phoneField.typeText("5005550000")
-
-        waitAndTap(app.buttons["Next"])
+        // Enter the mock number in full international form, including the "+1"
+        // country code. A valid number auto-advances to the code screen, so no
+        // "Next" tap is needed.
+        phoneField.typeText("+15005550000")
 
         // ConfirmPhoneScreen signature: the Confirm CodeButton. The hidden
         // code field auto-focuses ~100ms after appear; six typed digits


### PR DESCRIPTION
The phone verification screen now submits automatically the moment a valid number is entered, whether typed or pasted, instead of waiting for a manual Next tap. This mirrors the SMS code screen, which already auto-submits once the code is complete. The Next button stays as a manual fallback.

## Test plan
- [x] Paste a full valid number into the phone field → advances to the code screen without a Next tap
- [x] Type a full valid number by hand → advances the same way
- [x] A partial or invalid number does not advance
