### PR TITLE
fix: chat transcript crash when a message changes cell class

### DIFF
--- a/FlipcashTests/Regressions/Regression_6a4f895.swift
+++ b/FlipcashTests/Regressions/Regression_6a4f895.swift
@@ -18,7 +18,7 @@ import FlipcashCore
 /// identifier: ChatMessageCell"). The cell class must be part of the diff identity so a kind change
 /// diffs as delete+insert instead.
 @MainActor
-@Suite("Regression: 6a4f895 – chat transcript reconfigure across cell classes")
+@Suite("Regression: 6a4f895 – chat transcript reconfigure across cell classes", .bug("6a4f895be96556123e956f79"))
 struct Regression_6a4f895 {
 
     nonisolated private static func text(_ id: String, _ body: String = "hello", link: Bool = false, receipt: String? = nil) -> ChatItem {
@@ -40,12 +40,12 @@ struct Regression_6a4f895 {
     }
 
     @Test("A same-id cell-class flip diffs as delete+insert, never an update", arguments: [
-        (text("m"), cash("m")),             // ChatMessageCell → ChatCashCardCell (the crash)
-        (cash("m"), text("m")),             // ChatCashCardCell → ChatMessageCell
-        (text("m"), text("m", link: true)), // ChatMessageCell → ChatLinkMessageCell (edit gains a URL)
-        (text("m", link: true), text("m")), // ChatLinkMessageCell → ChatMessageCell (edit loses it)
+        ("text → cash (the crash)", text("m"), cash("m")),
+        ("cash → text", cash("m"), text("m")),
+        ("plain text → link text (edit gains a URL)", text("m"), text("m", link: true)),
+        ("link text → plain text (edit loses it)", text("m", link: true), text("m")),
     ])
-    func cellKindFlip_diffsAsReplace(before: ChatItem, after: ChatItem) {
+    func cellKindFlip_diffsAsReplace(label: String, before: ChatItem, after: ChatItem) {
         let changeset = StagedChangeset(source: [before], target: [after])
 
         #expect(changeset.flatMap(\.elementUpdated).isEmpty)

--- a/FlipcashTests/Regressions/Regression_6a4f895.swift
+++ b/FlipcashTests/Regressions/Regression_6a4f895.swift
@@ -1,0 +1,71 @@
+//
+//  Regression_6a4f895.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+import DifferenceKit
+import FlipcashCore
+@testable import FlipcashUI
+
+/// A message that keeps its stable id while its content flips to a different cell class (text → cash
+/// via a last-writer-wins merge) diffed as an *update*, which the transcript applies as
+/// `reconfigureItems` — and UIKit forbids reconfiguring an item into a different cell class
+/// (`NSInternalInconsistencyException`: "Dequeued reuse identifier: ChatCashCardCell; Original reuse
+/// identifier: ChatMessageCell"). The cell class must be part of the diff identity so a kind change
+/// diffs as delete+insert instead.
+@MainActor
+@Suite("Regression: 6a4f895 – chat transcript reconfigure across cell classes")
+struct Regression_6a4f895 {
+
+    nonisolated private static func text(_ id: String, _ body: String = "hello", link: Bool = false, receipt: String? = nil) -> ChatItem {
+        .message(ChatMessage(
+            id: id,
+            text: body,
+            sender: .me,
+            receipt: receipt,
+            linkPreview: link ? LinkPreview(url: URL(string: "https://example.com")!) : nil
+        ))
+    }
+
+    nonisolated private static func cash(_ id: String) -> ChatItem {
+        .message(ChatMessage(
+            id: id,
+            content: .cash(ChatCashContent(amount: "$5.00", token: "Cash", flagImageName: "us")),
+            sender: .me
+        ))
+    }
+
+    @Test("A same-id cell-class flip diffs as delete+insert, never an update", arguments: [
+        (text("m"), cash("m")),             // ChatMessageCell → ChatCashCardCell (the crash)
+        (cash("m"), text("m")),             // ChatCashCardCell → ChatMessageCell
+        (text("m"), text("m", link: true)), // ChatMessageCell → ChatLinkMessageCell (edit gains a URL)
+        (text("m", link: true), text("m")), // ChatLinkMessageCell → ChatMessageCell (edit loses it)
+    ])
+    func cellKindFlip_diffsAsReplace(before: ChatItem, after: ChatItem) {
+        let changeset = StagedChangeset(source: [before], target: [after])
+
+        #expect(changeset.flatMap(\.elementUpdated).isEmpty)
+        #expect(changeset.flatMap(\.elementDeleted) == [ElementPath(element: 0, section: 0)])
+        #expect(changeset.flatMap(\.elementInserted) == [ElementPath(element: 0, section: 0)])
+        #expect(changeset.flatMap(\.elementMoved).isEmpty)
+    }
+
+    @Test("A same-class content change still diffs as an update, not a replace")
+    func sameClassChange_staysAnUpdate() {
+        // A receipt tick ("Delivered" → "Read") must remain a cheap in-place reconfigure — guards
+        // the fix from over-broadening identity into whole-value equality, which would tear down
+        // and re-insert rows on every receipt or grouping change.
+        let before = [Self.text("m")]
+        let after = [Self.text("m", receipt: "Delivered")]
+
+        let changeset = StagedChangeset(source: before, target: after)
+
+        #expect(changeset.flatMap(\.elementUpdated) == [ElementPath(element: 0, section: 0)])
+        #expect(changeset.flatMap(\.elementDeleted).isEmpty)
+        #expect(changeset.flatMap(\.elementInserted).isEmpty)
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem+Differentiable.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem+Differentiable.swift
@@ -8,9 +8,34 @@
 import DifferenceKit
 import FlipcashCore
 
-/// Drives ChatLayout's canonical `reload(using:)` diffing: identity by `id` (stable across a
-/// re-group or receipt change), content equality by value (so a changed bubble reconfigures).
+/// Drives ChatLayout's canonical `reload(using:)` diffing: identity by cell class + `id` (stable
+/// across a re-group or receipt change), content equality by value (so a changed bubble
+/// reconfigures). The cell class is part of identity because UIKit forbids reconfiguring an item
+/// into a different cell class — a content change that lands in a different class (text ↔ cash,
+/// a link gained or lost) must diff as delete+insert, never as an update.
 extension ChatItem: Differentiable {
-    public var differenceIdentifier: String { id }
+    public var differenceIdentifier: String { "\(cellReuseIdentifier):\(id)" }
     public func isContentEqual(to source: ChatItem) -> Bool { self == source }
+}
+
+extension ChatItem {
+    /// The reuse identifier of the cell class this item renders with. Single source of truth for
+    /// the item → cell-class decision: `cellForItemAt` dequeues by it, and `differenceIdentifier`
+    /// folds it into identity, so the class dequeued at a position always matches the one the
+    /// diff promised there.
+    var cellReuseIdentifier: String {
+        switch self {
+        case .typingIndicator:
+            ChatTypingIndicatorCell.reuseIdentifier
+        case .dateSeparator:
+            ChatDateSeparatorCell.reuseIdentifier
+        case .message(let message):
+            switch message.content {
+            case .text:
+                message.linkPreview != nil ? ChatLinkMessageCell.reuseIdentifier : ChatMessageCell.reuseIdentifier
+            case .cash:
+                ChatCashCardCell.reuseIdentifier
+            }
+        }
+    }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -207,52 +207,36 @@ public final class ChatViewController: UICollectionViewController {
     }
 
     public override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        switch items[indexPath.item] {
+        let item = items[indexPath.item]
+        // Dequeue by the item's `cellReuseIdentifier` — the same value folded into the diff
+        // identity — so the class dequeued at a position always matches the one the diff promised
+        // there, and a reconfigure can never land on a cell of a different class (UIKit forbids that).
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: item.cellReuseIdentifier, for: indexPath)
+        switch item {
         case .typingIndicator:
-            return collectionView.dequeueReusableCell(
-                withReuseIdentifier: ChatTypingIndicatorCell.reuseIdentifier,
-                for: indexPath
-            ) as! ChatTypingIndicatorCell
+            break
         case .dateSeparator(_, let text):
-            let cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: ChatDateSeparatorCell.reuseIdentifier,
-                for: indexPath
-            ) as! ChatDateSeparatorCell
-            cell.configure(text: text)
-            return cell
+            (cell as! ChatDateSeparatorCell).configure(text: text)
         case .message(let message):
-            switch message.content {
-            case .text:
-                // Only text messages are sent optimistically, so only they can reach the failed state
-                // that arms retry (wired on both text cells). Cash messages are always server-confirmed.
-                let width = collectionView.bounds.width > 0 ? collectionView.bounds.width : UIScreen.main.bounds.width
-                let maxWidth = width * Self.maxBubbleWidthFraction
-                if message.linkPreview != nil {
-                    let cell = collectionView.dequeueReusableCell(
-                        withReuseIdentifier: ChatLinkMessageCell.reuseIdentifier,
-                        for: indexPath
-                    ) as! ChatLinkMessageCell
-                    cell.configure(with: message, maxWidth: maxWidth)
-                    cell.onRetry = { [weak self] id in self?.onRetry?(id) }
-                    cell.onOpenURL = { [weak self] url in self?.onOpenURL?(url) }
-                    return cell
-                }
-                let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: ChatMessageCell.reuseIdentifier,
-                    for: indexPath
-                ) as! ChatMessageCell
+            let width = collectionView.bounds.width > 0 ? collectionView.bounds.width : UIScreen.main.bounds.width
+            let maxWidth = width * Self.maxBubbleWidthFraction
+            switch cell {
+            // Only text messages are sent optimistically, so only they can reach the failed state
+            // that arms retry (wired on both text cells). Cash messages are always server-confirmed.
+            case let cell as ChatLinkMessageCell:
                 cell.configure(with: message, maxWidth: maxWidth)
                 cell.onRetry = { [weak self] id in self?.onRetry?(id) }
-                return cell
-            case .cash:
-                let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: ChatCashCardCell.reuseIdentifier,
-                    for: indexPath
-                ) as! ChatCashCardCell
+                cell.onOpenURL = { [weak self] url in self?.onOpenURL?(url) }
+            case let cell as ChatMessageCell:
+                cell.configure(with: message, maxWidth: maxWidth)
+                cell.onRetry = { [weak self] id in self?.onRetry?(id) }
+            case let cell as ChatCashCardCell:
                 cell.configure(with: message)
-                return cell
+            default:
+                assertionFailure("Unhandled chat cell class for reuse identifier \(item.cellReuseIdentifier)")
             }
         }
+        return cell
     }
 
     // MARK: - Selection


### PR DESCRIPTION
The transcript diffed messages by id alone while the cell class is derived from the content, so a message that kept its id but flipped from text to cash was applied as a reconfigure across cell classes — which UIKit forbids (Bugsnag 6a4f895). The cell class is now part of the diff identity, driven by a single classifier that both the diff and the dequeue consume, so a class flip applies as delete+insert while receipt and grouping changes stay cheap in-place reconfigures. Same-id edits that gain or lose a link were the same latent bug and are covered by the same fix.

Test plan:
- [x] Regression suite: all four cell-class flips diff as replace; a receipt tick stays an update
- [x] Chat suites: transcript rendering, changeset flattening, mapping, and cell tests pass
- [x] Full FlipcashTests + FlipcashCoreTests gate passes