### PR TITLE
fix: skip chat catch-up for conversations the client holds nothing for

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -212,8 +212,17 @@ final class ConversationController {
     /// Reconcile a conversation's transcript from its persisted event-log cursor via `GetDelta`,
     /// applying and persisting each batch's checkpoint as it arrives. Deduped per conversation — a
     /// second caller while one is in flight no-ops. Fired on chat-open, foreground, reconnect, and a
-    /// detected live gap; none of these wait for a server ping.
+    /// detected live gap; none of these wait for a server ping. No-ops for a conversation the client
+    /// holds nothing for — no feed entry, no messages, no applied cursor.
     func catchUp(conversationID: ConversationID) async {
+        guard conversation(withID: conversationID) != nil
+            || store.hasMessages(for: conversationID)
+            || store.appliedCursor(for: conversationID) > 0 else {
+            logger.info("Skipping catch-up for a conversation the client holds nothing for", metadata: [
+                "conversationID": "\(conversationID)",
+            ])
+            return
+        }
         guard !catchUpInFlight.contains(conversationID) else { return }
         catchUpInFlight.insert(conversationID)
         defer { catchUpInFlight.remove(conversationID) }

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -589,6 +589,8 @@ struct ConversationControllerTests {
 
         controller.start()
         try await waitUntil { mock.connectionStateStreamOpened }
+        // Catch-up requires a materialized conversation; wait for start()'s feed load to land.
+        try await waitUntil { !controller.conversations.isEmpty }
         controller.visibleConversationID = ConversationID.test(1)
 
         // The cursor is too far behind: GetDelta returns RESET_REQUIRED, so catch-up falls back to the

--- a/FlipcashTests/Regressions/Regression_6a510fab7372e33c88417bd4.swift
+++ b/FlipcashTests/Regressions/Regression_6a510fab7372e33c88417bd4.swift
@@ -1,0 +1,57 @@
+//
+//  Regression_6a510fab7372e33c88417bd4.swift
+//  FlipcashTests
+//
+//  "Chat delta catch-up failed: denied" — during a push deeplink,
+//  ConversationScreen.onAppear briefly set visibleConversationID to the pushed
+//  contact snapshot's stale dmChatID before onChange corrected it to the
+//  directory-resolved id. The scenePhase-active hook captured the transient and
+//  spent a GetDelta on a conversation the user has no membership in; the
+//  server denied it.
+//
+//  Fix: ConversationController.catchUp no-ops for a conversation the client
+//  holds nothing for — absent from the store, no messages, no applied cursor —
+//  so no trigger (foreground, reconnect, live gap) can spend a GetDelta on a
+//  transient id.
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Regression: 6a510fa – GetDelta spent on a non-materialized conversation", .bug("6a510fab7372e33c88417bd4"))
+struct Regression_6a510fa {
+
+    private func makeController(_ mock: MockConversations) -> ConversationController {
+        ConversationController(
+            fetching: mock, messaging: mock, streaming: mock,
+            contactNaming: MockDMContactNaming(),
+            database: try! Database.makeTemp().database,
+            owner: .generate()!, selfUserID: UUID()
+        )
+    }
+
+    @Test("catch-up no-ops for a conversation the client holds nothing for")
+    func catchUp_unmaterializedConversation_skipsGetDelta() async {
+        let mock = MockConversations()
+        let controller = makeController(mock)
+
+        await controller.catchUp(conversationID: .test(99))
+
+        #expect(mock.deltaAfterSequences.isEmpty)
+    }
+
+    @Test("catch-up still reconciles a conversation present in the feed, even with no cursor")
+    func catchUp_feedConversationWithoutCursor_runsGetDelta() async {
+        let mock = MockConversations()
+        mock.feed = [Conversation(id: .test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
+        let controller = makeController(mock)
+        await controller.loadFeed()
+
+        await controller.catchUp(conversationID: .test(1))
+
+        #expect(mock.deltaAfterSequences == [0])
+    }
+}


### PR DESCRIPTION
Opening a chat from a push deeplink briefly exposes the pushed contact snapshot's stale chat ID before the synced directory corrects it. The foreground catch-up trigger could capture that transient and spend a GetDelta on a chat the user isn't a member of, which the server denies and Bugsnag records (6a510fab). Catch-up now no-ops for a conversation the client holds nothing for — no feed entry, no messages, no cursor — which covers the foreground, reconnect, and live-gap triggers alike.

## Test plan

- [x] Regression suite: catch-up skips a non-materialized conversation and still runs for a feed-present one with no cursor
- [x] Conversation controller suite: reconnect, foreground, and reset catch-up behavior unchanged
- [x] Full FlipcashTests (904) + FlipcashCoreTests (625) pass locally