### PR TITLE
fix: improve typing indicator resilience

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,14 @@ When adding new information, place it in the appropriate existing section. Remov
 
 ## Hard Rules (Non-Negotiable)
 
+### Comments: One Line, Constraints Only
+
+A comment exists to state a non-obvious constraint the code cannot show — in **one sentence**. Never narrate what the code does, never restate a rationale that already appears elsewhere in the file, never document the obvious. If a doc comment needs a paragraph, fix the name or the shape of the code instead.
+
+### State Lives in Named Units
+
+A concern that owns **more than two pieces of state** (flags, tasks, queues, deadline maps) gets its own type — `@MainActor @Observable` class for UI-bound state, `actor` for cross-domain state — composed as a single `let` on the owner with thin forwards. Never loose fields accreted onto a shared controller. Judge by the concern's **total** field count at the end of the change, not the per-edit delta; extraction is part of the change itself, not a follow-up. Example: `ConversationTyping` owns all typing state; `ConversationController` holds one `let typing` and forwards.
+
 ### Testing Framework
 
 **Use Swift Testing, NOT XCTest:**
@@ -181,6 +189,8 @@ ErrorReporting.captureError(error, reason: "...")
 ```
 
 To change how a specific error type surfaces, conform it to `ServerError` (in `FlipcashCore/Sources/FlipcashCore/Models/ServerError.swift`) and return the right `ErrorReportingLevel` per case — `.suppressed` for network weather / success sentinels, `.info` for expected business outcomes (denied, not-found, rate-limited), `.error` for client/proto defects (`.unknown`, parse failures). There is deliberately no protocol default — the compiler forces every new conformer to classify its cases explicitly. That's the single source of truth — call sites stay uniform.
+
+**Best-effort chatter never reports at all.** `captureError` is for failures a developer should act on. Fire-and-forget UX signals (typing indicators and similar presence-style traffic, which the proto marks droppable) log at most one warning per burst and do **not** call `captureError` — a failed typing notification is not actionable.
 
 ### Form Input Validation: Use the `Validator` Family
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,9 +68,9 @@ When adding new information, place it in the appropriate existing section. Remov
 
 ## Hard Rules (Non-Negotiable)
 
-### Comments: One Line, Constraints Only
+### Comments: Document the API, Constrain the Implementation
 
-A comment exists to state a non-obvious constraint the code cannot show — in **one sentence**. Never narrate what the code does, never restate a rationale that already appears elsewhere in the file, never document the obvious. If a doc comment needs a paragraph, fix the name or the shape of the code instead.
+Non-private API carries a `///` doc comment in Apple's style: one third-person sentence stating the contract — what it returns or does for the caller — never the mechanism. Inline comments state only non-obvious constraints, one sentence, never repeating a rationale within the file.
 
 ### State Lives in Named Units
 

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -36,14 +36,6 @@ final class ConversationController {
     /// cross-fade onto a settled bubble; the transcript mapping suppresses that row's receipt while set.
     var settlingSendID: String? { receiptSettle.settlingID }
 
-    /// Per-conversation set of OTHER members currently typing, maintained from the live stream.
-    /// Ephemeral — never persisted (the proto marks typing transient/best-effort). Cleared when a
-    /// member sends a stopped/timed-out notification, or locally after `incomingTypingExpiry`: the
-    /// server is a stateless relay with no timeout of its own, so a dropped STOPPED would otherwise
-    /// stick the indicator forever. `Set<UserID>` is Equatable, so the @Observable setter skips
-    /// no-op re-inserts.
-    private var typingUserIDs: [ConversationID: Set<UserID>] = [:]
-
     /// The conversation with this ID, if the feed currently holds it.
     func conversation(withID id: ConversationID) -> Conversation? {
         conversations.first { $0.id == id }
@@ -90,28 +82,9 @@ final class ConversationController {
     @ObservationIgnored private var gapCatchUpTasks: [ConversationID: Task<Void, Never>] = [:]
     @ObservationIgnored private let receiptSettle = ReceiptSettleGate()
 
-    /// Re-send STILL no more often than this while the user keeps typing, and send STOPPED after this
-    /// long idle (matches the Android client so all clients agree on the cadence). Injected so tests
-    /// can shorten them; production always uses the init defaults.
-    private let typingHeartbeatInterval: Duration
-    private let typingTimeout: Duration
-    /// How long an incoming typist stays shown with no further STARTED/STILL. The server relays
-    /// typing best-effort with no timeout of its own, so a lost STOPPED would otherwise stick the
-    /// indicator forever. Comfortably above the senders' 3s heartbeat cadence.
-    private let incomingTypingExpiry: Duration
-    @ObservationIgnored private var isSelfTyping = false
-    @ObservationIgnored private var selfTypingTask: Task<Void, Never>?
-    /// When the last outgoing typing state was queued; lets a keystroke emit the STILL heartbeat
-    /// once `typingHeartbeatInterval` has passed even while the pause loop keeps restarting.
-    @ObservationIgnored private var lastTypingSentAt: ContinuousClock.Instant?
-    /// Outgoing typing states not yet on the wire, drained one at a time by `typingSendTask` so a
-    /// STOPPED can never overtake an in-flight STILL. States are absolute, so each conversation
-    /// holds at most one pending entry — later states supersede it in place.
-    @ObservationIgnored private var pendingTypingSends: [(conversationID: ConversationID, state: TypingState)] = []
-    @ObservationIgnored private var typingSendTask: Task<Void, Never>?
-    /// Per-typist staleness deadlines backing `typingUserIDs`, swept by `typingExpiryTask`.
-    @ObservationIgnored private var typingExpiries: [ConversationID: [UserID: ContinuousClock.Instant]] = [:]
-    @ObservationIgnored private var typingExpiryTask: Task<Void, Never>?
+    /// The typing-indicator concern, both directions (outgoing driver + incoming typist
+    /// tracking), owned by its own unit. Reads chain through `@Observable` tracking.
+    private let typing: ConversationTyping
 
     init(
         fetching: any ConversationFetching,
@@ -132,9 +105,14 @@ final class ConversationController {
         self.database = database
         self.owner = owner
         self.selfUserID = selfUserID
-        self.typingHeartbeatInterval = typingHeartbeatInterval
-        self.typingTimeout = typingTimeout
-        self.incomingTypingExpiry = incomingTypingExpiry
+        self.typing = ConversationTyping(
+            messaging: messaging,
+            owner: owner,
+            selfUserID: selfUserID,
+            heartbeatInterval: typingHeartbeatInterval,
+            timeout: typingTimeout,
+            incomingExpiry: incomingTypingExpiry
+        )
     }
 
     /// Seeds the store from the local cache so the feed, unread state, and
@@ -335,64 +313,15 @@ final class ConversationController {
         }
     }
 
-    /// Updates the ephemeral typing set from a live event. Self is excluded — the server may echo our
-    /// own typing and we never show ourselves typing. Every STARTED/STILL refreshes the typist's
-    /// staleness deadline.
+    /// Routes a live typing event to the typing unit.
     private func applyTyping(_ event: ConversationStreamEvent) {
         guard case .typingChanged(let conversationID, let notifications) = event else { return }
-        for notification in notifications where notification.userID != selfUserID {
-            switch notification.isActive {
-            case true:
-                typingUserIDs[conversationID, default: []].insert(notification.userID)
-                typingExpiries[conversationID, default: [:]][notification.userID] = ContinuousClock.now + incomingTypingExpiry
-            case false:
-                removeTypist(notification.userID, in: conversationID)
-            }
-        }
-        scheduleTypingExpirySweep()
-    }
-
-    private func removeTypist(_ userID: UserID, in conversationID: ConversationID) {
-        typingUserIDs[conversationID]?.remove(userID)
-        if typingUserIDs[conversationID]?.isEmpty == true {
-            typingUserIDs[conversationID] = nil
-        }
-        typingExpiries[conversationID]?[userID] = nil
-        if typingExpiries[conversationID]?.isEmpty == true {
-            typingExpiries[conversationID] = nil
-        }
-    }
-
-    /// (Re)arms the sweep for the earliest staleness deadline. One task at a time; each sweep
-    /// re-arms for whatever deadline is next, and the task ends when no typists remain.
-    private func scheduleTypingExpirySweep() {
-        typingExpiryTask?.cancel()
-        typingExpiryTask = nil
-        guard let earliest = typingExpiries.values.flatMap(\.values).min() else { return }
-        typingExpiryTask = Task { [weak self] in
-            try? await Task.sleep(until: earliest, clock: .continuous)
-            guard let self, !Task.isCancelled else { return }
-            self.sweepExpiredTypists()
-        }
-    }
-
-    private func sweepExpiredTypists() {
-        let now = ContinuousClock.now
-        for (conversationID, deadlines) in typingExpiries {
-            for (userID, deadline) in deadlines where deadline <= now {
-                logger.debug("Expiring stale typist", metadata: [
-                    "conversationID": "\(conversationID)",
-                    "userID": "\(userID)",
-                ])
-                removeTypist(userID, in: conversationID)
-            }
-        }
-        scheduleTypingExpirySweep()
+        typing.apply(notifications, in: conversationID)
     }
 
     /// Whether any OTHER member is currently typing in this conversation.
     func isCounterpartTyping(in conversationID: ConversationID) -> Bool {
-        !(typingUserIDs[conversationID]?.isEmpty ?? true)
+        typing.isCounterpartTyping(in: conversationID)
     }
 
     func stop() {
@@ -407,16 +336,7 @@ final class ConversationController {
         gapCatchUpTasks.values.forEach { $0.cancel() }
         gapCatchUpTasks.removeAll()
         catchUpInFlight.removeAll()
-        typingUserIDs.removeAll()
-        typingExpiries.removeAll()
-        typingExpiryTask?.cancel()
-        typingExpiryTask = nil
-        selfTypingTask?.cancel()
-        selfTypingTask = nil
-        isSelfTyping = false
-        pendingTypingSends.removeAll()
-        typingSendTask?.cancel()
-        typingSendTask = nil
+        typing.stop()
         receiptSettle.cancel()
         streaming.closeConversationStream()
     }
@@ -742,94 +662,13 @@ final class ConversationController {
 
     // MARK: - Outgoing typing
 
-    /// Drives outgoing typing from the composer's draft. STARTED on the first non-empty change, STILL
-    /// at least every `typingHeartbeatInterval` while typing continues, STOPPED at `typingTimeout`
-    /// idle or when the draft empties. Each change replaces the previous run, mirroring Android's
-    /// `transformLatest` driver.
+    /// Drives outgoing typing from the composer's draft; see `ConversationTyping`.
     func draftDidChange(_ text: String, in conversationID: ConversationID) {
-        selfTypingTask?.cancel()
-        guard !text.isEmpty else {
-            stopSelfTyping(in: conversationID)
-            return
-        }
-        selfTypingTask = Task { [weak self] in
-            // A task cancelled before its body runs (a fast type-then-clear) must send nothing — otherwise
-            // it would emit a STARTED with no matching STOPPED and wedge `isSelfTyping`.
-            guard let self, !Task.isCancelled else { return }
-            if !self.isSelfTyping {
-                self.isSelfTyping = true
-                self.sendTyping(.started, in: conversationID)
-            } else if let last = self.lastTypingSentAt,
-                      last.duration(to: ContinuousClock.now) >= self.typingHeartbeatInterval {
-                // The pause loop below restarts on every keystroke, so continuous typing would
-                // otherwise go silent after STARTED — and receivers expire stale typists.
-                self.sendTyping(.still, in: conversationID)
-            }
-            var elapsed: Duration = .zero
-            while elapsed < self.typingTimeout {
-                let wait = min(self.typingHeartbeatInterval, self.typingTimeout - elapsed)
-                try? await Task.sleep(for: wait)
-                if Task.isCancelled { return }
-                elapsed += wait
-                if elapsed < self.typingTimeout {
-                    self.sendTyping(.still, in: conversationID)
-                }
-            }
-            self.isSelfTyping = false
-            self.sendTyping(.stopped, in: conversationID)
-        }
+        typing.draftDidChange(text, in: conversationID)
     }
 
     /// Force-stop outgoing typing (draft cleared, message sent, or the composer lost focus).
     func stopSelfTyping(in conversationID: ConversationID) {
-        selfTypingTask?.cancel()
-        selfTypingTask = nil
-        guard isSelfTyping else { return }
-        isSelfTyping = false
-        sendTyping(.stopped, in: conversationID)
-    }
-
-    /// Queues a typing state and drains the queue one RPC at a time. Serialization keeps the wire
-    /// order equal to the intent order (a STOPPED must never be overtaken by an in-flight STILL —
-    /// the receiver would re-add the typist and stick). States are absolute, so each conversation
-    /// keeps at most one pending entry — later states supersede it in place, bounding the queue
-    /// and skipping stale sends after an offline burst. Only the first failure per drain logs (an
-    /// offline typing session would otherwise flood the export every few seconds); every failure
-    /// still routes through `captureError`, which classifies transient ones as `.suppressed`.
-    private func sendTyping(_ state: TypingState, in conversationID: ConversationID) {
-        logger.debug("Queued typing notification", metadata: [
-            "state": "\(state)",
-            "conversationID": "\(conversationID)",
-        ])
-        lastTypingSentAt = ContinuousClock.now
-        if let index = pendingTypingSends.firstIndex(where: { $0.conversationID == conversationID }) {
-            pendingTypingSends[index].state = state
-        } else {
-            pendingTypingSends.append((conversationID: conversationID, state: state))
-        }
-        guard typingSendTask == nil else { return }
-        typingSendTask = Task { [weak self] in
-            var loggedFailure = false
-            while let self, !Task.isCancelled, !self.pendingTypingSends.isEmpty {
-                let next = self.pendingTypingSends.removeFirst()
-                do {
-                    try await self.messaging.notifyIsTyping(owner: self.owner, conversationID: next.conversationID, state: next.state)
-                } catch {
-                    if !loggedFailure {
-                        loggedFailure = true
-                        logger.warning("Typing notification failed", metadata: [
-                            "state": "\(next.state)",
-                            "error": "\(error)",
-                        ])
-                    }
-                    ErrorReporting.captureError(error, reason: "Failed to notify typing")
-                }
-            }
-            // `stop()` is the only other place that clears the slot, and it also cancels — so a
-            // cancelled drainer resuming late must not clear what may be a successor's slot.
-            if let self, !Task.isCancelled {
-                self.typingSendTask = nil
-            }
-        }
+        typing.stopSelfTyping(in: conversationID)
     }
 }

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -38,8 +38,10 @@ final class ConversationController {
 
     /// Per-conversation set of OTHER members currently typing, maintained from the live stream.
     /// Ephemeral — never persisted (the proto marks typing transient/best-effort). Cleared when a
-    /// member sends a stopped/timed-out notification; no client-side expiry (server-driven, mirroring
-    /// Android). `Set<UserID>` is Equatable, so the @Observable setter skips no-op re-inserts.
+    /// member sends a stopped/timed-out notification, or locally after `incomingTypingExpiry`: the
+    /// server is a stateless relay with no timeout of its own, so a dropped STOPPED would otherwise
+    /// stick the indicator forever. `Set<UserID>` is Equatable, so the @Observable setter skips
+    /// no-op re-inserts.
     private var typingUserIDs: [ConversationID: Set<UserID>] = [:]
 
     /// The conversation with this ID, if the feed currently holds it.
@@ -89,11 +91,27 @@ final class ConversationController {
     @ObservationIgnored private let receiptSettle = ReceiptSettleGate()
 
     /// Re-send STILL no more often than this while the user keeps typing, and send STOPPED after this
-    /// long idle (matches the Android client so all clients agree on the cadence).
-    private static let typingHeartbeatInterval: Duration = .seconds(3)
-    private static let typingTimeout: Duration = .seconds(5)
+    /// long idle (matches the Android client so all clients agree on the cadence). Injected so tests
+    /// can shorten them; production always uses the init defaults.
+    private let typingHeartbeatInterval: Duration
+    private let typingTimeout: Duration
+    /// How long an incoming typist stays shown with no further STARTED/STILL. The server relays
+    /// typing best-effort with no timeout of its own, so a lost STOPPED would otherwise stick the
+    /// indicator forever. Comfortably above the senders' 3s heartbeat cadence.
+    private let incomingTypingExpiry: Duration
     @ObservationIgnored private var isSelfTyping = false
     @ObservationIgnored private var selfTypingTask: Task<Void, Never>?
+    /// When the last outgoing typing state was queued; lets a keystroke emit the STILL heartbeat
+    /// once `typingHeartbeatInterval` has passed even while the pause loop keeps restarting.
+    @ObservationIgnored private var lastTypingSentAt: ContinuousClock.Instant?
+    /// Outgoing typing states not yet on the wire, drained one at a time by `typingSendTask` so a
+    /// STOPPED can never overtake an in-flight STILL. States are absolute, so each conversation
+    /// holds at most one pending entry — later states supersede it in place.
+    @ObservationIgnored private var pendingTypingSends: [(conversationID: ConversationID, state: TypingState)] = []
+    @ObservationIgnored private var typingSendTask: Task<Void, Never>?
+    /// Per-typist staleness deadlines backing `typingUserIDs`, swept by `typingExpiryTask`.
+    @ObservationIgnored private var typingExpiries: [ConversationID: [UserID: ContinuousClock.Instant]] = [:]
+    @ObservationIgnored private var typingExpiryTask: Task<Void, Never>?
 
     init(
         fetching: any ConversationFetching,
@@ -102,7 +120,10 @@ final class ConversationController {
         contactNaming: any DMContactNaming,
         database: Database,
         owner: KeyPair,
-        selfUserID: UserID
+        selfUserID: UserID,
+        typingHeartbeatInterval: Duration = .seconds(3),
+        typingTimeout: Duration = .seconds(5),
+        incomingTypingExpiry: Duration = .seconds(10)
     ) {
         self.fetching = fetching
         self.messaging = messaging
@@ -111,6 +132,9 @@ final class ConversationController {
         self.database = database
         self.owner = owner
         self.selfUserID = selfUserID
+        self.typingHeartbeatInterval = typingHeartbeatInterval
+        self.typingTimeout = typingTimeout
+        self.incomingTypingExpiry = incomingTypingExpiry
     }
 
     /// Seeds the store from the local cache so the feed, unread state, and
@@ -312,20 +336,58 @@ final class ConversationController {
     }
 
     /// Updates the ephemeral typing set from a live event. Self is excluded — the server may echo our
-    /// own typing and we never show ourselves typing.
+    /// own typing and we never show ourselves typing. Every STARTED/STILL refreshes the typist's
+    /// staleness deadline.
     private func applyTyping(_ event: ConversationStreamEvent) {
         guard case .typingChanged(let conversationID, let notifications) = event else { return }
         for notification in notifications where notification.userID != selfUserID {
             switch notification.isActive {
             case true:
                 typingUserIDs[conversationID, default: []].insert(notification.userID)
+                typingExpiries[conversationID, default: [:]][notification.userID] = ContinuousClock.now + incomingTypingExpiry
             case false:
-                typingUserIDs[conversationID]?.remove(notification.userID)
-                if typingUserIDs[conversationID]?.isEmpty == true {
-                    typingUserIDs[conversationID] = nil
-                }
+                removeTypist(notification.userID, in: conversationID)
             }
         }
+        scheduleTypingExpirySweep()
+    }
+
+    private func removeTypist(_ userID: UserID, in conversationID: ConversationID) {
+        typingUserIDs[conversationID]?.remove(userID)
+        if typingUserIDs[conversationID]?.isEmpty == true {
+            typingUserIDs[conversationID] = nil
+        }
+        typingExpiries[conversationID]?[userID] = nil
+        if typingExpiries[conversationID]?.isEmpty == true {
+            typingExpiries[conversationID] = nil
+        }
+    }
+
+    /// (Re)arms the sweep for the earliest staleness deadline. One task at a time; each sweep
+    /// re-arms for whatever deadline is next, and the task ends when no typists remain.
+    private func scheduleTypingExpirySweep() {
+        typingExpiryTask?.cancel()
+        typingExpiryTask = nil
+        guard let earliest = typingExpiries.values.flatMap(\.values).min() else { return }
+        typingExpiryTask = Task { [weak self] in
+            try? await Task.sleep(until: earliest, clock: .continuous)
+            guard let self, !Task.isCancelled else { return }
+            self.sweepExpiredTypists()
+        }
+    }
+
+    private func sweepExpiredTypists() {
+        let now = ContinuousClock.now
+        for (conversationID, deadlines) in typingExpiries {
+            for (userID, deadline) in deadlines where deadline <= now {
+                logger.debug("Expiring stale typist", metadata: [
+                    "conversationID": "\(conversationID)",
+                    "userID": "\(userID)",
+                ])
+                removeTypist(userID, in: conversationID)
+            }
+        }
+        scheduleTypingExpirySweep()
     }
 
     /// Whether any OTHER member is currently typing in this conversation.
@@ -346,9 +408,15 @@ final class ConversationController {
         gapCatchUpTasks.removeAll()
         catchUpInFlight.removeAll()
         typingUserIDs.removeAll()
+        typingExpiries.removeAll()
+        typingExpiryTask?.cancel()
+        typingExpiryTask = nil
         selfTypingTask?.cancel()
         selfTypingTask = nil
         isSelfTyping = false
+        pendingTypingSends.removeAll()
+        typingSendTask?.cancel()
+        typingSendTask = nil
         receiptSettle.cancel()
         streaming.closeConversationStream()
     }
@@ -675,8 +743,9 @@ final class ConversationController {
     // MARK: - Outgoing typing
 
     /// Drives outgoing typing from the composer's draft. STARTED on the first non-empty change, STILL
-    /// after a `typingHeartbeatInterval` pause, STOPPED at `typingTimeout` idle or when the draft empties.
-    /// Each change replaces the previous run, mirroring Android's `transformLatest` driver.
+    /// at least every `typingHeartbeatInterval` while typing continues, STOPPED at `typingTimeout`
+    /// idle or when the draft empties. Each change replaces the previous run, mirroring Android's
+    /// `transformLatest` driver.
     func draftDidChange(_ text: String, in conversationID: ConversationID) {
         selfTypingTask?.cancel()
         guard !text.isEmpty else {
@@ -690,14 +759,19 @@ final class ConversationController {
             if !self.isSelfTyping {
                 self.isSelfTyping = true
                 self.sendTyping(.started, in: conversationID)
+            } else if let last = self.lastTypingSentAt,
+                      last.duration(to: ContinuousClock.now) >= self.typingHeartbeatInterval {
+                // The pause loop below restarts on every keystroke, so continuous typing would
+                // otherwise go silent after STARTED — and receivers expire stale typists.
+                self.sendTyping(.still, in: conversationID)
             }
             var elapsed: Duration = .zero
-            while elapsed < Self.typingTimeout {
-                let wait = min(Self.typingHeartbeatInterval, Self.typingTimeout - elapsed)
+            while elapsed < self.typingTimeout {
+                let wait = min(self.typingHeartbeatInterval, self.typingTimeout - elapsed)
                 try? await Task.sleep(for: wait)
                 if Task.isCancelled { return }
                 elapsed += wait
-                if elapsed < Self.typingTimeout {
+                if elapsed < self.typingTimeout {
                     self.sendTyping(.still, in: conversationID)
                 }
             }
@@ -715,16 +789,46 @@ final class ConversationController {
         sendTyping(.stopped, in: conversationID)
     }
 
-    /// Fire-and-forget. Deliberately not logged per-failure — typing fires every few seconds, so an
-    /// offline burst would flood the log — but errors still route through `captureError`: transient ones
-    /// classify as `.suppressed` and are dropped, denied surfaces at `.info`, and a genuine server
-    /// error reports at `.error`.
+    /// Queues a typing state and drains the queue one RPC at a time. Serialization keeps the wire
+    /// order equal to the intent order (a STOPPED must never be overtaken by an in-flight STILL —
+    /// the receiver would re-add the typist and stick). States are absolute, so each conversation
+    /// keeps at most one pending entry — later states supersede it in place, bounding the queue
+    /// and skipping stale sends after an offline burst. Only the first failure per drain logs (an
+    /// offline typing session would otherwise flood the export every few seconds); every failure
+    /// still routes through `captureError`, which classifies transient ones as `.suppressed`.
     private func sendTyping(_ state: TypingState, in conversationID: ConversationID) {
-        Task { [messaging, owner] in
-            do {
-                try await messaging.notifyIsTyping(owner: owner, conversationID: conversationID, state: state)
-            } catch {
-                ErrorReporting.captureError(error, reason: "Failed to notify typing")
+        logger.debug("Queued typing notification", metadata: [
+            "state": "\(state)",
+            "conversationID": "\(conversationID)",
+        ])
+        lastTypingSentAt = ContinuousClock.now
+        if let index = pendingTypingSends.firstIndex(where: { $0.conversationID == conversationID }) {
+            pendingTypingSends[index].state = state
+        } else {
+            pendingTypingSends.append((conversationID: conversationID, state: state))
+        }
+        guard typingSendTask == nil else { return }
+        typingSendTask = Task { [weak self] in
+            var loggedFailure = false
+            while let self, !Task.isCancelled, !self.pendingTypingSends.isEmpty {
+                let next = self.pendingTypingSends.removeFirst()
+                do {
+                    try await self.messaging.notifyIsTyping(owner: self.owner, conversationID: next.conversationID, state: next.state)
+                } catch {
+                    if !loggedFailure {
+                        loggedFailure = true
+                        logger.warning("Typing notification failed", metadata: [
+                            "state": "\(next.state)",
+                            "error": "\(error)",
+                        ])
+                    }
+                    ErrorReporting.captureError(error, reason: "Failed to notify typing")
+                }
+            }
+            // `stop()` is the only other place that clears the slot, and it also cancels — so a
+            // cancelled drainer resuming late must not clear what may be a successor's slot.
+            if let self, !Task.isCancelled {
+                self.typingSendTask = nil
             }
         }
     }

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -313,13 +313,11 @@ final class ConversationController {
         }
     }
 
-    /// Routes a live typing event to the typing unit.
     private func applyTyping(_ event: ConversationStreamEvent) {
         guard case .typingChanged(let conversationID, let notifications) = event else { return }
         typing.apply(notifications, in: conversationID)
     }
 
-    /// Whether any OTHER member is currently typing in this conversation.
     func isCounterpartTyping(in conversationID: ConversationID) -> Bool {
         typing.isCounterpartTyping(in: conversationID)
     }
@@ -662,12 +660,10 @@ final class ConversationController {
 
     // MARK: - Outgoing typing
 
-    /// Drives outgoing typing from the composer's draft; see `ConversationTyping`.
     func draftDidChange(_ text: String, in conversationID: ConversationID) {
         typing.draftDidChange(text, in: conversationID)
     }
 
-    /// Force-stop outgoing typing (draft cleared, message sent, or the composer lost focus).
     func stopSelfTyping(in conversationID: ConversationID) {
         typing.stopSelfTyping(in: conversationID)
     }

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -84,6 +84,7 @@ final class ConversationController {
 
     /// The typing-indicator concern, both directions (outgoing driver + incoming typist
     /// tracking), owned by its own unit. Reads chain through `@Observable` tracking.
+    /// The typing indicators for the user's conversations.
     private let typing: ConversationTyping
 
     init(
@@ -318,6 +319,7 @@ final class ConversationController {
         typing.apply(notifications, in: conversationID)
     }
 
+    /// Returns whether another member is currently typing in the conversation.
     func isCounterpartTyping(in conversationID: ConversationID) -> Bool {
         typing.isCounterpartTyping(in: conversationID)
     }
@@ -660,10 +662,12 @@ final class ConversationController {
 
     // MARK: - Outgoing typing
 
+    /// Broadcasts the user's typing state as the draft text changes.
     func draftDidChange(_ text: String, in conversationID: ConversationID) {
         typing.draftDidChange(text, in: conversationID)
     }
 
+    /// Stops broadcasting the user's typing state in the conversation.
     func stopSelfTyping(in conversationID: ConversationID) {
         typing.stopSelfTyping(in: conversationID)
     }

--- a/Flipcash/Core/Controllers/ConversationTyping.swift
+++ b/Flipcash/Core/Controllers/ConversationTyping.swift
@@ -10,18 +10,9 @@ import FlipcashCore
 
 nonisolated private let logger = Logger(label: "flipcash.conversation-controller")
 
-/// Owns the typing-indicator concern for DM conversations, both directions.
-///
-/// **Outgoing** — drives the signed-in user's typing state from the composer's draft:
-/// STARTED on the first non-empty change, STILL at least every `heartbeatInterval`
-/// while typing continues, STOPPED at `timeout` idle or when the draft empties.
-/// Sends are serialized and coalesced per conversation so a STOPPED can never be
-/// overtaken by an in-flight STILL.
-///
-/// **Incoming** — tracks which OTHER members are typing per conversation, expiring
-/// each typist `incomingExpiry` after their last STARTED/STILL: the server is a
-/// stateless relay with no timeout of its own, so a dropped STOPPED would otherwise
-/// stick the indicator forever.
+/// Typing indicators for DM conversations: broadcasts the signed-in user's typing state
+/// and tracks which counterparts are typing. The server relays typing best-effort with
+/// no timeout of its own, so stale typists are expired locally.
 @MainActor
 @Observable
 final class ConversationTyping {
@@ -29,32 +20,19 @@ final class ConversationTyping {
     @ObservationIgnored private let messaging: any ConversationMessaging
     @ObservationIgnored private let owner: KeyPair
     @ObservationIgnored private let selfUserID: UserID
-    /// Cadence constants match the Android client so all clients agree; injected so
-    /// tests can shorten them.
+    // 3s/5s cadence matches the Android client; injectable so tests can shorten them.
     private let heartbeatInterval: Duration
     private let timeout: Duration
     private let incomingExpiry: Duration
 
-    // MARK: - Incoming state
-
-    /// Per-conversation set of OTHER members currently typing, maintained from the live
-    /// stream. Ephemeral — never persisted (the proto marks typing transient/best-effort).
-    /// `Set<UserID>` is Equatable, so the @Observable setter skips no-op re-inserts.
-    private var typingUserIDs: [ConversationID: Set<UserID>] = [:]
-    /// Per-typist staleness deadlines backing `typingUserIDs`, swept by `expiryTask`.
-    @ObservationIgnored private var expiries: [ConversationID: [UserID: ContinuousClock.Instant]] = [:]
+    /// OTHER members typing per conversation, each keyed to their staleness deadline.
+    private var typists: [ConversationID: [UserID: ContinuousClock.Instant]] = [:]
     @ObservationIgnored private var expiryTask: Task<Void, Never>?
-
-    // MARK: - Outgoing state
 
     @ObservationIgnored private var isSelfTyping = false
     @ObservationIgnored private var selfTypingTask: Task<Void, Never>?
-    /// When the last outgoing state was queued; lets a keystroke emit the STILL heartbeat
-    /// once `heartbeatInterval` has passed even while the pause loop keeps restarting.
     @ObservationIgnored private var lastSentAt: ContinuousClock.Instant?
-    /// Outgoing states not yet on the wire, drained one at a time by `sendTask` so a
-    /// STOPPED can never overtake an in-flight STILL. States are absolute, so each
-    /// conversation holds at most one pending entry — later states supersede it in place.
+    /// At most one pending state per conversation; later states supersede in place.
     @ObservationIgnored private var pendingSends: [(conversationID: ConversationID, state: TypingState)] = []
     @ObservationIgnored private var sendTask: Task<Void, Never>?
 
@@ -76,20 +54,16 @@ final class ConversationTyping {
 
     // MARK: - Incoming
 
-    /// Whether any OTHER member is currently typing in this conversation.
     func isCounterpartTyping(in conversationID: ConversationID) -> Bool {
-        !(typingUserIDs[conversationID]?.isEmpty ?? true)
+        !(typists[conversationID]?.isEmpty ?? true)
     }
 
-    /// Applies a batch of typing notifications from the live stream. Self is excluded —
-    /// the server may echo our own typing and we never show ourselves typing. Every
-    /// STARTED/STILL refreshes the typist's staleness deadline.
+    /// Self is excluded — the server may echo our own typing.
     func apply(_ notifications: [TypingNotification], in conversationID: ConversationID) {
         for notification in notifications where notification.userID != selfUserID {
             switch notification.isActive {
             case true:
-                typingUserIDs[conversationID, default: []].insert(notification.userID)
-                expiries[conversationID, default: [:]][notification.userID] = ContinuousClock.now + incomingExpiry
+                typists[conversationID, default: [:]][notification.userID] = ContinuousClock.now + incomingExpiry
             case false:
                 removeTypist(notification.userID, in: conversationID)
             }
@@ -98,22 +72,17 @@ final class ConversationTyping {
     }
 
     private func removeTypist(_ userID: UserID, in conversationID: ConversationID) {
-        typingUserIDs[conversationID]?.remove(userID)
-        if typingUserIDs[conversationID]?.isEmpty == true {
-            typingUserIDs[conversationID] = nil
-        }
-        expiries[conversationID]?[userID] = nil
-        if expiries[conversationID]?.isEmpty == true {
-            expiries[conversationID] = nil
+        typists[conversationID]?[userID] = nil
+        if typists[conversationID]?.isEmpty == true {
+            typists[conversationID] = nil
         }
     }
 
-    /// (Re)arms the sweep for the earliest staleness deadline. One task at a time; each
-    /// sweep re-arms for whatever deadline is next, and the task ends when no typists remain.
+    /// One task, re-armed for the next-earliest deadline; ends when no typists remain.
     private func scheduleExpirySweep() {
         expiryTask?.cancel()
         expiryTask = nil
-        guard let earliest = expiries.values.flatMap(\.values).min() else { return }
+        guard let earliest = typists.values.flatMap(\.values).min() else { return }
         expiryTask = Task { [weak self] in
             try? await Task.sleep(until: earliest, clock: .continuous)
             guard let self, !Task.isCancelled else { return }
@@ -123,7 +92,7 @@ final class ConversationTyping {
 
     private func sweepExpiredTypists() {
         let now = ContinuousClock.now
-        for (conversationID, deadlines) in expiries {
+        for (conversationID, deadlines) in typists {
             for (userID, deadline) in deadlines where deadline <= now {
                 logger.debug("Expiring stale typist", metadata: [
                     "conversationID": "\(conversationID)",
@@ -137,8 +106,8 @@ final class ConversationTyping {
 
     // MARK: - Outgoing
 
-    /// Drives outgoing typing from the composer's draft. Each change replaces the previous
-    /// run, mirroring Android's `transformLatest` driver.
+    /// STARTED on first input, STILL at least every `heartbeatInterval` while typing
+    /// continues, STOPPED after `timeout` idle or when the draft empties.
     func draftDidChange(_ text: String, in conversationID: ConversationID) {
         selfTypingTask?.cancel()
         guard !text.isEmpty else {
@@ -146,16 +115,14 @@ final class ConversationTyping {
             return
         }
         selfTypingTask = Task { [weak self] in
-            // A task cancelled before its body runs (a fast type-then-clear) must send nothing — otherwise
-            // it would emit a STARTED with no matching STOPPED and wedge `isSelfTyping`.
+            // Cancelled before running (fast type-then-clear): send nothing, or `isSelfTyping` wedges.
             guard let self, !Task.isCancelled else { return }
             if !self.isSelfTyping {
                 self.isSelfTyping = true
                 self.send(.started, in: conversationID)
             } else if let last = self.lastSentAt,
                       last.duration(to: ContinuousClock.now) >= self.heartbeatInterval {
-                // The pause loop below restarts on every keystroke, so continuous typing would
-                // otherwise go silent after STARTED — and receivers expire stale typists.
+                // The pause loop below restarts on every keystroke; this keeps heartbeats flowing.
                 self.send(.still, in: conversationID)
             }
             var elapsed: Duration = .zero
@@ -182,10 +149,8 @@ final class ConversationTyping {
         send(.stopped, in: conversationID)
     }
 
-    /// Queues a typing state and drains the queue one RPC at a time. Only the first failure
-    /// per drain logs (an offline typing session would otherwise flood the export every few
-    /// seconds); every failure still routes through `captureError`, which classifies
-    /// transient ones as `.suppressed`.
+    /// Serialized so a STOPPED can never be overtaken by an in-flight STILL. Failures are
+    /// best-effort chatter: logged (once per drain) and never reported to Bugsnag.
     private func send(_ state: TypingState, in conversationID: ConversationID) {
         logger.debug("Queued typing notification", metadata: [
             "state": "\(state)",
@@ -212,11 +177,9 @@ final class ConversationTyping {
                             "error": "\(error)",
                         ])
                     }
-                    ErrorReporting.captureError(error, reason: "Failed to notify typing")
                 }
             }
-            // `stop()` is the only other place that clears the slot, and it also cancels — so a
-            // cancelled drainer resuming late must not clear what may be a successor's slot.
+            // A cancelled drainer resuming late must not clear a successor's slot.
             if let self, !Task.isCancelled {
                 self.sendTask = nil
             }
@@ -225,10 +188,8 @@ final class ConversationTyping {
 
     // MARK: - Teardown
 
-    /// Clears all typing state and cancels the driver, drainer, and expiry sweep.
     func stop() {
-        typingUserIDs.removeAll()
-        expiries.removeAll()
+        typists.removeAll()
         expiryTask?.cancel()
         expiryTask = nil
         selfTypingTask?.cancel()

--- a/Flipcash/Core/Controllers/ConversationTyping.swift
+++ b/Flipcash/Core/Controllers/ConversationTyping.swift
@@ -1,0 +1,241 @@
+//
+//  ConversationTyping.swift
+//  Flipcash
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+import FlipcashCore
+
+nonisolated private let logger = Logger(label: "flipcash.conversation-controller")
+
+/// Owns the typing-indicator concern for DM conversations, both directions.
+///
+/// **Outgoing** — drives the signed-in user's typing state from the composer's draft:
+/// STARTED on the first non-empty change, STILL at least every `heartbeatInterval`
+/// while typing continues, STOPPED at `timeout` idle or when the draft empties.
+/// Sends are serialized and coalesced per conversation so a STOPPED can never be
+/// overtaken by an in-flight STILL.
+///
+/// **Incoming** — tracks which OTHER members are typing per conversation, expiring
+/// each typist `incomingExpiry` after their last STARTED/STILL: the server is a
+/// stateless relay with no timeout of its own, so a dropped STOPPED would otherwise
+/// stick the indicator forever.
+@MainActor
+@Observable
+final class ConversationTyping {
+
+    @ObservationIgnored private let messaging: any ConversationMessaging
+    @ObservationIgnored private let owner: KeyPair
+    @ObservationIgnored private let selfUserID: UserID
+    /// Cadence constants match the Android client so all clients agree; injected so
+    /// tests can shorten them.
+    private let heartbeatInterval: Duration
+    private let timeout: Duration
+    private let incomingExpiry: Duration
+
+    // MARK: - Incoming state
+
+    /// Per-conversation set of OTHER members currently typing, maintained from the live
+    /// stream. Ephemeral — never persisted (the proto marks typing transient/best-effort).
+    /// `Set<UserID>` is Equatable, so the @Observable setter skips no-op re-inserts.
+    private var typingUserIDs: [ConversationID: Set<UserID>] = [:]
+    /// Per-typist staleness deadlines backing `typingUserIDs`, swept by `expiryTask`.
+    @ObservationIgnored private var expiries: [ConversationID: [UserID: ContinuousClock.Instant]] = [:]
+    @ObservationIgnored private var expiryTask: Task<Void, Never>?
+
+    // MARK: - Outgoing state
+
+    @ObservationIgnored private var isSelfTyping = false
+    @ObservationIgnored private var selfTypingTask: Task<Void, Never>?
+    /// When the last outgoing state was queued; lets a keystroke emit the STILL heartbeat
+    /// once `heartbeatInterval` has passed even while the pause loop keeps restarting.
+    @ObservationIgnored private var lastSentAt: ContinuousClock.Instant?
+    /// Outgoing states not yet on the wire, drained one at a time by `sendTask` so a
+    /// STOPPED can never overtake an in-flight STILL. States are absolute, so each
+    /// conversation holds at most one pending entry — later states supersede it in place.
+    @ObservationIgnored private var pendingSends: [(conversationID: ConversationID, state: TypingState)] = []
+    @ObservationIgnored private var sendTask: Task<Void, Never>?
+
+    init(
+        messaging: any ConversationMessaging,
+        owner: KeyPair,
+        selfUserID: UserID,
+        heartbeatInterval: Duration = .seconds(3),
+        timeout: Duration = .seconds(5),
+        incomingExpiry: Duration = .seconds(10)
+    ) {
+        self.messaging = messaging
+        self.owner = owner
+        self.selfUserID = selfUserID
+        self.heartbeatInterval = heartbeatInterval
+        self.timeout = timeout
+        self.incomingExpiry = incomingExpiry
+    }
+
+    // MARK: - Incoming
+
+    /// Whether any OTHER member is currently typing in this conversation.
+    func isCounterpartTyping(in conversationID: ConversationID) -> Bool {
+        !(typingUserIDs[conversationID]?.isEmpty ?? true)
+    }
+
+    /// Applies a batch of typing notifications from the live stream. Self is excluded —
+    /// the server may echo our own typing and we never show ourselves typing. Every
+    /// STARTED/STILL refreshes the typist's staleness deadline.
+    func apply(_ notifications: [TypingNotification], in conversationID: ConversationID) {
+        for notification in notifications where notification.userID != selfUserID {
+            switch notification.isActive {
+            case true:
+                typingUserIDs[conversationID, default: []].insert(notification.userID)
+                expiries[conversationID, default: [:]][notification.userID] = ContinuousClock.now + incomingExpiry
+            case false:
+                removeTypist(notification.userID, in: conversationID)
+            }
+        }
+        scheduleExpirySweep()
+    }
+
+    private func removeTypist(_ userID: UserID, in conversationID: ConversationID) {
+        typingUserIDs[conversationID]?.remove(userID)
+        if typingUserIDs[conversationID]?.isEmpty == true {
+            typingUserIDs[conversationID] = nil
+        }
+        expiries[conversationID]?[userID] = nil
+        if expiries[conversationID]?.isEmpty == true {
+            expiries[conversationID] = nil
+        }
+    }
+
+    /// (Re)arms the sweep for the earliest staleness deadline. One task at a time; each
+    /// sweep re-arms for whatever deadline is next, and the task ends when no typists remain.
+    private func scheduleExpirySweep() {
+        expiryTask?.cancel()
+        expiryTask = nil
+        guard let earliest = expiries.values.flatMap(\.values).min() else { return }
+        expiryTask = Task { [weak self] in
+            try? await Task.sleep(until: earliest, clock: .continuous)
+            guard let self, !Task.isCancelled else { return }
+            self.sweepExpiredTypists()
+        }
+    }
+
+    private func sweepExpiredTypists() {
+        let now = ContinuousClock.now
+        for (conversationID, deadlines) in expiries {
+            for (userID, deadline) in deadlines where deadline <= now {
+                logger.debug("Expiring stale typist", metadata: [
+                    "conversationID": "\(conversationID)",
+                    "userID": "\(userID)",
+                ])
+                removeTypist(userID, in: conversationID)
+            }
+        }
+        scheduleExpirySweep()
+    }
+
+    // MARK: - Outgoing
+
+    /// Drives outgoing typing from the composer's draft. Each change replaces the previous
+    /// run, mirroring Android's `transformLatest` driver.
+    func draftDidChange(_ text: String, in conversationID: ConversationID) {
+        selfTypingTask?.cancel()
+        guard !text.isEmpty else {
+            stopSelfTyping(in: conversationID)
+            return
+        }
+        selfTypingTask = Task { [weak self] in
+            // A task cancelled before its body runs (a fast type-then-clear) must send nothing — otherwise
+            // it would emit a STARTED with no matching STOPPED and wedge `isSelfTyping`.
+            guard let self, !Task.isCancelled else { return }
+            if !self.isSelfTyping {
+                self.isSelfTyping = true
+                self.send(.started, in: conversationID)
+            } else if let last = self.lastSentAt,
+                      last.duration(to: ContinuousClock.now) >= self.heartbeatInterval {
+                // The pause loop below restarts on every keystroke, so continuous typing would
+                // otherwise go silent after STARTED — and receivers expire stale typists.
+                self.send(.still, in: conversationID)
+            }
+            var elapsed: Duration = .zero
+            while elapsed < self.timeout {
+                let wait = min(self.heartbeatInterval, self.timeout - elapsed)
+                try? await Task.sleep(for: wait)
+                if Task.isCancelled { return }
+                elapsed += wait
+                if elapsed < self.timeout {
+                    self.send(.still, in: conversationID)
+                }
+            }
+            self.isSelfTyping = false
+            self.send(.stopped, in: conversationID)
+        }
+    }
+
+    /// Force-stop outgoing typing (draft cleared, message sent, or the composer lost focus).
+    func stopSelfTyping(in conversationID: ConversationID) {
+        selfTypingTask?.cancel()
+        selfTypingTask = nil
+        guard isSelfTyping else { return }
+        isSelfTyping = false
+        send(.stopped, in: conversationID)
+    }
+
+    /// Queues a typing state and drains the queue one RPC at a time. Only the first failure
+    /// per drain logs (an offline typing session would otherwise flood the export every few
+    /// seconds); every failure still routes through `captureError`, which classifies
+    /// transient ones as `.suppressed`.
+    private func send(_ state: TypingState, in conversationID: ConversationID) {
+        logger.debug("Queued typing notification", metadata: [
+            "state": "\(state)",
+            "conversationID": "\(conversationID)",
+        ])
+        lastSentAt = ContinuousClock.now
+        if let index = pendingSends.firstIndex(where: { $0.conversationID == conversationID }) {
+            pendingSends[index].state = state
+        } else {
+            pendingSends.append((conversationID: conversationID, state: state))
+        }
+        guard sendTask == nil else { return }
+        sendTask = Task { [weak self] in
+            var loggedFailure = false
+            while let self, !Task.isCancelled, !self.pendingSends.isEmpty {
+                let next = self.pendingSends.removeFirst()
+                do {
+                    try await self.messaging.notifyIsTyping(owner: self.owner, conversationID: next.conversationID, state: next.state)
+                } catch {
+                    if !loggedFailure {
+                        loggedFailure = true
+                        logger.warning("Typing notification failed", metadata: [
+                            "state": "\(next.state)",
+                            "error": "\(error)",
+                        ])
+                    }
+                    ErrorReporting.captureError(error, reason: "Failed to notify typing")
+                }
+            }
+            // `stop()` is the only other place that clears the slot, and it also cancels — so a
+            // cancelled drainer resuming late must not clear what may be a successor's slot.
+            if let self, !Task.isCancelled {
+                self.sendTask = nil
+            }
+        }
+    }
+
+    // MARK: - Teardown
+
+    /// Clears all typing state and cancels the driver, drainer, and expiry sweep.
+    func stop() {
+        typingUserIDs.removeAll()
+        expiries.removeAll()
+        expiryTask?.cancel()
+        expiryTask = nil
+        selfTypingTask?.cancel()
+        selfTypingTask = nil
+        isSelfTyping = false
+        pendingSends.removeAll()
+        sendTask?.cancel()
+        sendTask = nil
+    }
+}

--- a/Flipcash/Core/Controllers/ConversationTyping.swift
+++ b/Flipcash/Core/Controllers/ConversationTyping.swift
@@ -54,11 +54,12 @@ final class ConversationTyping {
 
     // MARK: - Incoming
 
+    /// Returns whether another member is currently typing in the conversation.
     func isCounterpartTyping(in conversationID: ConversationID) -> Bool {
         !(typists[conversationID]?.isEmpty ?? true)
     }
 
-    /// Self is excluded — the server may echo our own typing.
+    /// Applies typing notifications from the live stream, ignoring the user's own.
     func apply(_ notifications: [TypingNotification], in conversationID: ConversationID) {
         for notification in notifications where notification.userID != selfUserID {
             switch notification.isActive {
@@ -140,7 +141,7 @@ final class ConversationTyping {
         }
     }
 
-    /// Force-stop outgoing typing (draft cleared, message sent, or the composer lost focus).
+    /// Stops broadcasting the user's typing state in the conversation.
     func stopSelfTyping(in conversationID: ConversationID) {
         selfTypingTask?.cancel()
         selfTypingTask = nil
@@ -188,6 +189,7 @@ final class ConversationTyping {
 
     // MARK: - Teardown
 
+    /// Clears all typing state and cancels any in-flight work.
     func stop() {
         typists.removeAll()
         expiryTask?.cancel()

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -271,8 +271,7 @@ struct ConversationScreen: View {
             setVisibleConversation(id, source: "onChange")
         }
         .onDisappear {
-            // Leaving mid-typing must not strand the counterpart's indicator — the composer's
-            // focus `onChange` can't fire once its view is unmounted.
+            // The composer's focus `onChange` can't fire once unmounted, so stop typing here.
             if let conversationID {
                 conversationController.stopSelfTyping(in: conversationID)
             }

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -271,6 +271,11 @@ struct ConversationScreen: View {
             setVisibleConversation(id, source: "onChange")
         }
         .onDisappear {
+            // Leaving mid-typing must not strand the counterpart's indicator — the composer's
+            // focus `onChange` can't fire once its view is unmounted.
+            if let conversationID {
+                conversationController.stopSelfTyping(in: conversationID)
+            }
             // Guarded so a forward push that already set another ID isn't cleared.
             let matched = conversationController.visibleConversationID == conversationID
             logger.info("Clearing visible conversation on disappear", metadata: [

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -25,13 +25,17 @@ struct ConversationControllerTests {
         _ mock: MockConversations,
         selfUserID: UserID = UUID(),
         naming: MockDMContactNaming = MockDMContactNaming(),
-        database: Database? = nil
+        database: Database? = nil,
+        typingHeartbeatInterval: Duration = .seconds(3),
+        incomingTypingExpiry: Duration = .seconds(10)
     ) -> ConversationController {
         ConversationController(
             fetching: mock, messaging: mock, streaming: mock,
             contactNaming: naming,
             database: database ?? (try! Database.makeTemp().database),
-            owner: .generate()!, selfUserID: selfUserID
+            owner: .generate()!, selfUserID: selfUserID,
+            typingHeartbeatInterval: typingHeartbeatInterval,
+            incomingTypingExpiry: incomingTypingExpiry
         )
     }
 
@@ -114,6 +118,92 @@ struct ConversationControllerTests {
         #expect(mock.typingCalls.contains { $0.state == .started })
     }
 
+    @Test("an active typist expires locally when no further notification arrives")
+    func typistExpiresWithoutStop() async throws {
+        let them = UUID()
+        let mock = MockConversations()
+        let controller = makeController(mock, incomingTypingExpiry: .milliseconds(200))
+        controller.start()
+        try await waitUntil { mock.streamOpened }
+
+        mock.emit(.typingChanged(conversationID: .test(1), notifications: [TypingNotification(userID: them, isActive: true)]))
+        try await waitUntil { controller.isCounterpartTyping(in: .test(1)) }
+        // The STOPPED never arrives (dropped by the best-effort relay); the local
+        // expiry must clear the indicator on its own.
+        try await waitUntil { !controller.isCounterpartTyping(in: .test(1)) }
+    }
+
+    @Test("a refreshed typing notification extends the expiry window")
+    func typingRefreshExtendsExpiry() async throws {
+        let them = UUID()
+        let mock = MockConversations()
+        let controller = makeController(mock, incomingTypingExpiry: .milliseconds(500))
+        controller.start()
+        try await waitUntil { mock.streamOpened }
+
+        mock.emit(.typingChanged(conversationID: .test(1), notifications: [TypingNotification(userID: them, isActive: true)]))
+        try await waitUntil { controller.isCounterpartTyping(in: .test(1)) }
+
+        // A STILL ~300ms in pushes the deadline to ~800ms; at ~600ms the original
+        // 500ms deadline has passed but the refreshed one hasn't.
+        try await Task.sleep(for: .milliseconds(300))
+        mock.emit(.typingChanged(conversationID: .test(1), notifications: [TypingNotification(userID: them, isActive: true)]))
+        try await Task.sleep(for: .milliseconds(300))
+        #expect(controller.isCounterpartTyping(in: .test(1)))
+
+        try await waitUntil { !controller.isCounterpartTyping(in: .test(1)) }
+    }
+
+    @Test("a STOPPED never overtakes an in-flight earlier send")
+    func typingSendsStayOrdered() async throws {
+        let mock = MockConversations()
+        mock.typingDelays = [.started: .milliseconds(200)]
+        let controller = makeController(mock)
+
+        controller.draftDidChange("h", in: .test(1))
+        // Let the STARTED enter the (slow) transport before clearing the draft.
+        try await Task.sleep(for: .milliseconds(50))
+        controller.draftDidChange("", in: .test(1))
+
+        try await waitUntil { mock.typingCalls.count == 2 }
+        #expect(mock.typingCalls.map(\.state) == [.started, .stopped])
+    }
+
+    @Test("a rapid stop-then-restart coalesces to the latest state")
+    func typingBurstCoalesces() async throws {
+        let mock = MockConversations()
+        mock.typingDelays = [.started: .milliseconds(200)]
+        let controller = makeController(mock)
+
+        controller.draftDidChange("h", in: .test(1))
+        try await Task.sleep(for: .milliseconds(50))
+        // While the STARTED is still in flight: clear (queues STOPPED) then type
+        // again. States are absolute, so the queued STOPPED is superseded — the
+        // wire only ever needs the latest state.
+        controller.draftDidChange("", in: .test(1))
+        controller.draftDidChange("i", in: .test(1))
+
+        try await waitUntil { mock.typingCalls.count == 2 }
+        // Give any extra (non-coalesced) sends time to land before pinning the sequence.
+        try await Task.sleep(for: .milliseconds(250))
+        #expect(mock.typingCalls.map(\.state) == [.started, .started])
+    }
+
+    @Test("STILL heartbeats fire while the user keeps typing without pausing")
+    func heartbeatDuringContinuousTyping() async throws {
+        let mock = MockConversations()
+        let controller = makeController(mock, typingHeartbeatInterval: .milliseconds(300))
+
+        // Keystrokes every ~30ms for ~600ms — never a 300ms pause, so a purely
+        // pause-driven loop would stay silent after the initial STARTED.
+        var draft = ""
+        for _ in 0..<20 {
+            draft += "a"
+            controller.draftDidChange(draft, in: .test(1))
+            try await Task.sleep(for: .milliseconds(30))
+        }
+        #expect(mock.typingCalls.map(\.state).contains(.still))
+    }
 
     @Test("loadFeed populates conversations sorted by activity")
     func loadFeed() async {

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -14,11 +14,11 @@ struct ConversationControllerTests {
 
     /// Polls briefly for work the controller runs on its own task (stream
     /// consumption, feed paging) to land. Fails the test after ~1s.
-    private func waitUntil(_ condition: () -> Bool) async throws {
+    private func waitUntil(_ condition: () -> Bool, sourceLocation: SourceLocation = #_sourceLocation) async throws {
         for _ in 0..<50 where !condition() {
             try? await Task.sleep(for: .milliseconds(20))
         }
-        try #require(condition(), "Timed out waiting for condition after ~1s")
+        try #require(condition(), "Timed out waiting for condition after ~1s", sourceLocation: sourceLocation)
     }
 
     private func makeController(
@@ -143,15 +143,16 @@ struct ConversationControllerTests {
 
         mock.emit(.typingChanged(conversationID: .test(1), notifications: [TypingNotification(userID: them, isActive: true)]))
         try await waitUntil { controller.isCounterpartTyping(in: .test(1)) }
+        let shownAt = ContinuousClock.now
 
-        // A STILL ~300ms in pushes the deadline to ~800ms; at ~600ms the original
-        // 500ms deadline has passed but the refreshed one hasn't.
+        // A refresh ~300ms in moves the deadline to ~800ms after the typist appeared.
         try await Task.sleep(for: .milliseconds(300))
         mock.emit(.typingChanged(conversationID: .test(1), notifications: [TypingNotification(userID: them, isActive: true)]))
-        try await Task.sleep(for: .milliseconds(300))
-        #expect(controller.isCounterpartTyping(in: .test(1)))
 
         try await waitUntil { !controller.isCounterpartTyping(in: .test(1)) }
+        // Load can only lengthen the observed lifetime, never shorten it; without the
+        // extension the typist clears at ~500ms.
+        #expect(shownAt.duration(to: ContinuousClock.now) >= .milliseconds(700))
     }
 
     @Test("a STOPPED never overtakes an in-flight earlier send")
@@ -161,8 +162,8 @@ struct ConversationControllerTests {
         let controller = makeController(mock)
 
         controller.draftDidChange("h", in: .test(1))
-        // Let the STARTED enter the (slow) transport before clearing the draft.
-        try await Task.sleep(for: .milliseconds(50))
+        // Wait for the STARTED to enter the (slow) transport before clearing the draft.
+        try await waitUntil { mock.typingCallsBegun == 1 }
         controller.draftDidChange("", in: .test(1))
 
         try await waitUntil { mock.typingCalls.count == 2 }
@@ -176,7 +177,7 @@ struct ConversationControllerTests {
         let controller = makeController(mock)
 
         controller.draftDidChange("h", in: .test(1))
-        try await Task.sleep(for: .milliseconds(50))
+        try await waitUntil { mock.typingCallsBegun == 1 }
         // While the STARTED is still in flight: clear (queues STOPPED) then type
         // again. States are absolute, so the queued STOPPED is superseded — the
         // wire only ever needs the latest state.

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -29,6 +29,7 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     private var _sent: [Sent] = []
     private var _markedRead: [MessageID] = []
     private var _typingCalls: [TypingCall] = []
+    private var _typingCallsBegun = 0
     private var _typingDelays: [TypingState: Duration] = [:]
     private var _deltaBatches: [DeltaBatch] = []
     private var _deltaHead: UInt64 = 0
@@ -70,6 +71,9 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     var sent: [Sent] { lock.withLock { _sent } }
     var markedRead: [MessageID] { lock.withLock { _markedRead } }
     var typingCalls: [TypingCall] { lock.withLock { _typingCalls } }
+    /// Number of `notifyIsTyping` calls entered, counted before any artificial delay —
+    /// the awaitable signal that a send is in flight.
+    var typingCallsBegun: Int { lock.withLock { _typingCallsBegun } }
     /// Per-state artificial transport latency for `notifyIsTyping`; the call is
     /// recorded after the delay, so `typingCalls` reflects wire-arrival order.
     var typingDelays: [TypingState: Duration] {
@@ -167,6 +171,7 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     }
 
     func notifyIsTyping(owner: KeyPair, conversationID: ConversationID, state: TypingState) async throws {
+        lock.withLock { _typingCallsBegun += 1 }
         if let delay = typingDelays[state] {
             try? await Task.sleep(for: delay)
         }

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -29,6 +29,7 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     private var _sent: [Sent] = []
     private var _markedRead: [MessageID] = []
     private var _typingCalls: [TypingCall] = []
+    private var _typingDelays: [TypingState: Duration] = [:]
     private var _deltaBatches: [DeltaBatch] = []
     private var _deltaHead: UInt64 = 0
     private var _deltaError: Error?
@@ -69,6 +70,12 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     var sent: [Sent] { lock.withLock { _sent } }
     var markedRead: [MessageID] { lock.withLock { _markedRead } }
     var typingCalls: [TypingCall] { lock.withLock { _typingCalls } }
+    /// Per-state artificial transport latency for `notifyIsTyping`; the call is
+    /// recorded after the delay, so `typingCalls` reflects wire-arrival order.
+    var typingDelays: [TypingState: Duration] {
+        get { lock.withLock { _typingDelays } }
+        set { lock.withLock { _typingDelays = newValue } }
+    }
     /// Batches `getDelta` delivers to `onBatch`, in order.
     var deltaBatches: [DeltaBatch] {
         get { lock.withLock { _deltaBatches } }
@@ -160,6 +167,9 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     }
 
     func notifyIsTyping(owner: KeyPair, conversationID: ConversationID, state: TypingState) async throws {
+        if let delay = typingDelays[state] {
+            try? await Task.sleep(for: delay)
+        }
         lock.withLock { _typingCalls.append(TypingCall(conversationID: conversationID, state: state)) }
     }
 


### PR DESCRIPTION
Typing indicators ride a best-effort relay with no timeout at any layer, so one dropped notification could strand a stale indicator forever, and concurrent fire-and-forget sends could deliver a STOPPED before an in-flight STILL. This hardens the iOS side: incoming typists expire locally after 10 seconds without a heartbeat, outgoing notifications are serialized and coalesced per conversation, a STILL heartbeat keeps firing during continuous typing, leaving the chat mid-typing now sends a STOPPED, and typing sends are logged for diagnosis. Verified on device against a real counterpart: every send is delivered and server-acknowledged; the remaining stuck-indicator cases are in the server relay and the Android client's missing expiry, tracked separately.

Test plan:
- [x] FlipcashTests + FlipcashCoreTests pass
- [x] On device: typing in a DM shows on the counterpart within ~3s and clears within ~5s of going idle
- [x] With the counterpart's STOPPED lost (e.g. airplane mode mid-typing), the stale indicator clears locally after ~10s