### PR TITLE
chore: lock down the triage skill

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -12,7 +12,6 @@ allowed-tools:
   - Grep
   - Skill
   - Bash(./.claude/skills/triage/scripts/bugsnag-top.sh:*)
-  - Bash(curl:*)
   - Bash(jq:*)
   - Bash(git log:*)
   - Bash(git show:*)
@@ -32,7 +31,8 @@ You are running the daily Bugsnag triage ritual. The deliverable is **one lean r
 2. **No claim without a citation.** Every assertion in the brief (stack lines, "this is the root cause", "this code path runs first") must be followed by a `file.swift:NN` reference or a quoted log/breadcrumb excerpt. If unable to cite, mark as "hypothesis, unverified" and propose how to verify.
 3. **Root cause must be reachable from evidence.** The Root cause section is a short chain: `evidence → inference → evidence → inference → cause`. No leaps. If the chain breaks, the section is renamed "Leading hypothesis" and the Proposed direction becomes "Verification steps".
 4. **No mid-flow questions.** The brief is the review checkpoint. Don't ask the user anything until it's written.
-5. **Skip experts whose triggers don't apply.** Running an irrelevant expert wastes tokens.
+5. **The brief is the only file you create or modify.** Triage never touches source, tests, or config — the fix happens in a later session, after review.
+6. **Skip experts whose triggers don't apply.** Running an irrelevant expert wastes tokens.
 
 ## Steps
 
@@ -54,7 +54,7 @@ Parse the JSON. You'll use:
 - `events`, `users`, `first_seen`, `last_seen`, `release_stages`
 - `introduced_in_release`, `grouping_hint`
 - `html_url` (browser link to put in the brief header)
-- `latest_event_id`, `latest_event_url` (for fetching the full event report next)
+- `latest_event_id` (for the `--event` fetch in step 4)
 
 ### 2. Existing-plan check
 
@@ -72,23 +72,21 @@ Use the `Skill` tool to invoke `superpowers:systematic-debugging`. That skill ow
 
 ### 4. Fetch the full latest event
 
-The event endpoint returns a full report:
+Fetch the full event report through the script — it saves the JSON to a tempfile and prints the path:
 
 ```bash
-curl -sH "Authorization: token $BUGSNAG_TOKEN" -H "X-Version: 2" "<latest_event_url>"
+./.claude/skills/triage/scripts/bugsnag-top.sh --event <latest_event_id>
 ```
 
-Confirm the response has `is_full_report: true`. If `false`, the event is truncated and you cannot reason about its stack — note this in the brief and propose better instrumentation.
+On success it emits `{"event_file": "<path>", "is_full_report": <bool>}`. If `is_full_report` is `false`, the event is truncated and you cannot reason about its stack — note this in the brief and propose better instrumentation.
+
+Run every subsequent jq query against `event_file`. Never re-fetch the same event — it's the hottest part of the run.
 
 #### 4a. Version sanity check (skip stale versions)
 
 **Skip this step entirely if `$ARGUMENTS` contains `--id`.** The user explicitly chose this issue; honor the override.
 
-Otherwise, don't waste cycles investigating a bug that's only firing on old app builds. Read the current marketing version from the project:
-
-```bash
-grep -m1 'MARKETING_VERSION = ' Code.xcodeproj/project.pbxproj | sed 's/.*= //; s/;//' | xargs
-```
+Otherwise, don't waste cycles investigating a bug that's only firing on old app builds. Read the current marketing version with the Grep tool — pattern `MARKETING_VERSION = ` on `Code.xcodeproj/project.pbxproj`, content mode — and take the value from the first matching line.
 
 The first match is good enough — across configurations the app uses one marketing version, and any one of them is a valid baseline for the staleness comparison.
 
@@ -109,8 +107,6 @@ Read `references/event-shape.md` for the full structure of the event response an
 - `breadcrumbs[]` (timestamped UI/state events)
 
 Plus secondary context in `metaData.app`, `metaData.device`, `feature_flags`, `user`, `session`, `request`.
-
-Save the response to a tempfile (`mktemp`) and run subsequent jq queries against the file. Never re-curl the same event — it's the hottest part of the run.
 
 ### 5. Locate source files for app frames
 

--- a/.claude/skills/triage/references/brief-template.md
+++ b/.claude/skills/triage/references/brief-template.md
@@ -36,7 +36,11 @@ Hard cap: ~200–300 words total. If a section runs longer, tighten it. Skim-rea
 
 ## Proposed direction
 
-<one paragraph. The shape of the fix, not the steps.>
+<one paragraph. The shape of the smallest change that fixes the root cause — not a patch over the symptom, and not numbered steps.>
+
+## Verification
+
+<success criteria: `FlipcashTests/Regressions/Regression_<bugsnag_id>.swift` (full 24-char id) reproducing the crash path, plus any observable behavior that proves the fix.>
 
 ## Risk
 
@@ -49,7 +53,7 @@ Hard cap: ~200–300 words total. If a section runs longer, tighten it. Skim-rea
 
 ## Next step
 
-If actioned: run `superpowers:writing-plans` against this file to expand into an implementation plan.
+If actioned: run `superpowers:writing-plans` against this file to expand into an implementation plan, and load `karpathy-guidelines` before writing code. The fix must land with the regression test named in Verification (CLAUDE.md: every Bugsnag crash fix gets one).
 ```
 
 ## Notes on each section
@@ -58,5 +62,6 @@ If actioned: run `superpowers:writing-plans` against this file to expand into an
 - **Possible fix already in main** — optional. Only included when commits exist on the touched files since `last_seen`. Tells the reader to verify whether those commits address the issue before taking further action — but the brief is still produced normally.
 - **Root cause** — if the chain breaks, rename to "Leading hypothesis" and the Proposed direction becomes "Verification steps".
 - **Evidence** — schema is illustrative; include only the rows you have. A row with no quote is rot.
-- **Proposed direction** — the *shape* of the fix, not numbered steps. Numbered steps belong in the implementation plan that comes later.
+- **Proposed direction** — the *shape* of the fix, not numbered steps. Numbered steps belong in the implementation plan that comes later. "Smallest change" never means patching the symptom — the root cause is the target; smallest is measured among fixes that reach it.
+- **Verification** — concrete success criteria the implementation session can loop against. The regression test file uses the full Bugsnag id; the suite name includes the short id (see `FlipcashTests/Regressions/` convention).
 - **Expert input** — only triggered experts get a bullet. No empty headings.

--- a/.claude/skills/triage/scripts/bugsnag-top.sh
+++ b/.claude/skills/triage/scripts/bugsnag-top.sh
@@ -2,12 +2,19 @@
 # bugsnag-top.sh — fetch the top open production issue from Bugsnag (last 7 days).
 # Emits one JSON object to stdout on success.
 #
+# Modes:
+#   (default)         top open production issue with events in the last 7d
+#   --skip <N>        walk down the ranked list
+#   --id <id|url>     target one issue directly (bypasses the default filters)
+#   --event <id|url>  fetch one full event report, save it to a tempfile,
+#                     emit {event_file, is_full_report}
+#
 # Exit codes:
-#   0  success — issue found, JSON on stdout
+#   0  success — JSON on stdout
 #   2  missing/invalid argument or BUGSNAG_TOKEN unset
 #   3  token rejected by Bugsnag (401)
 #   4  Bugsnag API unreachable after one retry
-#   5  no qualifying issues (or --skip exceeds available results)
+#   5  no qualifying issues (or --skip exceeds available results, or --id/--event not found)
 
 set -euo pipefail
 
@@ -34,11 +41,26 @@ if [ -z "${BUGSNAG_TOKEN:-}" ]; then
   exit 2
 fi
 
-# Parse --skip <N> | --id <bugsnag_error_id_or_url>
+# Parse --skip <N> | --id <bugsnag_error_id_or_url> | --event <bugsnag_event_id_or_url>
 SKIP=0
 FORCED_ID=""
+EVENT_ID=""
 while [ $# -gt 0 ]; do
   case "$1" in
+    --event)
+      EVENT_ID="${2:-}"
+      if [ -z "$EVENT_ID" ]; then
+        echo "--event requires a Bugsnag event id (24-char hex) or a Bugsnag event URL" >&2
+        exit 2
+      fi
+      # If the user pasted a URL, extract the trailing id
+      EVENT_ID="${EVENT_ID##*/}"
+      if ! [[ "$EVENT_ID" =~ ^[0-9a-f]{24}$ ]]; then
+        echo "--event value '$EVENT_ID' is not a 24-char hex Bugsnag event id" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
     --skip)
       SKIP="${2:-}"
       if ! [[ "$SKIP" =~ ^[0-9]+$ ]]; then
@@ -73,7 +95,16 @@ if [ -n "$FORCED_ID" ] && [ "$SKIP" -ne 0 ]; then
   exit 2
 fi
 
-if [ -n "$FORCED_ID" ]; then
+if [ -n "$EVENT_ID" ] && { [ -n "$FORCED_ID" ] || [ "$SKIP" -ne 0 ]; }; then
+  echo "--event cannot be combined with --skip or --id. It fetches one event report directly." >&2
+  exit 2
+fi
+
+if [ -n "$EVENT_ID" ]; then
+  # Event-report lookup — lets the SKILL pull the full latest event without
+  # needing raw curl access.
+  URL="$API_BASE/events/$EVENT_ID"
+elif [ -n "$FORCED_ID" ]; then
   # Targeted lookup — bypass the filtered query so the user can triage anything
   # (closed, fixed, ignored, non-prod, older than 7d) by id.
   URL="$API_BASE/errors/$FORCED_ID"
@@ -120,7 +151,8 @@ report_unreachable_and_exit() {
   exit 4
 }
 
-fetch_errors() {
+# Curls whatever $URL points at (errors list, single error, or event report).
+fetch_url() {
   curl -sS \
     -H "Authorization: token $BUGSNAG_TOKEN" \
     -H "X-Version: 2" \
@@ -128,7 +160,7 @@ fetch_errors() {
     "$URL"
 }
 
-fetch_with_retry fetch_errors
+fetch_with_retry fetch_url
 
 if [ "$HTTP_CODE" = "401" ]; then
   echo "Bugsnag rejected the token (401). Check it hasn't expired or been revoked." >&2
@@ -140,8 +172,25 @@ if [ "$HTTP_CODE" = "404" ] && [ -n "$FORCED_ID" ]; then
   exit 5
 fi
 
+if [ "$HTTP_CODE" = "404" ] && [ -n "$EVENT_ID" ]; then
+  echo "Bugsnag has no event with id $EVENT_ID. Double-check the id (24-char hex) or the URL." >&2
+  exit 5
+fi
+
 if [ "$HTTP_CODE" != "200" ]; then
   report_unreachable_and_exit "Bugsnag API unreachable: HTTP $HTTP_CODE. Try again later."
+fi
+
+# Event mode: persist the full report to a tempfile and emit a small summary.
+# The SKILL runs its jq queries against event_file instead of re-fetching.
+if [ -n "$EVENT_ID" ]; then
+  if ! echo "$BODY" | jq -e 'type == "object"' >/dev/null; then
+    report_unreachable_and_exit "Unexpected Bugsnag event response shape (not a JSON object). API may have changed."
+  fi
+  EVENT_FILE=$(mktemp -t bugsnag-event)
+  printf '%s\n' "$BODY" > "$EVENT_FILE"
+  jq --arg f "$EVENT_FILE" '{event_file: $f, is_full_report: (.is_full_report // false)}' "$EVENT_FILE"
+  exit 0
 fi
 
 # The list endpoint returns an array; the by-id endpoint returns a single object.
@@ -198,7 +247,6 @@ fi
 echo "$ERRORS_BODY" | jq \
   --arg browser_base "$BROWSER_BASE" \
   --arg latest_event_id "$LATEST_EVENT_ID" \
-  --arg api_base "$API_BASE" \
   '.[0] | {
     id,
     short_id: (.id[0:7]),
@@ -212,6 +260,5 @@ echo "$ERRORS_BODY" | jq \
     introduced_in_release: (.introduced_in_releases[0].build_label // null),
     grouping_hint: (.grouping_fields.custom // null),
     html_url: ($browser_base + "/" + .id),
-    latest_event_id: $latest_event_id,
-    latest_event_url: ($api_base + "/events/" + $latest_event_id)
+    latest_event_id: $latest_event_id
   }'


### PR DESCRIPTION
Hardens the daily Bugsnag triage ritual. The review brief now frames the proposed direction as the smallest change that fixes the root cause and adds a Verification section carrying the mandatory regression test, with the implementing session pointed at the Karpathy guidelines at fix time. Every documented command now matches the skill's tool allowlist — the event fetch moves into the fetch script's new \`--event\` mode — so runs never stall on permission prompts and network access is confined to the Bugsnag API. A new hard rule makes the brief the only file triage may write.

## Test plan

- [x] Script verified live: top-issue fetch → \`--event\` full-report round-trip, plus pasted-URL, 404, and bad-argument paths
- [x] Next \`/triage\` run produces a brief with the Verification section filled