### PR TITLE
fix: stale conversation previews on the Send screen

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -63,7 +63,8 @@ public struct ConversationStore: Sendable {
     /// and makes an out-of-order delete converge — a tombstone that lands before the original send
     /// out-versions it and is never overwritten. Reconciles a server copy of one of our own optimistic
     /// sends — which carries no client id, because the server never echoes it — against the matching
-    /// pending row so the echo collapses onto that row instead of duplicating it.
+    /// pending row so the echo collapses onto that row instead of duplicating it. Every merge also
+    /// advances the conversation's feed preview to the newest visible message.
     public mutating func mergeMessages(_ incoming: [ConversationMessage], into conversationID: ConversationID) {
         guard !incoming.isEmpty else { return }
         let current = messagesByConversation[conversationID] ?? []
@@ -108,6 +109,20 @@ public struct ConversationStore: Sendable {
             // Otherwise the held copy is newer-or-equal-and-already-identified: keep it.
         }
         messagesByConversation[conversationID] = byID.values.sorted { $0.id < $1.id }
+        advanceLastMessage(in: conversationID)
+    }
+
+    /// Points the feed row's preview at the newest non-deleted confirmed message, mirroring the
+    /// visibility filter and last-writer-wins guard of the persisted cache (`Database.latestMessage`
+    /// / `writeMessage`) — it advances forward or refreshes an edit in place, never regresses, and
+    /// never touches `lastActivity` or the feed order.
+    private mutating func advanceLastMessage(in conversationID: ConversationID) {
+        guard let index = conversations.firstIndex(where: { $0.id == conversationID }),
+              let newest = messagesByConversation[conversationID]?.last(where: { $0.content != .deleted })
+        else { return }
+        if let current = conversations[index].lastMessage,
+           (current.id, current.eventSequence) >= (newest.id, newest.eventSequence) { return }
+        conversations[index].lastMessage = newest
     }
 
     /// Removes and returns the client id of the oldest pending send that matches `serverCopy` by sender
@@ -251,12 +266,14 @@ public struct ConversationStore: Sendable {
         conversations[convoIndex].members[memberIndex].readPointerTimestamp = date
     }
 
-    /// Bump a conversation's last message + activity and re-sort the feed.
+    /// Bump a conversation's last activity from a live message and re-sort the feed. The preview
+    /// itself follows the merge rule (``advanceLastMessage``), so a stale re-delivery or a deleted
+    /// copy on the live path can't overwrite a newer one.
     public mutating func setLastMessage(_ message: ConversationMessage, in conversationID: ConversationID) {
         guard let index = conversations.firstIndex(where: { $0.id == conversationID }) else { return }
-        conversations[index].lastMessage = message
         conversations[index].lastActivity = message.date
         sort()
+        advanceLastMessage(in: conversationID)
     }
 
     /// Signals whether applying a live event exposed a hole in the sequenced log that must be filled
@@ -300,8 +317,8 @@ public struct ConversationStore: Sendable {
 
     /// Apply sequenced event-log mutations in ascending order: merge each (last-writer-wins), advance
     /// the contiguous frontier while events arrive gapless, and flag a gap the moment one is skipped so
-    /// the caller catches up via `GetDelta`. Only `.sent` mutations advance the feed's last message —
-    /// an edit/delete carries the message's original (low) id and must not re-sort the feed.
+    /// the caller catches up via `GetDelta`. Only `.sent` mutations bump the feed's activity and
+    /// re-sort — an edit/delete carries the message's original (low) id and must not move the row.
     private mutating func applyChatEvents(_ events: [DecodedChatEvent], into conversationID: ConversationID) -> GapSignal {
         var cursor = appliedCursorByConversation[conversationID] ?? 0
         var newestSent: ConversationMessage?
@@ -346,8 +363,7 @@ public struct ConversationStore: Sendable {
     }
 
     /// Apply a `GetDelta` batch: merge its messages (last-writer-wins), then advance the frontier to
-    /// the batch's checkpoint. The feed preview is left to `loadFeed`/live events — a delta batch can
-    /// carry an old edit/delete whose id must not re-sort the feed.
+    /// the batch's checkpoint.
     public mutating func applyDeltaBatch(_ messages: [ConversationMessage], checkpoint: UInt64?, into conversationID: ConversationID) {
         mergeMessages(messages, into: conversationID) // no-ops on an empty batch
         if let checkpoint {

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -232,6 +232,98 @@ struct ConversationStoreTests {
         #expect(store.conversations.first?.members.first?.readPointerTimestamp == readAt)
     }
 
+    // MARK: - Feed preview from merge paths
+
+    private func cashMessage(_ id: UInt64) -> ConversationMessage {
+        ConversationMessage(
+            id: MessageID(value: id),
+            senderID: nil,
+            content: .cash(ExchangedFiat(nativeAmount: .usd(5.00), rate: .oneToOne)),
+            date: Date(timeIntervalSince1970: 0),
+            unreadSeq: 0,
+            eventSequence: id
+        )
+    }
+
+    @Test("a merged send-cash message newer than the preview becomes the feed's last message")
+    func mergeAdvancesPreviewToNewerCashMessage() {
+        var store = ConversationStore()
+        store.setFeed([conversation(1, lastActivity: 100)])
+        store.mergeMessages([message(3, "old text")], into: conversationID(1))
+        // The user's own cash send reaches the store via GetDelta catch-up — a merge-only path.
+        let cash = cashMessage(7)
+        store.applyDeltaBatch([cash], checkpoint: 7, into: conversationID(1))
+        #expect(store.conversations.first?.lastMessage == cash)
+    }
+
+    @Test("a merge seeds the preview of a conversation that has none")
+    func mergeSeedsMissingPreview() {
+        var store = ConversationStore()
+        store.setFeed([conversation(1, lastActivity: 100)])
+        store.mergeMessages([message(4, "first")], into: conversationID(1))
+        #expect(store.conversations.first?.lastMessage?.id.value == 4)
+    }
+
+    @Test("a paged-in older message does not regress the feed's last message")
+    func mergeDoesNotRegressPreview() {
+        var store = ConversationStore()
+        store.setFeed([conversation(1, lastActivity: 100)])
+        store.mergeMessages([message(9, "newest")], into: conversationID(1))
+        store.mergeMessages([message(2, "older history")], into: conversationID(1))
+        #expect(store.conversations.first?.lastMessage?.id.value == 9)
+    }
+
+    @Test("a merged tombstone is skipped — the newest visible message becomes the preview")
+    func mergeSkipsTombstoneForPreview() {
+        var store = ConversationStore()
+        store.setFeed([conversation(1, lastActivity: 100)])
+        store.mergeMessages([message(3, "old")], into: conversationID(1))
+        store.applyDeltaBatch([message(6, "visible", eventSequence: 6), deleted(7, eventSequence: 7)], checkpoint: 7, into: conversationID(1))
+        #expect(store.conversations.first?.lastMessage?.id.value == 6)
+    }
+
+    @Test("a merge advances the preview without re-sorting the feed — activity stays feed-owned")
+    func mergeDoesNotResortFeed() {
+        var store = ConversationStore()
+        store.setFeed([conversation(1, lastActivity: 100), conversation(2, lastActivity: 200)])
+        store.mergeMessages([message(5, "fresh", at: 500)], into: conversationID(1))
+        #expect(store.conversations.map(\.id) == [conversationID(2), conversationID(1)])
+        #expect(store.conversations.last?.lastMessage?.id.value == 5)
+    }
+
+    @Test("a stale re-delivered newMessages event does not regress the preview")
+    func staleNewMessagesDoesNotRegressPreview() {
+        var store = ConversationStore()
+        store.setFeed([conversation(1, lastActivity: 100)])
+        store.apply(.newMessages(conversationID: conversationID(1), messages: [message(10, "newest")]))
+        store.apply(.newMessages(conversationID: conversationID(1), messages: [message(8, "stale re-delivery")]))
+        #expect(store.conversations.first?.lastMessage?.id.value == 10)
+    }
+
+    @Test("a batch that sends and immediately deletes a message does not preview the deleted copy")
+    func sendPlusDeleteBatchDoesNotResurrectPreview() {
+        var store = ConversationStore()
+        store.setFeed([conversation(1, lastActivity: 100)])
+        store.mergeMessages([message(6, "visible", eventSequence: 6)], into: conversationID(1))
+        store.apply(.chatEvents(conversationID: conversationID(1), events: [
+            DecodedChatEvent(sequence: 7, count: 1, mutations: [.sent(message(7, "sent then deleted", eventSequence: 7))]),
+            DecodedChatEvent(sequence: 8, count: 1, mutations: [.deleted(deleted(7, eventSequence: 8))]),
+        ]))
+        #expect(store.conversations.first?.lastMessage?.id.value == 6)
+    }
+
+    @Test("an edit of the preview message refreshes its content without moving the row")
+    func editOfPreviewRefreshesContent() {
+        var store = ConversationStore()
+        store.setFeed([conversation(1, lastActivity: 100)])
+        store.mergeMessages([message(5, "old", eventSequence: 5)], into: conversationID(1))
+        store.apply(.chatEvents(conversationID: conversationID(1), events: [
+            DecodedChatEvent(sequence: 6, count: 1, mutations: [.edited(message(5, "edited", eventSequence: 6))]),
+        ]))
+        #expect(store.conversations.first?.lastMessage?.id.value == 5)
+        #expect(store.conversations.first?.lastMessage?.content == .text("edited"))
+    }
+
     // MARK: - Optimistic send
 
     @Test("A server-built message defaults to .sent with no client id; stableID is the server id")


### PR DESCRIPTION
The Send screen's conversation previews only advanced on live stream events and outgoing text sends — an outgoing cash message, or anything arriving via catch-up or a history load, never became the row preview until the next relaunch. The in-memory store now advances the preview after every merge with the same rule the database already uses: newest non-deleted message, last-writer-wins, never regressing. The live path delegates to that same guarded rule, so a stale re-delivery or a sent-then-deleted event batch can no longer clobber the preview either.

Test plan:
- [ ] ConversationStore suite passes (8 new tests: cash merge advances the preview, seeding, no regress, tombstone skip, no re-sort, stale re-delivery, send+delete batch, edit refresh in place)
- [ ] ConversationController and recipient feed suites pass
- [ ] On the simulator: send cash from a chat, return to the Send list — the row updates in-session and survives relaunch