### PR TITLE
fix: keep unit tests out of the real contact store

### DIFF
--- a/Flipcash/Core/Container.swift
+++ b/Flipcash/Core/Container.swift
@@ -63,7 +63,7 @@ class Container {
     /// Unit tests run the app inside the test runner process where
     /// `XCTestConfigurationFilePath` is set. UI tests run a separate app
     /// process that does not inherit that var, so this stays `false` there.
-    static var isRunningUnitTests: Bool {
+    nonisolated static var isRunningUnitTests: Bool {
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
 

--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -174,6 +174,10 @@ enum RecipientLoader {
 
     static func load(database: Database) async -> ResolvedContacts {
         await Task.detached(priority: .userInitiated) {
+            // Hosted unit tests must never reach the real contact store — on
+            // iOS 26 the access itself presents the system share picker over
+            // the test host app and wedges the run.
+            guard !Container.isRunningUnitTests else { return ResolvedContacts.empty }
             let snapshot: [Database.LocalContact]
             let matched: [MatchedContact]
             do {

--- a/Flipcash/Core/Controllers/ContactSyncController.swift
+++ b/Flipcash/Core/Controllers/ContactSyncController.swift
@@ -431,6 +431,10 @@ final class ContactSyncController {
     // MARK: - Address book -
 
     nonisolated private func readContacts() throws -> [Database.LocalContact] {
+        // Hosted unit tests must never reach the real contact store — on
+        // iOS 26 the access itself presents the system share picker over the
+        // test host app and wedges the run.
+        guard !Container.isRunningUnitTests else { return [] }
         let store = CNContactStore()
         let request = CNContactFetchRequest(keysToFetch: [
             CNContactPhoneNumbersKey as CNKeyDescriptor,

--- a/FlipcashTests/ContactSyncControllerTests.swift
+++ b/FlipcashTests/ContactSyncControllerTests.swift
@@ -339,8 +339,8 @@ struct ContactSyncControllerTests {
             await controller.syncTask?.value
             try await Self.awaitResolved(controller)
 
-            // The flag, not the contents: name resolution reads the real
-            // CNContactStore, which a unit test can't seed.
+            // The flag, not the contents: contact resolution is guarded off
+            // in unit-test hosts, so only the flag is assertable.
             #expect(controller.hasResolvedOnce)
         }
 
@@ -447,6 +447,38 @@ struct ContactSyncControllerTests {
             while !controller.hasResolvedOnce, Date.now < deadline {
                 await Task.yield()
             }
+        }
+    }
+
+    // MARK: - Contact store isolation
+
+    @Suite("Contact store isolation", .serialized)
+    @MainActor
+    struct ContactStoreIsolationTests {
+
+        /// Regression (2026-07-08): a hosted unit test must never reach the
+        /// real `CNContactStore`. On iOS 26 the access itself presents the
+        /// system share picker over the test host app and wedges the whole
+        /// xcodebuild run at unit-phase entry. `resolveDirectory` with a
+        /// seeded snapshot is the exact path that fired (tccd logged
+        /// `unifiedContactWithIdentifier: "alice"` → AUTHREQ_PROMPTING).
+        @Test("resolveDirectory in a unit-test host never resolves against the store")
+        func resolveDirectory_unitTestHost_staysEmpty() async throws {
+            let database = Database.mock
+            try database.replaceLocalContactsSnapshot([
+                Database.LocalContact(e164: "+14155550100", contactId: "alice"),
+            ])
+            let controller = ContactSyncController(
+                client:                      MockContactSync(),
+                database:                    database,
+                owner:                       .mock,
+                authorizationStatusProvider: { .authorized }
+            )
+
+            await controller.resolveDirectory()
+
+            #expect(Container.isRunningUnitTests)
+            #expect(controller.resolvedContacts.isEmpty)
         }
     }
 


### PR DESCRIPTION
Hosted unit tests were reaching the real contact store through contact sync's snapshot read and directory resolution. On iOS 26 that access presents the contacts share picker over the test host app, wedging every command-line AllTargets run at the start of the unit-test phase and re-poisoning the simulator's TCC state between runs. Both leaves are now guarded off in unit-test hosts using the existing detection, with a regression test locking it in.

## Test plan

- [x] FlipcashTests + FlipcashCoreTests pass from a clean simulator with no picker and no contacts TCC entry created
- [x] AllTargets from the command line no longer hangs entering the unit-testing phase