### PR TITLE
fix: uninvited contacts prompt and unread-badge accessibility label

### DIFF
--- a/Flipcash/Core/Controllers/ContactDirectory.swift
+++ b/Flipcash/Core/Controllers/ContactDirectory.swift
@@ -178,6 +178,15 @@ enum RecipientLoader {
             // iOS 26 the access itself presents the system share picker over
             // the test host app and wedges the run.
             guard !Container.isRunningUnitTests else { return ResolvedContacts.empty }
+            // Resolution reads the store once per snapshot row, and the
+            // snapshot outlives the TCC state (it persists in SQLite across
+            // logins and permission resets). On iOS 26 a store access while
+            // authorization is undetermined makes the OS present the contacts
+            // authorization prompt — uninvited, since this path runs at
+            // bootstrap. Never touch the store without a grant.
+            guard CNContactStore.authorizationStatus(for: .contacts).allowsContactAccess else {
+                return ResolvedContacts.empty
+            }
             let snapshot: [Database.LocalContact]
             let matched: [MatchedContact]
             do {

--- a/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Buttons/LargeButton.swift
@@ -68,6 +68,10 @@ private struct LargeButtonIcon: View {
             .frame(width: 40, height: 40)
             .overlay(alignment: .topTrailing) {
                 Bubble(size: .regular, count: displayCount, hasMore: showsMore, color: .unreadIndicator)
+                    // The count already reads through the button's
+                    // `accessibilityValue` ("N unread"); letting the pill's text
+                    // merge into the label turns "Send" into "1, Send".
+                    .accessibilityHidden(true)
                     .fixedSize()
                     .padding(ring)
                     .background(Capsule().fill(Color.black).blendMode(.destinationOut))


### PR DESCRIPTION
Resolving the cached contacts directory read the contact store without checking authorization, and the cached snapshot outlives logins and permission resets — so on iOS 26, any logged-in launch could make the OS present the contacts permission prompt uninvited, wedging test runs and reachable by real users. Resolution is now guarded on granted access, leaving the user's tap on Give Access To Contacts as the only path to the system prompt. Separately, the unread badge's count leaked into the Send button's accessibility label ("1, Send"), breaking VoiceOver and label-based lookups; the badge pill is now hidden from accessibility since the count already reads through the accessibility value.

## Test plan

- [x] Logging in on an iOS 26 simulator with a stale contacts snapshot and permissions not determined shows no system prompt
- [x] VoiceOver reads the Send button as "Send, 1 unread"
- [x] AllTargets passes across multiple runs