### PR TITLE
fix: classify cancelled transport errors as .info across typed errors

### DIFF
--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -496,6 +496,8 @@ final class ContactSyncController {
             return
         case .transportFailure:
             logger.info("Sync deferred — transport failure (will retry on next trigger)")
+        case .cancelled:
+            logger.info("Sync deferred — cancelled (will retry on next trigger)")
         case .checksumDrift:
             logger.info("Sync deferred — checksum drift (will retry on next trigger)")
         case .checksumMismatch:

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/AccountService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/AccountService.swift
@@ -158,6 +158,7 @@ public enum ErrorRegisterAccount: Int, Error {
     case denied
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorLoginAccount: Int, Error {
@@ -166,6 +167,7 @@ public enum ErrorLoginAccount: Int, Error {
     case denied
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorFetchUserFlags: Int, Error {
@@ -173,18 +175,21 @@ public enum ErrorFetchUserFlags: Int, Error {
     case denied
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorFetchUnauthenticatedUserFlags: Int, Error {
     case ok
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorRegisterAccount: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .invalidSignature, .denied: .info
         case .unknown: .error
         }
@@ -195,6 +200,7 @@ extension ErrorLoginAccount: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .invalidTimestamp, .denied: .info
         case .unknown: .error
         }
@@ -205,6 +211,7 @@ extension ErrorFetchUserFlags: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied: .info
         case .unknown: .error
         }
@@ -215,6 +222,7 @@ extension ErrorFetchUnauthenticatedUserFlags: ServerError, TransportClassifiable
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .unknown: .error
         }
     }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ActivityService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ActivityService.swift
@@ -108,6 +108,7 @@ public enum ErrorFetchTransactionHistory: Int, Error {
     case denied
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorFetchTransactionHistoryItemsByID: Int, Error {
@@ -116,12 +117,14 @@ public enum ErrorFetchTransactionHistoryItemsByID: Int, Error {
     case notFound
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorFetchTransactionHistory: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied: .info
         case .unknown: .error
         }
@@ -132,6 +135,7 @@ extension ErrorFetchTransactionHistoryItemsByID: ServerError, TransportClassifia
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .notFound: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
@@ -47,7 +47,7 @@ final class ChatMessagingService: Sendable {
                 case .notFound:
                     // An empty page is reported as NOT_FOUND, not empty OK.
                     await MainActor.run { completion(.success([])) }
-                case .denied, .unknown, .transportFailure:
+                case .denied, .unknown, .transportFailure, .cancelled:
                     logger.error("Failed to fetch messages")
                     await MainActor.run { completion(.failure(error)) }
                 }
@@ -135,6 +135,7 @@ public enum ErrorGetMessages: Int, Error {
     case notFound
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorSendMessage: Int, Error {
@@ -142,6 +143,7 @@ public enum ErrorSendMessage: Int, Error {
     case denied
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorAdvancePointer: Int, Error {
@@ -150,6 +152,7 @@ public enum ErrorAdvancePointer: Int, Error {
     case messageNotFound
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorNotifyIsTyping: Int, Error {
@@ -157,12 +160,14 @@ public enum ErrorNotifyIsTyping: Int, Error {
     case denied
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorGetMessages: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .notFound: .info
         case .unknown: .error
         }
@@ -173,6 +178,7 @@ extension ErrorSendMessage: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied: .info
         case .unknown: .error
         }
@@ -183,6 +189,7 @@ extension ErrorAdvancePointer: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .messageNotFound: .info
         case .unknown: .error
         }
@@ -193,6 +200,7 @@ extension ErrorNotifyIsTyping: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatService.swift
@@ -92,6 +92,7 @@ public enum ErrorGetDmChatFeed: Int, Error {
     case notFound
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorGetChat: Int, Error {
@@ -100,12 +101,14 @@ public enum ErrorGetChat: Int, Error {
     case notFound
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorGetDmChatFeed: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .notFound: .info
         case .unknown: .error
         }
@@ -116,6 +119,7 @@ extension ErrorGetChat: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .notFound: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
@@ -318,6 +318,7 @@ public enum ErrorContactSync: Int, Error, Equatable, Sendable {
     case notFound = 4
     case checksumDrift = 5
     case transportFailure = -2
+    case cancelled = -3
     case unknown = -1
 }
 
@@ -325,6 +326,7 @@ extension ErrorContactSync: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .tooManyContacts, .checksumDrift, .notFound: .info
         case .checksumMismatch, .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EmailService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EmailService.swift
@@ -119,6 +119,7 @@ public enum ErrorSendEmailCode: Int, Error {
     case invalidEmailAddress
     case unknown = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorCheckEmailCode: Int, Error {
@@ -138,6 +139,7 @@ public enum ErrorCheckEmailCode: Int, Error {
     case noVerification
     case unknown = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorUnlinkEmail: Int, Error {
@@ -145,12 +147,14 @@ public enum ErrorUnlinkEmail: Int, Error {
     case denied
     case unknown = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorSendEmailCode: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .rateLimited, .invalidEmailAddress: .info
         case .unknown: .error
         }
@@ -161,6 +165,7 @@ extension ErrorCheckEmailCode: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .rateLimited, .invalidCode, .noVerification: .info
         case .unknown: .error
         }
@@ -171,6 +176,7 @@ extension ErrorUnlinkEmail: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PhoneService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PhoneService.swift
@@ -145,6 +145,7 @@ public enum ErrorSendVerificationCode: Int, Error, Equatable, Sendable {
     case unsupportedPhoneType
     case unknown = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorCheckVerificationCode: Int, Error, Equatable, Sendable {
@@ -164,6 +165,7 @@ public enum ErrorCheckVerificationCode: Int, Error, Equatable, Sendable {
     case noVerification
     case unknown = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorUnlinkPhone: Int, Error, Equatable, Sendable {
@@ -171,6 +173,7 @@ public enum ErrorUnlinkPhone: Int, Error, Equatable, Sendable {
     case denied
     case unknown = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorLinkForPayment: Int, Error, Equatable, Sendable {
@@ -180,12 +183,14 @@ public enum ErrorLinkForPayment: Int, Error, Equatable, Sendable {
     case notAssociated
     case unknown = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorSendVerificationCode: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .rateLimited, .invalidPhoneNumber, .unsupportedPhoneType: .info
         case .unknown: .error
         }
@@ -196,6 +201,7 @@ extension ErrorCheckVerificationCode: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .rateLimited, .invalidCode, .noVerification: .info
         case .unknown: .error
         }
@@ -206,6 +212,7 @@ extension ErrorUnlinkPhone: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied: .info
         case .unknown: .error
         }
@@ -216,6 +223,7 @@ extension ErrorLinkForPayment: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .notAssociated: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
@@ -66,12 +66,14 @@ public enum ErrorFetchProfile: Int, Error {
     case notFound
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorFetchProfile: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .notFound: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PushService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/PushService.swift
@@ -85,18 +85,21 @@ public enum ErrorAddToken: Int, Error {
     case invalidPushToken
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorDeleteToken: Int, Error {
     case ok
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorAddToken: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .invalidPushToken: .info
         case .unknown: .error
         }
@@ -107,6 +110,7 @@ extension ErrorDeleteToken: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .unknown: .error
         }
     }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ResolverService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ResolverService.swift
@@ -73,6 +73,7 @@ public enum ErrorResolve: Int, Error, Equatable, Sendable {
     case denied = 1
     case notFound = 2
     case transportFailure = -2
+    case cancelled = -3
     case unknown = -1
 }
 
@@ -80,6 +81,7 @@ extension ErrorResolve: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .notFound: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/SettingsService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/SettingsService.swift
@@ -62,12 +62,14 @@ public enum ErrorUpdateSettings: Int, Error {
     case invalidRegion
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorUpdateSettings: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .invalidLocale, .invalidRegion: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ThirdPartyService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ThirdPartyService.swift
@@ -68,12 +68,14 @@ public enum ErrorFetchJWT: Int, Error {
     case emailVerificationRequired
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorFetchJWT: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .unsupportedProvider, .invalidApiKey, .phoneVerificationRequired, .emailVerificationRequired: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/AccountInfoService.swift
@@ -112,7 +112,7 @@ final class AccountInfoService: Sendable {
                 case .notFound:
                     // No ATA for this mint yet — caller treats as zero balance.
                     await MainActor.run { completion(.success(nil)) }
-                case .unknown, .accountNotInList, .parseFailed, .transportFailure:
+                case .unknown, .accountNotInList, .parseFailed, .transportFailure, .cancelled:
                     logger.error("Failed to fetch associated token account", metadata: [
                         "owner": "\(owner.publicKey.base58)",
                         "mint": "\(mint.base58)",
@@ -185,12 +185,14 @@ public enum ErrorFetchBalance: Int, Error, Equatable, Sendable {
     case accountNotInList = -2
     case parseFailed      = -3
     case transportFailure = -4
+    case cancelled        = -5
 }
 
 extension ErrorFetchBalance: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .notFound, .accountNotInList: .info
         case .unknown, .parseFailed: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/CurrencyService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/CurrencyService.swift
@@ -257,6 +257,7 @@ public enum ErrorRateHistory: Int, Error {
     case notFound
     case unknown          = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorLaunchCurrency: Error, Sendable {
@@ -271,6 +272,7 @@ extension ErrorRateHistory: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .notFound: .info
         case .unknown: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
@@ -655,6 +655,7 @@ public enum ErrorGetSwap: Int, Error {
     case unknown = -1
     case failedToParse = -2
     case transportFailure = -3
+    case cancelled = -4
 }
 
 extension ErrorSwap: ServerError {
@@ -672,6 +673,7 @@ extension ErrorGetSwap: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .notFound, .denied: .info
         case .unknown, .failedToParse: .error
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -1021,6 +1021,7 @@ public enum ErrorVoidGiftCard: Int, Error {
     case notFound
     case unknown = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 public enum ErrorFetchIntentMetadata: Int, Error {
@@ -1030,12 +1031,14 @@ public enum ErrorFetchIntentMetadata: Int, Error {
     case unknown = -1
     case failedToParse = -2
     case transportFailure = -3
+    case cancelled = -4
 }
 
 public enum ErrorFetchLimits: Int, Error {
     case ok
     case unknown = -1
     case transportFailure = -2
+    case cancelled = -3
 }
 
 extension ErrorSubmitIntent: ServerError {
@@ -1043,16 +1046,7 @@ extension ErrorSubmitIntent: ServerError {
         switch self {
         case .denied, .invalidIntent, .staleState: .info
         case .signatureError, .unknown, .deviceTokenUnavailable, .grpcError: .error
-        case .grpcStatus: isTransientNetworkError ? .suppressed : .error
-        }
-    }
-
-    public var isTransientNetworkError: Bool {
-        switch self {
-        case .grpcStatus(let status):
-            status.code.isTransientNetworkError
-        case .denied, .invalidIntent, .signatureError, .staleState, .unknown, .deviceTokenUnavailable, .grpcError:
-            false
+        case .grpcStatus(let status): status.reportingLevel
         }
     }
 }
@@ -1061,6 +1055,7 @@ extension ErrorVoidGiftCard: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .denied, .claimed, .notFound: .info
         case .unknown: .error
         }
@@ -1071,6 +1066,7 @@ extension ErrorFetchIntentMetadata: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .notFound, .denied: .info
         case .unknown, .failedToParse: .error
         }
@@ -1081,6 +1077,7 @@ extension ErrorFetchLimits: ServerError, TransportClassifiableError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
         case .unknown: .error
         }
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/TransportClassifiableError.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/TransportClassifiableError.swift
@@ -6,19 +6,23 @@
 import GRPCCore
 
 /// A `ServerError` whose failure can originate from a gRPC transport condition
-/// (request timeout, unavailable channel) rather than a server result code.
-/// The classification lives here once: a transient `RPCError` (per
-/// `RPCError.Code.isTransientNetworkError`) becomes `.transportFailure` — which
-/// the conformer must mark non-reportable — and anything else stays `.unknown`.
-/// Conformers just declare conformance; their `.transportFailure` and `.unknown`
-/// cases satisfy these requirements.
+/// (request timeout, cancellation, unavailable channel) rather than a server
+/// result code. Severity is decided in exactly one place — `RPCError.reportingLevel`
+/// — and `from(transportError:)` projects that verdict onto the conformer's three
+/// transport cases: `.transportFailure` (suppressed), `.cancelled` (info), and
+/// `.unknown` (error). Conformers declare the three cases; they never re-classify.
 public protocol TransportClassifiableError: ServerError {
     static var transportFailure: Self { get }
+    static var cancelled: Self { get }
     static var unknown: Self { get }
 }
 
 public extension TransportClassifiableError {
     static func from(transportError error: RPCError) -> Self {
-        error.code.isTransientNetworkError ? .transportFailure : .unknown
+        switch error.reportingLevel {
+        case .suppressed: .transportFailure
+        case .info:       .cancelled
+        case .error:      .unknown
+        }
     }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ErrorSubmitIntentTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ErrorSubmitIntentTests.swift
@@ -135,29 +135,32 @@ struct ErrorSubmitIntentTests {
         }
     }
 
-    // MARK: - isTransientNetworkError / reportingLevel
+    // MARK: - reportingLevel (forwards to the wrapped RPCError)
 
     @Test(
-        "grpcStatus(.deadlineExceeded) and grpcStatus(.unavailable) are transient network errors",
+        "transient grpcStatus codes are suppressed",
         arguments: [RPCError.Code.deadlineExceeded, .unavailable]
     )
-    func transientNetworkErrors(code: RPCError.Code) {
+    func transientGrpcStatusIsSuppressed(code: RPCError.Code) {
         let error = ErrorSubmitIntent.grpcStatus(RPCError(code: code, message: ""))
 
-        #expect(error.isTransientNetworkError)
         #expect(error.reportingLevel == .suppressed)
     }
 
-    // `.cancelled`/`.aborted`/`.unknown` are retryable per gRPC semantics
-    // but kept reportable here so app cancellations and server aborts stay visible.
+    @Test("grpcStatus(.cancelled) is app-initiated teardown, reported at .info not .error")
+    func cancelledGrpcStatusIsInfo() {
+        let error = ErrorSubmitIntent.grpcStatus(RPCError(code: .cancelled, message: ""))
+
+        #expect(error.reportingLevel == .info)
+    }
+
     @Test(
-        "non-network grpcStatus codes remain reportable and are not transient",
+        "non-network, non-cancelled grpcStatus codes report at .error",
         arguments: [
             RPCError.Code.internalError,
             .invalidArgument,
             .permissionDenied,
             .resourceExhausted,
-            .cancelled,
             .aborted,
             .unknown,
         ]
@@ -165,24 +168,7 @@ struct ErrorSubmitIntentTests {
     func reportableGrpcStatusCodes(code: RPCError.Code) {
         let error = ErrorSubmitIntent.grpcStatus(RPCError(code: code, message: ""))
 
-        #expect(!error.isTransientNetworkError)
         #expect(error.reportingLevel == .error)
-    }
-
-    @Test(
-        "non-grpcStatus cases are never transient network errors",
-        arguments: [
-            ErrorSubmitIntent.denied([], messages: []),
-            .invalidIntent([]),
-            .signatureError,
-            .staleState([], kinds: []),
-            .unknown,
-            .deviceTokenUnavailable,
-            .grpcError(RPCError(code: .unavailable, message: "")),
-        ]
-    )
-    func nonGrpcStatusCasesAreNotTransient(error: ErrorSubmitIntent) {
-        #expect(!error.isTransientNetworkError)
     }
 
     // MARK: - StaleStateKind

--- a/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
@@ -18,6 +18,9 @@ struct TransportClassificationTests {
     private func assertClassifies<E: TransportClassifiableError>(_ type: E.Type) {
         #expect(E.from(transportError: RPCError(code: .deadlineExceeded, message: "")).reportingLevel == .suppressed)
         #expect(E.from(transportError: RPCError(code: .unavailable, message: "")).reportingLevel == .suppressed)
+        // Regression 6a1b80a: app/user-initiated teardown lands on `.cancelled` at
+        // `.info`, never collapsed into `.unknown`/`.error`.
+        #expect(E.from(transportError: RPCError(code: .cancelled, message: "")).reportingLevel == .info)
         #expect(E.from(transportError: RPCError(code: .internalError, message: "")).reportingLevel == .error)
     }
 

--- a/FlipcashTests/Regressions/Regression_6a10ebf.swift
+++ b/FlipcashTests/Regressions/Regression_6a10ebf.swift
@@ -32,6 +32,7 @@ struct Regression_6a10ebf {
         (ErrorFetchBalance.unknown,          .error),
         (ErrorFetchBalance.parseFailed,      .error),
         (ErrorFetchBalance.transportFailure, .suppressed),
+        (ErrorFetchBalance.cancelled,        .info),
     ])
     func reportingLevel(error: ErrorFetchBalance, expected: ErrorReportingLevel) {
         #expect(error.reportingLevel == expected)
@@ -40,7 +41,7 @@ struct Regression_6a10ebf {
     @Test("gRPC transport errors map to the right ErrorFetchBalance case", arguments: [
         (RPCError.Code.deadlineExceeded, ErrorFetchBalance.transportFailure),
         (RPCError.Code.unavailable,      ErrorFetchBalance.transportFailure),
-        (RPCError.Code.cancelled,        ErrorFetchBalance.unknown),
+        (RPCError.Code.cancelled,        ErrorFetchBalance.cancelled),
         (RPCError.Code.invalidArgument,  ErrorFetchBalance.unknown),
         (RPCError.Code.permissionDenied, ErrorFetchBalance.unknown),
         (RPCError.Code.internalError,    ErrorFetchBalance.unknown),


### PR DESCRIPTION
Transport-error severity was decided in two places: the raw `RPCError` path already treats a cancellation as low-priority info, but the typed-error path recognised only timeouts and collapsed every other gRPC code — cancellations included — into an error-level unknown, so a call torn down when the app backgrounds got reported as a defect. This routes the typed path through that single classifier, adds a dedicated cancelled case to every transport error type, and folds the submit-intent error onto the same path so severity lives in one place. This is a scoped cleanup — not the fix for the phone-verification Bugsnag issue, which is a separate server-side change.

## Test plan
- [x] FlipcashCoreTests passes
- [x] FlipcashTests passes
- [ ] Cancelled transport failures surface as info, not error
