### PR TITLE
fix: add phone-entry feedback and region-aware validation

### DIFF
--- a/Flipcash/Core/Screens/PhoneVerification/EnterPhoneScreen.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/EnterPhoneScreen.swift
@@ -64,10 +64,7 @@ struct EnterPhoneScreen<VM: PhoneVerifying>: View {
                     }
                 }
 
-                Text("Please enter your phone number to continue")
-                    .foregroundStyle(.textSecondary)
-                    .font(.appTextSmall)
-                    .multilineTextAlignment(.center)
+                PhoneEntryHint(showsError: viewModel.showsInvalidPhoneHint)
 
                 Spacer()
 
@@ -107,5 +104,19 @@ struct EnterPhoneScreen<VM: PhoneVerifying>: View {
     private func didSelectRegion(region: Region) {
         viewModel.setRegion(region)
         isShowingRegionSelection = false
+    }
+}
+
+private struct PhoneEntryHint: View {
+
+    let showsError: Bool
+
+    var body: some View {
+        Text(showsError ? "Phone number invalid" : "Please enter your phone number to continue")
+            .foregroundStyle(showsError ? .textError : .textSecondary)
+            .font(.appTextSmall)
+            .multilineTextAlignment(.center)
+            .contentTransition(.opacity)
+            .animation(.easeInOut(duration: 0.2), value: showsError)
     }
 }

--- a/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/PhoneVerificationViewModel.swift
@@ -45,7 +45,6 @@ final class PhoneVerificationViewModel: PhoneVerifying {
     @ObservationIgnored private let owner: KeyPair
 
     @ObservationIgnored private let phoneFormatter = PhoneFormatter()
-    @ObservationIgnored private let phoneValidator = PhoneValidator()
 
     // MARK: - Analytics hooks -
 
@@ -118,12 +117,26 @@ final class PhoneVerificationViewModel: PhoneVerifying {
         "+\(phoneFormatter.countryCode(for: region)!)"
     }
 
+    var phoneValidation: PhoneValidation? {
+        PhoneValidator(region: region).validate(enteredPhone)
+    }
+
     var phone: Phone? {
-        phoneValidator.validate(enteredPhone)
+        switch phoneValidation {
+        case .valid(let phone):            phone
+        case .incomplete, .invalid, .none: nil
+        }
     }
 
     var canSendVerificationCode: Bool {
         phone != nil
+    }
+
+    /// True once the entered number has enough digits to be judged yet still
+    /// isn't valid — the point at which the screen surfaces an inline error
+    /// instead of nagging mid-entry.
+    var showsInvalidPhoneHint: Bool {
+        phoneValidation == .invalid
     }
 
     var isCodeComplete: Bool {

--- a/Flipcash/Core/Screens/PhoneVerification/PhoneVerifying.swift
+++ b/Flipcash/Core/Screens/PhoneVerification/PhoneVerifying.swift
@@ -29,6 +29,7 @@ protocol PhoneVerifying: Verifying {
     // MARK: - Derived state -
 
     var phone: Phone? { get }
+    var showsInvalidPhoneHint: Bool { get }
     var regionFlagStyle: Flag.Style { get }
     var countryCode: String { get }
     var canSendVerificationCode: Bool { get }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Phone.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Phone.swift
@@ -25,9 +25,7 @@ public struct Phone: Codable, Equatable, Hashable, Sendable {
             return nil
         }
 
-        self.phoneNumber = phoneNumber
-        self.e164        = Self.phoneNumberUtility.format(phoneNumber, toType: PhoneNumberFormat.e164)
-        self.national    = Self.phoneNumberUtility.format(phoneNumber, toType: PhoneNumberFormat.national)
+        self.init(phoneNumber: phoneNumber)
     }
 
     /// Parses national-format strings against `defaultRegion`; international-
@@ -41,9 +39,26 @@ public struct Phone: Codable, Equatable, Hashable, Sendable {
             return nil
         }
 
+        self.init(phoneNumber: phoneNumber)
+    }
+
+    private init(phoneNumber: PhoneNumber) {
         self.phoneNumber = phoneNumber
         self.e164        = Self.phoneNumberUtility.format(phoneNumber, toType: PhoneNumberFormat.e164)
         self.national    = Self.phoneNumberUtility.format(phoneNumber, toType: PhoneNumberFormat.national)
+    }
+}
+
+extension Phone {
+
+    /// The longest national-number length a mobile number in `region` can
+    /// have, or nil when the metadata is unavailable.
+    public static func expectedNationalLength(for region: Region) -> Int? {
+        phoneNumberUtility.possiblePhoneNumberLengths(
+            forCountry: region.rawValue.uppercased(),
+            phoneNumberType: .mobile,
+            lengthType: .national
+        ).max()
     }
 }
 
@@ -70,7 +85,7 @@ public struct PhoneFormatter {
     public func countryCode(for region: Region) -> UInt64? {
         Phone.phoneNumberUtility.countryCode(for: region.rawValue)
     }
-    
+
     public func format(_ rawPhoneNumber: String) -> String {
         partialFormatter.formatPartial(rawPhoneNumber)
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Region.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Region.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum Region: String, CaseIterable, Codable, Equatable, Hashable {
+public enum Region: String, CaseIterable, Codable, Equatable, Hashable, Sendable {
     
     case ad
     case ae

--- a/FlipcashCore/Sources/FlipcashCore/Validation/PhoneValidator.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Validation/PhoneValidator.swift
@@ -1,24 +1,48 @@
 import Foundation
 
-/// Validates a free-form phone number string and returns the parsed `Phone`.
+/// The outcome of validating a phone number that has some input: why it isn't
+/// yet valid, or the parsed number. Nothing-entered is the validator's `nil`.
+public enum PhoneValidation: Equatable, Sendable {
+    /// Too few digits to be judged — the user may still be typing.
+    case incomplete
+    /// Cannot become valid as typed.
+    case invalid
+    /// A complete, valid number.
+    case valid(Phone)
+}
+
+/// Validates a free-form phone number string against the country the user
+/// selected.
 ///
-/// Parsing is delegated to `Phone` (PhoneNumberKit); the resulting E.164 form
-/// is then checked against the server's PGV rule. Callers submit the output's
-/// `e164`, never the raw input.
+/// Parsing is delegated to `Phone` (PhoneNumberKit) using `region` so the flag
+/// is honoured; a valid number's E.164 form is checked against the server's PGV
+/// rule. Callers submit `valid`'s `e164`, never the raw input.
 public struct PhoneValidator: Validator {
 
-    public init() {}
+    private let region: Region
 
-    public func validate(_ input: String) -> Phone? {
-        guard let phone = Phone(input) else {
+    public init(region: Region) {
+        self.region = region
+    }
+
+    /// Classifies `input`: `nil` when nothing has been entered, otherwise the
+    /// `PhoneValidation` describing why it isn't yet valid or the parsed number.
+    public func validate(_ input: String) -> PhoneValidation? {
+        guard input.contains(where: \.isNumber) else {
             return nil
         }
 
-        guard phone.e164.wholeMatch(of: Self.pattern) != nil else {
-            return nil
+        if let phone = Phone(input, defaultRegion: region), phone.e164.wholeMatch(of: Self.pattern) != nil {
+            return .valid(phone)
         }
 
-        return phone
+        // Without a known length we can't tell "still typing" from "wrong", so
+        // stay quiet rather than flash an error on the first digit.
+        guard let expectedLength = Phone.expectedNationalLength(for: region) else {
+            return .incomplete
+        }
+
+        return input.filter(\.isNumber).count >= expectedLength ? .invalid : .incomplete
     }
 
     /// PGV regex from `FlipcashAPI/Core/proto/phone/v1/model.proto`.

--- a/FlipcashCore/Tests/FlipcashCoreTests/PhoneTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/PhoneTests.swift
@@ -87,4 +87,19 @@ struct PhoneTests {
             #expect(second?.e164 == "+14155550100")
         }
     }
+
+    @Suite("Phone.expectedNationalLength")
+    struct ExpectedNationalLengthTests {
+
+        @Test("US mobile numbers are ten national digits")
+        func usIsTen() {
+            #expect(Phone.expectedNationalLength(for: .us) == 10)
+        }
+
+        @Test("A supported region returns a positive length")
+        func gbIsPositive() {
+            let length = Phone.expectedNationalLength(for: .gb)
+            #expect((length ?? 0) > 0)
+        }
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/PhoneValidatorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/PhoneValidatorTests.swift
@@ -5,27 +5,89 @@ import Testing
 @Suite("PhoneValidator")
 struct PhoneValidatorTests {
 
-    @Test("Accepts parseable numbers and returns the E.164 form", arguments: [
-        ("+1 415 555 0100", "+14155550100"),
-        ("+14155550100", "+14155550100"),
-        ("+44 7400 123456", "+447400123456"),
-        ("+1 (415) 555-0100", "+14155550100"),
-    ])
-    func accepts_validPhone(input: String, e164: String) {
-        let validator = PhoneValidator()
-        #expect(validator.validate(input)?.e164 == e164)
-    }
-
-    @Test("Rejects strings that do not parse to a valid number", arguments: [
+    // Nothing to judge yet — the validator's `nil`.
+    @Test("Returns nil when no digits have been entered", arguments: [
         "",
         "   ",
         "hello",
-        "+1",
-        "+1 415 555",
-        "+999 123 4567",
     ])
-    func rejects_invalidPhone(input: String) {
-        let validator = PhoneValidator()
-        #expect(validator.validate(input) == nil)
+    func validate_empty(input: String) {
+        #expect(PhoneValidator(region: .us).validate(input) == nil)
+    }
+
+    // Too few digits to be judged — the user is still typing, so we stay quiet.
+    @Test("Reports incomplete while a number is still too short", arguments: [
+        "4",
+        "415",
+        "613 809",
+    ])
+    func validate_incomplete(input: String) {
+        #expect(PhoneValidator(region: .us).validate(input) == .incomplete)
+    }
+
+    // Full length but cannot resolve against the region: a leading 1 is read as
+    // the country code so the remainder is too short, and over-length input
+    // can't fit. These earn the red error.
+    @Test("Reports invalid for full-length numbers that cannot resolve", arguments: [
+        "1234567890",       // leading 1 → country code → remainder too short
+        "415555010099",     // too many digits
+    ])
+    func validate_invalid(input: String) {
+        #expect(PhoneValidator(region: .us).validate(input) == .invalid)
+    }
+
+    // Client validation is deliberately lenient: a plausible, full-length
+    // number proceeds and the server is the authority on deliverability. That
+    // is what lets a real number advance without a false error — even one with
+    // an unusual exchange the numbering plan would technically reject.
+    @Test("Accepts a plausible full-length number rather than false-rejecting it", arguments: [
+        "4151234567",
+        "2120112345",
+    ])
+    func validate_lenient(input: String) {
+        #expect(PhoneValidator(region: .us).validate(input) != .invalid)
+    }
+
+    // Validation honours the selected flag: a bare national number is valid
+    // only against its own country, while an international-format number
+    // carries its own country code and wins over the flag.
+    @Test("Validates against the selected region")
+    func validate_respectsRegion() {
+        #expect(PhoneValidator(region: .us).validate("4155550100") == .valid(Phone("4155550100", defaultRegion: .us)!))
+        #expect(PhoneValidator(region: .gb).validate("7400123456") == .valid(Phone("7400123456", defaultRegion: .gb)!))
+        #expect(PhoneValidator(region: .us).validate("+44 7400 123456") == .valid(Phone("+44 7400 123456", defaultRegion: .us)!))
+    }
+
+    // Autofill / QuickType drops in the whole number at once, sometimes with
+    // the country code included. Every form must read as valid and proceed
+    // with no error — the Apple-review path.
+    @Test("Accepts a full autofilled number in every form", arguments: [
+        "6138096933",     // national only
+        "16138096933",    // with the leading country digit
+        "+16138096933",   // full E.164
+    ])
+    func validate_autofill(input: String) {
+        guard case .valid(let phone)? = PhoneValidator(region: .ca).validate(input) else {
+            Issue.record("expected .valid for \(input)")
+            return
+        }
+        #expect(phone.e164 == "+16138096933")
+    }
+
+    // End-to-end guard: the screen's binding strips non-digits, prepends the
+    // selected country code, and formats before anything is validated. An
+    // autofilled full number must survive that round-trip and still proceed.
+    @Test("A full number survives the screen's prepend-and-format binding", arguments: [
+        "+16138096933",     // QuickType full E.164
+        "6138096933",       // national
+        "(613) 809-6933",   // pre-formatted
+    ])
+    func binding_autofill_proceeds(autofillText: String) {
+        let entered = PhoneFormatter().format("+1\(autofillText.filter(\.isNumber))")
+        guard case .valid(let phone)? = PhoneValidator(region: .ca).validate(entered) else {
+            Issue.record("expected .valid for autofill \(autofillText) → entered \(entered)")
+            return
+        }
+        #expect(phone.e164 == "+16138096933")
     }
 }


### PR DESCRIPTION
The phone entry screen gave no feedback when a number couldn't proceed — Next just sat disabled — and it validated the digits against the device's region rather than the country flag the user selected, so real or autofilled numbers could silently stall. This adds an inline hint once a number is long enough to judge, and validates against the selected region so the flag is honored and a full or autofilled number always proceeds. Addresses the App Store rejection about missing feedback on the entry screen.

## Test plan
- [x] Incomplete number → neutral prompt, no error
- [x] Full but invalid number → red "Phone number is invalid" (cross-fades in)
- [x] Valid or autofilled (+1…) number → proceeds with no error
- [x] FlipcashTests + FlipcashCoreTests pass