### PR TITLE
fix: stop re-firing the contacts-on-Flipcash dialog on schema bumps

### DIFF
--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -50,8 +50,9 @@ final class ContactSyncController {
     /// Set once, during the user's first contact scan, to the number of the
     /// user's contacts the server matched. `SendRootScreen` forwards it to
     /// `session.dialogItem` — surfaced above the Send sheet by `DialogWindow` —
-    /// then clears it. Gated on the first sync (no prior checksum) so it never
-    /// re-fires on later syncs or screen opens.
+    /// then clears it. Gated on the durable `contactsConnected` flag (UserDefaults,
+    /// not the DB) so it fires once per device and never re-fires after a
+    /// `SQLiteVersion` rebuild, later syncs, or screen opens.
     var onFlipcashMatchCount: Int?
 
     nonisolated private var ownerKeyPair: KeyPair {
@@ -196,9 +197,6 @@ final class ContactSyncController {
     /// preserved when called through the production `runSync` path.
     internal nonisolated func performSync(contacts: [Database.LocalContact]) async throws {
         let storedState = try database.contactSyncState()
-        // No prior checksum means this is the user's first scan — the only time
-        // the "already on Flipcash" dialog is allowed to fire.
-        let isFirstScan = storedState.checksum == nil
         // The snapshot stores every `(e164, contactId)` pair so the picker
         // can show each contact with each of their phone numbers. Upload
         // + checksum operate on the unique e164 set — the server doesn't
@@ -278,8 +276,15 @@ final class ContactSyncController {
 
         await resolveDirectory()
 
-        if isFirstScan, matchedCount > 0 {
-            await MainActor.run { self.onFlipcashMatchCount = matchedCount }
+        // Fire the one-time "already on Flipcash" dialog on the first connect.
+        // The flag lives in UserDefaults, not the DB, so a `SQLiteVersion`
+        // rebuild never re-fires it for an existing user.
+        await MainActor.run {
+            guard UserDefaults.contactsConnected != true else { return }
+            UserDefaults.contactsConnected = true
+            if matchedCount > 0 {
+                self.onFlipcashMatchCount = matchedCount
+            }
         }
     }
 
@@ -529,4 +534,14 @@ extension ContactSyncController: DMContactNaming {
     func contactDisplayName(forDMChat conversationID: ConversationID) -> String? {
         resolvedContacts.onFlipcash.first { $0.dmChatID == conversationID.data }?.displayName
     }
+}
+
+// MARK: - Defaults -
+
+extension UserDefaults {
+    /// `true` once this device has completed its first contact connect. Gates the
+    /// one-time "already on Flipcash" dialog; persisted here rather than in the
+    /// per-account SQLite store so a `SQLiteVersion` rebuild doesn't re-fire it.
+    @Defaults(.contactsConnected)
+    static var contactsConnected: Bool?
 }

--- a/Flipcash/Keychain/Defaults.swift
+++ b/Flipcash/Keychain/Defaults.swift
@@ -20,6 +20,8 @@ enum DefaultsKey: String {
     case storedTokenMint = "com.flipcash.token.storedTokenMint"
 
     case betaFlags = "com.flipcash.betaFlags"
+
+    case contactsConnected = "com.flipcash.contacts.connected"
 }
 
 private let defaultsEncoder = JSONEncoder()

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -9,7 +9,10 @@ import Testing
 import FlipcashCore
 @testable import Flipcash
 
-@Suite("ContactSyncController")
+// `.serialized` because the first-connect dialog tests mutate the shared
+// `UserDefaults.contactsConnected` flag (see RatesControllerTests for the same
+// constraint on `@Defaults`-backed state).
+@Suite("ContactSyncController", .serialized)
 struct ContactSyncControllerTests {
 
     // MARK: - Checksum
@@ -696,6 +699,7 @@ struct ContactSyncControllerTests {
 
         @Test("First scan signals how many contacts the server matched")
         func firstScan_withMatches_signalsCount() async throws {
+            UserDefaults.contactsConnected = nil
             let mock = MockContactSync()
             mock.streamYields = [MatchedContact(e164: Self.bobContact.e164), MatchedContact(e164: Self.carolContact.e164)]
             let database = Database.mock
@@ -708,6 +712,7 @@ struct ContactSyncControllerTests {
 
         @Test("First scan with no matches signals nothing")
         func firstScan_noMatches_signalsNothing() async throws {
+            UserDefaults.contactsConnected = nil
             let mock = MockContactSync()
             mock.streamYields = []
             let database = Database.mock
@@ -720,6 +725,7 @@ struct ContactSyncControllerTests {
 
         @Test("A later sync never re-signals")
         func laterSync_doesNotReSignal() async throws {
+            UserDefaults.contactsConnected = nil
             let mock = MockContactSync()
             mock.streamYields = [MatchedContact(e164: Self.bobContact.e164)]
             let database = Database.mock
@@ -738,6 +744,28 @@ struct ContactSyncControllerTests {
             try await controller.performSync(contacts: contacts)
 
             #expect(controller.onFlipcashMatchCount == nil)
+        }
+
+        @Test("A SQLiteVersion rebuild does not re-fire the first-connect dialog")
+        func schemaRebuild_doesNotReSignal() async throws {
+            UserDefaults.contactsConnected = nil
+            let contacts = [Self.aliceContact, Self.bobContact]
+
+            // First connect on a fresh database.
+            let firstMock = MockContactSync()
+            firstMock.streamYields = [MatchedContact(e164: Self.bobContact.e164)]
+            let firstController = Self.makeController(mock: firstMock, database: Database.mock)
+            try await firstController.performSync(contacts: contacts)
+            #expect(firstController.onFlipcashMatchCount == 1)
+
+            // A SQLiteVersion bump deletes and rebuilds the DB, so the stored
+            // checksum is gone and this sync takes the first-scan (full upload)
+            // path again — but the durable flag survives, so it must stay silent.
+            let rebuiltMock = MockContactSync()
+            rebuiltMock.streamYields = [MatchedContact(e164: Self.bobContact.e164)]
+            let rebuiltController = Self.makeController(mock: rebuiltMock, database: Database.mock)
+            try await rebuiltController.performSync(contacts: contacts)
+            #expect(rebuiltController.onFlipcashMatchCount == nil)
         }
     }
 


### PR DESCRIPTION
The "N Contacts Already On Flipcash" dialog was gated on the per-account SQLite checksum, which every SQLiteVersion bump wipes and rebuilds. That reset the gate and re-showed the dialog to every existing user on their next Send-screen open. It's now gated on a durable UserDefaults flag, set once on the first contact connect and untouched by database rebuilds.

## Test plan
- [x] `ContactSyncControllerTests` passes, including the new "A SQLiteVersion rebuild does not re-fire the first-connect dialog" regression test
- [x] First-time contact connect with matches still shows the dialog once
- [x] Bumping SQLiteVersion no longer re-shows the dialog for an existing user