### PR TITLE
feat: add search empty state to the region picker

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Selection/CurrencySelectionScreen.swift
@@ -28,9 +28,11 @@ struct CurrencySelectionScreen: View {
                 List {
                     Group {
                         if viewModel.isSearching {
-                            Section(header: ListHeader("Results")) {
-                                ForEach(viewModel.searchingCurrencies) { description in
-                                    CurrencyRow(description: description, viewModel: viewModel, allowDelete: false)
+                            if !viewModel.searchingCurrencies.isEmpty {
+                                Section(header: ListHeader("Results")) {
+                                    ForEach(viewModel.searchingCurrencies) { description in
+                                        CurrencyRow(description: description, viewModel: viewModel, allowDelete: false)
+                                    }
                                 }
                             }
                         } else {
@@ -56,6 +58,11 @@ struct CurrencySelectionScreen: View {
                 }
                 .listStyle(.grouped)
                 .scrollContentBackground(.hidden)
+                .overlay {
+                    if viewModel.isSearching && viewModel.searchingCurrencies.isEmpty {
+                        SearchResultsUnavailableView(searchText: viewModel.searchText)
+                    }
+                }
             }
             .navigationTitle("Select Region")
             .toolbarTitleDisplayMode(.inline)

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -146,28 +146,6 @@ private struct LimitedAccessEmptyState: View {
     }
 }
 
-/// Shown over the list when a search matches no contacts.
-private struct RecipientSearchEmptyState: View {
-
-    let searchText: String
-
-    var body: some View {
-        ContentUnavailableView {
-            Label {
-                Text("No Results for “\(searchText)”")
-                    .font(.appTextLarge)
-                    .foregroundStyle(Color.textMain)
-            } icon: {
-                Image(systemName: "magnifyingglass")
-            }
-        } description: {
-            Text("Check the spelling or try a new search.")
-                .font(.appTextMedium)
-                .foregroundStyle(Color.textSecondary)
-        }
-    }
-}
-
 // MARK: - List items -
 
 /// One row of the merged on-Flipcash recipient feed: a synced contact, a DM
@@ -372,7 +350,7 @@ private struct RecipientPickerList: View {
             // conversations are intentionally hidden while searching), so skip
             // the "No Results" overlay there and keep the CTA card visible.
             if !searchText.isEmpty && filtered.isEmpty && contactAccess != .denied {
-                RecipientSearchEmptyState(searchText: searchText)
+                SearchResultsUnavailableView(searchText: searchText)
             }
         }
     }

--- a/FlipcashUI/Sources/FlipcashUI/Views/SearchResultsUnavailableView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/SearchResultsUnavailableView.swift
@@ -1,0 +1,47 @@
+//
+//  SearchResultsUnavailableView.swift
+//  FlipcashUI
+//
+
+import SwiftUI
+
+/// The app's themed equivalent of `ContentUnavailableView.search(text:)`, shown
+/// over a list when a search matches nothing.
+public struct SearchResultsUnavailableView: View {
+
+    private let searchText: String
+
+    // MARK: - Init -
+
+    public init(searchText: String) {
+        self.searchText = searchText
+    }
+
+    // MARK: - Body -
+
+    public var body: some View {
+        ContentUnavailableView {
+            Label {
+                Text("No Results for “\(searchText)”")
+                    .font(.appTextLarge)
+                    .foregroundStyle(Color.textMain)
+            } icon: {
+                Image(systemName: "magnifyingglass")
+            }
+        } description: {
+            Text("Check the spelling or try a new search.")
+                .font(.appTextMedium)
+                .foregroundStyle(Color.textSecondary)
+        }
+    }
+}
+
+// MARK: - Previews -
+
+struct SearchResultsUnavailableView_Previews: PreviewProvider {
+    static var previews: some View {
+        Background(color: .backgroundMain) {
+            SearchResultsUnavailableView(searchText: "Zzzqqq")
+        }
+    }
+}


### PR DESCRIPTION
The region picker showed a bare "Results" header over an empty list when a search matched nothing. It now shows the same no-results empty state the recipient picker already uses. That view was extracted into FlipcashUI as a shared component, so both screens — and any future search list — draw from one place.

## Test plan
- [ ] Open the region picker, search for something with no matches → the "No Results" empty state appears (magnifying glass + guidance), no stray "Results" header
- [ ] Search for a real region (e.g. "peso") → the results list renders as before
- [ ] Recipient picker no-results state looks and behaves exactly as it did
