### PR TITLE
fix: surface swap poll timeout in logs and report the stuck state

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingViewModel.swift
@@ -147,6 +147,8 @@ class CurrencyLaunchProcessingViewModel {
             // transitions on iOS 18). Don't treat as failure — the view
             // will restart the task if still visible.
         } catch {
+            // No swap state was ever fetched within the poll budget
+            logger.error("Launch swap polling failed", metadata: ["error": "\(error)"])
             displayState = .failed
             Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, exchangedFiat: launchAmount, successful: false, error: error)
         }
@@ -263,6 +265,13 @@ class CurrencyLaunchProcessingViewModel {
     // MARK: - Reporting -
 
     private func reportLaunchFailure(state: SwapState, reason: String) {
+        logger.error("Launch swap failed", metadata: [
+            "swapId": "\(swapId.publicKey.base58)",
+            "fundingMethod": "\(fundingMethod)",
+            "state": "\(state)",
+            "mint": "\(launchedMint.base58)",
+            "reason": "\(reason)",
+        ])
         ErrorReporting.captureError(
             SwapError.failed(state: state),
             reason: reason,

--- a/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingViewModel.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 import FlipcashCore
 
+private let logger = Logger(label: "flipcash.swap-processing")
+
 @Observable
 class SwapProcessingViewModel {
 
@@ -149,7 +151,9 @@ class SwapProcessingViewModel {
             // transitions on iOS 18). Don't treat as failure — the view
             // will restart the task if still visible.
         } catch {
-            // Poll limit reached or other error
+            // No swap state was ever fetched within the poll budget
+            logger.error("Swap polling failed", metadata: ["error": "\(error)"])
+            trackTransaction(successful: false)
             displayState = .failed
         }
 
@@ -161,6 +165,12 @@ class SwapProcessingViewModel {
     }
 
     private func reportSwapFailure(state: SwapState, reason: String) {
+        logger.error("Swap failed", metadata: [
+            "swapId": "\(swapId.publicKey.base58)",
+            "swapType": "\(swapType)",
+            "state": "\(state)",
+            "reason": "\(reason)",
+        ])
         ErrorReporting.captureError(
             SwapError.failed(state: state),
             reason: reason,

--- a/Flipcash/Core/Screens/Main/Operations/ScanCashOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/ScanCashOperation.swift
@@ -158,6 +158,9 @@ class ScanCashOperation {
         )
 
         guard isStreamOpen else {
+            logger.warning("No open stream for rendezvous, bill expired or dismissed", metadata: [
+                "rendezvous": "\(rendezvous.publicKey.base58)"
+            ])
             throw Error.noOpenStreamForRendezvous
         }
 

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Messaging.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Messaging.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Combine
 
+private let logger = Logger(label: "flipcash.payment-client")
+
 extension Client {
 
     public func openMessageStream(rendezvous: KeyPair, completion: @MainActor @Sendable @escaping (Result<[StreamMessage], Error>) -> Void) -> AnyCancellable {
@@ -112,6 +114,7 @@ func firstPaymentRequest(
             return request
         }
     }
+    logger.warning("Message stream closed before a payment request arrived")
     throw MessagingWaitError.streamClosedBeforeRequest
 }
 
@@ -135,6 +138,7 @@ func pollForGiveRequest(
             return request
         }
     }
+    logger.warning("Poll limit reached for give request", metadata: ["maxAttempts": "\(maxAttempts)"])
     throw MessagingWaitError.timedOut
 }
 

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Transaction.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Transaction.swift
@@ -370,56 +370,23 @@ extension Client {
     ///   - owner: Owner keypair for authentication
     ///   - maxAttempts: Maximum number of poll attempts
     ///   - onStateChange: Optional callback for state changes (called on each poll)
-    /// - Returns: Final SwapMetadata when terminal state is reached
-    /// - Throws: ClientError.pollLimitReached if max attempts exceeded
+    /// - Returns: Final SwapMetadata when a terminal state is reached, or the
+    ///   last-fetched metadata when the poll budget is exhausted — callers
+    ///   treat a returned non-terminal state as a timeout.
+    /// - Throws: ClientError.pollLimitReached if max attempts are exceeded
+    ///   without ever fetching swap state
     public func pollSwapState(
         swapId: SwapId,
         owner: KeyPair,
         maxAttempts: Int,
         onStateChange: (@Sendable (SwapState) -> Void)? = nil
     ) async throws -> SwapMetadata {
-        var lastState: SwapState?
-
-        for i in 0..<maxAttempts {
-            if i > 0 {
-                try await Task.delay(milliseconds: 1_000)
-            }
-
-            logger.debug("Polling swap state", metadata: [
-                "attempt": "\(i + 1)/\(maxAttempts)",
-                "swapId": "\(swapId.publicKey.base58)"
-            ])
-
-            do {
-                let metadata = try await fetchSwapMetadata(swapId: swapId, owner: owner)
-
-                // Notify of state change
-                if metadata.state != lastState {
-                    lastState = metadata.state
-                    onStateChange?(metadata.state)
-                }
-
-                // Check for terminal states
-                switch metadata.state {
-                case .finalized, .failed, .cancelled:
-                    logger.info("Swap reached terminal state", metadata: ["state": "\(metadata.state)"])
-                    return metadata
-                case .unknown, .created, .funding, .funded, .submitting, .cancelling:
-                    // Continue polling
-                    continue
-                }
-            } catch ErrorGetSwap.notFound {
-                // Swap not yet visible — service layer already logs this at
-                // debug level. Continue polling.
-                continue
-            } catch {
-                // Log but continue polling for transient errors
-                logger.warning("Swap poll error, continuing", metadata: ["error": "\(error)"])
-                continue
-            }
-        }
-
-        throw ClientError.pollLimitReached
+        try await pollSwapTerminalState(
+            swapId: swapId,
+            maxAttempts: maxAttempts,
+            onStateChange: onStateChange,
+            fetch: { try await self.fetchSwapMetadata(swapId: swapId, owner: owner) }
+        )
     }
 
     // MARK: - Limits -
@@ -437,6 +404,72 @@ extension Client {
             transactionService.fetchDestinationMetadata(destination: destination, mint: mint) { c.resume(with: $0) }
         }
     }
+}
+
+// MARK: - Poll helpers (testable) -
+
+/// Polls `fetch` until the swap reaches a terminal state or `maxAttempts` is
+/// exhausted. On exhaustion, returns the last-fetched metadata so callers can
+/// see the state the swap was stuck in; throws
+/// ``ClientError/pollLimitReached`` only when no swap state was ever fetched.
+func pollSwapTerminalState(
+    swapId: SwapId,
+    maxAttempts: Int,
+    pollInterval: Duration = .seconds(1),
+    onStateChange: (@Sendable (SwapState) -> Void)? = nil,
+    fetch: @Sendable () async throws -> SwapMetadata
+) async throws -> SwapMetadata {
+    var lastMetadata: SwapMetadata?
+
+    for i in 0..<maxAttempts {
+        if i > 0 {
+            try await Task.sleep(for: pollInterval)
+        }
+
+        logger.debug("Polling swap state", metadata: [
+            "attempt": "\(i + 1)/\(maxAttempts)",
+            "swapId": "\(swapId.publicKey.base58)"
+        ])
+
+        do {
+            let metadata = try await fetch()
+
+            // Notify of state change
+            if metadata.state != lastMetadata?.state {
+                onStateChange?(metadata.state)
+            }
+            lastMetadata = metadata
+
+            // Check for terminal states
+            switch metadata.state {
+            case .finalized, .failed, .cancelled:
+                logger.info("Swap reached terminal state", metadata: ["state": "\(metadata.state)"])
+                return metadata
+            case .unknown, .created, .funding, .funded, .submitting, .cancelling:
+                // Continue polling
+                continue
+            }
+        } catch ErrorGetSwap.notFound {
+            // Swap not yet visible — service layer already logs this at
+            // debug level. Continue polling.
+            continue
+        } catch {
+            // Log but continue polling for transient errors
+            logger.warning("Swap poll error, continuing", metadata: ["error": "\(error)"])
+            continue
+        }
+    }
+
+    logger.error("Poll limit reached for swap", metadata: [
+        "swapId": "\(swapId.publicKey.base58)",
+        "maxAttempts": "\(maxAttempts)",
+        "lastState": "\(lastMetadata.map { "\($0.state)" } ?? "<never fetched>")"
+    ])
+
+    guard let lastMetadata else {
+        throw ClientError.pollLimitReached
+    }
+    return lastMetadata
 }
 
 // MARK: - Error -

--- a/FlipcashCore/Tests/FlipcashCoreTests/SwapStatePollingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SwapStatePollingTests.swift
@@ -1,0 +1,148 @@
+//
+//  SwapStatePollingTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("Swap state polling")
+struct SwapStatePollingTests {
+
+    // MARK: - Fixtures
+
+    private static func testKey(_ seed: Int) -> PublicKey {
+        try! PublicKey([UInt8](repeating: UInt8(seed), count: 32))
+    }
+
+    private static let swapId = SwapId.generate()
+    private static let signature = try! Signature(Array(repeating: Byte(0), count: 64))
+
+    private static func metadata(state: SwapState) -> SwapMetadata {
+        SwapMetadata(
+            verifiedMetadata: VerifiedSwapMetadata(
+                clientParameters: VerifiedSwapMetadata.ClientParameters(
+                    id: swapId,
+                    fromMint: .usdf,
+                    toMint: testKey(10),
+                    amount: TokenAmount(quarks: 1_000_000, mint: .usdf),
+                    fundingSource: .submitIntent(id: testKey(18))
+                ),
+                serverParameters: VerifiedSwapMetadata.ServerParameters(
+                    nonce: testKey(2),
+                    blockhash: try! Hash([UInt8](repeating: 3, count: 32))
+                )
+            ),
+            state: state,
+            signature: signature
+        )
+    }
+
+    // MARK: - Terminal states
+
+    @Test("Returns as soon as a terminal state is fetched", arguments: [SwapState.finalized, .failed, .cancelled])
+    func returnsOnTerminalState(_ terminalState: SwapState) async throws {
+        let attemptLog = AttemptLog()
+
+        let result = try await pollSwapTerminalState(
+            swapId: Self.swapId,
+            maxAttempts: 5,
+            pollInterval: .milliseconds(1),
+            fetch: {
+                let n = attemptLog.incrementAndGet()
+                return Self.metadata(state: n < 3 ? .funding : terminalState)
+            }
+        )
+
+        #expect(result.state == terminalState)
+        #expect(attemptLog.count == 3)
+    }
+
+    // MARK: - Poll exhaustion
+
+    @Test("Returns the last-fetched metadata when the budget is exhausted in an intermediate state")
+    func exhaustionReturnsLastMetadata() async throws {
+        let attemptLog = AttemptLog()
+
+        let result = try await pollSwapTerminalState(
+            swapId: Self.swapId,
+            maxAttempts: 3,
+            pollInterval: .milliseconds(1),
+            fetch: {
+                _ = attemptLog.incrementAndGet()
+                return Self.metadata(state: .submitting)
+            }
+        )
+
+        #expect(result.state == .submitting)
+        #expect(attemptLog.count == 3)
+    }
+
+    @Test("Throws pollLimitReached only when no swap state was ever fetched")
+    func exhaustionWithoutMetadataThrows() async {
+        let attemptLog = AttemptLog()
+
+        await #expect(throws: ClientError.pollLimitReached) {
+            _ = try await pollSwapTerminalState(
+                swapId: Self.swapId,
+                maxAttempts: 3,
+                pollInterval: .milliseconds(1),
+                fetch: {
+                    _ = attemptLog.incrementAndGet()
+                    throw ErrorGetSwap.notFound
+                }
+            )
+        }
+        #expect(attemptLog.count == 3)
+    }
+
+    // MARK: - State changes
+
+    @Test("Notifies onStateChange only when the state transitions")
+    func onStateChangeFiresOnTransitionsOnly() async throws {
+        let attemptLog = AttemptLog()
+        let stateLog = StateLog()
+
+        let states: [SwapState] = [.funding, .funding, .submitting, .submitting, .finalized]
+        let result = try await pollSwapTerminalState(
+            swapId: Self.swapId,
+            maxAttempts: states.count,
+            pollInterval: .milliseconds(1),
+            onStateChange: { stateLog.append($0) },
+            fetch: { Self.metadata(state: states[attemptLog.incrementAndGet() - 1]) }
+        )
+
+        #expect(result.state == .finalized)
+        #expect(stateLog.states == [.funding, .submitting, .finalized])
+    }
+
+    // MARK: - Test helpers
+
+    private final class AttemptLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var counter = 0
+        var count: Int {
+            lock.lock(); defer { lock.unlock() }
+            return counter
+        }
+        func incrementAndGet() -> Int {
+            lock.lock(); defer { lock.unlock() }
+            counter += 1
+            return counter
+        }
+    }
+
+    private final class StateLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [SwapState] = []
+        var states: [SwapState] {
+            lock.lock(); defer { lock.unlock() }
+            return storage
+        }
+        func append(_ state: SwapState) {
+            lock.lock(); defer { lock.unlock() }
+            storage.append(state)
+        }
+    }
+}


### PR DESCRIPTION
A swap that never reached a terminal state within the poll budget threw a bare error that nothing logged or reported — which is why today's demo failure (a buy stuck in submitting for ~98s while the server's RPC node lagged) left no trace in the exported logs. Polling now logs the exhaustion and returns the last-fetched state, which also makes the previously unreachable "timed out in intermediate state" reporting in the buy/sell and launch flows actually run, so these timeouts land in the local log, Bugsnag, and analytics.

The same silent-exhaustion pattern is fixed in the give-request poll, the payment-request stream wait, and the grab-bill stream check, and the swap failure reporters now write to the local log before capturing to Bugsnag.

Test plan:
- [x] FlipcashCoreTests + FlipcashTests pass (612 tests)
- [x] New swap-state polling suite covers terminal return, exhaustion returning the stuck state, never-fetched throwing, and state-change deduplication