### PR TITLE
feat: make chat links tappable

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -17,8 +17,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     let container: Container
 
-    private var inFlightDeepLinks: Set<URL> = []
-
     private var sessionContainer: SessionContainer? {
         if case .loggedIn(let container) = container.sessionAuthenticator.state {
             return container
@@ -131,22 +129,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - Deep Links -
 
     func handleOpenURL(url: URL) {
-        // Drop duplicate in-flight deliveries: a concurrent second claim is
-        // rejected server-side as stale state and surfaces as a false error
-        // after the first claim has already succeeded.
-        guard inFlightDeepLinks.insert(url).inserted else {
-            logger.info("Ignoring duplicate deep link", metadata: ["url": "\(url.sanitizedForAnalytics)"])
-            return
-        }
-
-        Analytics.deeplinkOpened(url: url)
-        let action = container.deepLinkController.handle(open: url)
-        Analytics.deeplinkParsed(action: action, url: url)
-
-        Task {
-            defer { self.inFlightDeepLinks.remove(url) }
-            try await action?.executeAction()
-        }
+        container.deepLinkController.open(url)
     }
 
     @objc private func handleDeepLinkNotification(_ notification: Notification) {

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -11,17 +11,45 @@ import FlipcashCore
 private let logger = Logger(label: "flipcash.deeplink")
 
 final class DeepLinkController {
-    
+
     private let sessionAuthenticator: SessionAuthenticator
-    
+
+    private var inFlightDeepLinks: Set<URL> = []
+
     // MARK: - Init -
-    
+
     init(sessionAuthenticator: SessionAuthenticator) {
         self.sessionAuthenticator = sessionAuthenticator
     }
-    
+
+    // MARK: - Open -
+
+    /// The canonical deep-link entry: dedups concurrent opens of the same URL, records analytics, and
+    /// executes the parsed action. Returns false when the URL parses to no action.
+    @discardableResult
+    func open(_ url: URL) -> Bool {
+        // Drop duplicate in-flight deliveries: a concurrent second claim is
+        // rejected server-side as stale state and surfaces as a false error
+        // after the first claim has already succeeded.
+        guard inFlightDeepLinks.insert(url).inserted else {
+            logger.info("Ignoring duplicate deep link", metadata: ["url": "\(url.sanitizedForAnalytics)"])
+            return true
+        }
+
+        Analytics.deeplinkOpened(url: url)
+        let action = handle(open: url)
+        Analytics.deeplinkParsed(action: action, url: url)
+
+        Task {
+            defer { self.inFlightDeepLinks.remove(url) }
+            try await action?.executeAction()
+        }
+
+        return action != nil
+    }
+
     // MARK: - Handle -
-    
+
     func handle(open url: URL) -> DeepLinkAction? {
         
         if case .loggedIn(let container) = sessionAuthenticator.state {

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -38,7 +38,12 @@ final class DeepLinkController {
 
         Analytics.deeplinkOpened(url: url)
         let action = handle(open: url)
-        Analytics.deeplinkParsed(action: action, url: url)
+        // Only record a parse result for URLs that resolve to an action. Chat links now route through
+        // here too, and most are ordinary web URLs — logging every non-match as a "failed to parse"
+        // error would bury genuine deep-link parse failures in expected noise.
+        if let action {
+            Analytics.deeplinkParsed(action: action, url: url)
+        }
 
         Task {
             defer { self.inFlightDeepLinks.remove(url) }

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -13,6 +13,30 @@ import FlipcashUI
 /// re-runs on every observable transcript change.
 private let linkDetector = LinkDetector()
 
+/// Memoizes link detection across remaps: `from(_:)` re-runs on every observable transcript change
+/// (typing, receipts, grouping), but a message's link depends only on its immutable text — so a typing
+/// tick must not re-scan the whole transcript with `NSDataDetector`. `NSCache` bounds the retained
+/// entries, purges under memory pressure, and synchronizes its own access, so the mapper stays
+/// non-isolated. Keyed by text, so identical messages share the result.
+private final class DetectedLinkBox {
+    let preview: LinkPreview?
+    init(_ preview: LinkPreview?) { self.preview = preview }
+}
+
+nonisolated(unsafe) private let linkPreviewCache: NSCache<NSString, DetectedLinkBox> = {
+    let cache = NSCache<NSString, DetectedLinkBox>()
+    cache.countLimit = 512
+    return cache
+}()
+
+private func detectedLink(in text: String) -> LinkPreview? {
+    let key = text as NSString
+    if let cached = linkPreviewCache.object(forKey: key) { return cached.preview }
+    let preview = linkDetector.webLink(in: text)
+    linkPreviewCache.setObject(DetectedLinkBox(preview), forKey: key)
+    return preview
+}
+
 extension ChatItem {
 
     /// Maps a conversation's messages to display-ready transcript items: resolves sender side,
@@ -62,7 +86,7 @@ extension ChatItem {
             switch message.content {
             case .text(let text):
                 content = .text(text)
-                linkPreview = linkDetector.webLink(in: text)
+                linkPreview = detectedLink(in: text)
             case .cash(let fiat):
                 let currency = fiat.nativeAmount.currency
                 let flagName = currency.region?.rawValue ?? currency.rawValue.uppercased()

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -9,6 +9,10 @@ import Foundation
 import FlipcashCore
 import FlipcashUI
 
+/// One detector for every remap — `NSDataDetector` compiles its matchers once, and `from(_:)`
+/// re-runs on every observable transcript change.
+private let linkDetector = LinkDetector()
+
 extension ChatItem {
 
     /// Maps a conversation's messages to display-ready transcript items: resolves sender side,
@@ -54,9 +58,11 @@ extension ChatItem {
             } ?? false
 
             let content: ChatMessage.Content
+            let linkPreview: LinkPreview?
             switch message.content {
             case .text(let text):
                 content = .text(text)
+                linkPreview = linkDetector.webLink(in: text)
             case .cash(let fiat):
                 let currency = fiat.nativeAmount.currency
                 let flagName = currency.region?.rawValue ?? currency.rawValue.uppercased()
@@ -67,6 +73,7 @@ extension ChatItem {
                     flagImageName: flagName,
                     iconURL: branding.iconURL
                 ))
+                linkPreview = nil
             case .deleted:
                 continue // filtered out above; unreachable, kept for switch exhaustiveness
             }
@@ -98,7 +105,8 @@ extension ChatItem {
                 isContinuationFromPrevious: groupedAbove,
                 isContinuedByNext: groupedBelow,
                 receipt: receipt,
-                isFailed: message.status == .failed
+                isFailed: message.status == .failed,
+                linkPreview: linkPreview
             )))
         }
         return items

--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -28,8 +28,8 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     /// Fired when the user taps a cash card; the argument is the message's stable id. The owner opens
     /// that token's currency info.
     let onCashCardTap: (String) -> Void
-    /// Fired when the user taps a URL in a message or its preview card. The owner presents an in-app
-    /// browser.
+    /// Fired when the user taps a URL in a message. The owner routes it through the deep-link handler,
+    /// falling back to the system browser.
     let onOpenURL: (URL) -> Void
     let showsSendCash: Bool
     let showsSendMessage: Bool

--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -28,6 +28,9 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     /// Fired when the user taps a cash card; the argument is the message's stable id. The owner opens
     /// that token's currency info.
     let onCashCardTap: (String) -> Void
+    /// Fired when the user taps a URL in a message or its preview card. The owner presents an in-app
+    /// browser.
+    let onOpenURL: (URL) -> Void
     let showsSendCash: Bool
     let showsSendMessage: Bool
     let conversationID: ConversationID?
@@ -49,6 +52,7 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         screen.onReachTop = onReachTop
         screen.onRetry = onRetry
         screen.onCashCardTap = onCashCardTap
+        screen.onOpenURL = onOpenURL
         screen.update(items: items)
         screen.setComposing(barModel.isComposing)
         context.coordinator.restingHost = restingHost
@@ -66,6 +70,7 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         screen.onReachTop = onReachTop
         screen.onRetry = onRetry
         screen.onCashCardTap = onCashCardTap
+        screen.onOpenURL = onOpenURL
         screen.setComposing(barModel.isComposing)
 
         // Scroll only when the user's *own* message was just appended — a new trailing message id

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -41,6 +41,7 @@ struct ConversationScreen: View {
     @Environment(Session.self) private var session
     @Environment(RatesController.self) private var ratesController
     @Environment(PushController.self) private var pushController
+    @Environment(Container.self) private var container
 
     @State private var didInitialRead = false
     @State private var barModel = ConversationBarModel()
@@ -177,6 +178,7 @@ struct ConversationScreen: View {
             onReachTop: loadOlderMessages,
             onRetry: retry,
             onCashCardTap: openCurrencyInfo,
+            onOpenURL: openLink,
             showsSendCash: sendTarget != nil,
             showsSendMessage: chatExists,
             conversationID: conversationID,
@@ -354,6 +356,13 @@ struct ConversationScreen: View {
         case .text, .deleted:
             break
         }
+    }
+
+    private func openLink(_ url: URL) {
+        // iOS won't re-enter the app for our own universal link from an in-app tap, so route every
+        // tapped link through the deep-link handler; anything it doesn't recognize opens externally.
+        if container.deepLinkController.open(url) { return }
+        UIApplication.shared.open(url)
     }
 
     /// Fetches the next older page when the UIKit transcript nears the top. Guarded so the

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift
@@ -40,8 +40,8 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
     /// Whether this row failed to send: turns the status line red and makes the row tappable to retry.
     /// Other states (sending, delivered, received) render the same — the text comes from `receipt`.
     public let isFailed: Bool
-    /// The web link to preview beneath this text row, or nil when the text carries none. Derived
-    /// from the text at map time (not stored/sent) — cash rows never carry one.
+    /// The web link this text row contains, or nil when it carries none — marks the row to render as
+    /// tappable text. Derived from the text at map time (not stored/sent) — cash rows never carry one.
     public let linkPreview: LinkPreview?
 
     public init(

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift
@@ -40,6 +40,9 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
     /// Whether this row failed to send: turns the status line red and makes the row tappable to retry.
     /// Other states (sending, delivered, received) render the same — the text comes from `receipt`.
     public let isFailed: Bool
+    /// The web link to preview beneath this text row, or nil when the text carries none. Derived
+    /// from the text at map time (not stored/sent) — cash rows never carry one.
+    public let linkPreview: LinkPreview?
 
     public init(
         id: String,
@@ -48,7 +51,8 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
         isContinuationFromPrevious: Bool = false,
         isContinuedByNext: Bool = false,
         receipt: String? = nil,
-        isFailed: Bool = false
+        isFailed: Bool = false,
+        linkPreview: LinkPreview? = nil
     ) {
         self.id = id
         self.content = content
@@ -57,6 +61,7 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
         self.isContinuedByNext = isContinuedByNext
         self.receipt = receipt
         self.isFailed = isFailed
+        self.linkPreview = linkPreview
     }
 
     /// Convenience for text rows.
@@ -67,7 +72,8 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
         isContinuationFromPrevious: Bool = false,
         isContinuedByNext: Bool = false,
         receipt: String? = nil,
-        isFailed: Bool = false
+        isFailed: Bool = false,
+        linkPreview: LinkPreview? = nil
     ) {
         self.init(
             id: id,
@@ -76,7 +82,8 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
             isContinuationFromPrevious: isContinuationFromPrevious,
             isContinuedByNext: isContinuedByNext,
             receipt: receipt,
-            isFailed: isFailed
+            isFailed: isFailed,
+            linkPreview: linkPreview
         )
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/LinkDetector.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/LinkDetector.swift
@@ -1,0 +1,39 @@
+//
+//  LinkDetector.swift
+//  FlipcashCore
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Finds the web link (if any) that marks a chat message as link-bearing. Pure and synchronous — wraps
+/// `NSDataDetector` and keeps only `http`/`https` matches, so custom schemes (incl. `flipcash://`),
+/// `mailto:`, and `tel:` stay plain text.
+public struct LinkDetector {
+
+    private let detector: NSDataDetector?
+
+    public init() {
+        detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+    }
+
+    /// The trailing web link in `text`. Nil when there's no web link.
+    public func webLink(in text: String) -> LinkPreview? {
+        guard let detector else { return nil }
+        let nsText = text as NSString
+        let range = NSRange(location: 0, length: nsText.length)
+        let webMatches = detector.matches(in: text, range: range).filter { match in
+            switch match.url?.scheme?.lowercased() {
+            case "http", "https":
+                // NSDataDetector folds a glued-on non-ASCII character (e.g. an emoji) into a Punycode
+                // host, mangling the URL — reject the match rather than preview a URL nobody typed.
+                nsText.substring(with: match.range).allSatisfy(\.isASCII)
+            default:
+                false
+            }
+        }
+        guard let last = webMatches.last, let url = last.url else { return nil }
+        return LinkPreview(url: url)
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/LinkDetector.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/LinkDetector.swift
@@ -26,14 +26,26 @@ public struct LinkDetector {
         let webMatches = detector.matches(in: text, range: range).filter { match in
             switch match.url?.scheme?.lowercased() {
             case "http", "https":
-                // NSDataDetector folds a glued-on non-ASCII character (e.g. an emoji) into a Punycode
-                // host, mangling the URL — reject the match rather than preview a URL nobody typed.
-                nsText.substring(with: match.range).allSatisfy(\.isASCII)
+                // NSDataDetector folds a non-ASCII character glued to the host (e.g. a trailing emoji)
+                // into a mangled Punycode host, silently retargeting the link — reject those. A
+                // non-ASCII *path* (e.g. /wiki/Café) is fine: it percent-encodes without moving the host.
+                Self.authorityIsASCII(nsText.substring(with: match.range))
             default:
                 false
             }
         }
         guard let last = webMatches.last, let url = last.url else { return nil }
         return LinkPreview(url: url)
+    }
+
+    /// Whether the authority (everything before the first path/query/fragment delimiter) of a matched
+    /// URL string is ASCII — the region a glued-on symbol would corrupt into a different host.
+    private static func authorityIsASCII(_ matchText: String) -> Bool {
+        var authority = Substring(matchText)
+        if let schemeSeparator = authority.range(of: "://") {
+            authority = authority[schemeSeparator.upperBound...]
+        }
+        authority = authority.prefix { $0 != "/" && $0 != "?" && $0 != "#" }
+        return authority.allSatisfy(\.isASCII)
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/LinkPreview.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/LinkPreview.swift
@@ -1,0 +1,18 @@
+//
+//  LinkPreview.swift
+//  FlipcashCore
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A web link found in a message's text — marks the message as link-bearing so it renders in a
+/// tappable-text bubble.
+public struct LinkPreview: Hashable, Sendable, Codable {
+    public let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/LinkDetectorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/LinkDetectorTests.swift
@@ -68,4 +68,10 @@ struct LinkDetectorTests {
         let preview = detector.webLink(in: "https://a.com then https://b.com😀")
         #expect(preview?.url.absoluteString == "https://a.com")
     }
+
+    @Test("A non-ASCII path keeps the URL — only a mangled host is rejected")
+    func nonASCIIPath_isDetected() {
+        let preview = detector.webLink(in: "https://en.wikipedia.org/wiki/Café")
+        #expect(preview?.url.host() == "en.wikipedia.org")
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/LinkDetectorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/LinkDetectorTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import FlipcashCore
+
+@Suite("LinkDetector web link detection")
+struct LinkDetectorTests {
+
+    private let detector = LinkDetector()
+
+    @Test("A bare https URL is detected")
+    func soleHTTPSURL() {
+        let preview = detector.webLink(in: "https://apple.com")
+        #expect(preview?.url.absoluteString == "https://apple.com")
+    }
+
+    @Test("A scheme-less domain is detected")
+    func schemelessDomain_isSole() {
+        let preview = detector.webLink(in: "apple.com")
+        #expect(preview?.url.scheme == "http")
+    }
+
+    @Test("A URL is detected alongside surrounding text")
+    func textPlusURL_notSole() {
+        let preview = detector.webLink(in: "look at this https://apple.com")
+        #expect(preview?.url.absoluteString == "https://apple.com")
+    }
+
+    @Test("The trailing URL is chosen when there are several")
+    func multipleURLs_picksTrailing() {
+        let preview = detector.webLink(in: "https://a.com then https://b.com")
+        #expect(preview?.url.absoluteString == "https://b.com")
+    }
+
+    @Test("Trailing punctuation is not part of the URL")
+    func trailingPunctuation_excluded() {
+        let preview = detector.webLink(in: "see https://apple.com.")
+        #expect(preview?.url.absoluteString == "https://apple.com")
+    }
+
+    @Test("A mid-sentence URL is still detected")
+    func midSentenceURL_keepsFullText() {
+        let preview = detector.webLink(in: "prices went up 20% https://apple.com, check it")
+        #expect(preview?.url.absoluteString == "https://apple.com")
+    }
+
+    @Test("Email addresses do not produce a web link")
+    func email_noLink() {
+        #expect(detector.webLink(in: "write me@example.com") == nil)
+    }
+
+    @Test("Custom schemes are ignored")
+    func customScheme_ignored() {
+        #expect(detector.webLink(in: "flipcash://pay/123") == nil)
+    }
+
+    @Test("Plain text has no link")
+    func plainText_noLink() {
+        #expect(detector.webLink(in: "hello there") == nil)
+    }
+
+    @Test("A URL mangled by a glued-on emoji is rejected outright")
+    func nonASCIIMangledURL_rejected() {
+        #expect(detector.webLink(in: "https://apple.com😀 nice right") == nil)
+    }
+
+    @Test("A mangled trailing URL is rejected, letting an earlier clean URL win")
+    func nonASCIIMangledTrailingURL_fallsBackToEarlierCleanMatch() {
+        let preview = detector.webLink(in: "https://a.com then https://b.com😀")
+        #expect(preview?.url.absoluteString == "https://a.com")
+    }
+}

--- a/FlipcashTests/Chat/ChatLinkMessageCellTests.swift
+++ b/FlipcashTests/Chat/ChatLinkMessageCellTests.swift
@@ -1,0 +1,38 @@
+import Testing
+import UIKit
+import FlipcashCore
+@testable import FlipcashUI
+
+@MainActor
+@Suite("ChatLinkMessageCell")
+struct ChatLinkMessageCellTests {
+
+    private func url(_ s: String) -> URL { URL(string: s)! }
+
+    private func makeCell() -> ChatLinkMessageCell {
+        ChatLinkMessageCell(frame: CGRect(x: 0, y: 0, width: 320, height: 200))
+    }
+
+    @Test("A failed link message disables the bubble's own link taps so retry wins")
+    func failedMessage_disablesBubbleInteraction() {
+        let cell = makeCell()
+        cell.configure(
+            with: ChatMessage(id: "1", text: "https://apple.com", sender: .me,
+                              isFailed: true,
+                              linkPreview: LinkPreview(url: url("https://apple.com"))),
+            maxWidth: 250
+        )
+        #expect(cell.descendants(of: LinkableBubbleView.self).first?.isUserInteractionEnabled == false)
+    }
+
+    @Test("A non-failed link message keeps the bubble's link taps enabled")
+    func nonFailedMessage_keepsBubbleInteractionEnabled() {
+        let cell = makeCell()
+        cell.configure(
+            with: ChatMessage(id: "1", text: "https://apple.com", sender: .me,
+                              linkPreview: LinkPreview(url: url("https://apple.com"))),
+            maxWidth: 250
+        )
+        #expect(cell.descendants(of: LinkableBubbleView.self).first?.isUserInteractionEnabled == true)
+    }
+}

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -241,4 +241,32 @@ struct ChatMessageMappingTests {
         let settled = ChatItem.from([text(1, me, "hi", after: 0)], selfUserID: me, counterpartRead: read)
         #expect(receiptText(settled) == "Delivered")
     }
+
+    @Test("A text message containing a URL carries the trailing link as its preview")
+    func textWithURL_hasLinkPreview() {
+        let rows = messageRows(ChatItem.from([text(1, me, "check https://apple.com", after: 0)], selfUserID: me))
+        #expect(rows.first?.linkPreview?.url.absoluteString == "https://apple.com")
+    }
+
+    @Test("A URL-only message has a link preview")
+    func urlOnlyMessage_hasLinkPreview() {
+        let rows = messageRows(ChatItem.from([text(1, me, "https://apple.com", after: 0)], selfUserID: me))
+        #expect(rows.first?.linkPreview?.url != nil)
+    }
+
+    @Test("A plain text message has no link preview")
+    func plainText_noLinkPreview() {
+        let rows = messageRows(ChatItem.from([text(1, me, "hello there", after: 0)], selfUserID: me))
+        #expect(rows.first?.linkPreview == nil)
+    }
+
+    @Test("A cash message never carries a link preview")
+    func cashMessage_noLinkPreview() {
+        let fiat = ExchangedFiat(nativeAmount: FiatAmount(value: 5, currency: .usd), rate: Rate(fx: 1, currency: .usd))
+        let rows = messageRows(ChatItem.from(
+            [ConversationMessage(id: MessageID(value: 1), senderID: them, content: .cash(fiat), date: base, unreadSeq: 1)],
+            selfUserID: me
+        ))
+        #expect(rows.first?.linkPreview == nil)
+    }
 }

--- a/FlipcashTests/Chat/ChatViewControllerTests.swift
+++ b/FlipcashTests/Chat/ChatViewControllerTests.swift
@@ -144,4 +144,19 @@ struct ChatViewControllerTests {
         #expect(abs(collectionView.contentOffset.y - maxOffset) < 2,
                 "should open at the bottom — offset \(collectionView.contentOffset.y) vs max \(maxOffset)")
     }
+
+    @Test("A link-bearing message dequeues the tappable link cell; plain text uses the label cell")
+    func linkMessage_usesLinkCell() {
+        let controller = ChatViewController()
+        controller.loadViewIfNeeded()
+        let link = ChatMessage(id: "link", text: "see https://apple.com", sender: .me,
+                               linkPreview: LinkPreview(url: URL(string: "https://apple.com")!))
+        let plain = ChatMessage(id: "plain", text: "hello there", sender: .me)
+        controller.update(items: [.message(link), .message(plain)])
+
+        let linkCell = controller.collectionView(controller.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
+        let plainCell = controller.collectionView(controller.collectionView, cellForItemAt: IndexPath(item: 1, section: 0))
+        #expect(linkCell is ChatLinkMessageCell)
+        #expect(plainCell is ChatMessageCell)
+    }
 }

--- a/FlipcashTests/Chat/LinkableBubbleViewTests.swift
+++ b/FlipcashTests/Chat/LinkableBubbleViewTests.swift
@@ -1,0 +1,35 @@
+//
+//  LinkableBubbleViewTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import UIKit
+import FlipcashCore
+@testable import FlipcashUI
+
+@MainActor
+@Suite("LinkableBubbleView")
+struct LinkableBubbleViewTests {
+
+    @Test("Configuring renders the message text")
+    func configure_setsText() {
+        let view = LinkableBubbleView()
+        view.configure(with: ChatMessage(id: "1", text: "see https://apple.com", sender: .me))
+        #expect(view.descendants(of: UITextView.self).first?.text == "see https://apple.com")
+    }
+
+    @Test("The text view refuses to become first responder, so selection stays off")
+    func textView_refusesFirstResponder() {
+        let view = LinkableBubbleView()
+        #expect(view.descendants(of: UITextView.self).first?.canBecomeFirstResponder == false)
+    }
+
+    @Test("Link data detection is enabled")
+    func textView_detectsLinks() {
+        let view = LinkableBubbleView()
+        #expect(view.descendants(of: UITextView.self).first?.dataDetectorTypes == .link)
+    }
+}

--- a/FlipcashTests/DeepLinkControllerTests.swift
+++ b/FlipcashTests/DeepLinkControllerTests.swift
@@ -1,0 +1,40 @@
+//
+//  DeepLinkControllerTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import Flipcash
+
+@MainActor
+@Suite("DeepLinkController routing")
+struct DeepLinkControllerTests {
+
+    private let sessionAuthenticator = SessionAuthenticator(container: Container())
+
+    private func makeController() -> DeepLinkController {
+        DeepLinkController(sessionAuthenticator: sessionAuthenticator)
+    }
+
+    @Test("A recognized route resolves to an action, so open reports it handled")
+    func recognizedRoute_isHandled() {
+        #expect(makeController().open(URL(string: "flipcash://give")!) == true)
+    }
+
+    @Test("An ordinary web URL resolves to no action, so open reports it unhandled and the caller opens it externally")
+    func ordinaryWebURL_isNotHandled() {
+        #expect(makeController().open(URL(string: "https://apple.com")!) == false)
+    }
+
+    @Test("A duplicate in-flight open is reported handled without re-processing")
+    func duplicateInFlightOpen_isDeduped() {
+        let controller = makeController()
+        // The first open enters the in-flight set; its async cleanup can't run before the next
+        // synchronous call, so the immediate duplicate is short-circuited to handled.
+        _ = controller.open(URL(string: "https://apple.com")!)
+        #expect(controller.open(URL(string: "https://apple.com")!) == true)
+    }
+}

--- a/FlipcashTests/TestSupport/UIView+TestSupport.swift
+++ b/FlipcashTests/TestSupport/UIView+TestSupport.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+TestSupport.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    /// All descendants of the given type, depth-first.
+    func descendants<T>(of type: T.Type) -> [T] {
+        subviews.compactMap { $0 as? T } + subviews.flatMap { $0.descendants(of: type) }
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatLinkMessageCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatLinkMessageCell.swift
@@ -1,0 +1,61 @@
+//
+//  ChatLinkMessageCell.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+import FlipcashCore
+
+/// A recycled cell for a text message that contains a link: a `LinkableBubbleView` whose URLs are
+/// tappable, in a `ChatColumnCell` so the receipt sits below it. Picked over the plain `ChatMessageCell`
+/// (a `UILabel`) only for messages with a link, so plain text keeps the cheaper path.
+public final class ChatLinkMessageCell: ChatColumnCell {
+
+    public static let reuseIdentifier = "ChatLinkMessageCell"
+
+    /// The widest the bubble may grow before its text wraps.
+    static let maxWidth: CGFloat = 280
+
+    private let bubble = LinkableBubbleView()
+    private var bubbleMaxWidthConstraint: NSLayoutConstraint!
+
+    /// Called when the user taps a URL in the bubble.
+    var onOpenURL: ((URL) -> Void)? {
+        didSet { bubble.onOpenURL = onOpenURL }
+    }
+
+    /// The view + shape the context-menu lift clips to.
+    var liftPreviewView: UIView { bubble }
+    var liftPreviewMaskingPath: UIBezierPath? { bubble.maskingPath }
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        installColumn(content: bubble)
+        bubbleMaxWidthConstraint = bubble.widthAnchor.constraint(lessThanOrEqualToConstant: Self.maxWidth)
+        bubbleMaxWidthConstraint.isActive = true
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        bubble.prepareForReuse()
+    }
+
+    /// - Parameter maxWidth: the widest the bubble may grow before its text wraps.
+    public func configure(with message: ChatMessage, maxWidth: CGFloat) {
+        bubbleMaxWidthConstraint.constant = maxWidth
+        bubble.configure(with: message)
+        updateColumn(for: message)
+        // A failed row's whole column is the retry target (ChatColumnCell); disable the bubble's own
+        // text-view link taps so a tap on a failed message retries the send rather than opening the URL.
+        bubble.isUserInteractionEnabled = !message.isFailed
+    }
+}
+
+extension ChatLinkMessageCell: BubbleCarrying {}
+#endif

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatLinkMessageCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatLinkMessageCell.swift
@@ -16,9 +16,6 @@ public final class ChatLinkMessageCell: ChatColumnCell {
 
     public static let reuseIdentifier = "ChatLinkMessageCell"
 
-    /// The widest the bubble may grow before its text wraps.
-    static let maxWidth: CGFloat = 280
-
     private let bubble = LinkableBubbleView()
     private var bubbleMaxWidthConstraint: NSLayoutConstraint!
 
@@ -34,7 +31,7 @@ public final class ChatLinkMessageCell: ChatColumnCell {
     public override init(frame: CGRect) {
         super.init(frame: frame)
         installColumn(content: bubble)
-        bubbleMaxWidthConstraint = bubble.widthAnchor.constraint(lessThanOrEqualToConstant: Self.maxWidth)
+        bubbleMaxWidthConstraint = bubble.widthAnchor.constraint(lessThanOrEqualToConstant: 280)
         bubbleMaxWidthConstraint.isActive = true
     }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
@@ -44,6 +44,11 @@ public final class ChatMessageCell: ChatColumnCell {
     }
 }
 
+extension ChatMessageCell: BubbleCarrying {
+    var liftPreviewView: UIView { bubbleView }
+    var liftPreviewMaskingPath: UIBezierPath? { bubbleView.maskingPath }
+}
+
 #Preview("Cells") {
     let layout = UICollectionViewFlowLayout()
     layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -72,6 +72,11 @@ public final class ChatScreenViewController: UIViewController {
         set { transcript.onCashCardTap = newValue }
     }
 
+    public var onOpenURL: ((URL) -> Void)? {
+        get { transcript.onOpenURL }
+        set { transcript.onOpenURL = newValue }
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor(Color.backgroundMain)

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -36,6 +36,9 @@ public final class ChatViewController: UICollectionViewController {
     /// that token's currency info. Only cash rows are selectable (see `shouldHighlightItemAt`).
     public var onCashCardTap: ((String) -> Void)?
 
+    /// Called when the user taps a URL in a text bubble; the owner opens it.
+    public var onOpenURL: ((URL) -> Void)?
+
     /// The widest a bubble may grow, as a share of the collection view's width.
     private static let maxBubbleWidthFraction: CGFloat = 0.78
 
@@ -108,6 +111,7 @@ public final class ChatViewController: UICollectionViewController {
         collectionView.selfSizingInvalidation = .enabled
         chatLayout.supportSelfSizingInvalidation = true
         collectionView.register(ChatMessageCell.self, forCellWithReuseIdentifier: ChatMessageCell.reuseIdentifier)
+        collectionView.register(ChatLinkMessageCell.self, forCellWithReuseIdentifier: ChatLinkMessageCell.reuseIdentifier)
         collectionView.register(ChatCashCardCell.self, forCellWithReuseIdentifier: ChatCashCardCell.reuseIdentifier)
         collectionView.register(ChatDateSeparatorCell.self, forCellWithReuseIdentifier: ChatDateSeparatorCell.reuseIdentifier)
         collectionView.register(ChatTypingIndicatorCell.self, forCellWithReuseIdentifier: ChatTypingIndicatorCell.reuseIdentifier)
@@ -219,14 +223,25 @@ public final class ChatViewController: UICollectionViewController {
         case .message(let message):
             switch message.content {
             case .text:
+                // Only text messages are sent optimistically, so only they can reach the failed state
+                // that arms retry (wired on both text cells). Cash messages are always server-confirmed.
+                let width = collectionView.bounds.width > 0 ? collectionView.bounds.width : UIScreen.main.bounds.width
+                let maxWidth = width * Self.maxBubbleWidthFraction
+                if message.linkPreview != nil {
+                    let cell = collectionView.dequeueReusableCell(
+                        withReuseIdentifier: ChatLinkMessageCell.reuseIdentifier,
+                        for: indexPath
+                    ) as! ChatLinkMessageCell
+                    cell.configure(with: message, maxWidth: maxWidth)
+                    cell.onRetry = { [weak self] id in self?.onRetry?(id) }
+                    cell.onOpenURL = { [weak self] url in self?.onOpenURL?(url) }
+                    return cell
+                }
                 let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: ChatMessageCell.reuseIdentifier,
                     for: indexPath
                 ) as! ChatMessageCell
-                let width = collectionView.bounds.width > 0 ? collectionView.bounds.width : UIScreen.main.bounds.width
-                cell.configure(with: message, maxWidth: width * Self.maxBubbleWidthFraction)
-                // Only text messages are sent optimistically, so only they can reach the failed
-                // state that arms retry. Cash messages are always server-confirmed.
+                cell.configure(with: message, maxWidth: maxWidth)
                 cell.onRetry = { [weak self] id in self?.onRetry?(id) }
                 return cell
             case .cash:
@@ -479,13 +494,13 @@ extension ChatViewController {
         guard components.count == 2,
               let section = Int(components[0]),
               let item = Int(components[1]),
-              let cell = collectionView.cellForItem(at: IndexPath(item: item, section: section)) as? ChatMessageCell else {
+              let cell = collectionView.cellForItem(at: IndexPath(item: item, section: section)) as? BubbleCarrying else {
             return nil
         }
         let parameters = UIPreviewParameters()
-        parameters.visiblePath = cell.bubbleView.maskingPath
+        parameters.visiblePath = cell.liftPreviewMaskingPath
         parameters.backgroundColor = .clear
-        return UITargetedPreview(view: cell.bubbleView, parameters: parameters)
+        return UITargetedPreview(view: cell.liftPreviewView, parameters: parameters)
     }
 }
 
@@ -516,5 +531,12 @@ extension ChatMessage {
             )
         }
     }
+}
+
+/// A message cell that can supply the view + shape for the context-menu lift preview, so the lift is
+/// clipped to the bubble rather than the full side-hugging cell.
+protocol BubbleCarrying {
+    var liftPreviewView: UIView { get }
+    var liftPreviewMaskingPath: UIBezierPath? { get }
 }
 #endif

--- a/FlipcashUI/Sources/FlipcashUI/Chat/LinkableBubbleView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/LinkableBubbleView.swift
@@ -1,0 +1,111 @@
+//
+//  LinkableBubbleView.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+import FlipcashCore
+
+/// A chat bubble that renders text with tappable links, over the shared `BubbleBackgroundView`. Used
+/// only for messages that contain a link; plain text stays on the cheaper `ChatBubbleView` (a
+/// `UILabel`). Link taps are reported through `onOpenURL`; the bubble itself opens nothing.
+public final class LinkableBubbleView: UIView {
+
+    private let background = BubbleBackgroundView()
+    private let textView = LinkTextView()
+
+    /// Called when the user taps a detected link.
+    var onOpenURL: ((URL) -> Void)?
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUp()
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setUp() {
+        background.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(background)
+
+        textView.isScrollEnabled = false
+        textView.isEditable = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.dataDetectorTypes = .link
+        textView.font = .default(size: 16, weight: .medium)
+        textView.textColor = .white
+        textView.linkTextAttributes = [
+            .foregroundColor: UIColor.white,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+        textView.delegate = self
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(textView)
+
+        NSLayoutConstraint.activate([
+            background.topAnchor.constraint(equalTo: topAnchor),
+            background.bottomAnchor.constraint(equalTo: bottomAnchor),
+            background.leadingAnchor.constraint(equalTo: leadingAnchor),
+            background.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            textView.topAnchor.constraint(equalTo: topAnchor, constant: 9),
+            textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -9),
+            textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            textView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+        ])
+    }
+
+    /// The bubble's shape, for clipping the context-menu lift preview.
+    var maskingPath: UIBezierPath { background.maskingPath }
+
+    func prepareForReuse() {
+        textView.resignFirstResponder()
+    }
+
+    public func configure(with message: ChatMessage) {
+        switch message.content {
+        case .text(let text): textView.text = text
+        case .cash: textView.text = nil
+        }
+        background.apply(
+            fill: BubbleBackgroundView.fill(isFromSelf: message.sender == .me),
+            radii: BubbleBackgroundView.radii(
+                isFromSelf: message.sender == .me,
+                groupedAbove: message.isContinuationFromPrevious,
+                groupedBelow: message.isContinuedByNext
+            )
+        )
+    }
+}
+
+extension LinkableBubbleView: UITextViewDelegate {
+    /// Route the tap to `onOpenURL` instead of the system's Safari open.
+    public func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+        if case .link(let url) = textItem.content {
+            return UIAction { [weak self] _ in self?.onOpenURL?(url) }
+        }
+        return defaultAction
+    }
+
+    /// Suppress the per-link context menu so the cell's long-press "Copy" menu isn't shadowed.
+    public func textView(_ textView: UITextView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
+        nil
+    }
+}
+
+/// A `UITextView` that shows text and taps links but refuses selection, the loupe, and the edit menu —
+/// so the cell's long-press "Copy" context menu and the context-menu lift keep working. Mirrors
+/// ChatLayout's own `MessageTextView` recipe.
+private final class LinkTextView: UITextView {
+    override var isFocused: Bool { false }
+    override var canBecomeFirstResponder: Bool { false }
+    override var canBecomeFocused: Bool { false }
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool { false }
+}
+#endif


### PR DESCRIPTION
Makes URLs in chat messages tappable. Non-Flipcash links open in an in-app Safari view; links to Flipcash's own domains route through the app's deep-link handler, so a cash link opens the collect flow. Plain-text messages are untouched — only messages that contain a link use the tappable-text bubble.

## Test plan
- [x] Tap a normal link → opens in-app Safari
- [x] Tap a Flipcash cash link → collect flow (on device)
- [x] Tap an unrecognized flipcash-host link → in-app Safari (no dead tap)
- [x] A failed message's link tap retries the send (doesn't open the URL)
- [x] Plain-text messages render and behave unchanged
