### PR TITLE
fix: use a neutral Continue button on the camera permission prompt

### DIFF
--- a/Flipcash/Core/Screens/Main/CameraPromptView.swift
+++ b/Flipcash/Core/Screens/Main/CameraPromptView.swift
@@ -1,0 +1,90 @@
+//
+//  CameraPromptView.swift
+//  Code
+//
+
+import SwiftUI
+import AVFoundation
+import FlipcashUI
+
+/// The call to action shown in place of the camera viewport when the camera
+/// isn't running, derived from authorization status and the auto-start
+/// preference.
+nonisolated enum CameraPrompt: Equatable {
+
+    /// Access hasn't been requested; the action runs the system permission
+    /// prompt. App Review requires a neutral label ("Continue"/"Next") on a
+    /// button that gates a permission prompt — never one implying the camera
+    /// starts.
+    case requestPermission
+
+    /// Access is denied or restricted; the action opens the app's Settings
+    /// page.
+    case openSettings
+
+    /// Access is granted but auto-start is off; the action starts the camera.
+    case startCamera
+
+    /// Returns `nil` when the camera viewport should be running instead of a
+    /// prompt.
+    init?(status: AVAuthorizationStatus, cameraEnabled: Bool) {
+        switch status {
+        case .notDetermined:
+            self = .requestPermission
+        case .denied, .restricted:
+            self = .openSettings
+        case .authorized:
+            if cameraEnabled {
+                return nil
+            }
+            self = .startCamera
+        @unknown default:
+            self = .openSettings
+        }
+    }
+
+    /// The explanatory text shown above the action button.
+    var message: String {
+        switch self {
+        case .requestPermission:
+            "Flipcash uses your camera to scan and grab cash"
+        case .openSettings:
+            "You need to turn on Camera in Settings to scan Codes"
+        case .startCamera:
+            "You need to start your camera to grab cash"
+        }
+    }
+
+    /// The label of the prompt's single action button.
+    var buttonTitle: String {
+        switch self {
+        case .requestPermission:
+            "Continue"
+        case .openSettings:
+            "Open Settings"
+        case .startCamera:
+            "Start Camera"
+        }
+    }
+}
+
+/// Full-screen prompt pairing a ``CameraPrompt``'s message and button with the
+/// action supplied by the host screen.
+struct CameraPromptView: View {
+
+    let prompt: CameraPrompt
+    let action: () -> Void
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Text(prompt.message)
+                .frame(maxWidth: 260)
+                .multilineTextAlignment(.center)
+
+            BubbleButton(text: prompt.buttonTitle, action: action)
+        }
+        .padding(40)
+        .font(.appTextSmall)
+        .foregroundStyle(.textMain)
+    }
+}

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -50,19 +50,8 @@ private struct ScanScreenContent: View {
         return nil
     }
     
-    var cameraAuthorized: Bool {
-        cameraAuthorizer.status == .authorized
-    }
-    
-    var directToSettingsForCamera: Bool? {
-        switch cameraAuthorizer.status {
-        case .authorized:
-            return nil
-        case .notDetermined:
-            return false
-        default:
-            return true
-        }
+    private var cameraPrompt: CameraPrompt? {
+        CameraPrompt(status: cameraAuthorizer.status, cameraEnabled: preferences.cameraEnabled)
     }
     
     private let sessionContainer: SessionContainer
@@ -84,16 +73,14 @@ private struct ScanScreenContent: View {
     var body: some View {
         let showControls = session.billState.bill == nil
         ZStack {
-            if cameraAuthorized {
-                if preferences.cameraEnabled {
-                    cameraViewport()
-                        .transition(
-                            .asymmetric(
-                                insertion: .opacity.animation(.easeInOut(duration: 0.2).delay(0.3)),
-                                removal: .identity
-                            )
+            if cameraPrompt == nil {
+                cameraViewport()
+                    .transition(
+                        .asymmetric(
+                            insertion: .opacity.animation(.easeInOut(duration: 0.2).delay(0.3)),
+                            removal: .identity
                         )
-                }
+                    )
             }
             
             billView()
@@ -102,15 +89,12 @@ private struct ScanScreenContent: View {
                 // Any actionable views need to be positioned
                 // in front of the BillCanvas, otherwise it
                 // will swallow all touch events
-                if !cameraAuthorized {
-                    authorizeView()
-                        .zIndex(1)
-                        .transition(.opacity)
-                    
-                } else if !preferences.cameraEnabled {
-                    manualCameraStart()
-                        .zIndex(1)
-                        .transition(.opacity)
+                if let cameraPrompt {
+                    CameraPromptView(prompt: cameraPrompt) {
+                        performCameraPromptAction(cameraPrompt)
+                    }
+                    .zIndex(1)
+                    .transition(.opacity)
                 }
             
                 interfaceView()
@@ -189,6 +173,9 @@ private struct ScanScreenContent: View {
         .onAppear {
             viewModel.configureCameraSession()
         }
+        .onDisappear {
+            viewModel.stopCamera()
+        }
     }
     
     @ViewBuilder private func billView() -> some View {
@@ -214,46 +201,19 @@ private struct ScanScreenContent: View {
         return rect.insetBy(dx: 20, dy: 20).size
     }
     
-    @ViewBuilder private func authorizeView() -> some View {
-        let goToSettings = directToSettingsForCamera == true
-        VStack(spacing: 40) {
-            Text(goToSettings ? "You need to turn on Camera in Settings to scan Codes" : "Start your camera to grab cash")
-                .frame(maxWidth: 260)
-                .multilineTextAlignment(.center)
-            
-            BubbleButton(text: goToSettings ? "Open Settings" : "Start Camera") {
-                if goToSettings {
-                    URL.openSettings()
-                } else {
-                    Task {
-                        try await cameraAuthorizer.authorize()
-                    }
-                }
+    private func performCameraPromptAction(_ prompt: CameraPrompt) {
+        switch prompt {
+        case .requestPermission:
+            Task {
+                try await cameraAuthorizer.authorize()
             }
-        }
-        .padding(40)
-        .font(.appTextSmall)
-        .foregroundStyle(.textMain)
-    }
-    
-    @ViewBuilder private func manualCameraStart() -> some View {
-        VStack(spacing: 40) {
-            Text("You need to start your camera to grab cash")
-                .frame(maxWidth: 240)
-                .multilineTextAlignment(.center)
-            
-            BubbleButton(text: "Start Camera") {
-                preferences.cameraEnabled.toggle()
-            }
-        }
-        .padding(40)
-        .font(.appTextSmall)
-        .foregroundStyle(.textMain)
-        .onAppear {
-            viewModel.stopCamera()
+        case .openSettings:
+            URL.openSettings()
+        case .startCamera:
+            preferences.cameraEnabled.toggle()
         }
     }
-    
+
     @ViewBuilder private func interfaceView() -> some View {
         VStack {
             ScanTopBar(

--- a/FlipcashTests/CameraPromptTests.swift
+++ b/FlipcashTests/CameraPromptTests.swift
@@ -1,0 +1,47 @@
+//
+//  CameraPromptTests.swift
+//  FlipcashTests
+//
+
+import AVFoundation
+import Testing
+@testable import Flipcash
+
+@Suite("CameraPrompt")
+struct CameraPromptTests {
+
+    @Test(
+        "Undetermined permission prompts with a neutral Continue",
+        arguments: [true, false],
+    )
+    func prompt_notDetermined_offersContinue(cameraEnabled: Bool) throws {
+        let prompt = try #require(CameraPrompt(status: .notDetermined, cameraEnabled: cameraEnabled))
+        #expect(prompt == .requestPermission)
+        #expect(prompt.buttonTitle == "Continue")
+        #expect(prompt.message == "Flipcash uses your camera to scan and grab cash")
+    }
+
+    @Test(
+        "Denied or restricted permission directs to Settings",
+        arguments: [AVAuthorizationStatus.denied, .restricted], [true, false],
+    )
+    func prompt_deniedOrRestricted_directsToSettings(status: AVAuthorizationStatus, cameraEnabled: Bool) throws {
+        let prompt = try #require(CameraPrompt(status: status, cameraEnabled: cameraEnabled))
+        #expect(prompt == .openSettings)
+        #expect(prompt.buttonTitle == "Open Settings")
+        #expect(prompt.message == "You need to turn on Camera in Settings to scan Codes")
+    }
+
+    @Test("Authorized with auto-start off offers Start Camera")
+    func prompt_authorizedCameraOff_offersStartCamera() throws {
+        let prompt = try #require(CameraPrompt(status: .authorized, cameraEnabled: false))
+        #expect(prompt == .startCamera)
+        #expect(prompt.buttonTitle == "Start Camera")
+        #expect(prompt.message == "You need to start your camera to grab cash")
+    }
+
+    @Test("Authorized with the camera running shows no prompt")
+    func prompt_authorizedCameraOn_showsNoPrompt() {
+        #expect(CameraPrompt(status: .authorized, cameraEnabled: true) == nil)
+    }
+}


### PR DESCRIPTION
App Review rejected the camera pre-permission screen because its button said "Start Camera". The button now says Continue and the copy explains why Flipcash needs the camera; the permission-denied and manual start states keep their existing labels. The prompt was also extracted into a dedicated view driven by a small state enum, so each state's copy and button label are locked in by unit tests, and the camera session stop is now paired with the start on the viewport's lifecycle.

Test plan:
- [x] Fresh install: scan screen shows Continue; tapping raises the system camera prompt
- [x] Deny the prompt: screen switches to Open Settings
- [x] Allow with Auto Start Camera off: the Start Camera prompt shows and starts the camera
- [x] Toggle Auto Start Camera off while scanning: the camera stops and the prompt returns