### PR TITLE
fix: ignore keyboard safe area on amount keypad screens

### DIFF
--- a/Flipcash/Core/Screens/Main/Buy/BuyAmountScreen.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyAmountScreen.swift
@@ -81,6 +81,7 @@ struct BuyAmountScreen: View {
             .foregroundStyle(.textMain)
             .padding(20)
         }
+        .ignoresSafeArea(.keyboard)
         .navigationTitle(viewModel.screenTitle)
         .toolbarTitleDisplayMode(.inline)
         .toolbar {

--- a/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellAmountScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellAmountScreen.swift
@@ -41,6 +41,7 @@ struct CurrencySellAmountScreen: View {
                 .foregroundStyle(.textMain)
                 .padding(20)
             }
+            .ignoresSafeArea(.keyboard)
             .navigationTitle(viewModel.screenTitle)
             .toolbarTitleDisplayMode(.inline)
             .navigationDestination(for: CurrencySellPath.self) { step in

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawAmountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawAmountScreen.swift
@@ -43,6 +43,7 @@ struct WithdrawAmountScreen: View {
                 CurrencySelectionScreen(ratesController: ratesController)
             }
         }
+        .ignoresSafeArea(.keyboard)
         .navigationTitle(title)
         .toolbarTitleDisplayMode(.inline)
     }


### PR DESCRIPTION
The buy, withdraw, and sell amount screens lay out a custom keypad with no text field, but a stale keyboard safe-area inset can still shrink the sheet — floating the action button partway up the screen with an empty gap below it, as seen in a user report. The give and send flows already guard against this; these three were built later and missed it. This opts them out of keyboard avoidance to match, which is a no-op in the normal case and only neutralizes an erroneous inset.

### Test plan
- [x] Open Buy, Withdraw, and Sell amount screens — keypad and action button sit correctly at the bottom
- [x] From Buy, tap the flag → currency picker search still pushes its list up normally