### PR TITLE
feat: adopt the chat event-log delta protocol

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -119,6 +119,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             sessionContainer?.usdcSweepOperation.start()
             sessionContainer?.contactSyncController.didBecomeActive()
             sessionContainer?.conversationController.ensureConnected()
+            sessionContainer?.conversationController.catchUpOpenChat()
             sessionContainer?.pushController.clearBadgeCount()
         case .inactive:
             break

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -79,6 +79,13 @@ final class ConversationController {
     @ObservationIgnored private var hasSeenStreamLive = false
     @ObservationIgnored private var hydratingConversationIDs: Set<ConversationID> = []
     @ObservationIgnored private var markReadTasks: [ConversationID: Task<Void, Never>] = [:]
+    /// Conversations with a `GetDelta` catch-up in flight. Dedups overlapping triggers (foreground +
+    /// a near-simultaneous reconnect, or a gap-fill racing a reconnect) so two streams don't apply
+    /// checkpoints out of order and regress the frontier.
+    @ObservationIgnored private var catchUpInFlight: Set<ConversationID> = []
+    /// Debounced live-gap catch-ups, one per conversation: a detected gap waits briefly (a late
+    /// out-of-order event may close it) before spending a `GetDelta`.
+    @ObservationIgnored private var gapCatchUpTasks: [ConversationID: Task<Void, Never>] = [:]
     @ObservationIgnored private let receiptSettle = ReceiptSettleGate()
 
     /// Re-send STILL no more often than this while the user keeps typing, and send STOPPED after this
@@ -121,6 +128,7 @@ final class ConversationController {
                 for (conversationID, messages) in cache.messages {
                     store.mergeMessages(messages, into: conversationID)
                 }
+                store.seedAppliedCursors(cache.cursors)
             }
         } catch {
             logger.error("Failed to load conversation cache", metadata: ["error": "\(error)"])
@@ -148,19 +156,23 @@ final class ConversationController {
         streamTask = Task { [weak self] in
             for await event in events {
                 guard let self else { return }
-                self.store.apply(event)
+                let gap = self.store.apply(event)
                 self.persist(event: event)
                 self.hydrateIfUnknown(event)
                 self.logCounterpartRead(event)
                 self.applyTyping(event)
+                if case .needsCatchUp(let conversationID, _) = gap {
+                    self.scheduleGapCatchUp(conversationID)
+                }
             }
         }
     }
 
-    /// The event stream is a live, cursorless push and the server never replays,
-    /// so messages delivered while it was down are lost. Watch the connection
-    /// state: the first `.live` is the initial connection, and every `.live`
-    /// after it is a reconnect whose missed window we refetch.
+    /// A reconnect can miss live events while the stream was down; the event log carries a per-chat
+    /// cursor, so on reconnect we reconcile the missed window from that cursor via `GetDelta`. The first
+    /// `.live` is the initial connection (already loaded by `start()`/the screen); every `.live` after
+    /// it is a reconnect. This edge is a belt-and-suspenders trigger — foreground, chat-open, and a
+    /// detected live gap already drive catch-up without waiting for a ping.
     private func observeConnectionState() {
         guard connectionStateTask == nil else { return }
         let states = streaming.conversationConnectionState()
@@ -178,13 +190,112 @@ final class ConversationController {
     }
 
     private func refetchAfterReconnect() async {
-        logger.info("Stream reconnected, refetching the missed window", metadata: [
+        logger.info("Stream reconnected, catching up the missed window", metadata: [
             "visibleConversation": visibleConversationID.map { "\($0)" } ?? "none",
         ])
-        await loadFeed()
+        // Refresh the feed (unread + head truth) and reconcile the open transcript from the event-log
+        // cursor via GetDelta — not a blind newest-page reload. Both are @MainActor (store mutations
+        // stay serial) but their network calls run off-main, so overlap them rather than awaiting in
+        // series.
+        async let feed: Void = loadFeed()
         if let visibleConversationID {
-            await loadMessages(for: visibleConversationID)
+            await catchUp(conversationID: visibleConversationID)
         }
+        await feed
+    }
+
+    // MARK: - Event-log catch-up
+
+    /// Reconcile a conversation's transcript from its persisted event-log cursor via `GetDelta`,
+    /// applying and persisting each batch's checkpoint as it arrives. Deduped per conversation — a
+    /// second caller while one is in flight no-ops. Fired on chat-open, foreground, reconnect, and a
+    /// detected live gap; none of these wait for a server ping.
+    func catchUp(conversationID: ConversationID) async {
+        guard !catchUpInFlight.contains(conversationID) else { return }
+        catchUpInFlight.insert(conversationID)
+        defer { catchUpInFlight.remove(conversationID) }
+
+        let after = store.appliedCursor(for: conversationID)
+        do {
+            let head = try await messaging.getDelta(owner: owner, conversationID: conversationID, afterSequence: after) { [weak self] messages, checkpoint in
+                guard let self else { return }
+                self.store.applyDeltaBatch(messages, checkpoint: checkpoint, into: conversationID)
+                if !messages.isEmpty {
+                    self.persist(operation: "delta-batch") { try self.database.upsertConversationMessages(messages, conversationID: conversationID) }
+                }
+                self.persistCursor(for: conversationID)
+            }
+            // Clean completion: the head is authoritative even if the intervening events weren't observed.
+            store.setAppliedCursor(head, for: conversationID)
+            persistCursor(for: conversationID)
+            // `after` vs `head`: equal means already current; a jump means the delta window that was
+            // caught up. Observable so the production catch-up cadence can be traced.
+            logger.info("Chat catch-up complete", metadata: [
+                "conversationID": "\(conversationID)",
+                "after": "\(after)",
+                "head": "\(head)",
+            ])
+        } catch let error as ErrorGetDelta where error == .resetRequired {
+            await resyncAfterReset(conversationID: conversationID)
+        } catch {
+            // Transport / denied / unknown: leave the cursor at the last persisted checkpoint so the
+            // next trigger resumes from there. captureError classifies transient failures as suppressed.
+            logger.error("Chat catch-up failed", metadata: [
+                "conversationID": "\(conversationID)",
+                "error": "\(error)",
+            ])
+            ErrorReporting.captureError(error, reason: "Chat delta catch-up failed")
+        }
+    }
+
+    /// Foreground hook (`AppDelegate` `.active`): reconcile the on-screen chat regardless of any ping.
+    func catchUpOpenChat() {
+        guard let visibleConversationID else { return }
+        Task { await catchUp(conversationID: visibleConversationID) }
+    }
+
+    /// A live event exposed a gap. Debounce briefly — a late out-of-order event may close it before we
+    /// spend a round trip — then reconcile from the (possibly already-advanced) cursor.
+    private func scheduleGapCatchUp(_ conversationID: ConversationID) {
+        gapCatchUpTasks[conversationID]?.cancel()
+        gapCatchUpTasks[conversationID] = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            await self?.catchUp(conversationID: conversationID)
+        }
+    }
+
+    /// `RESET_REQUIRED`: the cursor is too far behind to stream a delta. Discard it, re-sync the newest
+    /// page via `GetMessages`, and seat the cursor to that page's lowest event sequence — a safe floor
+    /// the next catch-up backfills from, never the head (which would skip the un-loaded window).
+    private func resyncAfterReset(conversationID: ConversationID) async {
+        logger.info("Chat catch-up reset required, re-syncing history", metadata: ["conversationID": "\(conversationID)"])
+        store.resetCursor(for: conversationID)
+        // Persist the reset now (persistCursor won't write 0): if the re-sync below throws, the stale
+        // too-far-behind cursor must not survive to the next launch and immediately re-hit RESET_REQUIRED.
+        persist(operation: "reset-cursor") { try database.updateCatchupCursor(0, for: conversationID) }
+        do {
+            let messages = try await messaging.getMessages(owner: owner, conversationID: conversationID, before: nil)
+            store.mergeMessages(messages, into: conversationID)
+            persist(operation: "reset-resync") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
+            if let floor = messages.map(\.eventSequence).filter({ $0 > 0 }).min() {
+                store.setAppliedCursor(floor, for: conversationID)
+                persistCursor(for: conversationID)
+            }
+        } catch {
+            logger.error("Failed to re-sync after catch-up reset", metadata: [
+                "conversationID": "\(conversationID)",
+                "error": "\(error)",
+            ])
+            ErrorReporting.captureError(error, reason: "Failed to re-sync after chat catch-up reset")
+        }
+    }
+
+    /// Persist the store's current catch-up frontier (no-op until one is established).
+    private func persistCursor(for conversationID: ConversationID) {
+        let cursor = store.appliedCursor(for: conversationID)
+        guard cursor > 0 else { return }
+        persist(operation: "update-cursor") { try database.updateCatchupCursor(cursor, for: conversationID) }
     }
 
     /// Surfaces a counterpart's READ pointer advance — the signal behind the
@@ -231,6 +342,9 @@ final class ConversationController {
         connectionStateTask = nil
         markReadTasks.values.forEach { $0.cancel() }
         markReadTasks.removeAll()
+        gapCatchUpTasks.values.forEach { $0.cancel() }
+        gapCatchUpTasks.removeAll()
+        catchUpInFlight.removeAll()
         typingUserIDs.removeAll()
         selfTypingTask?.cancel()
         selfTypingTask = nil
@@ -250,7 +364,7 @@ final class ConversationController {
     private func hydrateIfUnknown(_ event: ConversationStreamEvent) {
         let conversationID: ConversationID
         switch event {
-        case .newMessages(let id, _), .lastActivityChanged(let id, _), .readPointersChanged(let id, _):
+        case .newMessages(let id, _), .chatEvents(let id, _), .lastActivityChanged(let id, _), .readPointersChanged(let id, _):
             conversationID = id
         case .metadataRefresh:
             return
@@ -302,6 +416,13 @@ final class ConversationController {
         switch event {
         case .newMessages(let conversationID, let messages):
             persist(operation: "upsert-messages") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
+            persistConversation(conversationID)
+        case .chatEvents(let conversationID, let events):
+            let messages = events.flatMap { $0.mutations.map(\.message) }
+            if !messages.isEmpty {
+                persist(operation: "upsert-events") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
+            }
+            persistCursor(for: conversationID)
             persistConversation(conversationID)
         case .metadataRefresh(let conversation):
             persistConversation(conversation)
@@ -398,6 +519,14 @@ final class ConversationController {
                 "count": "\(messages.count)",
             ])
             store.mergeMessages(messages, into: conversationID)
+            // Establish the event-log frontier from the newest page so a following catch-up resumes from
+            // head — fetching only genuinely newer messages, appended at the tail — instead of a
+            // `GetDelta(after: 0)` that re-pulls the whole history and prepends it, knocking the
+            // transcript off the bottom on first open.
+            if let head = messages.map(\.eventSequence).max(), head > 0 {
+                store.setAppliedCursor(head, for: conversationID)
+                persistCursor(for: conversationID)
+            }
             persist(operation: "load-messages") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
         } catch {
             logger.error("Failed to load conversation messages", metadata: [

--- a/Flipcash/Core/Controllers/Database/Database+Conversations.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Conversations.swift
@@ -15,7 +15,7 @@ nonisolated extension Database {
 
     /// Async wrapper that runs the synchronous cache reads off the caller's
     /// actor so session start never blocks the main thread on row decoding.
-    func loadConversationCache() async throws -> (conversations: [Conversation], messages: [ConversationID: [ConversationMessage]]) {
+    func loadConversationCache() async throws -> (conversations: [Conversation], messages: [ConversationID: [ConversationMessage]], cursors: [ConversationID: UInt64]) {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
@@ -24,11 +24,24 @@ nonisolated extension Database {
                     for conversation in conversations {
                         messages[conversation.id] = try self.getConversationMessages(conversationID: conversation.id)
                     }
-                    continuation.resume(returning: (conversations, messages))
+                    let cursors = try self.getCatchupCursors()
+                    continuation.resume(returning: (conversations, messages, cursors))
                 } catch {
                     continuation.resume(throwing: error)
                 }
             }
+        }
+    }
+
+    /// The persisted per-conversation event-log catch-up frontier (`GetDelta.after_sequence`), omitting
+    /// conversations with no cursor yet.
+    func getCatchupCursors() throws -> [ConversationID: UInt64] {
+        let c = ConversationTable()
+        let rows = try reader.prepareRowIterator(c.table).map { row in
+            (id: ConversationID(data: row[c.id]), cursor: row[c.catchupCursor])
+        }
+        return rows.reduce(into: [:]) { result, row in
+            if let cursor = row.cursor { result[row.id] = cursor }
         }
     }
 
@@ -67,11 +80,13 @@ nonisolated extension Database {
         }
     }
 
-    /// The newest stored message for a conversation, or nil when none is cached.
+    /// The newest stored non-deleted message for a conversation, or nil when none is cached. Tombstones
+    /// (`kind == 2`) are skipped so the feed preview shows the newest *visible* message rather than a
+    /// blank row for a deleted last message.
     private func latestMessage(conversationId: Data) throws -> ConversationMessage? {
         let m = ConversationMessageTable()
         guard let row = try reader.pluck(
-            m.table.filter(m.conversationId == conversationId).order(m.id.desc)
+            m.table.filter(m.conversationId == conversationId && m.kind != 2).order(m.id.desc)
         ) else {
             return nil
         }
@@ -98,17 +113,30 @@ nonisolated extension Database {
         let msg = ConversationMessageTable()
         let ids = conversations.map(\.id.data)
         try writer.transaction {
-            try writer.run(c.table.delete())
-            try writer.run(m.table.delete())
+            // Delete only the conversations that dropped out of the feed, then upsert the rest.
+            // `writeConversation` upserts the row (leaving `catchupCursor` untouched on conflict) and
+            // replaces that conversation's members, so a surviving conversation keeps its event-log
+            // cursor without a read-and-restore dance.
             if ids.isEmpty {
+                try writer.run(c.table.delete())
+                try writer.run(m.table.delete())
                 try writer.run(msg.table.delete())
             } else {
+                try writer.run(c.table.filter(!ids.contains(c.id)).delete())
+                try writer.run(m.table.filter(!ids.contains(m.conversationId)).delete())
                 try writer.run(msg.table.filter(!ids.contains(msg.conversationId)).delete())
             }
             for conversation in conversations {
                 try writeConversation(conversation)
             }
         }
+    }
+
+    /// Advance the persisted catch-up cursor for a conversation without rewriting its members or
+    /// last-message preview. No-ops for a conversation not yet in the feed.
+    func updateCatchupCursor(_ value: UInt64, for conversationID: ConversationID) throws {
+        let c = ConversationTable()
+        try writer.run(c.table.filter(c.id == conversationID.data).update(c.catchupCursor <- value))
     }
 
     /// Upsert one conversation: its row, its members (replaced wholesale), and
@@ -185,6 +213,15 @@ nonisolated extension Database {
     private func writeMessage(_ message: ConversationMessage, conversationId: Data) throws {
         let m = ConversationMessageTable()
 
+        // Last-writer-wins parity with the in-memory `ConversationStore`: never let a stale re-delivery
+        // (e.g. the deprecated `new_messages` overlay landing after the `events` tombstone, or a
+        // duplicate delta batch) overwrite a newer persisted version — that would resurrect a
+        // deleted/pre-edit message across a relaunch, since the cache is what hydrates on cold boot.
+        if let existing = try writer.pluck(m.table.filter(m.conversationId == conversationId && m.id == message.id.value)),
+           existing[m.eventSequence] > message.eventSequence {
+            return
+        }
+
         let kind: Int
         var text: String?
         var quarks: UInt64?
@@ -202,6 +239,8 @@ nonisolated extension Database {
             nativeAmount = amount.nativeAmount.value.description
             currency = amount.nativeAmount.currency
             mint = amount.mint
+        case .deleted:
+            kind = 2
         }
 
         try writer.run(
@@ -217,7 +256,8 @@ nonisolated extension Database {
                 m.currency       <- currency,
                 m.mint           <- mint,
                 m.date           <- message.date.timeIntervalSinceReferenceDate,
-                m.unreadSeq      <- message.unreadSeq
+                m.unreadSeq      <- message.unreadSeq,
+                m.eventSequence  <- message.eventSequence
             )
         )
     }
@@ -253,6 +293,8 @@ nonisolated extension Database {
                 nativeAmount: native,
                 currencyRate: Rate(fx: fx, currency: currency)
             ))
+        case 2:
+            content = .deleted
         default:
             return nil
         }
@@ -262,7 +304,8 @@ nonisolated extension Database {
             senderID: row[m.senderId],
             content: content,
             date: Date(timeIntervalSinceReferenceDate: row[m.date]),
-            unreadSeq: row[m.unreadSeq]
+            unreadSeq: row[m.unreadSeq],
+            eventSequence: row[m.eventSequence]
         )
     }
 }

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -168,8 +168,11 @@ nonisolated struct ConversationTable: Sendable {
     static let name = "conversation"
 
     let table        = Table(Self.name)
-    let id           = Expression <Data>   ("id")          // 32-byte ChatId
-    let lastActivity = Expression <Double> ("lastActivity")
+    let id           = Expression <Data>    ("id")          // 32-byte ChatId
+    let lastActivity = Expression <Double>  ("lastActivity")
+    // Highest contiguous event-log sequence applied for this chat — the resume
+    // point passed to GetDelta. Nil until the first catch-up establishes one.
+    let catchupCursor = Expression <UInt64?> ("catchupCursor")
 }
 
 nonisolated struct ConversationMemberTable: Sendable {
@@ -201,6 +204,9 @@ nonisolated struct ConversationMessageTable: Sendable {
     let mint           = Expression <PublicKey?>    ("mint")
     let date           = Expression <Double>        ("date")
     let unreadSeq      = Expression <UInt64>        ("unreadSeq")
+    // Event-log version of this message's current state; the store applies
+    // last-writer-wins by it. Zero for legacy/optimistic rows.
+    let eventSequence  = Expression <UInt64>        ("eventSequence")
 }
 
 nonisolated extension Expression {
@@ -383,6 +389,7 @@ nonisolated extension Database {
             try writer.run(conversationTable.table.create(ifNotExists: true, withoutRowid: true) { t in
                 t.column(conversationTable.id, primaryKey: true)
                 t.column(conversationTable.lastActivity)
+                t.column(conversationTable.catchupCursor)
             })
         }
 
@@ -417,6 +424,7 @@ nonisolated extension Database {
                 t.column(conversationMessageTable.mint)
                 t.column(conversationMessageTable.date)
                 t.column(conversationMessageTable.unreadSeq)
+                t.column(conversationMessageTable.eventSequence)
                 t.primaryKey(conversationMessageTable.conversationId, conversationMessageTable.id)
             })
         }

--- a/Flipcash/Core/Controllers/FlipClient+Protocols.swift
+++ b/Flipcash/Core/Controllers/FlipClient+Protocols.swift
@@ -71,6 +71,16 @@ protocol ConversationMessaging: AnyObject, Sendable {
     /// Fetches a page of messages. `before == nil` returns the newest page;
     /// pass the oldest currently-loaded id to page strictly older (history).
     func getMessages(owner: KeyPair, conversationID: ConversationID, before: MessageID?) async throws -> [ConversationMessage]
+    /// Reconnect/cold-boot catch-up. Streams the messages changed since `afterSequence` to `onBatch`
+    /// (each with its resume checkpoint), returning the chat's head sequence on clean completion.
+    /// Throws `ErrorGetDelta.resetRequired` when the cursor is too far behind (caller re-syncs via
+    /// `getMessages`).
+    func getDelta(
+        owner: KeyPair,
+        conversationID: ConversationID,
+        afterSequence: UInt64,
+        onBatch: @MainActor @Sendable @escaping (_ messages: [ConversationMessage], _ checkpoint: UInt64?) -> Void
+    ) async throws -> UInt64
     func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID) async throws -> ConversationMessage
     func markRead(owner: KeyPair, conversationID: ConversationID, messageID: MessageID) async throws
     func notifyIsTyping(owner: KeyPair, conversationID: ConversationID, state: TypingState) async throws
@@ -80,9 +90,9 @@ protocol ConversationMessaging: AnyObject, Sendable {
 /// `event.v1 StreamEvents` lifecycle behind `ConversationStreamEvent`.
 protocol ConversationEventStreaming: AnyObject, Sendable {
     func openConversationStream(owner: KeyPair) -> AsyncStream<ConversationStreamEvent>
-    /// The event stream's connection state. The stream carries no cursor and the
-    /// server never replays, so the controller treats the first `.live` as the
-    /// initial connection and refetches the missed window on each `.live` after.
+    /// The event stream's connection state. The event stream carries no cursor, so the controller
+    /// treats the first `.live` as the initial connection and, on each `.live` after (a reconnect),
+    /// reconciles the missed window from the event-log cursor via `GetDelta`.
     func conversationConnectionState() -> AsyncStream<EventStreamConnectionState>
     func ensureConversationStreamConnected()
     func closeConversationStream()

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -25,6 +25,11 @@ extension ChatItem {
         suppressReceiptFor: String? = nil,
         cashBranding: (ExchangedFiat) -> (token: String, iconURL: URL?) = { _ in ("Cash", nil) }
     ) -> [ChatItem] {
+        // Tombstoned (deleted) messages are retained in the store for gapless ordering but rendered
+        // nowhere. Drop them up front so they never skew a date separator, group an adjacent bubble to
+        // an invisible row, or steal the "Delivered"/"Read" receipt anchor below.
+        let messages = messages.filter { if case .deleted = $0.content { false } else { true } }
+
         // "Delivered"/"Read" rides the latest *confirmed* self message, so an in-flight or failed send
         // trailing it doesn't strip the receipt off the last delivered bubble. A sending row shows
         // nothing; a failed row shows its own "Not Delivered" line (each independently retryable).
@@ -62,6 +67,8 @@ extension ChatItem {
                     flagImageName: flagName,
                     iconURL: branding.iconURL
                 ))
+            case .deleted:
+                continue // filtered out above; unreachable, kept for switch exhaustiveness
             }
 
             // The status line rides on the bubble itself (not a separate row, so a send is a clean

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -226,6 +226,9 @@ struct ConversationScreen: View {
         // created yet error-reports. Fires when the chat materializes.
         .task(id: chatExists ? conversationID : nil) {
             guard chatExists, let conversationID else { return }
+            // The newest page IS the fresh state and seats the event-log cursor to head, so opening a
+            // chat needs no separate catch-up. Missed-while-open windows are reconciled by the
+            // foreground / reconnect / live-gap triggers instead.
             await conversationController.loadMessages(for: conversationID)
             await conversationController.markRead(conversationID: conversationID)
             // Reading the thread clears its own delivered pushes; other chats keep theirs.
@@ -348,7 +351,7 @@ struct ConversationScreen: View {
         switch message.content {
         case .cash(let fiat):
             router.push(.currencyInfo(fiat.mint))
-        case .text:
+        case .text, .deleted:
             break
         }
     }

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -506,6 +506,8 @@ private struct RecipientListItemRow: View {
                     return "\(verb) \(formatted)"
                 }
                 return "\(verb) \(formatted) of \(name)"
+            case .deleted:
+                return nil
             }
         }
     }

--- a/Flipcash/Core/Spotlight/ChatSpotlightItem.swift
+++ b/Flipcash/Core/Spotlight/ChatSpotlightItem.swift
@@ -59,7 +59,7 @@ nonisolated struct ChatSpotlightItem {
         switch message?.content {
         case .text(let text):    text
         case .cash(let amount):  "Cash · \(amount.nativeAmount.formatted())"
-        case nil:                nil
+        case .deleted, nil:      nil
         }
     }
 

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 		<string>com.flipcash.app.openChat</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>21</integer>
+	<integer>22</integer>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
@@ -40,6 +40,20 @@ extension FlipClient {
         }
     }
 
+    /// Streams the delta since `afterSequence` to `onBatch` (each with its resume checkpoint) and
+    /// returns the chat's head on clean completion. Throws `ErrorGetDelta` on `.resetRequired`/denied/
+    /// transport failure.
+    public func getDelta(
+        owner: KeyPair,
+        conversationID: ConversationID,
+        afterSequence: UInt64,
+        onBatch: @MainActor @Sendable @escaping (_ messages: [ConversationMessage], _ checkpoint: UInt64?) -> Void
+    ) async throws -> UInt64 {
+        try await withCheckedThrowingContinuation { c in
+            chatMessagingService.getDelta(owner: owner, conversationID: conversationID, afterSequence: afterSequence, onBatch: onBatch) { c.resume(with: $0) }
+        }
+    }
+
     @discardableResult
     public func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID) async throws -> ConversationMessage {
         try await withCheckedThrowingContinuation { c in

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
@@ -59,6 +59,59 @@ final class ChatMessagingService: Sendable {
         }
     }
 
+    /// Reconnect/cold-boot catch-up: a BOUNDED server stream of the messages changed since
+    /// `afterSequence`, up to the chat's head. Each data batch is delivered to `onBatch` with its
+    /// `checkpointSequence` (the resume point through that batch) so the caller applies-and-persists
+    /// incrementally — a mid-stream drop resumes from the last checkpoint. `completion` fires once with
+    /// the chat's head (`latestSequence`) on clean completion, `.resetRequired` when the cursor is too
+    /// far behind (caller re-syncs via `getMessages`), or a transport/denied failure. No deadline: a
+    /// bounded stream must not be truncated by one.
+    func getDelta(
+        owner: KeyPair,
+        conversationID: ConversationID,
+        afterSequence: UInt64,
+        onBatch: @MainActor @Sendable @escaping (_ messages: [ConversationMessage], _ checkpoint: UInt64?) -> Void,
+        completion: @Sendable @escaping (Result<UInt64, ErrorGetDelta>) -> Void
+    ) {
+        let request = Flipcash_Messaging_V1_GetDeltaRequest.with {
+            $0.chatID = conversationID.proto
+            $0.afterSequence = afterSequence
+            $0.auth = owner.authFor(message: $0)
+        }
+
+        Task {
+            do {
+                try await service.getDelta(request: .init(message: request), options: .defaults) { response in
+                    var head: UInt64 = 0
+                    var terminal: ErrorGetDelta?
+                    for try await message in response.messages {
+                        head = max(head, message.latestSequence)
+                        let result = ErrorGetDelta(rawValue: message.result.rawValue) ?? .unknown
+                        switch result {
+                        case .ok:
+                            guard message.hasMessages else { continue }
+                            let messages = message.messages.messages.compactMap(ConversationMessage.init)
+                            let checkpoint = message.checkpointSequence == 0 ? nil : message.checkpointSequence
+                            await MainActor.run { onBatch(messages, checkpoint) }
+                        case .denied, .resetRequired:
+                            terminal = result
+                        case .unknown, .transportFailure, .cancelled:
+                            // Server results are only ok/denied/resetRequired; a transport case here is
+                            // defensive — treat as an unknown terminal.
+                            terminal = .unknown
+                        }
+                    }
+                    let outcome: Result<UInt64, ErrorGetDelta> = terminal.map { .failure($0) } ?? .success(head)
+                    await MainActor.run { completion(outcome) }
+                }
+            } catch let error as RPCError {
+                await MainActor.run { completion(.failure(.from(transportError: error))) }
+            } catch {
+                await MainActor.run { completion(.failure(.unknown)) }
+            }
+        }
+    }
+
     func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID, completion: @Sendable @escaping (Result<ConversationMessage, ErrorSendMessage>) -> Void) {
         let request = Flipcash_Messaging_V1_SendMessageRequest.with {
             $0.chatID = conversationID.proto
@@ -138,6 +191,15 @@ public enum ErrorGetMessages: Int, Error {
     case cancelled = -3
 }
 
+public enum ErrorGetDelta: Int, Error {
+    case ok
+    case denied
+    case resetRequired
+    case unknown          = -1
+    case transportFailure = -2
+    case cancelled        = -3
+}
+
 public enum ErrorSendMessage: Int, Error {
     case ok
     case denied
@@ -169,6 +231,18 @@ extension ErrorGetMessages: ServerError, TransportClassifiableError {
         case .ok, .transportFailure: .suppressed
         case .cancelled: .info
         case .denied, .notFound: .info
+        case .unknown: .error
+        }
+    }
+}
+
+extension ErrorGetDelta: ServerError, TransportClassifiableError {
+    public var reportingLevel: ErrorReportingLevel {
+        switch self {
+        case .ok, .transportFailure: .suppressed
+        // `resetRequired` is a routine "cursor too old, re-sync" outcome, `denied` an expected
+        // membership/business result, and `.cancelled` app-initiated teardown — none is a client defect.
+        case .denied, .resetRequired, .cancelled: .info
         case .unknown: .error
         }
     }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
@@ -38,10 +38,10 @@ public actor EventStreamer {
     public nonisolated let events: AsyncStream<ConversationStreamEvent>
     private let continuation: AsyncStream<ConversationStreamEvent>.Continuation
 
-    /// The stream's connection state over time. The stream carries no cursor and
-    /// the server never replays, so a consumer treats the first `.live` as the
-    /// initial connection and refetches the missed window on each `.live` after
-    /// that. Consume with `for await state in streamer.connectionState`.
+    /// The stream's connection state over time. The event stream itself carries no cursor, so a
+    /// consumer treats the first `.live` as the initial connection and, on each `.live` after that
+    /// (a reconnect), reconciles the missed window from its own durable cursor (chat catch-up runs
+    /// `GetDelta`). Consume with `for await state in streamer.connectionState`.
     public nonisolated let connectionState: AsyncStream<EventStreamConnectionState>
     private let connectionStateContinuation: AsyncStream<EventStreamConnectionState>.Continuation
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatPreviewMapping.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatPreviewMapping.swift
@@ -41,7 +41,12 @@ extension ChatItem {
         limit: Int = 3,
         mintBranding: [PublicKey: MintBrandingInfo] = [:]
     ) -> [ChatItem] {
-        let sorted = messages.sorted { $0.id < $1.id }
+        // Drop tombstones before slicing so the preview keeps the newest `limit` *visible* messages —
+        // filtering after `.suffix` would let a recent delete crowd out a real message (or blank the
+        // preview) and leave an orphaned leading separator.
+        let sorted = messages
+            .filter { if case .deleted = $0.content { false } else { true } }
+            .sorted { $0.id < $1.id }
         let slice = sorted.suffix(limit)
 
         var items: [ChatItem] = []
@@ -71,6 +76,8 @@ extension ChatItem {
                     flagImageName: currency.region?.rawValue ?? currency.rawValue.uppercased(),
                     iconURL: branding?.iconURL
                 ))
+            case .deleted:
+                continue // filtered out above; unreachable, kept for switch exhaustiveness
             }
 
             items.append(.message(ChatMessage(

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
@@ -22,9 +22,13 @@ public struct ConversationMessage: Identifiable, Hashable, Sendable {
 
     /// The message payload. Cash messages are created server-side when a
     /// payment intent carries chat metadata — clients never send them directly.
+    /// `deleted` is a tombstone: the server (a moderation removal, or another
+    /// client's delete) replaced the content, so the row is retained for gapless
+    /// ordering but rendered nowhere.
     public enum Content: Hashable, Sendable {
         case text(String)
         case cash(ExchangedFiat)
+        case deleted
     }
 
     public let id: MessageID
@@ -32,6 +36,12 @@ public struct ConversationMessage: Identifiable, Hashable, Sendable {
     public let content: Content
     public let date: Date
     public let unreadSeq: UInt64
+    /// The event-log version at which this message reached its current state,
+    /// advancing on every send/edit/delete. The store applies last-writer-wins
+    /// by this value, so a stale copy (from any delivery path) never overwrites a
+    /// newer one. Zero for optimistic sends and legacy cache rows that predate
+    /// the event log — a real server copy (always `>= 1`) out-versions them.
+    public let eventSequence: UInt64
     /// Delivery state. `.sent` for every server/cache message; `.sending`/`.failed` only for an
     /// in-flight optimistic message.
     public var status: SendStatus
@@ -47,6 +57,7 @@ public struct ConversationMessage: Identifiable, Hashable, Sendable {
         content: Content,
         date: Date,
         unreadSeq: UInt64,
+        eventSequence: UInt64 = 0,
         status: SendStatus = .sent,
         clientMessageID: UUID? = nil
     ) {
@@ -55,6 +66,7 @@ public struct ConversationMessage: Identifiable, Hashable, Sendable {
         self.content = content
         self.date = date
         self.unreadSeq = unreadSeq
+        self.eventSequence = eventSequence
         self.status = status
         self.clientMessageID = clientMessageID
     }
@@ -78,7 +90,10 @@ extension ConversationMessage {
 
 extension ConversationMessage {
     /// Builds a message from its proto, returning nil for content the client
-    /// can't represent (unknown type, or a cash amount that fails to parse).
+    /// can't represent (unknown type, or a cash amount that fails to parse). A
+    /// deleted message materializes as a `.deleted` tombstone — never nil — so
+    /// it converges the same way across the stream, `GetMessages`, and `GetDelta`
+    /// and can't leave the pre-delete content on screen.
     public init?(_ proto: Flipcash_Messaging_V1_Message) {
         switch proto.content.first?.type {
         case .text(let textContent):
@@ -88,7 +103,9 @@ extension ConversationMessage {
                 return nil
             }
             self.content = .cash(amount)
-        case .reply, .media, .system, .deleted, .none:
+        case .deleted:
+            self.content = .deleted
+        case .reply, .media, .system, .none:
             return nil
         }
 
@@ -96,6 +113,7 @@ extension ConversationMessage {
         self.senderID = try? UUID(data: proto.senderID.value)
         self.date = proto.hasTs ? proto.ts.date : .now
         self.unreadSeq = proto.unreadSeq
+        self.eventSequence = proto.eventSequence
         self.status = .sent
         self.clientMessageID = nil
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -23,6 +23,11 @@ public struct ConversationStore: Sendable {
     /// Monotonic counter stamped on each optimistic send, breaking ties among rows that share an anchor
     /// and keeping send order stable across out-of-order reconciles.
     private var pendingSequence: UInt64 = 0
+    /// The highest contiguous event-log `sequence` applied per conversation — the frontier passed to
+    /// `GetDelta` as `after_sequence`. Zero means "not yet established"; a catch-up seeds it, after
+    /// which live events advance it and gap-detect against it. Distinct from a message's `MessageId`
+    /// and from any per-message `eventSequence`.
+    private var appliedCursorByConversation: [ConversationID: UInt64] = [:]
 
     /// An optimistic send plus the keys that place it in the transcript: `anchor` is the newest
     /// confirmed server id at send time (the row this send sits after), `sequence` is its send order.
@@ -51,10 +56,14 @@ public struct ConversationStore: Sendable {
     /// reconciles a fresh pending send.
     private static let pendingReconcileWindow: TimeInterval = 5 * 60
 
-    /// Insert/replace messages keyed by their gapless id, keeping oldest first. Reconciles a server
-    /// copy of one of our own optimistic sends — which carries no client id, because the server never
-    /// echoes it — against the matching pending row, so the echo collapses onto that row instead of
-    /// duplicating it, no matter which path (stream, history load, or the send RPC) delivers it first.
+    /// Insert/replace messages keyed by their gapless id, keeping oldest first, applying
+    /// last-writer-wins by `eventSequence`. A strictly-newer version (edit, delete, re-fetch) replaces
+    /// the held copy; an older one is ignored; an equal one keeps the held copy. This makes a message
+    /// self-locating regardless of delivery path (stream, history load, `GetDelta`, or the send RPC)
+    /// and makes an out-of-order delete converge — a tombstone that lands before the original send
+    /// out-versions it and is never overwritten. Reconciles a server copy of one of our own optimistic
+    /// sends — which carries no client id, because the server never echoes it — against the matching
+    /// pending row so the echo collapses onto that row instead of duplicating it.
     public mutating func mergeMessages(_ incoming: [ConversationMessage], into conversationID: ConversationID) {
         guard !incoming.isEmpty else { return }
         let current = messagesByConversation[conversationID] ?? []
@@ -65,20 +74,38 @@ public struct ConversationStore: Sendable {
         )
         for message in incoming {
             var message = message
-            // A server copy with no client id is either the echo of one of our optimistic sends or a
-            // re-delivery of an already-known row. Only a brand-new id (not already confirmed) can be a
-            // fresh send's echo, so only then do we content-match a pending row — this keeps a
-            // re-delivery of an OLD identical message from stealing a fresh pending send. Adopting the
-            // pending row's client id (and dropping that pending copy) keeps one stable identity across
-            // sending → sent; for an already-known id we just keep the client id already on the row.
-            if message.clientMessageID == nil {
-                if byID[message.id] == nil, let clientMessageID = reconcilePendingMatch(for: message, in: conversationID) {
-                    message.clientMessageID = clientMessageID
-                } else if let existing = byID[message.id]?.clientMessageID {
-                    message.clientMessageID = existing
-                }
+            let existing = byID[message.id]
+
+            // A brand-new server id with no client id may be the echo of one of our pending sends —
+            // adopt that pending row's client id (dropping the pending copy) so identity survives
+            // sending → sent. Only a genuinely new id can be a fresh echo, so an old identical
+            // re-delivery never steals a pending send.
+            if message.clientMessageID == nil, existing == nil,
+               let clientMessageID = reconcilePendingMatch(for: message, in: conversationID) {
+                message.clientMessageID = clientMessageID
             }
-            byID[message.id] = message
+
+            guard let existing else {
+                byID[message.id] = message
+                continue
+            }
+
+            if message.eventSequence > existing.eventSequence {
+                // Newer version wins. Preserve the row's stable identity if the newer copy lacks one.
+                if message.clientMessageID == nil {
+                    message.clientMessageID = existing.clientMessageID
+                }
+                byID[message.id] = message
+            } else if message.eventSequence == existing.eventSequence, existing.clientMessageID == nil,
+                      let clientMessageID = message.clientMessageID {
+                // Same version, but this copy carries the client id the held one lacks (a reconcile copy
+                // landing after a stream echo, or vice versa). Adopt the id so the transcript diff keeps
+                // one stable identity instead of re-inserting the row.
+                var kept = existing
+                kept.clientMessageID = clientMessageID
+                byID[message.id] = kept
+            }
+            // Otherwise the held copy is newer-or-equal-and-already-identified: keep it.
         }
         messagesByConversation[conversationID] = byID.values.sorted { $0.id < $1.id }
     }
@@ -232,27 +259,120 @@ public struct ConversationStore: Sendable {
         sort()
     }
 
-    /// Apply a live event from the per-user event stream.
-    public mutating func apply(_ event: ConversationStreamEvent) {
+    /// Signals whether applying a live event exposed a hole in the sequenced log that must be filled
+    /// from `GetDelta`. Only `.chatEvents` can raise `.needsCatchUp`; every other event returns `.none`.
+    public enum GapSignal: Sendable, Equatable {
+        case none
+        case needsCatchUp(ConversationID, after: UInt64)
+    }
+
+    /// Apply a live event from the per-user event stream. Returns a gap signal so the controller can
+    /// trigger a `GetDelta` catch-up when the sequenced log skipped ahead.
+    @discardableResult
+    public mutating func apply(_ event: ConversationStreamEvent) -> GapSignal {
         switch event {
         case .newMessages(let conversationID, let messages):
             mergeMessages(messages, into: conversationID)
             if let latest = messages.max(by: { $0.id < $1.id }) {
                 setLastMessage(latest, in: conversationID)
             }
+            return .none
+        case .chatEvents(let conversationID, let events):
+            return applyChatEvents(events, into: conversationID)
         case .metadataRefresh(let conversation):
             upsert(conversation)
+            return .none
         case .lastActivityChanged(let conversationID, let date):
-            guard let index = conversations.firstIndex(where: { $0.id == conversationID }) else { return }
+            guard let index = conversations.firstIndex(where: { $0.id == conversationID }) else { return .none }
             conversations[index].lastActivity = date
             sort()
+            return .none
         case .readPointersChanged(let conversationID, let pointers):
             for pointer in pointers {
                 advanceReadPointer(to: pointer.value, for: pointer.userID, at: pointer.date, in: conversationID)
             }
+            return .none
         case .typingChanged:
             // Typing is ephemeral UI state held by the controller, never the persisted message store.
-            break
+            return .none
+        }
+    }
+
+    /// Apply sequenced event-log mutations in ascending order: merge each (last-writer-wins), advance
+    /// the contiguous frontier while events arrive gapless, and flag a gap the moment one is skipped so
+    /// the caller catches up via `GetDelta`. Only `.sent` mutations advance the feed's last message —
+    /// an edit/delete carries the message's original (low) id and must not re-sort the feed.
+    private mutating func applyChatEvents(_ events: [DecodedChatEvent], into conversationID: ConversationID) -> GapSignal {
+        var cursor = appliedCursorByConversation[conversationID] ?? 0
+        var newestSent: ConversationMessage?
+        var gapAfter: UInt64?
+        var incoming: [ConversationMessage] = []
+
+        for event in events.sorted(by: { $0.sequence < $1.sequence }) {
+            incoming.append(contentsOf: event.mutations.map(\.message))
+            for case .sent(let message) in event.mutations {
+                if newestSent.map({ message.id > $0.id }) ?? true { newestSent = message }
+            }
+
+            // Gap-detect only once the frontier is established (a catch-up seeds it); before that, live
+            // events are applied by LWW and the initial GetDelta owns the cursor.
+            guard gapAfter == nil, cursor > 0 else { continue }
+            if event.sequence <= cursor {
+                continue // already applied — a duplicate/stale re-delivery, merged harmlessly
+            }
+            if event.sequence == cursor + event.count {
+                cursor = event.sequence // contiguous — advance the frontier
+            } else {
+                gapAfter = cursor // hole below this event; stop advancing and catch up from here
+            }
+        }
+
+        // One merge for the whole batch (LWW is order-independent, so a per-event merge only re-sorted
+        // the full transcript K times); `mergeMessages` no-ops on an empty batch.
+        mergeMessages(incoming, into: conversationID)
+        appliedCursorByConversation[conversationID] = cursor
+        if let newestSent {
+            setLastMessage(newestSent, in: conversationID)
+        }
+        return gapAfter.map { .needsCatchUp(conversationID, after: $0) } ?? .none
+    }
+
+    // MARK: - Event-log catch-up cursor
+
+    /// The frontier to pass as `GetDelta.after_sequence` for a conversation (zero = fetch from the
+    /// beginning of the retained log).
+    public func appliedCursor(for conversationID: ConversationID) -> UInt64 {
+        appliedCursorByConversation[conversationID] ?? 0
+    }
+
+    /// Apply a `GetDelta` batch: merge its messages (last-writer-wins), then advance the frontier to
+    /// the batch's checkpoint. The feed preview is left to `loadFeed`/live events — a delta batch can
+    /// carry an old edit/delete whose id must not re-sort the feed.
+    public mutating func applyDeltaBatch(_ messages: [ConversationMessage], checkpoint: UInt64?, into conversationID: ConversationID) {
+        mergeMessages(messages, into: conversationID) // no-ops on an empty batch
+        if let checkpoint {
+            setAppliedCursor(checkpoint, for: conversationID)
+        }
+    }
+
+    /// Seat the frontier to the head reported by a cleanly-completed `GetDelta` — authoritative even
+    /// though the client never observed the intervening contiguous events. Never regresses it.
+    public mutating func setAppliedCursor(_ value: UInt64, for conversationID: ConversationID) {
+        if value > appliedCursor(for: conversationID) {
+            appliedCursorByConversation[conversationID] = value
+        }
+    }
+
+    /// Discard the frontier (a `RESET_REQUIRED`): the next catch-up re-syncs history and re-establishes
+    /// the cursor from a fresh floor.
+    public mutating func resetCursor(for conversationID: ConversationID) {
+        appliedCursorByConversation[conversationID] = 0
+    }
+
+    /// Seed frontiers from the persisted cache at hydrate time. Ignores zero (unestablished) cursors.
+    public mutating func seedAppliedCursors(_ cursors: [ConversationID: UInt64]) {
+        for (conversationID, cursor) in cursors where cursor > 0 {
+            appliedCursorByConversation[conversationID] = cursor
         }
     }
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStreamEvent.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStreamEvent.swift
@@ -16,6 +16,11 @@ public enum ConversationStreamEvent: Sendable {
     /// New messages arrived in a conversation.
     case newMessages(conversationID: ConversationID, messages: [ConversationMessage])
 
+    /// Durable, sequenced event-log mutations for a conversation (message sent/edited/deleted). The
+    /// store applies them last-writer-wins by `event_sequence` and gap-detects via `sequence`/`count`,
+    /// catching up with `GetDelta` on a gap. Supersedes the deprecated `newMessages` overlay.
+    case chatEvents(conversationID: ConversationID, events: [DecodedChatEvent])
+
     /// A conversation's full metadata was refreshed (members/last message/last activity).
     case metadataRefresh(Conversation)
 
@@ -29,6 +34,37 @@ public enum ConversationStreamEvent: Sendable {
     /// event log; the controller holds it as transient UI state and the server clears it with a
     /// stopped/timed-out notification.
     case typingChanged(conversationID: ConversationID, notifications: [TypingNotification])
+}
+
+/// One durable event in a chat's log: a contiguous run of mutations delivered atomically. `sequence`
+/// is the END of the half-open range this event occupies; `count` is the number of mutations. Clients
+/// apply mutations in ascending `sequence` and gap-detect via `localCursor + count == sequence`.
+public struct DecodedChatEvent: Sendable {
+    public let sequence: UInt64
+    public let count: UInt64
+    public let mutations: [DecodedMutation]
+
+    public init(sequence: UInt64, count: UInt64, mutations: [DecodedMutation]) {
+        self.sequence = sequence
+        self.count = count
+        self.mutations = mutations
+    }
+}
+
+/// A single mutation within an event. Each carries the full materialized message; a delete carries a
+/// `.deleted` tombstone. The store applies them uniformly by last-writer-wins.
+public enum DecodedMutation: Sendable {
+    case sent(ConversationMessage)
+    case edited(ConversationMessage)
+    case deleted(ConversationMessage)
+
+    /// The materialized message this mutation applies (a send, the edited state, or the tombstone).
+    public var message: ConversationMessage {
+        switch self {
+        case .sent(let message), .edited(let message), .deleted(let message):
+            return message
+        }
+    }
 }
 
 /// A member's READ watermark from a live pointer update: everything at or before
@@ -57,6 +93,16 @@ extension ConversationStreamEvent {
         let conversationID = ConversationID(update.chat)
         var events: [ConversationStreamEvent] = []
 
+        // The sequenced event log (message sent/edited/deleted). Additive with `new_messages`: both may
+        // carry the same send during the server's migration window, and last-writer-wins by
+        // `event_sequence` in the store lands it exactly once.
+        let chatEvents = update.events.events.map(DecodedChatEvent.init)
+        if !chatEvents.isEmpty {
+            events.append(.chatEvents(conversationID: conversationID, events: chatEvents))
+        }
+
+        // The deprecated real-time overlay. Decoded regardless of `events` so a message that arrives
+        // only here (an events-empty or malformed batch) is never dropped; the store dedups by version.
         let messages = update.newMessages.messages.compactMap(ConversationMessage.init)
         if !messages.isEmpty {
             events.append(.newMessages(conversationID: conversationID, messages: messages))
@@ -92,5 +138,39 @@ extension ConversationStreamEvent {
         }
 
         return events
+    }
+}
+
+extension DecodedChatEvent {
+    /// Non-failable: an event whose mutations are all unrepresentable (e.g. a media message this client
+    /// can't show) still carries a valid `sequence`/`count`, so the cursor must advance past it rather
+    /// than gap-loop forever. `count` stays the server's value — the log advanced by it regardless of
+    /// what the client can materialize.
+    init(_ proto: Flipcash_Messaging_V1_Event) {
+        self.init(
+            sequence: proto.sequence,
+            count: UInt64(proto.count),
+            mutations: proto.mutations.compactMap(DecodedMutation.init)
+        )
+    }
+}
+
+extension DecodedMutation {
+    /// Nil for a mutation whose message the client can't represent (unknown/media/reply content). A
+    /// deleted message materializes as a `.deleted` tombstone via `ConversationMessage.init`.
+    init?(_ proto: Flipcash_Messaging_V1_Mutation) {
+        switch proto.type {
+        case .messageSent(let proto):
+            guard let message = ConversationMessage(proto) else { return nil }
+            self = .sent(message)
+        case .messageEdited(let proto):
+            guard let message = ConversationMessage(proto) else { return nil }
+            self = .edited(message)
+        case .messageDeleted(let proto):
+            guard let message = ConversationMessage(proto) else { return nil }
+            self = .deleted(message)
+        case .none:
+            return nil
+        }
     }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -25,8 +25,12 @@ struct ConversationStoreTests {
         )
     }
 
-    private func message(_ id: UInt64, _ text: String = "hi", at: TimeInterval = 0) -> ConversationMessage {
-        ConversationMessage(id: MessageID(value: id), senderID: nil, content: .text(text), date: Date(timeIntervalSince1970: at), unreadSeq: 0)
+    private func message(_ id: UInt64, _ text: String = "hi", at: TimeInterval = 0, eventSequence: UInt64 = 0) -> ConversationMessage {
+        ConversationMessage(id: MessageID(value: id), senderID: nil, content: .text(text), date: Date(timeIntervalSince1970: at), unreadSeq: 0, eventSequence: eventSequence)
+    }
+
+    private func deleted(_ id: UInt64, at: TimeInterval = 0, eventSequence: UInt64) -> ConversationMessage {
+        ConversationMessage(id: MessageID(value: id), senderID: nil, content: .deleted, date: Date(timeIntervalSince1970: at), unreadSeq: 0, eventSequence: eventSequence)
     }
 
     @Test("setFeed sorts by last activity, most recent first")
@@ -40,25 +44,124 @@ struct ConversationStoreTests {
         #expect(store.conversations.map(\.id) == [conversationID(2), conversationID(3), conversationID(1)])
     }
 
-    @Test("mergeMessages dedupes by id and keeps oldest first")
+    @Test("mergeMessages dedupes by id and keeps oldest first; a higher event_sequence wins")
     func messagesMergeGapless() {
         var store = ConversationStore()
-        store.mergeMessages([message(3), message(1)], into: conversationID(1))
-        store.mergeMessages([message(1, "updated"), message(2)], into: conversationID(1))
+        store.mergeMessages([message(3, eventSequence: 3), message(1, eventSequence: 1)], into: conversationID(1))
+        store.mergeMessages([message(1, "updated", eventSequence: 2), message(2, eventSequence: 2)], into: conversationID(1))
 
         let messages = store.messages(for: conversationID(1))
         #expect(messages.map(\.id.value) == [1, 2, 3])
-        #expect(messages.first?.content == .text("updated")) // last write wins per id
+        #expect(messages.first?.content == .text("updated")) // higher event_sequence wins
     }
 
-    @Test("mergeMessages dedupes a re-delivered newest message (send echo)")
+    @Test("mergeMessages dedupes a re-delivered message without duplicating the row")
     func messagesDedupeEcho() {
         var store = ConversationStore()
-        store.mergeMessages([message(1), message(2)], into: conversationID(1))
-        store.mergeMessages([message(2, "echo")], into: conversationID(1))    // equal id → fallback dedups
+        store.mergeMessages([message(1, eventSequence: 1), message(2, "hi", eventSequence: 2)], into: conversationID(1))
+        store.mergeMessages([message(2, "echo", eventSequence: 2)], into: conversationID(1))    // equal version → no dup
         let messages = store.messages(for: conversationID(1))
         #expect(messages.map(\.id.value) == [1, 2])
-        #expect(messages.last?.content == .text("echo"))
+        #expect(messages.last?.content == .text("hi")) // equal event_sequence keeps the held copy
+    }
+
+    @Test("last-writer-wins: a lower event_sequence is ignored; a higher one replaces")
+    func mergeLastWriterWins() {
+        var store = ConversationStore()
+        store.mergeMessages([message(1, "v2", eventSequence: 2)], into: conversationID(1))
+        store.mergeMessages([message(1, "v1-stale", eventSequence: 1)], into: conversationID(1)) // older → ignored
+        #expect(store.messages(for: conversationID(1)).first?.content == .text("v2"))
+        store.mergeMessages([message(1, "v3", eventSequence: 3)], into: conversationID(1))        // newer → wins
+        #expect(store.messages(for: conversationID(1)).first?.content == .text("v3"))
+    }
+
+    @Test("a delete tombstone replaces a prior message, and an out-of-order older send can't resurrect it")
+    func deleteTombstoneConverges() {
+        var store = ConversationStore()
+        // Tombstone (event 10) lands before the original send (event 5) is re-delivered.
+        store.mergeMessages([deleted(1, eventSequence: 10)], into: conversationID(1))
+        store.mergeMessages([message(1, "original", eventSequence: 5)], into: conversationID(1))
+        let first = store.messages(for: conversationID(1)).first
+        #expect(first?.content == .deleted)   // stale older send never overwrites the newer tombstone
+    }
+
+    // MARK: - Event-log cursor & gap detection
+
+    private func sentEvent(sequence: UInt64, count: UInt64 = 1, _ messages: ConversationMessage...) -> DecodedChatEvent {
+        DecodedChatEvent(sequence: sequence, count: count, mutations: messages.map { .sent($0) })
+    }
+
+    /// One `.chatEvents` apply over the frontier arithmetic: an event is contiguous when
+    /// `sequence == cursor + count` (advance the frontier), a hole otherwise (flag catch-up, hold the
+    /// frontier), and stale when `sequence <= cursor` (ignore). `count` drives the math independently of
+    /// how many mutations the event carries.
+    @Test("gap detection advances the frontier only on a contiguous event", arguments: [
+        (start: UInt64(5), sequence: UInt64(6), count: UInt64(1), expected: UInt64(6), gapped: false), // contiguous
+        (start: 6, sequence: 9, count: 1, expected: 6, gapped: true),                                   // hole below the event
+        (start: 10, sequence: 13, count: 3, expected: 13, gapped: false),                               // multi-mutation, contiguous
+        (start: 10, sequence: 8, count: 1, expected: 10, gapped: false),                                // stale, ignored
+    ])
+    func gapDetection(start: UInt64, sequence: UInt64, count: UInt64, expected: UInt64, gapped: Bool) {
+        var store = ConversationStore()
+        store.setAppliedCursor(start, for: conversationID(1))
+        let signal = store.apply(.chatEvents(conversationID: conversationID(1), events: [sentEvent(sequence: sequence, count: count, message(sequence, eventSequence: sequence))]))
+        #expect(store.appliedCursor(for: conversationID(1)) == expected)
+        let expectedSignal: ConversationStore.GapSignal = gapped ? .needsCatchUp(conversationID(1), after: expected) : .none
+        #expect(signal == expectedSignal)
+    }
+
+    @Test("a gapped event's messages are still merged — LWW is independent of gap detection")
+    func gappedEventStillMergesMessages() {
+        var store = ConversationStore()
+        store.setAppliedCursor(5, for: conversationID(1))
+        store.apply(.chatEvents(conversationID: conversationID(1), events: [sentEvent(sequence: 6, message(6, eventSequence: 6))]))
+        store.apply(.chatEvents(conversationID: conversationID(1), events: [sentEvent(sequence: 9, message(9, eventSequence: 9))])) // gap
+        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [6, 9])
+    }
+
+    @Test("an unestablished frontier applies messages by LWW without advancing or flagging a gap")
+    func chatEventsUnestablishedFrontier() {
+        var store = ConversationStore()
+        let signal = store.apply(.chatEvents(conversationID: conversationID(1), events: [sentEvent(sequence: 42, message(42, eventSequence: 42))]))
+        #expect(signal == .none)
+        #expect(store.appliedCursor(for: conversationID(1)) == 0) // catch-up owns the cursor until seeded
+        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [42])
+    }
+
+    @Test("applyDeltaBatch merges and advances the frontier to the checkpoint; setAppliedCursor never regresses")
+    func applyDeltaBatchAdvancesCursor() {
+        var store = ConversationStore()
+        store.applyDeltaBatch([message(1, eventSequence: 1), message(2, eventSequence: 2)], checkpoint: 2, into: conversationID(1))
+        #expect(store.appliedCursor(for: conversationID(1)) == 2)
+        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [1, 2])
+        store.setAppliedCursor(1, for: conversationID(1)) // lower → ignored
+        #expect(store.appliedCursor(for: conversationID(1)) == 2)
+        store.setAppliedCursor(9, for: conversationID(1)) // head → advances
+        #expect(store.appliedCursor(for: conversationID(1)) == 9)
+    }
+
+    @Test("resetCursor discards the frontier; seedAppliedCursors restores non-zero cursors")
+    func cursorResetAndSeed() {
+        var store = ConversationStore()
+        store.setAppliedCursor(7, for: conversationID(1))
+        store.resetCursor(for: conversationID(1))
+        #expect(store.appliedCursor(for: conversationID(1)) == 0)
+        store.seedAppliedCursors([conversationID(1): 12, conversationID(2): 0])
+        #expect(store.appliedCursor(for: conversationID(1)) == 12)
+        #expect(store.appliedCursor(for: conversationID(2)) == 0) // zero ignored
+    }
+
+    @Test("an edit of an old message does not advance the feed's last message")
+    func chatEventsEditDoesNotBumpLastMessage() {
+        var store = ConversationStore()
+        store.setFeed([conversation(1, lastActivity: 0)])
+        store.mergeMessages([message(5, "old", eventSequence: 5)], into: conversationID(1))
+        store.setLastMessage(message(5, "old", eventSequence: 5), in: conversationID(1))
+        store.apply(.chatEvents(conversationID: conversationID(1), events: [
+            DecodedChatEvent(sequence: 6, count: 1, mutations: [.edited(message(5, "edited", eventSequence: 6))])
+        ]))
+        #expect(store.conversations.first?.lastMessage?.id.value == 5)
+        #expect(store.messages(for: conversationID(1)).first?.content == .text("edited")) // transcript updates by LWW
     }
 
     @Test("newMessages event appends and bumps the conversation's last activity")

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStreamEventDecodeTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStreamEventDecodeTests.swift
@@ -194,4 +194,85 @@ struct ConversationStreamEventDecodeTests {
         #expect(decoded.contains { if case .newMessages = $0 { true } else { false } })
         #expect(decoded.contains { if case .typingChanged = $0 { true } else { false } })
     }
+
+    // MARK: - Event log (ChatUpdate.events)
+
+    private func sentMutation(_ id: UInt64, _ text: String) -> Flipcash_Messaging_V1_Mutation {
+        .with { $0.messageSent = textMessage(id, text) }
+    }
+
+    @Test("chatEvents decode: sent + deleted carry sequence/count; a delete materializes a tombstone, not nil")
+    func chatEventsDecode() {
+        let event = Flipcash_Event_V1_Event.with {
+            $0.chatUpdate = .with {
+                $0.chat = .with { $0.value = conversationBytes }
+                $0.events = .with {
+                    $0.events = [
+                        .with { $0.sequence = 6; $0.count = 1; $0.mutations = [sentMutation(6, "hi")] },
+                        .with {
+                            $0.sequence = 7; $0.count = 1
+                            $0.mutations = [.with { $0.messageDeleted = .with { $0.messageID = .with { $0.value = 3 }; $0.content = [.with { $0.deleted = .init() }] } }]
+                        },
+                    ]
+                }
+            }
+        }
+        let decoded = ConversationStreamEvent.decode(event)
+        guard case .chatEvents(let cid, let events) = decoded.first else { Issue.record("expected .chatEvents"); return }
+        #expect(cid == ConversationID(data: conversationBytes))
+        #expect(events.map(\.sequence) == [6, 7])
+        #expect(events.map(\.count) == [1, 1])
+        guard case .sent(let sent) = events[0].mutations.first else { Issue.record("expected .sent"); return }
+        #expect(sent.content == .text("hi"))
+        guard case .deleted(let tombstone) = events[1].mutations.first else { Issue.record("expected .deleted"); return }
+        #expect(tombstone.content == .deleted)
+        #expect(tombstone.id.value == 3)
+    }
+
+    @Test("both events and new_messages present decode to both (additive migration gate)")
+    func chatEventsAndNewMessagesAdditive() {
+        let event = Flipcash_Event_V1_Event.with {
+            $0.chatUpdate = .with {
+                $0.chat = .with { $0.value = conversationBytes }
+                $0.newMessages = .with { $0.messages = [textMessage(9, "dup")] }
+                $0.events = .with { $0.events = [.with { $0.sequence = 9; $0.count = 1; $0.mutations = [sentMutation(9, "dup")] }] }
+            }
+        }
+        let decoded = ConversationStreamEvent.decode(event)
+        #expect(decoded.contains { if case .chatEvents = $0 { true } else { false } })
+        #expect(decoded.contains { if case .newMessages = $0 { true } else { false } })
+    }
+
+    @Test("an absent events batch does not suppress new_messages (deprecated path still works)")
+    func emptyEventsKeepsNewMessages() {
+        let event = Flipcash_Event_V1_Event.with {
+            $0.chatUpdate = .with {
+                $0.chat = .with { $0.value = conversationBytes }
+                $0.newMessages = .with { $0.messages = [textMessage(1, "keep")] }
+            }
+        }
+        let decoded = ConversationStreamEvent.decode(event)
+        #expect(decoded.contains { if case .newMessages = $0 { true } else { false } })
+        #expect(!decoded.contains { if case .chatEvents = $0 { true } else { false } })
+    }
+
+    @Test("an event whose only mutation is unrepresentable still carries sequence/count so the cursor advances")
+    func unrepresentableMutationStillAdvances() {
+        let event = Flipcash_Event_V1_Event.with {
+            $0.chatUpdate = .with {
+                $0.chat = .with { $0.value = conversationBytes }
+                $0.events = .with {
+                    $0.events = [.with {
+                        $0.sequence = 12; $0.count = 1
+                        $0.mutations = [.with { $0.messageSent = .with { $0.messageID = .with { $0.value = 12 }; $0.content = [.with { $0.reply = .init() }] } }]
+                    }]
+                }
+            }
+        }
+        let decoded = ConversationStreamEvent.decode(event)
+        guard case .chatEvents(_, let events) = decoded.first else { Issue.record("expected .chatEvents"); return }
+        #expect(events.count == 1)
+        #expect(events[0].sequence == 12)
+        #expect(events[0].mutations.isEmpty) // reply content unrepresentable → dropped, event survives
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
@@ -55,6 +55,7 @@ struct TransportClassificationTests {
     @Test func errorResolve() { assertClassifies(ErrorResolve.self) }
     @Test func errorGetMessages() { assertClassifies(ErrorGetMessages.self) }
     @Test func errorSendMessage() { assertClassifies(ErrorSendMessage.self) }
+    @Test func errorGetDelta() { assertClassifies(ErrorGetDelta.self) }
     @Test func errorAdvancePointer() { assertClassifies(ErrorAdvancePointer.self) }
     @Test func errorNotifyIsTyping() { assertClassifies(ErrorNotifyIsTyping.self) }
     @Test func errorGetDmChatFeed() { assertClassifies(ErrorGetDmChatFeed.self) }

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -54,6 +54,25 @@ struct ChatMessageMappingTests {
         messageRows(items).map(\.isFailed)
     }
 
+    private func deleted(_ id: UInt64, _ sender: UUID, after offset: TimeInterval) -> ConversationMessage {
+        ConversationMessage(id: MessageID(value: id), senderID: sender, content: .deleted, date: base.addingTimeInterval(offset), unreadSeq: id, eventSequence: id)
+    }
+
+    @Test("a deleted tombstone is dropped: no stray separator, no grouping to an invisible row, receipt intact")
+    func deletedTombstoneIsDroppedCleanly() {
+        // A tombstone opens the transcript, then a real same-sender message shortly after.
+        let items = ChatItem.from([deleted(1, them, after: 0), text(2, them, "hi", after: 30)], selfUserID: me)
+        let rows = messageRows(items)
+        #expect(rows.count == 1)                     // tombstone not rendered
+        #expect(rows[0].content == .text("hi"))
+        #expect(!rows[0].isContinuationFromPrevious) // not grouped to the invisible tombstone
+        #expect(separatorCount(items) == 1)          // one separator for the real message, no orphan
+
+        // A tombstone as the newest self message must not steal the "Delivered" receipt from the last visible one.
+        let withReceipt = ChatItem.from([text(1, me, "hello", after: 0), deleted(2, me, after: 60)], selfUserID: me)
+        #expect(receiptText(withReceipt) == "Delivered")
+    }
+
     @Test("Same-sender run within the gap groups; a sender change breaks it; gaps add separators")
     func grouping() {
         let messages = [

--- a/FlipcashTests/ChatPreviewMappingTests.swift
+++ b/FlipcashTests/ChatPreviewMappingTests.swift
@@ -55,6 +55,19 @@ struct ChatPreviewMappingTests {
 
     // MARK: - Sender resolution
 
+    @Test("a deleted message is dropped before the limit slice, so the preview keeps the newest visible messages")
+    func deletedMessageFilteredFromPreview() {
+        let deleted = ConversationMessage(id: MessageID(value: 3), senderID: otherID, content: .deleted, date: Date(timeIntervalSince1970: 3), unreadSeq: 0)
+        let items = ChatItem.preview(from: [
+            textMessage(id: 1, senderID: otherID, text: "one"),
+            textMessage(id: 2, senderID: otherID, text: "two"),
+            deleted,
+        ], selfUserID: meID, limit: 2)
+        let rows = messageRows(items)
+        #expect(rows.count == 2) // newest two VISIBLE messages, not [two, <deleted hole>]
+        #expect(rows.map { if case .text(let t) = $0.content { t } else { "" } } == ["one", "two"])
+    }
+
     @Test("My messages map to .me sender")
     func mySenderMapsToMe() {
         let messages = [textMessage(id: 1, senderID: meID, text: "hello")]

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -428,11 +428,11 @@ struct ConversationControllerTests {
 
     // MARK: - Reconnect catch-up -
 
-    @Test("a reconnect refetches the visible conversation, catching up messages missed while the stream was down")
+    @Test("a reconnect catches up the visible conversation via GetDelta, filling messages missed while the stream was down")
     func reconnectCatchesUpVisibleTranscript() async throws {
         let mock = MockConversations()
         mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
-        mock.messages = [ConversationMessage(id: MessageID(value: 1), senderID: nil, content: .text("one"), date: Date(timeIntervalSince1970: 10), unreadSeq: 1)]
+        mock.messages = [ConversationMessage(id: MessageID(value: 1), senderID: nil, content: .text("one"), date: Date(timeIntervalSince1970: 10), unreadSeq: 1, eventSequence: 1)]
         let controller = makeController(mock)
 
         controller.start()
@@ -443,26 +443,92 @@ struct ConversationControllerTests {
         // Open the chat: load its first page and mark it visible (as the screen does).
         await controller.loadMessages(for: ConversationID.test(1))
         controller.visibleConversationID = ConversationID.test(1)
-        // Prerequisite for the catch-up assertion below: the transcript must start at [1].
         try #require(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [1])
 
-        // A newer message lands server-side during the window the stream was down —
-        // the live event for it was never delivered.
-        mock.messages = [
-            ConversationMessage(id: MessageID(value: 1), senderID: nil, content: .text("one"), date: Date(timeIntervalSince1970: 10), unreadSeq: 1),
-            ConversationMessage(id: MessageID(value: 2), senderID: nil, content: .text("two"), date: Date(timeIntervalSince1970: 20), unreadSeq: 2),
-        ]
+        // The missed message is delivered by the reconnect catch-up (GetDelta), not a blind page reload.
+        mock.deltaBatches = [MockConversations.DeltaBatch(
+            messages: [ConversationMessage(id: MessageID(value: 2), senderID: nil, content: .text("two"), date: Date(timeIntervalSince1970: 20), unreadSeq: 2, eventSequence: 2)],
+            checkpoint: 2
+        )]
+        mock.deltaHead = 2
 
         // The stream drops and comes back: the reconnect's `.live` triggers catch-up.
         mock.emitConnectionState(.disconnected)
         mock.emitConnectionState(.live)
 
-        // The reconnect refetch pulls the newest page and the missed message appears.
         try await waitUntil { controller.messages(for: ConversationID.test(1)).map(\.id.value) == [1, 2] }
-        // Reaching catch-up proves the FIFO consumer processed both `.live`s. The
-        // transcript was paged exactly twice — the explicit open + the one reconnect
-        // — so the baseline `.live` correctly fetched nothing.
-        #expect(mock.latestPageQueries == [ConversationID.test(1), ConversationID.test(1)])
+        // loadMessages seated the frontier to the newest loaded message's eventSequence (1), so the
+        // reconnect catch-up resumes from there — not a from-zero full refetch.
+        #expect(mock.deltaAfterSequences == [1])
+        controller.stop()
+    }
+
+    @Test("foreground catches up the open chat via GetDelta with no ping (missed-message-on-unlock regression)")
+    func foregroundCatchUpFillsOpenTranscript() async throws {
+        let mock = MockConversations()
+        mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
+        mock.messages = [ConversationMessage(id: MessageID(value: 1), senderID: nil, content: .text("one"), date: Date(timeIntervalSince1970: 10), unreadSeq: 1, eventSequence: 1)]
+        let controller = makeController(mock)
+
+        controller.start()
+        try await waitUntil { mock.connectionStateStreamOpened }
+        await controller.loadMessages(for: ConversationID.test(1))
+        controller.visibleConversationID = ConversationID.test(1)
+        try #require(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [1])
+
+        // A message arrived while the phone was locked (stream suspended); no ping, no live event.
+        mock.deltaBatches = [MockConversations.DeltaBatch(
+            messages: [ConversationMessage(id: MessageID(value: 2), senderID: nil, content: .text("locked while away"), date: Date(timeIntervalSince1970: 20), unreadSeq: 2, eventSequence: 2)],
+            checkpoint: 2
+        )]
+        mock.deltaHead = 2
+
+        // Unlock → foreground. No stream reconnect, no ping — the open transcript still fills.
+        controller.catchUpOpenChat()
+
+        try await waitUntil { controller.messages(for: ConversationID.test(1)).map(\.id.value) == [1, 2] }
+        controller.stop()
+    }
+
+    @Test("RESET_REQUIRED discards the cursor and re-syncs history via GetMessages")
+    func catchUpResetResyncsHistory() async throws {
+        let mock = MockConversations()
+        mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
+        let controller = makeController(mock)
+
+        controller.start()
+        try await waitUntil { mock.connectionStateStreamOpened }
+        controller.visibleConversationID = ConversationID.test(1)
+
+        // The cursor is too far behind: GetDelta returns RESET_REQUIRED, so catch-up falls back to the
+        // newest page and re-establishes the cursor from that page's floor.
+        mock.deltaError = ErrorGetDelta.resetRequired
+        mock.messages = [
+            ConversationMessage(id: MessageID(value: 8), senderID: nil, content: .text("h8"), date: Date(timeIntervalSince1970: 80), unreadSeq: 8, eventSequence: 8),
+            ConversationMessage(id: MessageID(value: 9), senderID: nil, content: .text("h9"), date: Date(timeIntervalSince1970: 90), unreadSeq: 9, eventSequence: 9),
+        ]
+
+        await controller.catchUp(conversationID: ConversationID.test(1))
+
+        #expect(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [8, 9])
+        #expect(mock.latestPageQueries == [ConversationID.test(1)]) // re-synced the newest page
+        controller.stop()
+    }
+
+    @Test("loadMessages seats the cursor to the newest page's head, so catch-up resumes from there (no from-zero full refetch that would prepend history)")
+    func loadMessagesSeatsCursorToHead() async throws {
+        let mock = MockConversations()
+        mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
+        mock.messages = [ConversationMessage(id: MessageID(value: 9), senderID: nil, content: .text("newest"), date: Date(timeIntervalSince1970: 90), unreadSeq: 9, eventSequence: 42)]
+        let controller = makeController(mock)
+        controller.start()
+        try await waitUntil { mock.streamOpened }
+
+        await controller.loadMessages(for: ConversationID.test(1))
+        await controller.catchUp(conversationID: ConversationID.test(1))
+        // Resumes from the seated head (42), NOT 0 — the from-zero refetch is what re-pulled the full
+        // history and knocked the transcript off the bottom on first open.
+        #expect(mock.deltaAfterSequences == [42])
         controller.stop()
     }
 
@@ -502,6 +568,7 @@ struct ConversationControllerTests {
 
         try await waitUntil { controller.conversations.map(\.id) == [ConversationID.test(1)] }
         #expect(mock.latestPageQueries.isEmpty)
+        #expect(mock.deltaAfterSequences.isEmpty) // no visible chat → no catch-up
         controller.stop()
     }
 

--- a/FlipcashTests/Database/Database+ConversationsTests.swift
+++ b/FlipcashTests/Database/Database+ConversationsTests.swift
@@ -102,7 +102,7 @@ struct DatabaseConversationsTests {
         switch loadedMessage.content {
         case .cash(let loadedExchanged):
             #expect(loadedExchanged.nativeAmount.value == amount)
-        case .text:
+        case .text, .deleted:
             Issue.record("Expected cash message content")
         }
     }
@@ -233,6 +233,73 @@ struct DatabaseConversationsTests {
 
         #expect(try database.getConversationMessages(conversationID: ConversationID.test(1)).map(\.id.value) == [1])
         #expect(try database.getConversationMessages(conversationID: ConversationID.test(2)).map(\.id.value) == [2])
+    }
+
+    // MARK: - Event log persistence -
+
+    @Test("event_sequence and a deleted tombstone round-trip")
+    func eventSequenceAndTombstoneRoundTrip() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        let text = ConversationMessage(id: MessageID(value: 1), senderID: otherID, content: .text("hi"), date: Date(timeIntervalSince1970: 10), unreadSeq: 1, eventSequence: 7)
+        let tombstone = ConversationMessage(id: MessageID(value: 2), senderID: otherID, content: .deleted, date: Date(timeIntervalSince1970: 20), unreadSeq: 2, eventSequence: 9)
+
+        try database.upsertConversationMessages([text, tombstone], conversationID: id)
+
+        let loaded = try database.getConversationMessages(conversationID: id)
+        #expect(loaded == [text, tombstone])
+        #expect(loaded.map(\.eventSequence) == [7, 9])
+        #expect(loaded.last?.content == .deleted)
+    }
+
+    @Test("the catch-up cursor round-trips and survives a feed replace")
+    func catchupCursorRoundTrip() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversation(conversation(byte: 1))
+        try database.updateCatchupCursor(42, for: id)
+        #expect(try database.getCatchupCursors()[id] == 42)
+
+        // A feed replace deletes+reinserts every conversation row but must preserve the cursor.
+        try database.replaceConversationFeed([conversation(byte: 1)])
+        #expect(try database.getCatchupCursors()[id] == 42)
+    }
+
+    @Test("a stale re-delivery does not clobber a newer persisted version (DB last-writer-wins)")
+    func writeMessageIsLastWriterWins() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        let tombstone = ConversationMessage(id: MessageID(value: 1), senderID: otherID, content: .deleted, date: Date(timeIntervalSince1970: 20), unreadSeq: 1, eventSequence: 10)
+        let staleOriginal = ConversationMessage(id: MessageID(value: 1), senderID: otherID, content: .text("original"), date: Date(timeIntervalSince1970: 10), unreadSeq: 1, eventSequence: 5)
+
+        try database.upsertConversationMessages([tombstone], conversationID: id)
+        try database.upsertConversationMessages([staleOriginal], conversationID: id) // older version → ignored
+
+        let loaded = try database.getConversationMessages(conversationID: id)
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.content == .deleted)   // tombstone survives the stale re-delivery
+        #expect(loaded.first?.eventSequence == 10)
+
+        // A genuinely newer version still wins.
+        let newer = ConversationMessage(id: MessageID(value: 1), senderID: otherID, content: .text("edited"), date: Date(timeIntervalSince1970: 30), unreadSeq: 1, eventSequence: 12)
+        try database.upsertConversationMessages([newer], conversationID: id)
+        #expect(try database.getConversationMessages(conversationID: id).first?.content == .text("edited"))
+    }
+
+    @Test("the feed preview skips a deleted newest message and shows the newest visible one")
+    func latestMessageSkipsTombstone() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        try database.upsertConversation(conversation(byte: 1))
+        let visible = ConversationMessage(id: MessageID(value: 1), senderID: otherID, content: .text("hello"), date: Date(timeIntervalSince1970: 10), unreadSeq: 1, eventSequence: 1)
+        let deletedNewest = ConversationMessage(id: MessageID(value: 2), senderID: otherID, content: .deleted, date: Date(timeIntervalSince1970: 20), unreadSeq: 2, eventSequence: 5)
+        try database.upsertConversationMessages([visible, deletedNewest], conversationID: ConversationID.test(1))
+
+        let loaded = try #require(try database.getConversations().first)
+        #expect(loaded.lastMessage?.content == .text("hello")) // preview shows the visible message, not the tombstone
     }
 
     // MARK: - Conversations -

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -13,6 +13,8 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
 
     struct Sent: Sendable { let conversationID: ConversationID; let text: String }
     struct TypingCall: Sendable { let conversationID: ConversationID; let state: TypingState }
+    /// A scripted `GetDelta` batch: one `onBatch` call with these messages + checkpoint.
+    struct DeltaBatch: Sendable { let messages: [ConversationMessage]; let checkpoint: UInt64? }
 
     private let lock = NSLock()
 
@@ -27,6 +29,10 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     private var _sent: [Sent] = []
     private var _markedRead: [MessageID] = []
     private var _typingCalls: [TypingCall] = []
+    private var _deltaBatches: [DeltaBatch] = []
+    private var _deltaHead: UInt64 = 0
+    private var _deltaError: Error?
+    private var _deltaAfterSequences: [UInt64] = []
     private var _didEnsure = false
     private var _didClose = false
     private var _streamContinuation: AsyncStream<ConversationStreamEvent>.Continuation?
@@ -63,6 +69,23 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     var sent: [Sent] { lock.withLock { _sent } }
     var markedRead: [MessageID] { lock.withLock { _markedRead } }
     var typingCalls: [TypingCall] { lock.withLock { _typingCalls } }
+    /// Batches `getDelta` delivers to `onBatch`, in order.
+    var deltaBatches: [DeltaBatch] {
+        get { lock.withLock { _deltaBatches } }
+        set { lock.withLock { _deltaBatches = newValue } }
+    }
+    /// The head sequence `getDelta` returns on clean completion.
+    var deltaHead: UInt64 {
+        get { lock.withLock { _deltaHead } }
+        set { lock.withLock { _deltaHead = newValue } }
+    }
+    /// When set, `getDelta` throws this after delivering any scripted batches (e.g. `.resetRequired`).
+    var deltaError: Error? {
+        get { lock.withLock { _deltaError } }
+        set { lock.withLock { _deltaError = newValue } }
+    }
+    /// The `afterSequence` cursors `getDelta` was called with, in order.
+    var deltaAfterSequences: [UInt64] { lock.withLock { _deltaAfterSequences } }
     var didEnsure: Bool { lock.withLock { _didEnsure } }
     var didClose: Bool { lock.withLock { _didClose } }
     /// Whether `openConversationStream` has been called — events emitted
@@ -115,6 +138,21 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
             id: MessageID(value: 1), senderID: nil, content: .text(text),
             date: Date(timeIntervalSince1970: 0), unreadSeq: 0
         )
+    }
+
+    func getDelta(
+        owner: KeyPair,
+        conversationID: ConversationID,
+        afterSequence: UInt64,
+        onBatch: @MainActor @Sendable @escaping (_ messages: [ConversationMessage], _ checkpoint: UInt64?) -> Void
+    ) async throws -> UInt64 {
+        lock.withLock { _deltaAfterSequences.append(afterSequence) }
+        let (batches, head, error) = lock.withLock { (_deltaBatches, _deltaHead, _deltaError) }
+        for batch in batches {
+            await MainActor.run { onBatch(batch.messages, batch.checkpoint) }
+        }
+        if let error { throw error }
+        return head
     }
 
     func markRead(owner: KeyPair, conversationID: ConversationID, messageID: MessageID) async throws {


### PR DESCRIPTION
Chat was wired to the deprecated `new_messages` stream field and recovered missed messages with a blind, ping-gated refetch — so a conversation left open while the phone was locked wouldn't show messages that arrived until you backed out and re-entered. This moves chat onto the sequenced event log the server already speaks: it reads `ChatUpdate.events`, applies last-writer-wins by `event_sequence`, tracks a persisted per-chat cursor with gap detection, and catches up through `GetDelta` on open / foreground / reconnect / detected-gap. An open chat now recovers missed messages with no re-entry, and edits/deletes converge. Bumps the local schema, so the chat cache rebuilds from the server on first launch.

Verified end-to-end against dev on a simulator, including the lock-then-unlock case.

## Test plan
- [x] Open a chat, background the app, receive a message, foreground → it appears without re-entering
- [x] Cold-open a chat → lands on the newest message, no scroll jump
- [x] Send and receive messages live; a deleted message doesn't render and doesn't blank the feed row
- [x] `FlipcashCoreTests` and `FlipcashTests` pass
