### PR TITLE
refactor: make the local database the source of truth for the chat transcript

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -226,21 +226,33 @@ final class ConversationController {
 
         let after = store.appliedCursor(for: conversationID)
         do {
+            var anyBatchFailed = false
             let head = try await messaging.getDelta(owner: owner, conversationID: conversationID, afterSequence: after) { [weak self] messages, checkpoint in
                 guard let self else { return }
-                let reconciled = self.reconciledForPersist(messages, in: conversationID)
+                let (reconciled, pairs) = self.reconciledForPersist(messages, in: conversationID)
                 // Batch + checkpoint cursor persist atomically; advance the in-memory checkpoint only
                 // after the write succeeds, so a rolled-back batch isn't skipped on the next catch-up.
                 let cursor = checkpoint ?? self.store.appliedCursor(for: conversationID)
                 let ok = self.persist(operation: "delta-batch") {
                     try self.database.persistMessages(reconciled, cursor: cursor, conversationID: conversationID)
                 }
-                if ok, let checkpoint { self.store.setAppliedCursor(checkpoint, for: conversationID) }
+                if ok {
+                    self.commitReconciled(pairs, in: conversationID)
+                    if let checkpoint { self.store.setAppliedCursor(checkpoint, for: conversationID) }
+                } else {
+                    anyBatchFailed = true
+                }
                 self.refreshFeedPreview(for: conversationID)
             }
-            // Clean completion: the head is authoritative even if the intervening events weren't observed.
-            store.setAppliedCursor(head, for: conversationID)
-            persistCursor(for: conversationID)
+            // Clean completion: the head is authoritative — but only when every batch landed. Seating
+            // head over a rolled-back batch would orphan its messages from every future GetDelta.
+            if anyBatchFailed {
+                store.reseatCursor((try? database.catchupCursor(conversationID: conversationID)) ?? 0, for: conversationID)
+                scheduleGapCatchUp(conversationID)
+            } else {
+                store.setAppliedCursor(head, for: conversationID)
+                persistCursor(for: conversationID)
+            }
             // `after` vs `head`: equal means already current; a jump means the delta window that was
             // caught up. Observable so the production catch-up cadence can be traced.
             logger.info("Chat catch-up complete", metadata: [
@@ -289,13 +301,19 @@ final class ConversationController {
         persist(operation: "reset-cursor") { try database.updateCatchupCursor(0, for: conversationID) }
         do {
             let messages = try await messaging.getMessages(owner: owner, conversationID: conversationID, before: nil)
-            let reconciled = reconciledForPersist(messages, in: conversationID)
-            persist(operation: "reset-resync") { try database.upsertConversationMessages(reconciled, conversationID: conversationID) }
-            refreshFeedPreview(for: conversationID)
-            if let floor = messages.map(\.eventSequence).filter({ $0 > 0 }).min() {
-                store.setAppliedCursor(floor, for: conversationID)
-                persistCursor(for: conversationID)
+            let (reconciled, pairs) = reconciledForPersist(messages, in: conversationID)
+            let floor = messages.map(\.eventSequence).filter({ $0 > 0 }).min() ?? 0
+            // Page + floor cursor land atomically (a failed write must not seat the cursor), and a
+            // non-overlapping page drops the stale older epoch first.
+            let ok = persist(operation: "reset-resync") {
+                try dropStaleEpochIfNeeded(before: messages, in: conversationID)
+                try database.persistMessages(reconciled, cursor: floor, conversationID: conversationID)
             }
+            if ok {
+                commitReconciled(pairs, in: conversationID)
+                if floor > 0 { store.setAppliedCursor(floor, for: conversationID) }
+            }
+            refreshFeedPreview(for: conversationID)
         } catch {
             logger.error("Failed to re-sync after catch-up reset", metadata: [
                 "conversationID": "\(conversationID)",
@@ -414,12 +432,18 @@ final class ConversationController {
     private func persist(event: ConversationStreamEvent) {
         switch event {
         case .newMessages(let conversationID, let messages):
-            let reconciled = reconciledForPersist(messages, in: conversationID)
-            persist(operation: "upsert-messages") { try database.upsertConversationMessages(reconciled, conversationID: conversationID) }
+            let (reconciled, pairs) = reconciledForPersist(messages, in: conversationID)
+            let ok = persist(operation: "upsert-messages") { try database.upsertConversationMessages(reconciled, conversationID: conversationID) }
+            if ok {
+                commitReconciled(pairs, in: conversationID)
+            } else {
+                // The delivered batch is in neither the DB nor the store — refetch it from the event log.
+                scheduleGapCatchUp(conversationID)
+            }
             refreshFeedPreview(for: conversationID)
             persistConversation(conversationID)
         case .chatEvents(let conversationID, let events):
-            let reconciled = reconciledForPersist(events.flatMap { $0.mutations.map(\.message) }, in: conversationID)
+            let (reconciled, pairs) = reconciledForPersist(events.flatMap { $0.mutations.map(\.message) }, in: conversationID)
             // Messages + the advanced cursor persist atomically. `store.apply` already advanced the
             // in-memory cursor optimistically, so if this write rolls back, re-seat the cursor to the
             // persisted value and catch up — otherwise the un-persisted messages are skipped by the next
@@ -427,7 +451,9 @@ final class ConversationController {
             let ok = persist(operation: "apply-chat-events") {
                 try database.persistMessages(reconciled, cursor: store.appliedCursor(for: conversationID), conversationID: conversationID)
             }
-            if !ok {
+            if ok {
+                commitReconciled(pairs, in: conversationID)
+            } else {
                 store.reseatCursor((try? database.catchupCursor(conversationID: conversationID)) ?? 0, for: conversationID)
                 scheduleGapCatchUp(conversationID)
             }
@@ -435,6 +461,9 @@ final class ConversationController {
             persistConversation(conversationID)
         case .metadataRefresh(let conversation):
             persistConversation(conversation)
+            // A conversation entering the feed (e.g. re-hydrated after a stale feed snapshot dropped it)
+            // regains its preview from the retained rows.
+            refreshFeedPreview(for: conversation.id)
         case .lastActivityChanged(let conversationID, _),
              .readPointersChanged(let conversationID, _):
             persistConversation(conversationID)
@@ -443,29 +472,62 @@ final class ConversationController {
         }
     }
 
-    /// Adopt a pending send's client id onto a *fresh* server echo of it (one not already persisted), so
-    /// the persisted confirmed row keeps the send's identity and the echo collapses onto the pending row
+    /// Adopt pending sends' client ids onto *fresh* server echoes (ones not already persisted), so the
+    /// persisted confirmed rows keep each send's identity and the echo collapses onto the pending row
     /// instead of duplicating it. A re-delivery of an already-stored id is left alone (it can't steal a
-    /// send). Returns the messages ready to persist.
-    private func reconciledForPersist(_ messages: [ConversationMessage], in conversationID: ConversationID) -> [ConversationMessage] {
+    /// send). Returns the enriched messages plus the matched pairs; the caller drops the matched
+    /// pendings — via ``commitReconciled(_:in:)`` — only after the write persisting the batch succeeds,
+    /// so a failed write never loses a send from the transcript.
+    private func reconciledForPersist(_ messages: [ConversationMessage], in conversationID: ConversationID) -> (messages: [ConversationMessage], reconciled: [(clientID: UUID, confirmedID: MessageID)]) {
         // No pending send to reconcile against → skip the per-message existence probes (the common
         // receive/catch-up path, where every server message would otherwise cost a DB read).
-        guard store.hasPendingMessages(for: conversationID) else { return messages }
-        return messages.map { message in
+        guard store.hasPendingMessages(for: conversationID) else { return (messages, []) }
+        var claimed: Set<UUID> = []
+        var pairs: [(clientID: UUID, confirmedID: MessageID)] = []
+        let enriched = messages.map { message in
             guard message.clientMessageID == nil,
                   !((try? database.messageExists(id: message.id, conversationID: conversationID)) ?? true),
-                  let clientID = store.reconcilePending(for: message, in: conversationID)
+                  let clientID = store.pendingMatch(for: message, in: conversationID, excluding: claimed)
             else { return message }
+            claimed.insert(clientID)
+            pairs.append((clientID, message.id))
             var reconciled = message
             reconciled.clientMessageID = clientID
             return reconciled
         }
+        return (enriched, pairs)
+    }
+
+    /// Drop the pending rows whose echoes just persisted, re-anchoring later still-pending sends.
+    private func commitReconciled(_ pairs: [(clientID: UUID, confirmedID: MessageID)], in conversationID: ConversationID) {
+        for pair in pairs {
+            store.dropPending(clientMessageID: pair.clientID, confirmedAt: pair.confirmedID, in: conversationID)
+        }
+    }
+
+    /// A freshly fetched newest page that does not overlap the retained history proves nothing about
+    /// contiguity — the interior gap would render seamlessly stitched and can never be fetched (older
+    /// paging anchors below the *oldest* persisted row). Drop the stale older epoch; it re-pages from
+    /// the server on scroll. Must run before the page itself is persisted.
+    private func dropStaleEpochIfNeeded(before page: [ConversationMessage], in conversationID: ConversationID) throws {
+        guard let oldestOfPage = page.map(\.id.value).min(),
+              let newestPersisted = try database.newestMessageID(conversationID: conversationID),
+              newestPersisted.value < oldestOfPage else { return }
+        try database.deleteMessages(conversationID: conversationID)
     }
 
     /// Recompute the feed row's preview from the newest persisted *visible* message (the store no longer
     /// holds the confirmed transcript to derive it from).
     private func refreshFeedPreview(for conversationID: ConversationID) {
-        store.setFeedPreview((try? database.latestMessage(conversationID: conversationID)) ?? nil, in: conversationID)
+        let visible = (try? database.latestMessage(conversationID: conversationID)) ?? nil
+        // A newest row that is itself invisible (a tombstone) is the one case the preview must regress —
+        // the never-regress guard would otherwise keep showing the deleted content.
+        let newestID = (try? database.newestMessageID(conversationID: conversationID)) ?? nil
+        let newestIsTombstone: Bool = {
+            guard let newestID, let visible else { return false }
+            return newestID.value > visible.id.value
+        }()
+        store.setFeedPreview(visible, in: conversationID, force: newestIsTombstone)
     }
 
     /// Persists the store's current version of a conversation. No-ops for
@@ -553,33 +615,52 @@ final class ConversationController {
     /// re-fire through the store directly.
     private(set) var messageRevision = 0
 
-    /// The transcript's bounded window: the newest `limit` confirmed messages read from the DB, with the
-    /// in-memory optimistic overlay applied. The DB is the source of the confirmed rows; the store
-    /// contributes only the pending overlay.
-    func windowedMessages(for conversationID: ConversationID, limit: Int) -> [ConversationMessage] {
+    /// The transcript's bounded window with the in-memory optimistic overlay applied: every confirmed
+    /// message from `startID` to the newest when anchored, else the newest `limit`. The DB is the source
+    /// of the confirmed rows; the store contributes only the pending overlay. Anchoring by id means an
+    /// arriving message grows the window at the tail instead of sliding the oldest revealed row out.
+    func windowedMessages(for conversationID: ConversationID, startingAt startID: UInt64?, limit: Int) -> [ConversationMessage] {
         _ = messageRevision   // observe: re-read when a confirmed DB write lands
-        let confirmed = (try? database.messagesWindow(conversationID: conversationID, before: nil, limit: limit)) ?? []
+        let confirmed: [ConversationMessage]
+        if let startID {
+            confirmed = (try? database.messages(conversationID: conversationID, from: startID)) ?? []
+        } else {
+            confirmed = (try? database.messagesWindow(conversationID: conversationID, before: nil, limit: limit)) ?? []
+        }
         return store.displayedMessages(for: conversationID, over: confirmed)
     }
 
-    /// How many confirmed messages are persisted locally — the ceiling the window can grow to before
-    /// older history must be paged from the server.
-    func confirmedMessageCount(for conversationID: ConversationID) -> Int {
-        (try? database.messageCount(conversationID: conversationID)) ?? 0
+    func windowedMessages(for conversationID: ConversationID, limit: Int) -> [ConversationMessage] {
+        windowedMessages(for: conversationID, startingAt: nil, limit: limit)
+    }
+
+    /// The oldest confirmed id inside the newest-`limit` window — the anchor a first page-back grows
+    /// from; nil when nothing is persisted.
+    func oldestWindowedMessageID(for conversationID: ConversationID, limit: Int) -> UInt64? {
+        ((try? database.messagesWindow(conversationID: conversationID, before: nil, limit: limit)) ?? []).first?.id.value
+    }
+
+    /// The persisted id `step` rows older than `before` — the loader's next window anchor — or nil when
+    /// no older history is persisted locally (time to page the server).
+    func olderAnchor(for conversationID: ConversationID, before: UInt64, step: Int) -> UInt64? {
+        (try? database.olderAnchor(conversationID: conversationID, before: before, step: step)) ?? nil
     }
 
     /// The general "recent messages" window for the misc accessor.
     private static let recentWindow = 100
 
-    /// The newest confirmed *visible* message — what the receive buzz and mark-read track, so an
-    /// unresolved optimistic send never masks an incoming one. Sourced from the DB (the truth).
+    /// The newest confirmed message, tombstones included — what the receive buzz and mark-read track, so
+    /// an unresolved optimistic send never masks an incoming one, and a delete of the newest message
+    /// doesn't regress the anchor to the previous row (which would buzz as if it just arrived).
     func lastConfirmedMessage(for conversationID: ConversationID) -> ConversationMessage? {
-        (try? database.latestMessage(conversationID: conversationID)) ?? nil
+        _ = messageRevision   // observe: identity-keyed triggers must re-evaluate when a write lands
+        return (try? database.newestMessage(conversationID: conversationID)) ?? nil
     }
 
     /// Whether the conversation holds any message — an in-flight optimistic send, or a persisted one.
     func hasMessages(for conversationID: ConversationID) -> Bool {
-        store.hasPendingMessages(for: conversationID) || (try? database.newestMessageID(conversationID: conversationID)).flatMap { $0 } != nil
+        _ = messageRevision
+        return store.hasPendingMessages(for: conversationID) || (try? database.newestMessageID(conversationID: conversationID)).flatMap { $0 } != nil
     }
 
     func loadMessages(for conversationID: ConversationID) async {
@@ -592,12 +673,19 @@ final class ConversationController {
             // Establish the event-log frontier from the newest page so a following catch-up resumes from
             // head — fetching only genuinely newer messages, appended at the tail — instead of a
             // `GetDelta(after: 0)` that re-pulls the whole history and prepends it, knocking the
-            // transcript off the bottom on first open.
-            if let head = messages.map(\.eventSequence).max(), head > 0 {
-                store.setAppliedCursor(head, for: conversationID)
-                persistCursor(for: conversationID)
+            // transcript off the bottom on first open. Page + cursor land atomically (a failed write
+            // must not seat the cursor past messages that never persisted), and a non-overlapping page
+            // drops the stale older epoch first.
+            let (reconciled, pairs) = reconciledForPersist(messages, in: conversationID)
+            let head = messages.map(\.eventSequence).max() ?? 0
+            let ok = persist(operation: "load-messages") {
+                try dropStaleEpochIfNeeded(before: messages, in: conversationID)
+                try database.persistMessages(reconciled, cursor: head, conversationID: conversationID)
             }
-            persist(operation: "load-messages") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
+            if ok {
+                commitReconciled(pairs, in: conversationID)
+                if head > 0 { store.setAppliedCursor(head, for: conversationID) }
+            }
             refreshFeedPreview(for: conversationID)
         } catch {
             logger.error("Failed to load conversation messages", metadata: [
@@ -695,13 +783,19 @@ final class ConversationController {
     private func deliver(clientMessageID: UUID, text: String, to conversationID: ConversationID) async -> Bool {
         do {
             let message = try await messaging.sendMessage(owner: owner, conversationID: conversationID, text: text, clientMessageID: clientMessageID)
-            store.dropPending(clientMessageID: clientMessageID, confirmedAt: message.id, in: conversationID)
-            store.advanceLastActivity(to: message.date, in: conversationID)
             // Persist the row carrying its client id (the server echoes none) so the DB keeps the send's
-            // identity across a round-trip.
+            // identity across a round-trip. The pending row is dropped only once the confirmed copy is
+            // durably readable — a failed write leaves the send visible (the stream echo or a catch-up
+            // reconciles it later) instead of vanishing it.
             var confirmed = message
             confirmed.clientMessageID = clientMessageID
-            persist(operation: "send-message") { try database.upsertConversationMessages([confirmed], conversationID: conversationID) }
+            let ok = persist(operation: "send-message") { try database.upsertConversationMessages([confirmed], conversationID: conversationID) }
+            if ok {
+                store.dropPending(clientMessageID: clientMessageID, confirmedAt: message.id, in: conversationID)
+            } else {
+                scheduleGapCatchUp(conversationID)
+            }
+            store.advanceLastActivity(to: message.date, in: conversationID)
             refreshFeedPreview(for: conversationID)
             persistConversation(conversationID)
             Analytics.track(event: Analytics.ConversationEvent.sentMessage)

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -160,6 +160,7 @@ final class ConversationController {
             for await event in events {
                 guard let self else { return }
                 let gap = self.store.apply(event)
+                self.boundBackgroundTranscript(for: event)
                 self.persist(event: event)
                 self.hydrateIfUnknown(event)
                 self.logCounterpartRead(event)
@@ -496,6 +497,31 @@ final class ConversationController {
     func messages(for conversationID: ConversationID) -> [ConversationMessage] {
         store.displayedMessages(for: conversationID)
     }
+
+    /// Trims a left conversation's in-memory transcript back to the cached window so a paged-back
+    /// thread doesn't retain its whole history for the session. Older history re-pages on reopen.
+    func trimTranscript(for conversationID: ConversationID) {
+        store.trimMessages(for: conversationID, keepingNewest: Self.retainedMessageWindow)
+    }
+
+    // A conversation the user never opens still accretes its whole stream backlog in memory — the
+    // on-leave trim only fires for a chat that was opened. Cap every conversation that isn't on screen
+    // to the cached window as its message events land; the visible chat stays uncapped so a paged-back
+    // scroll keeps its history.
+    private func boundBackgroundTranscript(for event: ConversationStreamEvent) {
+        let conversationID: ConversationID
+        switch event {
+        case .newMessages(let id, _), .chatEvents(let id, _):
+            conversationID = id
+        case .metadataRefresh, .lastActivityChanged, .readPointersChanged, .typingChanged:
+            return
+        }
+        guard conversationID != visibleConversationID else { return }
+        store.trimMessages(for: conversationID, keepingNewest: Self.retainedMessageWindow)
+    }
+
+    /// How many newest confirmed messages a left conversation keeps in memory — the DB-cache page size.
+    private static let retainedMessageWindow = 100
 
     /// The newest server-confirmed message — what the screen's receive buzz and mark-read track, so an
     /// unresolved optimistic send (which renders after the confirmed run) never masks an incoming one.

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -128,9 +128,6 @@ final class ConversationController {
             transaction.disablesAnimations = true
             withTransaction(transaction) {
                 store.setFeed(cache.conversations)
-                for (conversationID, messages) in cache.messages {
-                    store.mergeMessages(messages, into: conversationID)
-                }
                 store.seedAppliedCursors(cache.cursors)
             }
         } catch {
@@ -160,7 +157,6 @@ final class ConversationController {
             for await event in events {
                 guard let self else { return }
                 let gap = self.store.apply(event)
-                self.boundBackgroundTranscript(for: event)
                 self.persist(event: event)
                 self.hydrateIfUnknown(event)
                 self.logCounterpartRead(event)
@@ -217,7 +213,7 @@ final class ConversationController {
     /// holds nothing for — no feed entry, no messages, no applied cursor.
     func catchUp(conversationID: ConversationID) async {
         guard conversation(withID: conversationID) != nil
-            || store.hasMessages(for: conversationID)
+            || hasMessages(for: conversationID)
             || store.appliedCursor(for: conversationID) > 0 else {
             logger.info("Skipping catch-up for a conversation the client holds nothing for", metadata: [
                 "conversationID": "\(conversationID)",
@@ -232,11 +228,15 @@ final class ConversationController {
         do {
             let head = try await messaging.getDelta(owner: owner, conversationID: conversationID, afterSequence: after) { [weak self] messages, checkpoint in
                 guard let self else { return }
-                self.store.applyDeltaBatch(messages, checkpoint: checkpoint, into: conversationID)
-                if !messages.isEmpty {
-                    self.persist(operation: "delta-batch") { try self.database.upsertConversationMessages(messages, conversationID: conversationID) }
+                let reconciled = self.reconciledForPersist(messages, in: conversationID)
+                // Batch + checkpoint cursor persist atomically; advance the in-memory checkpoint only
+                // after the write succeeds, so a rolled-back batch isn't skipped on the next catch-up.
+                let cursor = checkpoint ?? self.store.appliedCursor(for: conversationID)
+                let ok = self.persist(operation: "delta-batch") {
+                    try self.database.persistMessages(reconciled, cursor: cursor, conversationID: conversationID)
                 }
-                self.persistCursor(for: conversationID)
+                if ok, let checkpoint { self.store.setAppliedCursor(checkpoint, for: conversationID) }
+                self.refreshFeedPreview(for: conversationID)
             }
             // Clean completion: the head is authoritative even if the intervening events weren't observed.
             store.setAppliedCursor(head, for: conversationID)
@@ -289,8 +289,9 @@ final class ConversationController {
         persist(operation: "reset-cursor") { try database.updateCatchupCursor(0, for: conversationID) }
         do {
             let messages = try await messaging.getMessages(owner: owner, conversationID: conversationID, before: nil)
-            store.mergeMessages(messages, into: conversationID)
-            persist(operation: "reset-resync") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
+            let reconciled = reconciledForPersist(messages, in: conversationID)
+            persist(operation: "reset-resync") { try database.upsertConversationMessages(reconciled, conversationID: conversationID) }
+            refreshFeedPreview(for: conversationID)
             if let floor = messages.map(\.eventSequence).filter({ $0 > 0 }).min() {
                 store.setAppliedCursor(floor, for: conversationID)
                 persistCursor(for: conversationID)
@@ -413,14 +414,24 @@ final class ConversationController {
     private func persist(event: ConversationStreamEvent) {
         switch event {
         case .newMessages(let conversationID, let messages):
-            persist(operation: "upsert-messages") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
+            let reconciled = reconciledForPersist(messages, in: conversationID)
+            persist(operation: "upsert-messages") { try database.upsertConversationMessages(reconciled, conversationID: conversationID) }
+            refreshFeedPreview(for: conversationID)
             persistConversation(conversationID)
         case .chatEvents(let conversationID, let events):
-            let messages = events.flatMap { $0.mutations.map(\.message) }
-            if !messages.isEmpty {
-                persist(operation: "upsert-events") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
+            let reconciled = reconciledForPersist(events.flatMap { $0.mutations.map(\.message) }, in: conversationID)
+            // Messages + the advanced cursor persist atomically. `store.apply` already advanced the
+            // in-memory cursor optimistically, so if this write rolls back, re-seat the cursor to the
+            // persisted value and catch up — otherwise the un-persisted messages are skipped by the next
+            // GetDelta and lost (the store no longer holds a confirmed copy).
+            let ok = persist(operation: "apply-chat-events") {
+                try database.persistMessages(reconciled, cursor: store.appliedCursor(for: conversationID), conversationID: conversationID)
             }
-            persistCursor(for: conversationID)
+            if !ok {
+                store.reseatCursor((try? database.catchupCursor(conversationID: conversationID)) ?? 0, for: conversationID)
+                scheduleGapCatchUp(conversationID)
+            }
+            refreshFeedPreview(for: conversationID)
             persistConversation(conversationID)
         case .metadataRefresh(let conversation):
             persistConversation(conversation)
@@ -430,6 +441,31 @@ final class ConversationController {
         case .typingChanged:
             break
         }
+    }
+
+    /// Adopt a pending send's client id onto a *fresh* server echo of it (one not already persisted), so
+    /// the persisted confirmed row keeps the send's identity and the echo collapses onto the pending row
+    /// instead of duplicating it. A re-delivery of an already-stored id is left alone (it can't steal a
+    /// send). Returns the messages ready to persist.
+    private func reconciledForPersist(_ messages: [ConversationMessage], in conversationID: ConversationID) -> [ConversationMessage] {
+        // No pending send to reconcile against → skip the per-message existence probes (the common
+        // receive/catch-up path, where every server message would otherwise cost a DB read).
+        guard store.hasPendingMessages(for: conversationID) else { return messages }
+        return messages.map { message in
+            guard message.clientMessageID == nil,
+                  !((try? database.messageExists(id: message.id, conversationID: conversationID)) ?? true),
+                  let clientID = store.reconcilePending(for: message, in: conversationID)
+            else { return message }
+            var reconciled = message
+            reconciled.clientMessageID = clientID
+            return reconciled
+        }
+    }
+
+    /// Recompute the feed row's preview from the newest persisted *visible* message (the store no longer
+    /// holds the confirmed transcript to derive it from).
+    private func refreshFeedPreview(for conversationID: ConversationID) {
+        store.setFeedPreview((try? database.latestMessage(conversationID: conversationID)) ?? nil, in: conversationID)
     }
 
     /// Persists the store's current version of a conversation. No-ops for
@@ -443,17 +479,31 @@ final class ConversationController {
         persist(operation: "upsert-conversation") { try database.upsertConversation(conversation) }
     }
 
-    private func persist(operation: String, _ write: () throws -> Void) {
+    @discardableResult
+    private func persist(operation: String, _ write: () throws -> Void) -> Bool {
         do {
             try write()
+            // A successful confirmed-message write invalidates the DB-backed transcript window; bump the
+            // revision the coordinator observes so it re-reads.
+            if Self.messageWriteOperations.contains(operation) {
+                messageRevision &+= 1
+            }
+            return true
         } catch {
             logger.error("Failed to persist conversation state", metadata: [
                 "operation": "\(operation)",
                 "error": "\(error)",
             ])
             ErrorReporting.captureError(error, reason: "Failed to persist conversation state [\(operation)]")
+            return false
         }
     }
+
+    /// Persist operations that write confirmed messages — the ones that must bump `messageRevision`.
+    private static let messageWriteOperations: Set<String> = [
+        "upsert-messages", "apply-chat-events", "delta-batch", "load-messages", "load-older",
+        "send-message", "reset-resync",
+    ]
 
     // MARK: - Names
 
@@ -495,43 +545,41 @@ final class ConversationController {
     // MARK: - Conversation
 
     func messages(for conversationID: ConversationID) -> [ConversationMessage] {
-        store.displayedMessages(for: conversationID)
+        windowedMessages(for: conversationID, limit: Self.recentWindow)
     }
 
-    /// Trims a left conversation's in-memory transcript back to the cached window so a paged-back
-    /// thread doesn't retain its whole history for the session. Older history re-pages on reopen.
-    func trimTranscript(for conversationID: ConversationID) {
-        store.trimMessages(for: conversationID, keepingNewest: Self.retainedMessageWindow)
+    /// Bumped after every successful confirmed-message DB write, so the coordinator — which reads the
+    /// transcript from the DB, not the store — knows to re-read its window. Pending-overlay changes
+    /// re-fire through the store directly.
+    private(set) var messageRevision = 0
+
+    /// The transcript's bounded window: the newest `limit` confirmed messages read from the DB, with the
+    /// in-memory optimistic overlay applied. The DB is the source of the confirmed rows; the store
+    /// contributes only the pending overlay.
+    func windowedMessages(for conversationID: ConversationID, limit: Int) -> [ConversationMessage] {
+        _ = messageRevision   // observe: re-read when a confirmed DB write lands
+        let confirmed = (try? database.messagesWindow(conversationID: conversationID, before: nil, limit: limit)) ?? []
+        return store.displayedMessages(for: conversationID, over: confirmed)
     }
 
-    // A conversation the user never opens still accretes its whole stream backlog in memory — the
-    // on-leave trim only fires for a chat that was opened. Cap every conversation that isn't on screen
-    // to the cached window as its message events land; the visible chat stays uncapped so a paged-back
-    // scroll keeps its history.
-    private func boundBackgroundTranscript(for event: ConversationStreamEvent) {
-        let conversationID: ConversationID
-        switch event {
-        case .newMessages(let id, _), .chatEvents(let id, _):
-            conversationID = id
-        case .metadataRefresh, .lastActivityChanged, .readPointersChanged, .typingChanged:
-            return
-        }
-        guard conversationID != visibleConversationID else { return }
-        store.trimMessages(for: conversationID, keepingNewest: Self.retainedMessageWindow)
+    /// How many confirmed messages are persisted locally — the ceiling the window can grow to before
+    /// older history must be paged from the server.
+    func confirmedMessageCount(for conversationID: ConversationID) -> Int {
+        (try? database.messageCount(conversationID: conversationID)) ?? 0
     }
 
-    /// How many newest confirmed messages a left conversation keeps in memory — the DB-cache page size.
-    private static let retainedMessageWindow = 100
+    /// The general "recent messages" window for the misc accessor.
+    private static let recentWindow = 100
 
-    /// The newest server-confirmed message — what the screen's receive buzz and mark-read track, so an
-    /// unresolved optimistic send (which renders after the confirmed run) never masks an incoming one.
+    /// The newest confirmed *visible* message — what the receive buzz and mark-read track, so an
+    /// unresolved optimistic send never masks an incoming one. Sourced from the DB (the truth).
     func lastConfirmedMessage(for conversationID: ConversationID) -> ConversationMessage? {
-        store.lastConfirmedMessage(for: conversationID)
+        (try? database.latestMessage(conversationID: conversationID)) ?? nil
     }
 
-    /// Whether the conversation holds any message, without building the merged transcript.
+    /// Whether the conversation holds any message — an in-flight optimistic send, or a persisted one.
     func hasMessages(for conversationID: ConversationID) -> Bool {
-        store.hasMessages(for: conversationID)
+        store.hasPendingMessages(for: conversationID) || (try? database.newestMessageID(conversationID: conversationID)).flatMap { $0 } != nil
     }
 
     func loadMessages(for conversationID: ConversationID) async {
@@ -541,7 +589,6 @@ final class ConversationController {
                 "conversationID": "\(conversationID)",
                 "count": "\(messages.count)",
             ])
-            store.mergeMessages(messages, into: conversationID)
             // Establish the event-log frontier from the newest page so a following catch-up resumes from
             // head — fetching only genuinely newer messages, appended at the tail — instead of a
             // `GetDelta(after: 0)` that re-pulls the whole history and prepends it, knocking the
@@ -551,6 +598,7 @@ final class ConversationController {
                 persistCursor(for: conversationID)
             }
             persist(operation: "load-messages") { try database.upsertConversationMessages(messages, conversationID: conversationID) }
+            refreshFeedPreview(for: conversationID)
         } catch {
             logger.error("Failed to load conversation messages", metadata: [
                 "conversationID": "\(conversationID)",
@@ -578,13 +626,13 @@ final class ConversationController {
         olderPageState[conversationID]?.isLoading ?? false
     }
 
-    /// Pages strictly older than the oldest loaded message and prepends the page
-    /// to the in-memory window. The newest-100 are the DB cache; older pages are
-    /// session-only (persisting them would just be pruned), so a reopen re-pages.
-    /// No-ops while a page is in flight or once history is exhausted.
+    /// Pages strictly older than the oldest loaded message, prepends it to the in-memory window, and
+    /// persists it — retention is on, so paged-in history stays in the DB and a reopen reads it locally
+    /// instead of re-fetching. No-ops while a page is in flight or once history is exhausted.
     func loadOlderMessages(for conversationID: ConversationID) async {
         guard hasMoreOlderMessages(for: conversationID), !isLoadingOlderMessages(for: conversationID) else { return }
-        guard let oldest = store.messages(for: conversationID).first?.id else { return }
+        // Page before the oldest PERSISTED id — the DB holds all viewed history; the store may be trimmed.
+        guard let oldest = (try? database.oldestMessageID(conversationID: conversationID)).flatMap({ $0 }) else { return }
 
         olderPageState[conversationID, default: OlderPageState()].isLoading = true
         defer { olderPageState[conversationID]?.isLoading = false }
@@ -594,12 +642,13 @@ final class ConversationController {
             if older.isEmpty {
                 olderPageState[conversationID]?.hasMore = false
             } else {
-                // Prepended history must not play insertion transitions — match the
-                // animation-suppressed merge used for the cache hydrate.
+                // Retention is on, so persist the paged-in history: the next open reads it from the DB
+                // instead of re-fetching. Prepended history must not play insertion transitions — the
+                // revision bump and the resulting re-read ride an animation-suppressed transaction.
                 var transaction = Transaction()
                 transaction.disablesAnimations = true
                 withTransaction(transaction) {
-                    store.mergeMessages(older, into: conversationID)
+                    _ = persist(operation: "load-older") { try database.upsertConversationMessages(older, conversationID: conversationID) }
                 }
             }
         } catch {
@@ -626,7 +675,8 @@ final class ConversationController {
             status: .sending,
             clientMessageID: clientMessageID
         )
-        store.insertPending(pending, into: conversationID)
+        let anchor = (try? database.newestMessageID(conversationID: conversationID)).flatMap { $0 }?.value ?? 0
+        store.insertPending(pending, anchoredTo: anchor, into: conversationID)
         receiptSettle.hold(clientMessageID.uuidString)
         return await deliver(clientMessageID: clientMessageID, text: text, to: conversationID)
     }
@@ -645,9 +695,14 @@ final class ConversationController {
     private func deliver(clientMessageID: UUID, text: String, to conversationID: ConversationID) async -> Bool {
         do {
             let message = try await messaging.sendMessage(owner: owner, conversationID: conversationID, text: text, clientMessageID: clientMessageID)
-            store.reconcile(clientMessageID: clientMessageID, with: message, in: conversationID)
-            store.setLastMessage(message, in: conversationID)
-            persist(operation: "send-message") { try database.upsertConversationMessages([message], conversationID: conversationID) }
+            store.dropPending(clientMessageID: clientMessageID, confirmedAt: message.id, in: conversationID)
+            store.advanceLastActivity(to: message.date, in: conversationID)
+            // Persist the row carrying its client id (the server echoes none) so the DB keeps the send's
+            // identity across a round-trip.
+            var confirmed = message
+            confirmed.clientMessageID = clientMessageID
+            persist(operation: "send-message") { try database.upsertConversationMessages([confirmed], conversationID: conversationID) }
+            refreshFeedPreview(for: conversationID)
             persistConversation(conversationID)
             Analytics.track(event: Analytics.ConversationEvent.sentMessage)
             return true
@@ -676,15 +731,15 @@ final class ConversationController {
     }
 
     func markRead(conversationID: ConversationID) async {
-        guard let latest = store.messages(for: conversationID).last else { return }
+        guard let latestID = (try? database.newestMessageID(conversationID: conversationID)).flatMap({ $0 }) else { return }
         // Skip the round-trip when the server-known READ watermark already covers
         // the latest message. We advance the watermark locally after each success.
-        if let read = store.selfReadPointer(for: conversationID, selfUserID: selfUserID), latest.id <= read {
+        if let read = store.selfReadPointer(for: conversationID, selfUserID: selfUserID), latestID <= read {
             return
         }
         do {
-            try await messaging.markRead(owner: owner, conversationID: conversationID, messageID: latest.id)
-            store.advanceSelfReadPointer(to: latest.id, in: conversationID, selfUserID: selfUserID)
+            try await messaging.markRead(owner: owner, conversationID: conversationID, messageID: latestID)
+            store.advanceSelfReadPointer(to: latestID, in: conversationID, selfUserID: selfUserID)
             persistConversation(conversationID)
         } catch {
             logger.error("Failed to mark conversation read", metadata: [

--- a/Flipcash/Core/Controllers/Database/Database+Conversations.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Conversations.swift
@@ -15,17 +15,13 @@ nonisolated extension Database {
 
     /// Async wrapper that runs the synchronous cache reads off the caller's
     /// actor so session start never blocks the main thread on row decoding.
-    func loadConversationCache() async throws -> (conversations: [Conversation], messages: [ConversationID: [ConversationMessage]], cursors: [ConversationID: UInt64]) {
+    func loadConversationCache() async throws -> (conversations: [Conversation], cursors: [ConversationID: UInt64]) {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
                     let conversations = try self.getConversations()
-                    var messages: [ConversationID: [ConversationMessage]] = [:]
-                    for conversation in conversations {
-                        messages[conversation.id] = try self.getConversationMessages(conversationID: conversation.id)
-                    }
                     let cursors = try self.getCatchupCursors()
-                    continuation.resume(returning: (conversations, messages, cursors))
+                    continuation.resume(returning: (conversations, cursors))
                 } catch {
                     continuation.resume(throwing: error)
                 }
@@ -43,6 +39,13 @@ nonisolated extension Database {
         return rows.reduce(into: [:]) { result, row in
             if let cursor = row.cursor { result[row.id] = cursor }
         }
+    }
+
+    /// The persisted catch-up cursor for one conversation (0 when none) — used to re-seat the in-memory
+    /// cursor after a failed message persist so recovery refetches, rather than skips, the window.
+    func catchupCursor(conversationID: ConversationID) throws -> UInt64 {
+        let c = ConversationTable()
+        return (try reader.pluck(c.table.filter(c.id == conversationID.data))).flatMap { $0[c.catchupCursor] } ?? 0
     }
 
     /// The cached DM feed, most-recent activity first, with members and the
@@ -83,6 +86,10 @@ nonisolated extension Database {
     /// The newest stored non-deleted message for a conversation, or nil when none is cached. Tombstones
     /// (`kind == 2`) are skipped so the feed preview shows the newest *visible* message rather than a
     /// blank row for a deleted last message.
+    func latestMessage(conversationID: ConversationID) throws -> ConversationMessage? {
+        try latestMessage(conversationId: conversationID.data)
+    }
+
     private func latestMessage(conversationId: Data) throws -> ConversationMessage? {
         let m = ConversationMessageTable()
         guard let row = try reader.pluck(
@@ -93,13 +100,62 @@ nonisolated extension Database {
         return conversationMessage(from: row)
     }
 
-    /// All cached messages for a conversation, oldest first.
-    func getConversationMessages(conversationID: ConversationID) throws -> [ConversationMessage] {
+    /// The newest stored message id (tombstones included) — the mark-read / receive-buzz anchor.
+    func newestMessageID(conversationID: ConversationID) throws -> MessageID? {
         let m = ConversationMessageTable()
-        let rows = try reader.prepareRowIterator(
-            m.table.filter(m.conversationId == conversationID.data).order(m.id.asc)
-        )
+        return try reader.pluck(
+            m.table.filter(m.conversationId == conversationID.data).order(m.id.desc)
+        ).map { MessageID(value: $0[m.id]) }
+    }
+
+    /// Whether a specific message id is already persisted — the "is this a fresh echo?" gate for the
+    /// optimistic-send reconcile, replacing the in-memory existence check.
+    func messageExists(id: MessageID, conversationID: ConversationID) throws -> Bool {
+        let m = ConversationMessageTable()
+        return try reader.scalar(m.table.filter(m.conversationId == conversationID.data && m.id == id.value).count) > 0
+    }
+
+    /// Cached messages for a conversation, oldest first. `newest` bounds it to the most recent N
+    /// (still oldest-first) so a cold-boot hydrate reads a window, not the whole retained history;
+    /// nil returns everything.
+    func getConversationMessages(conversationID: ConversationID, newest limit: Int? = nil) throws -> [ConversationMessage] {
+        let m = ConversationMessageTable()
+        let base = m.table.filter(m.conversationId == conversationID.data)
+        if let limit {
+            let rows = try reader.prepareRowIterator(base.order(m.id.desc).limit(limit))
+            return Array(try rows.map { conversationMessage(from: $0) }.compactMap { $0 }.reversed())
+        }
+        let rows = try reader.prepareRowIterator(base.order(m.id.asc))
         return try rows.map { conversationMessage(from: $0) }.compactMap { $0 }
+    }
+
+    /// A bounded window of a conversation's messages, oldest-first: the newest `limit` when `before` is
+    /// nil, otherwise the `limit` messages immediately older than `before`. Index-backed by the
+    /// composite `(conversationId, id)` primary key — no scan, no sort.
+    func messagesWindow(conversationID: ConversationID, before: MessageID? = nil, limit: Int) throws -> [ConversationMessage] {
+        let m = ConversationMessageTable()
+        var query = m.table.filter(m.conversationId == conversationID.data)
+        if let before {
+            query = query.filter(m.id < before.value)
+        }
+        let rows = try reader.prepareRowIterator(query.order(m.id.desc).limit(limit))
+        return Array(try rows.map { conversationMessage(from: $0) }.compactMap { $0 }.reversed())
+    }
+
+    /// The number of confirmed messages persisted for a conversation — the ceiling the transcript
+    /// window can grow to before older history must be paged from the server.
+    func messageCount(conversationID: ConversationID) throws -> Int {
+        let m = ConversationMessageTable()
+        return try reader.scalar(m.table.filter(m.conversationId == conversationID.data).count)
+    }
+
+    /// The oldest persisted message id for a conversation, or nil when none is cached — the anchor for
+    /// paging genuinely older history from the server.
+    func oldestMessageID(conversationID: ConversationID) throws -> MessageID? {
+        let m = ConversationMessageTable()
+        return try reader.pluck(
+            m.table.filter(m.conversationId == conversationID.data).order(m.id.asc)
+        ).map { MessageID(value: $0[m.id]) }
     }
 
     // MARK: - Write -
@@ -147,34 +203,34 @@ nonisolated extension Database {
         }
     }
 
-    /// Newest messages kept per conversation. The slack is hysteresis: pruning
-    /// only fires once a conversation exceeds the window by this much, so
-    /// steady-state single-message writes don't pay a prune each time.
+    /// How many newest messages to seed into memory per conversation on cold-boot hydrate. The DB now
+    /// retains all history; this only bounds what a fresh launch reads into the loader's window.
     static let messageWindow = 100
-    static let messageWindowSlack = 20
 
-    /// Upsert messages for a conversation (insert-or-replace on the
-    /// (conversation, id) key), then prune anything older than the window.
+    /// Upsert messages for a conversation (insert-or-replace on the (conversation, id) key). History is
+    /// retained — the transcript reads a bounded window from it, so there is no prune.
     func upsertConversationMessages(_ messages: [ConversationMessage], conversationID: ConversationID) throws {
         try writer.transaction {
             for message in messages {
                 try writeMessage(message, conversationId: conversationID.data)
             }
-            try pruneMessages(conversationId: conversationID.data)
         }
     }
 
-    /// Deletes all but the newest ``messageWindow`` rows once the count exceeds
-    /// the window plus ``messageWindowSlack``. Must be called inside a
-    /// `writer.transaction`.
-    private func pruneMessages(conversationId: Data) throws {
-        let m = ConversationMessageTable()
-        let scoped = m.table.filter(m.conversationId == conversationId)
-        guard try writer.scalar(scoped.count) > Self.messageWindow + Self.messageWindowSlack else { return }
-        guard let cutoff = try writer.pluck(
-            scoped.order(m.id.desc).limit(1, offset: Self.messageWindow - 1)
-        ) else { return }
-        try writer.run(scoped.filter(m.id < cutoff[m.id]).delete())
+    /// Atomically persist a batch and advance the catch-up cursor in one transaction, so a failed write
+    /// can never leave the persisted cursor past a message that wasn't stored — which, once the DB is
+    /// the working set, would orphan that message from GetDelta recovery. The cursor advances only when
+    /// established (> 0); the conversation row need not exist yet (the update no-ops until it does).
+    func persistMessages(_ messages: [ConversationMessage], cursor: UInt64, conversationID: ConversationID) throws {
+        let c = ConversationTable()
+        try writer.transaction {
+            for message in messages {
+                try writeMessage(message, conversationId: conversationID.data)
+            }
+            if cursor > 0 {
+                try writer.run(c.table.filter(c.id == conversationID.data).update(c.catchupCursor <- cursor))
+            }
+        }
     }
 
     /// Must be called inside a `writer.transaction`.
@@ -213,13 +269,30 @@ nonisolated extension Database {
     private func writeMessage(_ message: ConversationMessage, conversationId: Data) throws {
         let m = ConversationMessageTable()
 
+        let scoped = m.table.filter(m.conversationId == conversationId && m.id == message.id.value)
+        var message = message
+
         // Last-writer-wins parity with the in-memory `ConversationStore`: never let a stale re-delivery
         // (e.g. the deprecated `new_messages` overlay landing after the `events` tombstone, or a
         // duplicate delta batch) overwrite a newer persisted version — that would resurrect a
         // deleted/pre-edit message across a relaunch, since the cache is what hydrates on cold boot.
-        if let existing = try writer.pluck(m.table.filter(m.conversationId == conversationId && m.id == message.id.value)),
-           existing[m.eventSequence] > message.eventSequence {
-            return
+        if let existing = try writer.pluck(scoped) {
+            let existingSequence = existing[m.eventSequence]
+            if existingSequence > message.eventSequence {
+                return // stale re-delivery — keep the newer stored version
+            }
+            if existingSequence == message.eventSequence {
+                // Equal version: keep the stored row, adopting only a client id it lacks (a reconcile
+                // copy landing after a stream echo, or vice versa) so identity stays stable.
+                if existing[m.clientMessageID] == nil, let clientMessageID = message.clientMessageID {
+                    try writer.run(scoped.update(m.clientMessageID <- clientMessageID))
+                }
+                return
+            }
+            // Newer version wins; preserve the row's established identity if the newer copy lacks one.
+            if message.clientMessageID == nil {
+                message.clientMessageID = existing[m.clientMessageID]
+            }
         }
 
         let kind: Int
@@ -257,7 +330,8 @@ nonisolated extension Database {
                 m.mint           <- mint,
                 m.date           <- message.date.timeIntervalSinceReferenceDate,
                 m.unreadSeq      <- message.unreadSeq,
-                m.eventSequence  <- message.eventSequence
+                m.eventSequence  <- message.eventSequence,
+                m.clientMessageID <- message.clientMessageID
             )
         )
     }
@@ -305,7 +379,8 @@ nonisolated extension Database {
             content: content,
             date: Date(timeIntervalSinceReferenceDate: row[m.date]),
             unreadSeq: row[m.unreadSeq],
-            eventSequence: row[m.eventSequence]
+            eventSequence: row[m.eventSequence],
+            clientMessageID: row[m.clientMessageID]
         )
     }
 }

--- a/Flipcash/Core/Controllers/Database/Database+Conversations.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Conversations.swift
@@ -108,6 +108,19 @@ nonisolated extension Database {
         ).map { MessageID(value: $0[m.id]) }
     }
 
+    /// The newest stored message (tombstones included). Unlike ``latestMessage(conversationID:)``, a
+    /// delete of the newest message does not regress this value to the previous row — it returns the
+    /// tombstone itself — so identity-keyed triggers (receive buzz, mark-read) don't misfire on deletes.
+    func newestMessage(conversationID: ConversationID) throws -> ConversationMessage? {
+        let m = ConversationMessageTable()
+        guard let row = try reader.pluck(
+            m.table.filter(m.conversationId == conversationID.data).order(m.id.desc)
+        ) else {
+            return nil
+        }
+        return conversationMessage(from: row)
+    }
+
     /// Whether a specific message id is already persisted — the "is this a fresh echo?" gate for the
     /// optimistic-send reconcile, replacing the in-memory existence check.
     func messageExists(id: MessageID, conversationID: ConversationID) throws -> Bool {
@@ -115,17 +128,12 @@ nonisolated extension Database {
         return try reader.scalar(m.table.filter(m.conversationId == conversationID.data && m.id == id.value).count) > 0
     }
 
-    /// Cached messages for a conversation, oldest first. `newest` bounds it to the most recent N
-    /// (still oldest-first) so a cold-boot hydrate reads a window, not the whole retained history;
-    /// nil returns everything.
-    func getConversationMessages(conversationID: ConversationID, newest limit: Int? = nil) throws -> [ConversationMessage] {
+    /// All cached messages for a conversation, oldest first.
+    func getConversationMessages(conversationID: ConversationID) throws -> [ConversationMessage] {
         let m = ConversationMessageTable()
-        let base = m.table.filter(m.conversationId == conversationID.data)
-        if let limit {
-            let rows = try reader.prepareRowIterator(base.order(m.id.desc).limit(limit))
-            return Array(try rows.map { conversationMessage(from: $0) }.compactMap { $0 }.reversed())
-        }
-        let rows = try reader.prepareRowIterator(base.order(m.id.asc))
+        let rows = try reader.prepareRowIterator(
+            m.table.filter(m.conversationId == conversationID.data).order(m.id.asc)
+        )
         return try rows.map { conversationMessage(from: $0) }.compactMap { $0 }
     }
 
@@ -140,6 +148,28 @@ nonisolated extension Database {
         }
         let rows = try reader.prepareRowIterator(query.order(m.id.desc).limit(limit))
         return Array(try rows.map { conversationMessage(from: $0) }.compactMap { $0 }.reversed())
+    }
+
+    /// Every message from `startID` (inclusive) to the newest, oldest-first — the id-anchored window.
+    /// Anchoring by id means an arriving message grows the window at the tail instead of sliding the
+    /// oldest revealed row out from under a reader who has scrolled up.
+    func messages(conversationID: ConversationID, from startID: UInt64) throws -> [ConversationMessage] {
+        let m = ConversationMessageTable()
+        let rows = try reader.prepareRowIterator(
+            m.table.filter(m.conversationId == conversationID.data && m.id >= startID).order(m.id.asc)
+        )
+        return try rows.map { conversationMessage(from: $0) }.compactMap { $0 }
+    }
+
+    /// The id `step` rows older than `before` — the next anchor when the reader pages back — falling
+    /// back to the oldest available older row; nil when nothing older is persisted.
+    func olderAnchor(conversationID: ConversationID, before: UInt64, step: Int) throws -> UInt64? {
+        let m = ConversationMessageTable()
+        let older = m.table.filter(m.conversationId == conversationID.data && m.id < before)
+        if let row = try reader.pluck(older.order(m.id.desc).limit(1, offset: step - 1)) {
+            return row[m.id]
+        }
+        return try reader.pluck(older.order(m.id.asc)).map { $0[m.id] }
     }
 
     /// The number of confirmed messages persisted for a conversation — the ceiling the transcript
@@ -160,27 +190,27 @@ nonisolated extension Database {
 
     // MARK: - Write -
 
-    /// Mirror a paged feed load: replaces the conversation + member sets and
-    /// prunes messages of conversations no longer in the feed, then stores
-    /// each conversation's last-message preview.
+    /// Mirror a paged feed load: replaces the conversation + member sets (messages are retained), then
+    /// stores each conversation's last-message preview.
     func replaceConversationFeed(_ conversations: [Conversation]) throws {
         let c = ConversationTable()
         let m = ConversationMemberTable()
-        let msg = ConversationMessageTable()
         let ids = conversations.map(\.id.data)
         try writer.transaction {
             // Delete only the conversations that dropped out of the feed, then upsert the rest.
             // `writeConversation` upserts the row (leaving `catchupCursor` untouched on conflict) and
             // replaces that conversation's members, so a surviving conversation keeps its event-log
             // cursor without a read-and-restore dance.
+            // Messages are deliberately NOT deleted here: they are the transcript's source of truth,
+            // and a feed snapshot fetched before a brand-new chat's first message landed would
+            // otherwise wipe that just-persisted message. Rows for conversations that genuinely left
+            // the feed are orphaned but unread — nothing windows a conversation that isn't opened.
             if ids.isEmpty {
                 try writer.run(c.table.delete())
                 try writer.run(m.table.delete())
-                try writer.run(msg.table.delete())
             } else {
                 try writer.run(c.table.filter(!ids.contains(c.id)).delete())
                 try writer.run(m.table.filter(!ids.contains(m.conversationId)).delete())
-                try writer.run(msg.table.filter(!ids.contains(msg.conversationId)).delete())
             }
             for conversation in conversations {
                 try writeConversation(conversation)
@@ -203,10 +233,6 @@ nonisolated extension Database {
         }
     }
 
-    /// How many newest messages to seed into memory per conversation on cold-boot hydrate. The DB now
-    /// retains all history; this only bounds what a fresh launch reads into the loader's window.
-    static let messageWindow = 100
-
     /// Upsert messages for a conversation (insert-or-replace on the (conversation, id) key). History is
     /// retained — the transcript reads a bounded window from it, so there is no prune.
     func upsertConversationMessages(_ messages: [ConversationMessage], conversationID: ConversationID) throws {
@@ -220,7 +246,9 @@ nonisolated extension Database {
     /// Atomically persist a batch and advance the catch-up cursor in one transaction, so a failed write
     /// can never leave the persisted cursor past a message that wasn't stored — which, once the DB is
     /// the working set, would orphan that message from GetDelta recovery. The cursor advances only when
-    /// established (> 0); the conversation row need not exist yet (the update no-ops until it does).
+    /// established (> 0) and only forward — a catch-up batch's interior checkpoint must not regress a
+    /// cursor a live event already persisted. The conversation row need not exist yet (the update no-ops
+    /// until it does).
     func persistMessages(_ messages: [ConversationMessage], cursor: UInt64, conversationID: ConversationID) throws {
         let c = ConversationTable()
         try writer.transaction {
@@ -228,9 +256,21 @@ nonisolated extension Database {
                 try writeMessage(message, conversationId: conversationID.data)
             }
             if cursor > 0 {
-                try writer.run(c.table.filter(c.id == conversationID.data).update(c.catchupCursor <- cursor))
+                let scoped = c.table.filter(c.id == conversationID.data)
+                let current = try writer.pluck(scoped).flatMap { $0[c.catchupCursor] } ?? 0
+                if cursor > current {
+                    try writer.run(scoped.update(c.catchupCursor <- cursor))
+                }
             }
         }
+    }
+
+    /// Deletes a conversation's persisted messages — used when a freshly fetched newest page does not
+    /// overlap the retained history, so a stale older epoch can't render seamlessly stitched to the new
+    /// page across an unfetchable gap.
+    func deleteMessages(conversationID: ConversationID) throws {
+        let m = ConversationMessageTable()
+        try writer.run(m.table.filter(m.conversationId == conversationID.data).delete())
     }
 
     /// Must be called inside a `writer.transaction`.

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -207,6 +207,9 @@ nonisolated struct ConversationMessageTable: Sendable {
     // Event-log version of this message's current state; the store applies
     // last-writer-wins by it. Zero for legacy/optimistic rows.
     let eventSequence  = Expression <UInt64>        ("eventSequence")
+    // Stable client identity of an optimistic send, carried onto the server row it reconciles to so a
+    // row keeps one identity across sending → sent and survives a DB round-trip.
+    let clientMessageID = Expression <UUID?>        ("clientMessageID")
 }
 
 nonisolated extension Expression {
@@ -425,6 +428,7 @@ nonisolated extension Database {
                 t.column(conversationMessageTable.date)
                 t.column(conversationMessageTable.unreadSeq)
                 t.column(conversationMessageTable.eventSequence)
+                t.column(conversationMessageTable.clientMessageID)
                 t.primaryKey(conversationMessageTable.conversationId, conversationMessageTable.id)
             })
         }

--- a/Flipcash/Core/Screens/ContactsPermission/ContactsPermissionScreen.swift
+++ b/Flipcash/Core/Screens/ContactsPermission/ContactsPermissionScreen.swift
@@ -92,6 +92,9 @@ private struct ContactsPrimingContent: View {
 
             Button("Continue", action: onContinue)
                 .buttonStyle(.filled)
+                // A bare "Continue" query is ambiguous — the scan screen's camera prompt behind this
+                // sheet carries the same label — so UI tests target this identifier.
+                .accessibilityIdentifier("contacts-continue-button")
         }
     }
 }

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -10,8 +10,9 @@ import FlipcashCore
 import FlipcashUI
 
 /// One detector for every remap — `NSDataDetector` compiles its matchers once, and `from(_:)`
-/// re-runs on every observable transcript change.
-private let linkDetector = LinkDetector()
+/// re-runs on every observable transcript change. `nonisolated(unsafe)` because the mapper runs off
+/// the main actor and `LinkDetector` is an immutable wrapper over a thread-safe `NSDataDetector`.
+nonisolated(unsafe) private let linkDetector = LinkDetector()
 
 /// Memoizes link detection across remaps: `from(_:)` re-runs on every observable transcript change
 /// (typing, receipts, grouping), but a message's link depends only on its immutable text — so a typing
@@ -19,8 +20,8 @@ private let linkDetector = LinkDetector()
 /// entries, purges under memory pressure, and synchronizes its own access, so the mapper stays
 /// non-isolated. Keyed by text, so identical messages share the result.
 private final class DetectedLinkBox {
-    let preview: LinkPreview?
-    init(_ preview: LinkPreview?) { self.preview = preview }
+    nonisolated let preview: LinkPreview?
+    nonisolated init(_ preview: LinkPreview?) { self.preview = preview }
 }
 
 nonisolated(unsafe) private let linkPreviewCache: NSCache<NSString, DetectedLinkBox> = {
@@ -29,7 +30,7 @@ nonisolated(unsafe) private let linkPreviewCache: NSCache<NSString, DetectedLink
     return cache
 }()
 
-private func detectedLink(in text: String) -> LinkPreview? {
+nonisolated private func detectedLink(in text: String) -> LinkPreview? {
     let key = text as NSString
     if let cached = linkPreviewCache.object(forKey: key) { return cached.preview }
     let preview = linkDetector.webLink(in: text)
@@ -45,7 +46,7 @@ extension ChatItem {
     /// way the transcript does. Pure — `cashBranding` supplies the token name + launchpad icon so
     /// this stays testable; it defaults to plain "Cash" (USDF), and the screen injects bonded-mint
     /// branding from `Session`.
-    static func from(
+    nonisolated static func from(
         _ messages: [ConversationMessage],
         selfUserID: UserID,
         gap: TimeInterval = 15 * 60,
@@ -138,7 +139,7 @@ extension ChatItem {
 
     /// "Read 3:42 PM" / "Read Yesterday" / "Read Monday" / "Read Tue, Jun 17" once the counterpart's
     /// read pointer reaches the message, else "Delivered".
-    private static func receiptText(for messageID: MessageID, counterpartRead: (pointer: MessageID, date: Date?)?) -> String {
+    nonisolated private static func receiptText(for messageID: MessageID, counterpartRead: (pointer: MessageID, date: Date?)?) -> String {
         guard let read = counterpartRead, read.pointer >= messageID else { return "Delivered" }
         guard let date = read.date else { return "Read" }
         return "Read \(date.formattedRelatively(useTimeForToday: true))"

--- a/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
@@ -1,0 +1,121 @@
+//
+//  ConversationLoadCoordinator.swift
+//  Flipcash
+//
+
+import Foundation
+import FlipcashCore
+import FlipcashUI
+
+/// Owns a conversation's `MessageLoader` and turns its window into display-ready `[ChatItem]`.
+/// It observes exactly the inputs the mapping consumes, maps them off the main thread, and lands
+/// the result as immutable `items`; the view reads only `items`, never raw messages. An unrelated
+/// observable tick (a typing heartbeat, another conversation's event) leaves the inputs unchanged
+/// and does no work.
+@MainActor @Observable
+final class ConversationLoadCoordinator {
+
+    let loader: MessageLoader
+
+    /// The rendered transcript, produced off the main thread and landed here as immutable state.
+    private(set) var items: [ChatItem] = []
+
+    private let conversationID: ConversationID
+    private let controller: ConversationController
+    private let session: Session
+
+    @ObservationIgnored private var lastInputs: Inputs?
+    @ObservationIgnored private var mapTask: Task<Void, Never>?
+
+    init(conversationID: ConversationID, controller: ConversationController, session: Session) {
+        self.conversationID = conversationID
+        self.controller = controller
+        self.session = session
+        self.loader = MessageLoader(conversationID: conversationID, controller: controller)
+
+        // First paint is synchronous so an open never flashes an empty transcript; every later
+        // change maps off the main thread.
+        let initial = currentInputs()
+        self.lastInputs = initial
+        self.items = Self.map(initial)
+        observeInputs()
+    }
+
+    /// The reader reached the top — reveal older history.
+    func reachedTop() { loader.loadOlder() }
+
+    // Tracks exactly the inputs `map` reads; on the next change to any of them it re-maps off the
+    // main thread and re-arms. An unchanged input set short-circuits before spawning any work.
+    private func observeInputs() {
+        let inputs = withObservationTracking {
+            currentInputs()
+        } onChange: { [weak self] in
+            Task { @MainActor in self?.observeInputs() }
+        }
+        guard inputs != lastInputs else { return }
+        lastInputs = inputs
+        mapTask?.cancel()
+        mapTask = Task { [weak self] in
+            let mapped = await Task.detached { Self.map(inputs) }.value
+            guard let self, !Task.isCancelled else { return }
+            self.items = mapped
+        }
+    }
+
+    private func currentInputs() -> Inputs {
+        let read = controller.conversation(withID: conversationID)?
+            .counterpartReadReceipt(excluding: controller.selfUserID)
+        let window = loader.messages
+        var branding: [PublicKey: Inputs.Branding] = [:]
+        for message in window {
+            guard case .cash(let fiat) = message.content, branding[fiat.mint] == nil else { continue }
+            if let balance = session.balance(for: fiat.mint) {
+                branding[fiat.mint] = .init(token: balance.name, iconURL: balance.imageURL)
+            }
+        }
+        return Inputs(
+            messages: window,
+            selfUserID: controller.selfUserID,
+            counterpartPointer: read?.pointer,
+            counterpartReadDate: read?.date,
+            suppressReceiptFor: controller.settlingSendID,
+            isTyping: controller.isCounterpartTyping(in: conversationID),
+            branding: branding
+        )
+    }
+
+    nonisolated private static func map(_ inputs: Inputs) -> [ChatItem] {
+        var items = ChatItem.from(
+            inputs.messages,
+            selfUserID: inputs.selfUserID,
+            counterpartRead: inputs.counterpartPointer.map { (pointer: $0, date: inputs.counterpartReadDate) },
+            suppressReceiptFor: inputs.suppressReceiptFor,
+            cashBranding: { fiat in
+                guard let branding = inputs.branding[fiat.mint] else { return ("Cash", nil) }
+                return (branding.token, branding.iconURL)
+            }
+        )
+        if inputs.isTyping {
+            items.append(.typingIndicator)
+        }
+        return items
+    }
+
+    /// Everything `map` reads, captured by value so an unchanged set short-circuits the remap and
+    /// the snapshot can cross to a background task. Cash branding is pre-resolved per mint so a
+    /// branding change participates.
+    struct Inputs: Equatable, Sendable {
+        var messages: [ConversationMessage]
+        var selfUserID: UserID
+        var counterpartPointer: MessageID?
+        var counterpartReadDate: Date?
+        var suppressReceiptFor: String?
+        var isTyping: Bool
+        var branding: [PublicKey: Branding]
+
+        struct Branding: Equatable, Sendable {
+            var token: String
+            var iconURL: URL?
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
@@ -20,7 +20,7 @@ final class ConversationLoadCoordinator {
     /// The rendered transcript, produced off the main thread and landed here as immutable state.
     private(set) var items: [ChatItem] = []
 
-    private let conversationID: ConversationID
+    let conversationID: ConversationID
     private let controller: ConversationController
     private let session: Session
 

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -340,11 +340,12 @@ struct ConversationScreen: View {
         UIApplication.shared.open(url)
     }
 
-    /// Builds (or clears) the transcript loader/coordinator as the conversation id resolves.
-    /// `.id(context)` remounts per conversation, so this only ever creates one per open.
+    /// Builds (or clears) the transcript loader/coordinator as the conversation id resolves — including
+    /// a re-resolution to a *different* id (a contact's pre-assigned chat id replaced by the
+    /// server-assigned one), which must re-window the new conversation, not keep rendering the old.
     private func syncCoordinator(_ id: ConversationID?) {
         guard let id else { coordinator = nil; return }
-        if coordinator == nil {
+        if coordinator?.conversationID != id {
             coordinator = ConversationLoadCoordinator(
                 conversationID: id,
                 controller: conversationController,

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -130,11 +130,6 @@ struct ConversationScreen: View {
         return contact?.displayName ?? ConversationController.fallbackCounterpartName
     }
 
-    private var messages: [ConversationMessage] {
-        guard let conversationID else { return [] }
-        return conversationController.messages(for: conversationID)
-    }
-
     /// The newest server-confirmed message — what the receive buzz and mark-read track. Optimistic
     /// pending sends render after the confirmed run, so they must not drive these signals (an unresolved
     /// send would otherwise sit at the transcript's tail and mask incoming messages).
@@ -249,9 +244,6 @@ struct ConversationScreen: View {
             // The composer's focus `onChange` can't fire once unmounted, so stop typing here.
             if let conversationID {
                 conversationController.stopSelfTyping(in: conversationID)
-                // Drop the paged-back history so a long thread doesn't retain its whole transcript
-                // in memory for the session; the newest cached window stays and older re-pages.
-                conversationController.trimTranscript(for: conversationID)
             }
             // Guarded so a forward push that already set another ID isn't cleared.
             let matched = conversationController.visibleConversationID == conversationID
@@ -330,7 +322,9 @@ struct ConversationScreen: View {
     /// Push the tapped cash card's token currency info onto the current chat stack (so back returns
     /// here). The id is the row's stable id; resolve it to the cash message's mint.
     private func openCurrencyInfo(messageID: String) {
-        guard let message = messages.first(where: { $0.stableID == messageID }) else { return }
+        // Resolve against the displayed window (the DB-backed transcript), not the store — the window
+        // can hold older/paged messages the trimmed store no longer does.
+        guard let message = (coordinator?.loader.messages ?? []).first(where: { $0.stableID == messageID }) else { return }
         switch message.content {
         case .cash(let fiat):
             router.push(.currencyInfo(fiat.mint))

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -47,6 +47,7 @@ struct ConversationScreen: View {
     @State private var barModel = ConversationBarModel()
     @State private var navBarWidth: CGFloat = 0
     @State private var presentedCard: ContactCard?
+    @State private var coordinator: ConversationLoadCoordinator?
 
     /// Horizontal space the back button (leading) reserves on each side of the
     /// centered title item, so the avatar + name can left-align inside a
@@ -142,40 +143,12 @@ struct ConversationScreen: View {
         return conversationController.lastConfirmedMessage(for: conversationID)
     }
 
-    /// The transcript's messages mapped to the UIKit chat's display items (messages + date
-    /// separators). Cash branding mirrors the SwiftUI bubble: USDF reads as "Cash"; a launchpad
-    /// currency uses its cached name + icon.
-    private var mappedItems: [ChatItem] {
-        var items = ChatItem.from(
-            messages,
-            selfUserID: conversationController.selfUserID,
-            counterpartRead: counterpartRead.map { (pointer: $0.pointer, date: $0.date) },
-            suppressReceiptFor: conversationController.settlingSendID,
-            cashBranding: { fiat in
-                guard let balance = session.balance(for: fiat.mint) else { return ("Cash", nil) }
-                return (balance.name, balance.imageURL)
-            }
-        )
-        if let conversationID, conversationController.isCounterpartTyping(in: conversationID) {
-            items.append(.typingIndicator)
-        }
-        return items
-    }
-
-    /// The counterpart's read watermark + time, read live from the observable
-    /// controller so the receipt updates the moment they read.
-    private var counterpartRead: ReadReceiptState? {
-        guard let conversationID else { return nil }
-        return conversationController.conversation(withID: conversationID)?
-            .counterpartReadReceipt(excluding: conversationController.selfUserID)
-    }
-
     var body: some View {
         // The UIKit transcript hosts the bar internally and owns all keyboard handling, so there's
         // no SwiftUI `.safeAreaInset` bar here.
         ChatScreenRepresentable(
-            items: mappedItems,
-            onReachTop: loadOlderMessages,
+            items: coordinator?.items ?? [],
+            onReachTop: { coordinator?.reachedTop() },
             onRetry: retry,
             onCashCardTap: openCurrencyInfo,
             onOpenURL: openLink,
@@ -258,6 +231,7 @@ struct ConversationScreen: View {
         }
         .onAppear {
             setVisibleConversation(conversationID, source: "onAppear")
+            syncCoordinator(conversationID)
         }
         // Send Cash stacks the amount entry as a cover, so the chat stays
         // mounted and `onAppear` won't re-fire when it's dismissed. Poll for the
@@ -269,11 +243,15 @@ struct ConversationScreen: View {
         // flipping the ID from nil to the new conversation; track it live.
         .onChange(of: conversationID) { _, id in
             setVisibleConversation(id, source: "onChange")
+            syncCoordinator(id)
         }
         .onDisappear {
             // The composer's focus `onChange` can't fire once unmounted, so stop typing here.
             if let conversationID {
                 conversationController.stopSelfTyping(in: conversationID)
+                // Drop the paged-back history so a long thread doesn't retain its whole transcript
+                // in memory for the session; the newest cached window stays and older re-pages.
+                conversationController.trimTranscript(for: conversationID)
             }
             // Guarded so a forward push that already set another ID isn't cleared.
             let matched = conversationController.visibleConversationID == conversationID
@@ -368,13 +346,17 @@ struct ConversationScreen: View {
         UIApplication.shared.open(url)
     }
 
-    /// Fetches the next older page when the UIKit transcript nears the top. Guarded so the
-    /// continuously-fired signal never stacks requests or pages past the first message.
-    private func loadOlderMessages() {
-        guard let conversationID,
-              conversationController.hasMoreOlderMessages(for: conversationID),
-              !conversationController.isLoadingOlderMessages(for: conversationID) else { return }
-        Task { await conversationController.loadOlderMessages(for: conversationID) }
+    /// Builds (or clears) the transcript loader/coordinator as the conversation id resolves.
+    /// `.id(context)` remounts per conversation, so this only ever creates one per open.
+    private func syncCoordinator(_ id: ConversationID?) {
+        guard let id else { coordinator = nil; return }
+        if coordinator == nil {
+            coordinator = ConversationLoadCoordinator(
+                conversationID: id,
+                controller: conversationController,
+                session: session
+            )
+        }
     }
 
     /// After returning from the amount screen for a contact's first payment,

--- a/Flipcash/Core/Screens/Conversation/MessageLoader.swift
+++ b/Flipcash/Core/Screens/Conversation/MessageLoader.swift
@@ -1,0 +1,59 @@
+//
+//  MessageLoader.swift
+//  Flipcash
+//
+
+import Foundation
+import FlipcashCore
+
+/// A per-conversation, bounded window over a conversation's messages. It renders only a recent
+/// slice so a fresh open lays out a window rather than the whole thread; `loadOlder()` grows it
+/// and pages from the server once the loaded set is exhausted. The window is anchored by message
+/// id, so an arriving message never drops the oldest shown row out from under a reader who has
+/// scrolled up.
+@MainActor @Observable
+final class MessageLoader {
+
+    private let conversationID: ConversationID
+    private let controller: ConversationController
+
+    /// The oldest message id currently shown; `nil` renders the most recent `initialWindow`.
+    private var startID: MessageID?
+
+    init(conversationID: ConversationID, controller: ConversationController) {
+        self.conversationID = conversationID
+        self.controller = controller
+    }
+
+    /// The bounded slice actually rendered.
+    var messages: [ConversationMessage] {
+        let all = controller.messages(for: conversationID)
+        guard let startID, let start = all.firstIndex(where: { $0.id >= startID }) else {
+            return Array(all.suffix(Self.initialWindow))
+        }
+        return Array(all[start...])
+    }
+
+    /// Reveals an older step of the loaded history, paging from the server once the window
+    /// reaches the oldest loaded message.
+    func loadOlder() {
+        let all = controller.messages(for: conversationID)
+        guard let oldest = messages.first,
+              let index = all.firstIndex(where: { $0.id == oldest.id }) else {
+            fetchOlder()
+            return
+        }
+        if index == 0 {
+            fetchOlder()
+        } else {
+            startID = all[max(0, index - Self.step)].id
+        }
+    }
+
+    private func fetchOlder() {
+        Task { await controller.loadOlderMessages(for: conversationID) }
+    }
+
+    private static let initialWindow = 60
+    private static let step = 40
+}

--- a/Flipcash/Core/Screens/Conversation/MessageLoader.swift
+++ b/Flipcash/Core/Screens/Conversation/MessageLoader.swift
@@ -7,35 +7,49 @@ import Foundation
 import FlipcashCore
 
 /// A per-conversation, bounded window over a conversation's messages, read from the local database.
-/// It renders only a recent slice so a fresh open lays out a window rather than the whole thread;
-/// `loadOlder()` grows the window over already-persisted history and pages the next older batch from
-/// the server (which persists it) once the local history is exhausted.
+/// It renders only a recent slice so a fresh open lays out a window rather than the whole thread. The
+/// window is anchored by message id once the reader pages back, so an arriving message grows it at the
+/// tail instead of sliding the oldest revealed row out from under the reader; `loadOlder()` steps the
+/// anchor over already-persisted history and pages the next older batch from the server (which
+/// persists it) once local history is exhausted.
 @MainActor @Observable
 final class MessageLoader {
 
     private let conversationID: ConversationID
     private let controller: ConversationController
 
-    /// How many newest confirmed messages the window currently reveals; grows as the reader pages back.
-    private var windowLimit = MessageLoader.initialWindow
+    /// The oldest revealed confirmed id; nil renders the newest `initialWindow`.
+    private var startID: UInt64?
+    /// `onReachTop` fires on every scroll tick near the top, so accept at most one growth step per
+    /// interval — the async remap needs time to move the reader out of the trigger zone.
+    @ObservationIgnored private var lastGrowth: ContinuousClock.Instant?
+    private let growthInterval: Duration
 
-    init(conversationID: ConversationID, controller: ConversationController) {
+    init(conversationID: ConversationID, controller: ConversationController, growthInterval: Duration = .milliseconds(300)) {
         self.conversationID = conversationID
         self.controller = controller
+        self.growthInterval = growthInterval
     }
 
-    /// The bounded slice actually rendered: the newest `windowLimit` confirmed messages (from the DB)
-    /// with the optimistic overlay applied.
+    /// The bounded slice actually rendered: the anchored window (or the newest `initialWindow`) from
+    /// the DB with the optimistic overlay applied.
     var messages: [ConversationMessage] {
-        controller.windowedMessages(for: conversationID, limit: windowLimit)
+        controller.windowedMessages(for: conversationID, startingAt: startID, limit: Self.initialWindow)
     }
 
-    /// Reveals an older step: grows the window over already-persisted history, or pages the next older
-    /// batch from the server (which persists it) once the local history is exhausted.
+    /// Reveals an older step: moves the anchor back over already-persisted history, or pages the next
+    /// older batch from the server (which persists it) once the local history is exhausted.
     func loadOlder() {
-        let available = controller.confirmedMessageCount(for: conversationID)
-        if windowLimit < available {
-            windowLimit = min(windowLimit + Self.step, available)
+        let now = ContinuousClock.now
+        if let lastGrowth, lastGrowth.duration(to: now) < growthInterval { return }
+        lastGrowth = now
+
+        guard let anchor = startID ?? controller.oldestWindowedMessageID(for: conversationID, limit: Self.initialWindow) else {
+            fetchOlder()
+            return
+        }
+        if let older = controller.olderAnchor(for: conversationID, before: anchor, step: Self.step) {
+            startID = older
         } else {
             fetchOlder()
         }
@@ -44,10 +58,10 @@ final class MessageLoader {
     private func fetchOlder() {
         Task {
             await controller.loadOlderMessages(for: conversationID)
-            let available = controller.confirmedMessageCount(for: conversationID)
-            if available > windowLimit {
-                windowLimit = min(windowLimit + Self.step, available)
-            }
+            // Reveal the newly persisted page; no-ops when history was already exhausted.
+            guard let anchor = startID ?? controller.oldestWindowedMessageID(for: conversationID, limit: Self.initialWindow),
+                  let older = controller.olderAnchor(for: conversationID, before: anchor, step: Self.step) else { return }
+            startID = older
         }
     }
 

--- a/Flipcash/Core/Screens/Conversation/MessageLoader.swift
+++ b/Flipcash/Core/Screens/Conversation/MessageLoader.swift
@@ -6,52 +6,49 @@
 import Foundation
 import FlipcashCore
 
-/// A per-conversation, bounded window over a conversation's messages. It renders only a recent
-/// slice so a fresh open lays out a window rather than the whole thread; `loadOlder()` grows it
-/// and pages from the server once the loaded set is exhausted. The window is anchored by message
-/// id, so an arriving message never drops the oldest shown row out from under a reader who has
-/// scrolled up.
+/// A per-conversation, bounded window over a conversation's messages, read from the local database.
+/// It renders only a recent slice so a fresh open lays out a window rather than the whole thread;
+/// `loadOlder()` grows the window over already-persisted history and pages the next older batch from
+/// the server (which persists it) once the local history is exhausted.
 @MainActor @Observable
 final class MessageLoader {
 
     private let conversationID: ConversationID
     private let controller: ConversationController
 
-    /// The oldest message id currently shown; `nil` renders the most recent `initialWindow`.
-    private var startID: MessageID?
+    /// How many newest confirmed messages the window currently reveals; grows as the reader pages back.
+    private var windowLimit = MessageLoader.initialWindow
 
     init(conversationID: ConversationID, controller: ConversationController) {
         self.conversationID = conversationID
         self.controller = controller
     }
 
-    /// The bounded slice actually rendered.
+    /// The bounded slice actually rendered: the newest `windowLimit` confirmed messages (from the DB)
+    /// with the optimistic overlay applied.
     var messages: [ConversationMessage] {
-        let all = controller.messages(for: conversationID)
-        guard let startID, let start = all.firstIndex(where: { $0.id >= startID }) else {
-            return Array(all.suffix(Self.initialWindow))
-        }
-        return Array(all[start...])
+        controller.windowedMessages(for: conversationID, limit: windowLimit)
     }
 
-    /// Reveals an older step of the loaded history, paging from the server once the window
-    /// reaches the oldest loaded message.
+    /// Reveals an older step: grows the window over already-persisted history, or pages the next older
+    /// batch from the server (which persists it) once the local history is exhausted.
     func loadOlder() {
-        let all = controller.messages(for: conversationID)
-        guard let oldest = messages.first,
-              let index = all.firstIndex(where: { $0.id == oldest.id }) else {
-            fetchOlder()
-            return
-        }
-        if index == 0 {
-            fetchOlder()
+        let available = controller.confirmedMessageCount(for: conversationID)
+        if windowLimit < available {
+            windowLimit = min(windowLimit + Self.step, available)
         } else {
-            startID = all[max(0, index - Self.step)].id
+            fetchOlder()
         }
     }
 
     private func fetchOlder() {
-        Task { await controller.loadOlderMessages(for: conversationID) }
+        Task {
+            await controller.loadOlderMessages(for: conversationID)
+            let available = controller.confirmedMessageCount(for: conversationID)
+            if available > windowLimit {
+                windowLimit = min(windowLimit + Self.step, available)
+            }
+        }
     }
 
     private static let initialWindow = 60

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 		<string>com.flipcash.app.openChat</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>22</integer>
+	<integer>23</integer>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -7,18 +7,17 @@
 
 import Foundation
 
-/// Pure, value-semantic store of conversation state: the feed (sorted by last
-/// activity) and the messages of open conversations. All reconciliation of
-/// paged loads and live `ConversationStreamEvent`s happens here so it is
-/// unit-testable in isolation, without a controller, network, or actor.
+/// Pure, value-semantic store of the in-memory conversation state that is NOT the persisted transcript:
+/// the feed (sorted by last activity), the optimistic (pending) send overlay, and the event-log
+/// catch-up cursor. Confirmed messages live in the database — the transcript reads a bounded window
+/// from there and the store's overlay is interleaved onto it at read time. Kept free of a controller,
+/// network, or actor so the overlay + cursor logic stays unit-testable in isolation.
 public struct ConversationStore: Sendable {
 
     public private(set) var conversations: [Conversation] = []
-    private var messagesByConversation: [ConversationID: [ConversationMessage]] = [:]
-    /// Optimistic messages not yet confirmed by the server, kept separate from the server-mirrored
-    /// `messagesByConversation` so paging, mark-read, and the feed never see them. Each carries the
-    /// server id it was sent after (its `anchor`) and a monotonic send `sequence`, so the transcript
-    /// orders it relative to confirmed rows without comparing client and server wall-clock times.
+    /// Optimistic messages not yet confirmed by the server. Each carries the server id it was sent
+    /// after (its `anchor`) and a monotonic send `sequence`, so the transcript orders it relative to
+    /// confirmed rows without comparing client and server wall-clock times.
     private var pendingByConversation: [ConversationID: [PendingEntry]] = [:]
     /// Monotonic counter stamped on each optimistic send, breaking ties among rows that share an anchor
     /// and keeping send order stable across out-of-order reconciles.
@@ -41,19 +40,6 @@ public struct ConversationStore: Sendable {
 
     public init() {}
 
-    public func messages(for conversationID: ConversationID) -> [ConversationMessage] {
-        messagesByConversation[conversationID] ?? []
-    }
-
-    /// Drops all but the newest `count` confirmed messages for a conversation. Called when the
-    /// transcript is left so a paged-back thread doesn't retain its whole history in memory for the
-    /// session. Pending sends and the applied cursor are untouched, and the feed preview is the
-    /// newest message either way — older history re-pages from the server on reopen.
-    public mutating func trimMessages(for conversationID: ConversationID, keepingNewest count: Int) {
-        guard let messages = messagesByConversation[conversationID], messages.count > count else { return }
-        messagesByConversation[conversationID] = Array(messages.suffix(count))
-    }
-
     /// Replace the feed from a paged load, sorted most-recent-activity first.
     public mutating func setFeed(_ conversations: [Conversation]) {
         self.conversations = conversations.sorted { $0.lastActivity > $1.lastActivity }
@@ -65,124 +51,29 @@ public struct ConversationStore: Sendable {
     /// reconciles a fresh pending send.
     private static let pendingReconcileWindow: TimeInterval = 5 * 60
 
-    /// Insert/replace messages keyed by their gapless id, keeping oldest first, applying
-    /// last-writer-wins by `eventSequence`. A strictly-newer version (edit, delete, re-fetch) replaces
-    /// the held copy; an older one is ignored; an equal one keeps the held copy. This makes a message
-    /// self-locating regardless of delivery path (stream, history load, `GetDelta`, or the send RPC)
-    /// and makes an out-of-order delete converge — a tombstone that lands before the original send
-    /// out-versions it and is never overwritten. Reconciles a server copy of one of our own optimistic
-    /// sends — which carries no client id, because the server never echoes it — against the matching
-    /// pending row so the echo collapses onto that row instead of duplicating it. Every merge also
-    /// advances the conversation's feed preview to the newest visible message.
-    public mutating func mergeMessages(_ incoming: [ConversationMessage], into conversationID: ConversationID) {
-        guard !incoming.isEmpty else { return }
-        let current = messagesByConversation[conversationID] ?? []
+    // MARK: - Transcript overlay
 
-        var byID = Dictionary(
-            current.map { ($0.id, $0) },
-            uniquingKeysWith: { _, new in new }
-        )
-        for message in incoming {
-            var message = message
-            let existing = byID[message.id]
-
-            // A brand-new server id with no client id may be the echo of one of our pending sends —
-            // adopt that pending row's client id (dropping the pending copy) so identity survives
-            // sending → sent. Only a genuinely new id can be a fresh echo, so an old identical
-            // re-delivery never steals a pending send.
-            if message.clientMessageID == nil, existing == nil,
-               let clientMessageID = reconcilePendingMatch(for: message, in: conversationID) {
-                message.clientMessageID = clientMessageID
-            }
-
-            guard let existing else {
-                byID[message.id] = message
-                continue
-            }
-
-            if message.eventSequence > existing.eventSequence {
-                // Newer version wins. Preserve the row's stable identity if the newer copy lacks one.
-                if message.clientMessageID == nil {
-                    message.clientMessageID = existing.clientMessageID
-                }
-                byID[message.id] = message
-            } else if message.eventSequence == existing.eventSequence, existing.clientMessageID == nil,
-                      let clientMessageID = message.clientMessageID {
-                // Same version, but this copy carries the client id the held one lacks (a reconcile copy
-                // landing after a stream echo, or vice versa). Adopt the id so the transcript diff keeps
-                // one stable identity instead of re-inserting the row.
-                var kept = existing
-                kept.clientMessageID = clientMessageID
-                byID[message.id] = kept
-            }
-            // Otherwise the held copy is newer-or-equal-and-already-identified: keep it.
-        }
-        messagesByConversation[conversationID] = byID.values.sorted { $0.id < $1.id }
-        advanceLastMessage(in: conversationID)
-    }
-
-    /// Points the feed row's preview at the newest non-deleted confirmed message, mirroring the
-    /// visibility filter and last-writer-wins guard of the persisted cache (`Database.latestMessage`
-    /// / `writeMessage`) — it advances forward or refreshes an edit in place, never regresses, and
-    /// never touches `lastActivity` or the feed order.
-    private mutating func advanceLastMessage(in conversationID: ConversationID) {
-        guard let index = conversations.firstIndex(where: { $0.id == conversationID }),
-              let newest = messagesByConversation[conversationID]?.last(where: { $0.content != .deleted })
-        else { return }
-        if let current = conversations[index].lastMessage,
-           (current.id, current.eventSequence) >= (newest.id, newest.eventSequence) { return }
-        conversations[index].lastMessage = newest
-    }
-
-    /// Removes and returns the client id of the oldest pending send that matches `serverCopy` by sender
-    /// and content within the reconcile window — the optimistic row this server copy confirms. Returns
-    /// nil when nothing matches (a counterpart message, or an unrelated history message).
-    private mutating func reconcilePendingMatch(for serverCopy: ConversationMessage, in conversationID: ConversationID) -> UUID? {
-        guard var pending = pendingByConversation[conversationID] else { return nil }
-        let matches = pending.indices.filter {
-            pending[$0].message.senderID == serverCopy.senderID
-                && pending[$0].message.content == serverCopy.content
-                && abs(pending[$0].message.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
-        }
-        // Reconcile only an unambiguous match. Two in-flight sends with identical text can't be told
-        // apart (the server echoes no client id), so leave them for their own send-RPC responses —
-        // which key on the exact client id — rather than cross-wiring one send's id onto the other's
-        // row (which would briefly give two rows the same stableID).
-        guard matches.count == 1, let index = matches.first else { return nil }
-        let matched = pending.remove(at: index)
-        pendingByConversation[conversationID] = pending
-        reanchorLaterSends(after: matched.sequence, toAtLeast: serverCopy.id.value, in: conversationID)
-        return matched.message.clientMessageID
-    }
-
-    /// After an optimistic send (`sequence`) confirms at `confirmedID`, any still-pending send made
-    /// after it (higher sequence) was sent after that now-confirmed row, so re-anchor it to at least
-    /// `confirmedID`. This keeps send order even when an earlier send reconciles before a later one.
-    private mutating func reanchorLaterSends(after sequence: UInt64, toAtLeast confirmedID: UInt64, in conversationID: ConversationID) {
-        guard var pending = pendingByConversation[conversationID] else { return }
-        for i in pending.indices where pending[i].sequence > sequence && pending[i].anchor < confirmedID {
-            pending[i].anchor = confirmedID
-        }
-        pendingByConversation[conversationID] = pending
-    }
-
-    // MARK: - Optimistic (pending) sends
-
-    /// The transcript's source of truth: confirmed rows in server order, with each in-flight optimistic
-    /// row placed right after the confirmed row it was sent after (its anchor), ties broken by send
-    /// sequence. Ordering by the server `MessageId` anchor — not wall-clock dates — means a fresh send
-    /// lands at the tail (immune to clock skew, scroll-to-bottom stays reliable), a failed send keeps
-    /// its place even as newer messages arrive, and out-of-order reconciles never reshuffle (a
-    /// reconciled row's real id is greater than its anchor, so it lands where the pending row was).
-    /// `messages(for:)` stays confirmed-only for mark-read and paging.
-    public func displayedMessages(for conversationID: ConversationID) -> [ConversationMessage] {
-        let confirmed = messagesByConversation[conversationID] ?? []
+    /// Interleaves the conversation's optimistic overlay onto a caller-supplied confirmed window (read
+    /// from the database) — each pending row right after the confirmed row it was sent after (its
+    /// anchor), ties by send sequence, trailing pending after the last confirmed row. Ordering by the
+    /// server `MessageId` anchor — not wall-clock dates — means a fresh send lands at the tail (immune
+    /// to clock skew), a failed send keeps its place as newer messages arrive, and out-of-order
+    /// reconciles never reshuffle.
+    public func displayedMessages(for conversationID: ConversationID, over confirmed: [ConversationMessage]) -> [ConversationMessage] {
         guard let pending = pendingByConversation[conversationID], !pending.isEmpty else { return confirmed }
 
         let ordered = pending.sorted { ($0.anchor, $0.sequence) < ($1.anchor, $1.sequence) }
         var result: [ConversationMessage] = []
         result.reserveCapacity(confirmed.count + ordered.count)
         var p = 0
+        // A pending anchored older than this window (its anchor row scrolled out of the newest-N slice,
+        // or it was sent before any message loaded) belongs above the window, not at the tail — surface
+        // it at the head in send order.
+        let windowFloor = confirmed.first?.id.value ?? .max
+        while p < ordered.count, ordered[p].anchor < windowFloor {
+            result.append(ordered[p].message)
+            p += 1
+        }
         for message in confirmed {
             result.append(message)
             while p < ordered.count, ordered[p].anchor == message.id.value {
@@ -199,23 +90,17 @@ public struct ConversationStore: Sendable {
         return result
     }
 
-    /// The newest server-confirmed message, or nil. Confirmed rows are kept sorted oldest-first and are
-    /// always `.sent` (pending sends live separately), so this is what the receive buzz and mark-read
-    /// track — never a pending row.
-    public func lastConfirmedMessage(for conversationID: ConversationID) -> ConversationMessage? {
-        messagesByConversation[conversationID]?.last
+    // MARK: - Optimistic (pending) sends
+
+    /// Whether the conversation has an in-flight optimistic send. (Confirmed emptiness is a database
+    /// question, answered by the controller.)
+    public func hasPendingMessages(for conversationID: ConversationID) -> Bool {
+        !(pendingByConversation[conversationID]?.isEmpty ?? true)
     }
 
-    /// Whether the conversation has any message (confirmed or in-flight) — checked without building the
-    /// merged transcript, so an emptiness test doesn't allocate the whole array.
-    public func hasMessages(for conversationID: ConversationID) -> Bool {
-        !(messagesByConversation[conversationID]?.isEmpty ?? true) || !(pendingByConversation[conversationID]?.isEmpty ?? true)
-    }
-
-    /// Add an optimistic message that the server hasn't confirmed yet, anchored to the newest confirmed
-    /// id at send time so the transcript can position it without a wall-clock comparison.
-    public mutating func insertPending(_ message: ConversationMessage, into conversationID: ConversationID) {
-        let anchor = messagesByConversation[conversationID]?.last?.id.value ?? 0
+    /// Add an optimistic message the server hasn't confirmed yet, anchored to the caller-supplied
+    /// newest confirmed id at send time so the transcript can position it without a wall-clock compare.
+    public mutating func insertPending(_ message: ConversationMessage, anchoredTo anchor: UInt64, into conversationID: ConversationID) {
         pendingByConversation[conversationID, default: []].append(PendingEntry(message: message, anchor: anchor, sequence: pendingSequence))
         pendingSequence += 1
     }
@@ -231,38 +116,68 @@ public struct ConversationStore: Sendable {
         pendingByConversation[conversationID]?[index].message.status = status
     }
 
-    /// Replace a server-confirmed send (the send RPC's own response): drop the optimistic copy and merge
-    /// the server message, carrying the client id onto it so the row keeps its identity across
-    /// sending → sent (no delete+insert).
-    public mutating func reconcile(clientMessageID: UUID, with serverMessage: ConversationMessage, in conversationID: ConversationID) {
+    /// Reconcile a server copy against the matching pending optimistic send: remove the pending row and
+    /// return its client id so the caller can carry that identity onto the persisted confirmed row (the
+    /// echo collapses onto the send instead of duplicating it). Returns nil when nothing matches (a
+    /// counterpart message, or an unrelated history message). The caller gates this on the id being a
+    /// *fresh* server id (not already persisted) so an old identical re-delivery never steals a send.
+    public mutating func reconcilePending(for serverCopy: ConversationMessage, in conversationID: ConversationID) -> UUID? {
+        guard var pending = pendingByConversation[conversationID] else { return nil }
+        let matches = pending.indices.filter {
+            pending[$0].message.senderID == serverCopy.senderID
+                && pending[$0].message.content == serverCopy.content
+                && abs(pending[$0].message.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
+        }
+        // Reconcile only an unambiguous match. Two in-flight sends with identical text can't be told
+        // apart (the server echoes no client id), so leave them for their own send-RPC responses —
+        // which key on the exact client id — rather than cross-wiring one send's id onto the other's row.
+        guard matches.count == 1, let index = matches.first else { return nil }
+        let matched = pending.remove(at: index)
+        pendingByConversation[conversationID] = pending
+        reanchorLaterSends(after: matched.sequence, toAtLeast: serverCopy.id.value, in: conversationID)
+        return matched.message.clientMessageID
+    }
+
+    /// Drop a pending send confirmed by the send RPC's own response (keyed on the exact client id) and
+    /// re-anchor any later still-pending send to the now-confirmed id, so send order holds even when an
+    /// earlier send confirms after a later one.
+    public mutating func dropPending(clientMessageID: UUID, confirmedAt confirmedID: MessageID, in conversationID: ConversationID) {
         let reconciledSequence = pendingByConversation[conversationID]?.first { $0.message.clientMessageID == clientMessageID }?.sequence
         pendingByConversation[conversationID]?.removeAll { $0.message.clientMessageID == clientMessageID }
-        var confirmed = serverMessage
-        confirmed.status = .sent
-        confirmed.clientMessageID = clientMessageID
-        mergeMessages([confirmed], into: conversationID)
         if let reconciledSequence {
-            reanchorLaterSends(after: reconciledSequence, toAtLeast: serverMessage.id.value, in: conversationID)
+            reanchorLaterSends(after: reconciledSequence, toAtLeast: confirmedID.value, in: conversationID)
         }
     }
 
-    /// The signed-in user's READ watermark for a conversation, as last reported by
-    /// the feed/stream and locally advanced after each successful markRead.
+    /// After an optimistic send (`sequence`) confirms at `confirmedID`, any still-pending send made
+    /// after it (higher sequence) was sent after that now-confirmed row, so re-anchor it to at least
+    /// `confirmedID`.
+    private mutating func reanchorLaterSends(after sequence: UInt64, toAtLeast confirmedID: UInt64, in conversationID: ConversationID) {
+        guard var pending = pendingByConversation[conversationID] else { return }
+        for i in pending.indices where pending[i].sequence > sequence && pending[i].anchor < confirmedID {
+            pending[i].anchor = confirmedID
+        }
+        pendingByConversation[conversationID] = pending
+    }
+
+    // MARK: - Feed
+
+    /// The signed-in user's READ watermark for a conversation, as last reported by the feed/stream and
+    /// locally advanced after each successful markRead.
     public func selfReadPointer(for conversationID: ConversationID, selfUserID: UserID) -> MessageID? {
         conversations.first { $0.id == conversationID }?.selfReadPointer(for: selfUserID)
     }
 
-    /// Locally advance the signed-in user's READ watermark after a successful
-    /// markRead so the next call can short-circuit.
+    /// Locally advance the signed-in user's READ watermark after a successful markRead so the next call
+    /// can short-circuit.
     public mutating func advanceSelfReadPointer(to messageID: MessageID, in conversationID: ConversationID, selfUserID: UserID) {
-        // Self's read time is never surfaced — only the counterpart's receipt
-        // shows one — so advance the watermark without a timestamp.
+        // Self's read time is never surfaced — only the counterpart's receipt shows one — so advance
+        // the watermark without a timestamp.
         advanceReadPointer(to: messageID, for: selfUserID, at: nil, in: conversationID)
     }
 
-    /// Monotonically advance a member's READ watermark; never moves it backward.
-    /// `date` is when the pointer was advanced (for the read receipt); stored
-    /// only when the watermark actually moves.
+    /// Monotonically advance a member's READ watermark; never moves it backward. `date` is when the
+    /// pointer was advanced (for the read receipt); stored only when the watermark actually moves.
     private mutating func advanceReadPointer(to messageID: MessageID, for userID: UserID, at date: Date?, in conversationID: ConversationID) {
         guard let convoIndex = conversations.firstIndex(where: { $0.id == conversationID }),
               let memberIndex = conversations[convoIndex].members.firstIndex(where: { $0.userID == userID }) else {
@@ -275,15 +190,26 @@ public struct ConversationStore: Sendable {
         conversations[convoIndex].members[memberIndex].readPointerTimestamp = date
     }
 
-    /// Bump a conversation's last activity from a live message and re-sort the feed. The preview
-    /// itself follows the merge rule (``advanceLastMessage``), so a stale re-delivery or a deleted
-    /// copy on the live path can't overwrite a newer one.
-    public mutating func setLastMessage(_ message: ConversationMessage, in conversationID: ConversationID) {
+    /// Bump a conversation's last activity and re-sort the feed. No-ops for a conversation not in the
+    /// feed.
+    public mutating func advanceLastActivity(to date: Date, in conversationID: ConversationID) {
         guard let index = conversations.firstIndex(where: { $0.id == conversationID }) else { return }
-        conversations[index].lastActivity = message.date
+        conversations[index].lastActivity = date
         sort()
-        advanceLastMessage(in: conversationID)
     }
+
+    /// Set the feed row's preview to the caller-supplied newest visible message (computed from the
+    /// database), never regressing: an older or equal-versioned candidate is ignored, so a stale
+    /// re-delivery or a deleted-copy path can't overwrite a newer preview. Never touches `lastActivity`
+    /// or the feed order.
+    public mutating func setFeedPreview(_ newest: ConversationMessage?, in conversationID: ConversationID) {
+        guard let newest, let index = conversations.firstIndex(where: { $0.id == conversationID }) else { return }
+        if let current = conversations[index].lastMessage,
+           (current.id, current.eventSequence) >= (newest.id, newest.eventSequence) { return }
+        conversations[index].lastMessage = newest
+    }
+
+    // MARK: - Live events (cursor + gap detection + feed activity)
 
     /// Signals whether applying a live event exposed a hole in the sequenced log that must be filled
     /// from `GetDelta`. Only `.chatEvents` can raise `.needsCatchUp`; every other event returns `.none`.
@@ -292,15 +218,16 @@ public struct ConversationStore: Sendable {
         case needsCatchUp(ConversationID, after: UInt64)
     }
 
-    /// Apply a live event from the per-user event stream. Returns a gap signal so the controller can
-    /// trigger a `GetDelta` catch-up when the sequenced log skipped ahead.
+    /// Apply a live event's non-message effects: catch-up cursor + gap detection, feed activity, read
+    /// pointers, and metadata. The confirmed messages themselves are persisted to the database by the
+    /// controller — the store no longer holds them. Returns a gap signal so the controller can trigger a
+    /// `GetDelta` catch-up when the sequenced log skipped ahead.
     @discardableResult
     public mutating func apply(_ event: ConversationStreamEvent) -> GapSignal {
         switch event {
         case .newMessages(let conversationID, let messages):
-            mergeMessages(messages, into: conversationID)
             if let latest = messages.max(by: { $0.id < $1.id }) {
-                setLastMessage(latest, in: conversationID)
+                advanceLastActivity(to: latest.date, in: conversationID)
             }
             return .none
         case .chatEvents(let conversationID, let events):
@@ -309,9 +236,7 @@ public struct ConversationStore: Sendable {
             upsert(conversation)
             return .none
         case .lastActivityChanged(let conversationID, let date):
-            guard let index = conversations.firstIndex(where: { $0.id == conversationID }) else { return .none }
-            conversations[index].lastActivity = date
-            sort()
+            advanceLastActivity(to: date, in: conversationID)
             return .none
         case .readPointersChanged(let conversationID, let pointers):
             for pointer in pointers {
@@ -324,27 +249,24 @@ public struct ConversationStore: Sendable {
         }
     }
 
-    /// Apply sequenced event-log mutations in ascending order: merge each (last-writer-wins), advance
-    /// the contiguous frontier while events arrive gapless, and flag a gap the moment one is skipped so
-    /// the caller catches up via `GetDelta`. Only `.sent` mutations bump the feed's activity and
-    /// re-sort — an edit/delete carries the message's original (low) id and must not move the row.
+    /// Advance the contiguous event-log frontier while events arrive gapless and flag a gap the moment
+    /// one is skipped so the caller catches up via `GetDelta`; bump the feed activity to the newest
+    /// `.sent` mutation (an edit/delete carries the message's original low id and must not move the row).
     private mutating func applyChatEvents(_ events: [DecodedChatEvent], into conversationID: ConversationID) -> GapSignal {
         var cursor = appliedCursorByConversation[conversationID] ?? 0
         var newestSent: ConversationMessage?
         var gapAfter: UInt64?
-        var incoming: [ConversationMessage] = []
 
         for event in events.sorted(by: { $0.sequence < $1.sequence }) {
-            incoming.append(contentsOf: event.mutations.map(\.message))
             for case .sent(let message) in event.mutations {
                 if newestSent.map({ message.id > $0.id }) ?? true { newestSent = message }
             }
 
             // Gap-detect only once the frontier is established (a catch-up seeds it); before that, live
-            // events are applied by LWW and the initial GetDelta owns the cursor.
+            // events are applied by the DB and the initial GetDelta owns the cursor.
             guard gapAfter == nil, cursor > 0 else { continue }
             if event.sequence <= cursor {
-                continue // already applied — a duplicate/stale re-delivery, merged harmlessly
+                continue // already applied — a duplicate/stale re-delivery, persisted harmlessly
             }
             if event.sequence == cursor + event.count {
                 cursor = event.sequence // contiguous — advance the frontier
@@ -353,12 +275,9 @@ public struct ConversationStore: Sendable {
             }
         }
 
-        // One merge for the whole batch (LWW is order-independent, so a per-event merge only re-sorted
-        // the full transcript K times); `mergeMessages` no-ops on an empty batch.
-        mergeMessages(incoming, into: conversationID)
         appliedCursorByConversation[conversationID] = cursor
         if let newestSent {
-            setLastMessage(newestSent, in: conversationID)
+            advanceLastActivity(to: newestSent.date, in: conversationID)
         }
         return gapAfter.map { .needsCatchUp(conversationID, after: $0) } ?? .none
     }
@@ -369,15 +288,6 @@ public struct ConversationStore: Sendable {
     /// beginning of the retained log).
     public func appliedCursor(for conversationID: ConversationID) -> UInt64 {
         appliedCursorByConversation[conversationID] ?? 0
-    }
-
-    /// Apply a `GetDelta` batch: merge its messages (last-writer-wins), then advance the frontier to
-    /// the batch's checkpoint.
-    public mutating func applyDeltaBatch(_ messages: [ConversationMessage], checkpoint: UInt64?, into conversationID: ConversationID) {
-        mergeMessages(messages, into: conversationID) // no-ops on an empty batch
-        if let checkpoint {
-            setAppliedCursor(checkpoint, for: conversationID)
-        }
     }
 
     /// Seat the frontier to the head reported by a cleanly-completed `GetDelta` — authoritative even
@@ -392,6 +302,13 @@ public struct ConversationStore: Sendable {
     /// the cursor from a fresh floor.
     public mutating func resetCursor(for conversationID: ConversationID) {
         appliedCursorByConversation[conversationID] = 0
+    }
+
+    /// Force the in-memory cursor to a value regardless of monotonicity — used to recover from a failed
+    /// message persist by re-seating from the (rolled-back) DB value, so a catch-up refetches the
+    /// un-persisted window instead of skipping it.
+    public mutating func reseatCursor(_ value: UInt64, for conversationID: ConversationID) {
+        appliedCursorByConversation[conversationID] = value
     }
 
     /// Seed frontiers from the persisted cache at hydrate time. Ignores zero (unestablished) cursors.

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -62,15 +62,18 @@ public struct ConversationStore: Sendable {
     public func displayedMessages(for conversationID: ConversationID, over confirmed: [ConversationMessage]) -> [ConversationMessage] {
         guard let pending = pendingByConversation[conversationID], !pending.isEmpty else { return confirmed }
 
-        let ordered = pending.sorted { ($0.anchor, $0.sequence) < ($1.anchor, $1.sequence) }
+        // An anchor of 0 means the send predates any loaded history — it is the newest thing the user
+        // did, so it belongs at the tail with the other unmatched fresh sends, not above history that
+        // lands afterward. Sorting it as +∞ places it after every real anchor.
+        let effectiveAnchor: (PendingEntry) -> UInt64 = { $0.anchor == 0 ? .max : $0.anchor }
+        let ordered = pending.sorted { (effectiveAnchor($0), $0.sequence) < (effectiveAnchor($1), $1.sequence) }
         var result: [ConversationMessage] = []
         result.reserveCapacity(confirmed.count + ordered.count)
         var p = 0
-        // A pending anchored older than this window (its anchor row scrolled out of the newest-N slice,
-        // or it was sent before any message loaded) belongs above the window, not at the tail — surface
-        // it at the head in send order.
+        // A pending anchored older than this window (its anchor row scrolled out of the newest-N slice)
+        // belongs above the window, not at the tail — surface it at the head in send order.
         let windowFloor = confirmed.first?.id.value ?? .max
-        while p < ordered.count, ordered[p].anchor < windowFloor {
+        while p < ordered.count, effectiveAnchor(ordered[p]) < windowFloor {
             result.append(ordered[p].message)
             p += 1
         }
@@ -116,26 +119,27 @@ public struct ConversationStore: Sendable {
         pendingByConversation[conversationID]?[index].message.status = status
     }
 
-    /// Reconcile a server copy against the matching pending optimistic send: remove the pending row and
-    /// return its client id so the caller can carry that identity onto the persisted confirmed row (the
-    /// echo collapses onto the send instead of duplicating it). Returns nil when nothing matches (a
-    /// counterpart message, or an unrelated history message). The caller gates this on the id being a
-    /// *fresh* server id (not already persisted) so an old identical re-delivery never steals a send.
-    public mutating func reconcilePending(for serverCopy: ConversationMessage, in conversationID: ConversationID) -> UUID? {
-        guard var pending = pendingByConversation[conversationID] else { return nil }
-        let matches = pending.indices.filter {
-            pending[$0].message.senderID == serverCopy.senderID
-                && pending[$0].message.content == serverCopy.content
-                && abs(pending[$0].message.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
+    /// Match a server copy against the pending optimistic sends WITHOUT removing anything, returning
+    /// the matched send's client id so the caller can carry that identity onto the persisted confirmed
+    /// row (the echo collapses onto the send instead of duplicating it). The pending row is removed
+    /// separately — via ``dropPending(clientMessageID:confirmedAt:in:)`` — only after the write that
+    /// persists the copy succeeds, so a failed write never loses the send from the transcript. Returns
+    /// nil when nothing matches (a counterpart message, or an unrelated history message); `claimed`
+    /// excludes sends already matched earlier in the same batch. The caller gates this on the id being
+    /// a *fresh* server id (not already persisted) so an old identical re-delivery never steals a send.
+    public func pendingMatch(for serverCopy: ConversationMessage, in conversationID: ConversationID, excluding claimed: Set<UUID>) -> UUID? {
+        guard let pending = pendingByConversation[conversationID] else { return nil }
+        let matches = pending.filter {
+            $0.message.senderID == serverCopy.senderID
+                && $0.message.content == serverCopy.content
+                && abs($0.message.date.timeIntervalSince(serverCopy.date)) < Self.pendingReconcileWindow
+                && $0.message.clientMessageID.map { !claimed.contains($0) } ?? false
         }
         // Reconcile only an unambiguous match. Two in-flight sends with identical text can't be told
         // apart (the server echoes no client id), so leave them for their own send-RPC responses —
         // which key on the exact client id — rather than cross-wiring one send's id onto the other's row.
-        guard matches.count == 1, let index = matches.first else { return nil }
-        let matched = pending.remove(at: index)
-        pendingByConversation[conversationID] = pending
-        reanchorLaterSends(after: matched.sequence, toAtLeast: serverCopy.id.value, in: conversationID)
-        return matched.message.clientMessageID
+        guard matches.count == 1 else { return nil }
+        return matches[0].message.clientMessageID
     }
 
     /// Drop a pending send confirmed by the send RPC's own response (keyed on the exact client id) and
@@ -200,11 +204,13 @@ public struct ConversationStore: Sendable {
 
     /// Set the feed row's preview to the caller-supplied newest visible message (computed from the
     /// database), never regressing: an older or equal-versioned candidate is ignored, so a stale
-    /// re-delivery or a deleted-copy path can't overwrite a newer preview. Never touches `lastActivity`
-    /// or the feed order.
-    public mutating func setFeedPreview(_ newest: ConversationMessage?, in conversationID: ConversationID) {
+    /// re-delivery can't overwrite a newer preview. `force` bypasses the guard for the one legitimate
+    /// regression — the newest message was tombstoned, so the preview must fall back to the previous
+    /// visible one instead of showing deleted content. Never touches `lastActivity` or the feed order.
+    public mutating func setFeedPreview(_ newest: ConversationMessage?, in conversationID: ConversationID, force: Bool = false) {
         guard let newest, let index = conversations.firstIndex(where: { $0.id == conversationID }) else { return }
-        if let current = conversations[index].lastMessage,
+        if !force,
+           let current = conversations[index].lastMessage,
            (current.id, current.eventSequence) >= (newest.id, newest.eventSequence) { return }
         conversations[index].lastMessage = newest
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationStore.swift
@@ -45,6 +45,15 @@ public struct ConversationStore: Sendable {
         messagesByConversation[conversationID] ?? []
     }
 
+    /// Drops all but the newest `count` confirmed messages for a conversation. Called when the
+    /// transcript is left so a paged-back thread doesn't retain its whole history in memory for the
+    /// session. Pending sends and the applied cursor are untouched, and the feed preview is the
+    /// newest message either way — older history re-pages from the server on reopen.
+    public mutating func trimMessages(for conversationID: ConversationID, keepingNewest count: Int) {
+        guard let messages = messagesByConversation[conversationID], messages.count > count else { return }
+        messagesByConversation[conversationID] = Array(messages.suffix(count))
+    }
+
     /// Replace the feed from a paged load, sorted most-recent-activity first.
     public mutating func setFeed(_ conversations: [Conversation]) {
         self.conversations = conversations.sorted { $0.lastActivity > $1.lastActivity }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -635,4 +635,41 @@ struct ConversationStoreTests {
         let ids = store.displayedMessages(for: conversationID(1)).map(\.stableID)
         #expect(Set(ids).count == ids.count)
     }
+
+    // MARK: - Transcript trimming
+
+    @Test("trimMessages keeps only the newest N confirmed messages")
+    func trimKeepsNewest() {
+        var store = ConversationStore()
+        store.mergeMessages((1...10).map { message(UInt64($0)) }, into: conversationID(1))
+        store.trimMessages(for: conversationID(1), keepingNewest: 4)
+        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [7, 8, 9, 10])
+    }
+
+    @Test("trimMessages is a no-op when the thread is at or under the cap")
+    func trimNoOpUnderCap() {
+        var store = ConversationStore()
+        store.mergeMessages([message(1), message(2), message(3)], into: conversationID(1))
+        store.trimMessages(for: conversationID(1), keepingNewest: 5)
+        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [1, 2, 3])
+    }
+
+    @Test("trimMessages leaves pending sends and the applied cursor intact")
+    func trimPreservesPendingAndCursor() {
+        var store = ConversationStore()
+        store.setAppliedCursor(9, for: conversationID(1))
+        store.mergeMessages((1...6).map { message(UInt64($0)) }, into: conversationID(1))
+        let clientID = UUID()
+        store.insertPending(
+            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
+                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
+                                status: .sending, clientMessageID: clientID),
+            into: conversationID(1)
+        )
+        store.trimMessages(for: conversationID(1), keepingNewest: 2)
+        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [5, 6])              // confirmed trimmed
+        #expect(store.appliedCursor(for: conversationID(1)) == 9)                               // delta cursor intact
+        // The pending send survives and still rides after the trimmed confirmed tail.
+        #expect(store.displayedMessages(for: conversationID(1)).map(\.stableID) == ["5", "6", clientID.uuidString])
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -128,36 +128,49 @@ struct ConversationStoreTests {
 
     // MARK: - Reconcile
 
-    @Test("reconcilePending matches a send by sender+content+window, returns its client id, drops it")
-    func reconcilePendingMatches() {
+    @Test("pendingMatch matches a send by sender+content+window without dropping it; dropPending commits")
+    func pendingMatchThenDrop() {
         let me = UUID()
         var store = ConversationStore()
         let clientID = UUID()
         store.insertPending(pending(clientID, "c", sender: me, at: 0), anchoredTo: 0, into: conversationID(1))
         let echo = ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("c"), date: Date(timeIntervalSince1970: 1), unreadSeq: 0)
-        #expect(store.reconcilePending(for: echo, in: conversationID(1)) == clientID)
-        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) == nil)   // dropped
+        #expect(store.pendingMatch(for: echo, in: conversationID(1), excluding: []) == clientID)
+        // Matching is non-destructive: the pending row survives a failed persist.
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
+        store.dropPending(clientMessageID: clientID, confirmedAt: echo.id, in: conversationID(1))
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) == nil)   // committed
     }
 
-    @Test("a counterpart message with identical text does not reconcile a pending self-send")
+    @Test("a claimed send is excluded so one echo can't match twice in a batch")
+    func claimedSendExcluded() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(pending(clientID, "c", sender: me, at: 0), anchoredTo: 0, into: conversationID(1))
+        let echo = ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("c"), date: Date(timeIntervalSince1970: 1), unreadSeq: 0)
+        #expect(store.pendingMatch(for: echo, in: conversationID(1), excluding: [clientID]) == nil)
+    }
+
+    @Test("a counterpart message with identical text does not match a pending self-send")
     func counterpartDoesNotReconcile() {
         let me = UUID(), them = UUID()
         var store = ConversationStore()
         let clientID = UUID()
         store.insertPending(pending(clientID, "hi", sender: me, at: 0), anchoredTo: 0, into: conversationID(1))
         let counterpart = ConversationMessage(id: MessageID(value: 5), senderID: them, content: .text("hi"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
-        #expect(store.reconcilePending(for: counterpart, in: conversationID(1)) == nil)
+        #expect(store.pendingMatch(for: counterpart, in: conversationID(1), excluding: []) == nil)
         #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)   // untouched
     }
 
-    @Test("an old message outside the reconcile window does not reconcile a fresh pending send")
+    @Test("an old message outside the reconcile window does not match a fresh pending send")
     func oldMessageOutsideWindowDoesNotReconcile() {
         let me = UUID()
         var store = ConversationStore()
         let clientID = UUID()
         store.insertPending(pending(clientID, "hi", sender: me, at: 100_000), anchoredTo: 0, into: conversationID(1))
         let old = ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
-        #expect(store.reconcilePending(for: old, in: conversationID(1)) == nil)     // far outside the 5-min window
+        #expect(store.pendingMatch(for: old, in: conversationID(1), excluding: []) == nil)     // far outside the 5-min window
     }
 
     @Test("two identical-text in-flight sends are not cross-wired by an ambiguous echo")
@@ -168,9 +181,34 @@ struct ConversationStoreTests {
         store.insertPending(pending(clientA, "hi", sender: me, at: 0), anchoredTo: 0, into: conversationID(1))
         store.insertPending(pending(clientB, "hi", sender: me, at: 0), anchoredTo: 0, into: conversationID(1))
         let echo = ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
-        #expect(store.reconcilePending(for: echo, in: conversationID(1)) == nil)    // ambiguous → leave both
+        #expect(store.pendingMatch(for: echo, in: conversationID(1), excluding: []) == nil)    // ambiguous → leave both
         #expect(store.pendingMessage(clientMessageID: clientA, in: conversationID(1)) != nil)
         #expect(store.pendingMessage(clientMessageID: clientB, in: conversationID(1)) != nil)
+    }
+
+    @Test("a send anchored at 0 (no history at send time) stays at the tail once history lands")
+    func unanchoredSendStaysAtTail() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientID = UUID()
+        // Sent while the conversation had no persisted rows (a fresh DB after the schema wipe).
+        store.insertPending(pending(clientID, "hi", sender: me), anchoredTo: 0, into: conversationID(1))
+        // The history page then lands and the window renders it.
+        let window = (100...110).map { message(UInt64($0)) }
+        let displayed = store.displayedMessages(for: conversationID(1), over: window)
+        #expect(displayed.last?.stableID == clientID.uuidString)    // the send trails — newest thing the user did
+        #expect(displayed.first?.id.value == 100)                    // history is not pushed below it
+    }
+
+    @Test("setFeedPreview(force:) allows the tombstoned-newest regression the guard otherwise blocks")
+    func forcedPreviewRegression() {
+        var store = ConversationStore()
+        store.setFeed([Conversation(id: conversationID(1), members: [], lastMessage: message(10), lastActivity: Date(timeIntervalSince1970: 0))])
+        let previous = message(9)
+        store.setFeedPreview(previous, in: conversationID(1))                 // guard blocks the regression
+        #expect(store.conversations.first?.lastMessage?.id.value == 10)
+        store.setFeedPreview(previous, in: conversationID(1), force: true)    // newest was tombstoned → forced
+        #expect(store.conversations.first?.lastMessage?.id.value == 9)
     }
 
     @Test("dropPending removes a send and keeps a later still-pending send in send order")

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationStoreTests.swift
@@ -9,7 +9,11 @@ import Testing
 import Foundation
 @testable import FlipcashCore
 
-@Suite("ConversationStore reconciliation")
+/// The store now holds only the feed, the optimistic (pending) overlay, and the catch-up cursor —
+/// confirmed messages live in the database (their last-writer-wins reconciliation is covered by
+/// `Database+ConversationsTests`). These tests cover the overlay positioning, the echo→pending
+/// reconcile, and gap/cursor detection.
+@Suite("ConversationStore overlay + cursor")
 struct ConversationStoreTests {
 
     private func conversationID(_ byte: UInt8) -> ConversationID {
@@ -29,9 +33,15 @@ struct ConversationStoreTests {
         ConversationMessage(id: MessageID(value: id), senderID: nil, content: .text(text), date: Date(timeIntervalSince1970: at), unreadSeq: 0, eventSequence: eventSequence)
     }
 
-    private func deleted(_ id: UInt64, at: TimeInterval = 0, eventSequence: UInt64) -> ConversationMessage {
-        ConversationMessage(id: MessageID(value: id), senderID: nil, content: .deleted, date: Date(timeIntervalSince1970: at), unreadSeq: 0, eventSequence: eventSequence)
+    private func pending(_ clientID: UUID, _ text: String, sender: UserID? = nil, at: TimeInterval = 0, status: SendStatus = .sending) -> ConversationMessage {
+        ConversationMessage(id: MessageID(value: .max), senderID: sender, content: .text(text), date: Date(timeIntervalSince1970: at), unreadSeq: 0, status: status, clientMessageID: clientID)
     }
+
+    private func displayedTexts(_ store: ConversationStore, _ id: ConversationID, over confirmed: [ConversationMessage]) -> [String] {
+        store.displayedMessages(for: id, over: confirmed).map { if case .text(let t) = $0.content { t } else { "" } }
+    }
+
+    // MARK: - Feed
 
     @Test("setFeed sorts by last activity, most recent first")
     func feedSortsByActivity() {
@@ -44,62 +54,149 @@ struct ConversationStoreTests {
         #expect(store.conversations.map(\.id) == [conversationID(2), conversationID(3), conversationID(1)])
     }
 
-    @Test("mergeMessages dedupes by id and keeps oldest first; a higher event_sequence wins")
-    func messagesMergeGapless() {
+    @Test("advanceLastActivity moves the conversation to the front")
+    func advanceActivityResorts() {
         var store = ConversationStore()
-        store.mergeMessages([message(3, eventSequence: 3), message(1, eventSequence: 1)], into: conversationID(1))
-        store.mergeMessages([message(1, "updated", eventSequence: 2), message(2, eventSequence: 2)], into: conversationID(1))
-
-        let messages = store.messages(for: conversationID(1))
-        #expect(messages.map(\.id.value) == [1, 2, 3])
-        #expect(messages.first?.content == .text("updated")) // higher event_sequence wins
+        store.setFeed([conversation(1, lastActivity: 100), conversation(2, lastActivity: 200)])
+        store.advanceLastActivity(to: Date(timeIntervalSince1970: 999), in: conversationID(1))
+        #expect(store.conversations.first?.id == conversationID(1))
     }
 
-    @Test("mergeMessages dedupes a re-delivered message without duplicating the row")
-    func messagesDedupeEcho() {
+    @Test("setFeedPreview advances to a newer message and never regresses to an older one")
+    func feedPreviewNeverRegresses() {
         var store = ConversationStore()
-        store.mergeMessages([message(1, eventSequence: 1), message(2, "hi", eventSequence: 2)], into: conversationID(1))
-        store.mergeMessages([message(2, "echo", eventSequence: 2)], into: conversationID(1))    // equal version → no dup
-        let messages = store.messages(for: conversationID(1))
-        #expect(messages.map(\.id.value) == [1, 2])
-        #expect(messages.last?.content == .text("hi")) // equal event_sequence keeps the held copy
+        store.setFeed([conversation(1, lastActivity: 100)])
+        store.setFeedPreview(message(5, "newest"), in: conversationID(1))
+        #expect(store.conversations.first?.lastMessage?.id.value == 5)
+        store.setFeedPreview(message(2, "older"), in: conversationID(1))         // older → ignored
+        #expect(store.conversations.first?.lastMessage?.id.value == 5)
+        store.setFeedPreview(message(9, "newer"), in: conversationID(1))         // newer → wins
+        #expect(store.conversations.first?.lastMessage?.id.value == 9)
     }
 
-    @Test("last-writer-wins: a lower event_sequence is ignored; a higher one replaces")
-    func mergeLastWriterWins() {
+    @Test("setFeedPreview does not re-sort the feed — activity stays feed-owned")
+    func previewDoesNotResort() {
         var store = ConversationStore()
-        store.mergeMessages([message(1, "v2", eventSequence: 2)], into: conversationID(1))
-        store.mergeMessages([message(1, "v1-stale", eventSequence: 1)], into: conversationID(1)) // older → ignored
-        #expect(store.messages(for: conversationID(1)).first?.content == .text("v2"))
-        store.mergeMessages([message(1, "v3", eventSequence: 3)], into: conversationID(1))        // newer → wins
-        #expect(store.messages(for: conversationID(1)).first?.content == .text("v3"))
+        store.setFeed([conversation(1, lastActivity: 100), conversation(2, lastActivity: 200)])
+        store.setFeedPreview(message(5, "fresh"), in: conversationID(1))
+        #expect(store.conversations.map(\.id) == [conversationID(2), conversationID(1)])
+        #expect(store.conversations.last?.lastMessage?.id.value == 5)
     }
 
-    @Test("a delete tombstone replaces a prior message, and an out-of-order older send can't resurrect it")
-    func deleteTombstoneConverges() {
+    // MARK: - Optimistic overlay
+
+    @Test("insertPending shows the optimistic message after its anchor; the confirmed window is unchanged")
+    func insertPendingDisplaysAfterAnchor() {
         var store = ConversationStore()
-        // Tombstone (event 10) lands before the original send (event 5) is re-delivered.
-        store.mergeMessages([deleted(1, eventSequence: 10)], into: conversationID(1))
-        store.mergeMessages([message(1, "original", eventSequence: 5)], into: conversationID(1))
-        let first = store.messages(for: conversationID(1)).first
-        #expect(first?.content == .deleted)   // stale older send never overwrites the newer tombstone
+        let confirmed = [message(1), message(2)]
+        let clientID = UUID()
+        store.insertPending(pending(clientID, "c"), anchoredTo: 2, into: conversationID(1))
+        #expect(store.displayedMessages(for: conversationID(1), over: confirmed).map(\.stableID) == ["1", "2", clientID.uuidString])
     }
 
-    // MARK: - Event-log cursor & gap detection
+    @Test("markPending flips a pending message to failed")
+    func markPendingFailed() {
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(pending(clientID, "c"), anchoredTo: 0, into: conversationID(1))
+        store.markPending(clientMessageID: clientID, status: .failed, in: conversationID(1))
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1))?.status == .failed)
+    }
+
+    @Test("a failed send keeps its chronological place when newer messages arrive")
+    func failedSendHoldsPosition() {
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(pending(clientID, "mine"), anchoredTo: 3, into: conversationID(1))  // sent after id 3
+        store.markPending(clientMessageID: clientID, status: .failed, in: conversationID(1))
+        // A newer confirmed message arrives; the failed send stays after id 3, before id 4.
+        let confirmed = [message(1, "a"), message(2, "b"), message(3, "c"), message(4, "later")]
+        #expect(displayedTexts(store, conversationID(1), over: confirmed) == ["a", "b", "c", "mine", "later"])
+    }
+
+    @Test("a pending anchored older than the window surfaces at the head, not the tail")
+    func pendingOlderThanWindowGoesToHead() {
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(pending(clientID, "failed", status: .failed), anchoredTo: 3, into: conversationID(1))
+        // The rendered window is the newest slice (ids 11...20) — the anchor (3) scrolled out.
+        let window = (11...20).map { message(UInt64($0)) }
+        let displayed = store.displayedMessages(for: conversationID(1), over: window)
+        #expect(displayed.first?.stableID == clientID.uuidString)   // above the window, not dumped at the tail
+        #expect(displayed.last?.id.value == 20)
+    }
+
+    // MARK: - Reconcile
+
+    @Test("reconcilePending matches a send by sender+content+window, returns its client id, drops it")
+    func reconcilePendingMatches() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(pending(clientID, "c", sender: me, at: 0), anchoredTo: 0, into: conversationID(1))
+        let echo = ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("c"), date: Date(timeIntervalSince1970: 1), unreadSeq: 0)
+        #expect(store.reconcilePending(for: echo, in: conversationID(1)) == clientID)
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) == nil)   // dropped
+    }
+
+    @Test("a counterpart message with identical text does not reconcile a pending self-send")
+    func counterpartDoesNotReconcile() {
+        let me = UUID(), them = UUID()
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(pending(clientID, "hi", sender: me, at: 0), anchoredTo: 0, into: conversationID(1))
+        let counterpart = ConversationMessage(id: MessageID(value: 5), senderID: them, content: .text("hi"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
+        #expect(store.reconcilePending(for: counterpart, in: conversationID(1)) == nil)
+        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)   // untouched
+    }
+
+    @Test("an old message outside the reconcile window does not reconcile a fresh pending send")
+    func oldMessageOutsideWindowDoesNotReconcile() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientID = UUID()
+        store.insertPending(pending(clientID, "hi", sender: me, at: 100_000), anchoredTo: 0, into: conversationID(1))
+        let old = ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
+        #expect(store.reconcilePending(for: old, in: conversationID(1)) == nil)     // far outside the 5-min window
+    }
+
+    @Test("two identical-text in-flight sends are not cross-wired by an ambiguous echo")
+    func ambiguousSendsNotCrossWired() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientA = UUID(), clientB = UUID()
+        store.insertPending(pending(clientA, "hi", sender: me, at: 0), anchoredTo: 0, into: conversationID(1))
+        store.insertPending(pending(clientB, "hi", sender: me, at: 0), anchoredTo: 0, into: conversationID(1))
+        let echo = ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
+        #expect(store.reconcilePending(for: echo, in: conversationID(1)) == nil)    // ambiguous → leave both
+        #expect(store.pendingMessage(clientMessageID: clientA, in: conversationID(1)) != nil)
+        #expect(store.pendingMessage(clientMessageID: clientB, in: conversationID(1)) != nil)
+    }
+
+    @Test("dropPending removes a send and keeps a later still-pending send in send order")
+    func dropPendingKeepsSendOrder() {
+        let me = UUID()
+        var store = ConversationStore()
+        let clientA = UUID(), clientB = UUID()
+        store.insertPending(pending(clientA, "A", sender: me), anchoredTo: 3, into: conversationID(1))
+        store.insertPending(pending(clientB, "B", sender: me), anchoredTo: 3, into: conversationID(1))
+        // B (sent second) confirms first at id 4; A (sent first, still pending) must stay above it.
+        store.dropPending(clientMessageID: clientB, confirmedAt: MessageID(value: 4), in: conversationID(1))
+        let confirmed = [message(3, "x"), message(4, "B")]
+        #expect(displayedTexts(store, conversationID(1), over: confirmed) == ["x", "A", "B"])
+    }
+
+    // MARK: - Cursor + gap detection
 
     private func sentEvent(sequence: UInt64, count: UInt64 = 1, _ messages: ConversationMessage...) -> DecodedChatEvent {
         DecodedChatEvent(sequence: sequence, count: count, mutations: messages.map { .sent($0) })
     }
 
-    /// One `.chatEvents` apply over the frontier arithmetic: an event is contiguous when
-    /// `sequence == cursor + count` (advance the frontier), a hole otherwise (flag catch-up, hold the
-    /// frontier), and stale when `sequence <= cursor` (ignore). `count` drives the math independently of
-    /// how many mutations the event carries.
     @Test("gap detection advances the frontier only on a contiguous event", arguments: [
-        (start: UInt64(5), sequence: UInt64(6), count: UInt64(1), expected: UInt64(6), gapped: false), // contiguous
-        (start: 6, sequence: 9, count: 1, expected: 6, gapped: true),                                   // hole below the event
-        (start: 10, sequence: 13, count: 3, expected: 13, gapped: false),                               // multi-mutation, contiguous
-        (start: 10, sequence: 8, count: 1, expected: 10, gapped: false),                                // stale, ignored
+        (start: UInt64(5), sequence: UInt64(6), count: UInt64(1), expected: UInt64(6), gapped: false),
+        (start: 6, sequence: 9, count: 1, expected: 6, gapped: true),
+        (start: 10, sequence: 13, count: 3, expected: 13, gapped: false),
+        (start: 10, sequence: 8, count: 1, expected: 10, gapped: false),
     ])
     func gapDetection(start: UInt64, sequence: UInt64, count: UInt64, expected: UInt64, gapped: Bool) {
         var store = ConversationStore()
@@ -110,91 +207,55 @@ struct ConversationStoreTests {
         #expect(signal == expectedSignal)
     }
 
-    @Test("a gapped event's messages are still merged — LWW is independent of gap detection")
-    func gappedEventStillMergesMessages() {
-        var store = ConversationStore()
-        store.setAppliedCursor(5, for: conversationID(1))
-        store.apply(.chatEvents(conversationID: conversationID(1), events: [sentEvent(sequence: 6, message(6, eventSequence: 6))]))
-        store.apply(.chatEvents(conversationID: conversationID(1), events: [sentEvent(sequence: 9, message(9, eventSequence: 9))])) // gap
-        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [6, 9])
-    }
-
-    @Test("an unestablished frontier applies messages by LWW without advancing or flagging a gap")
-    func chatEventsUnestablishedFrontier() {
+    @Test("an unestablished frontier neither advances nor flags a gap")
+    func unestablishedFrontier() {
         var store = ConversationStore()
         let signal = store.apply(.chatEvents(conversationID: conversationID(1), events: [sentEvent(sequence: 42, message(42, eventSequence: 42))]))
         #expect(signal == .none)
-        #expect(store.appliedCursor(for: conversationID(1)) == 0) // catch-up owns the cursor until seeded
-        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [42])
+        #expect(store.appliedCursor(for: conversationID(1)) == 0)   // catch-up owns the cursor until seeded
     }
 
-    @Test("applyDeltaBatch merges and advances the frontier to the checkpoint; setAppliedCursor never regresses")
-    func applyDeltaBatchAdvancesCursor() {
+    @Test("chatEvents bumps the feed activity to the newest sent mutation")
+    func chatEventsBumpsActivity() {
         var store = ConversationStore()
-        store.applyDeltaBatch([message(1, eventSequence: 1), message(2, eventSequence: 2)], checkpoint: 2, into: conversationID(1))
-        #expect(store.appliedCursor(for: conversationID(1)) == 2)
-        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [1, 2])
-        store.setAppliedCursor(1, for: conversationID(1)) // lower → ignored
-        #expect(store.appliedCursor(for: conversationID(1)) == 2)
-        store.setAppliedCursor(9, for: conversationID(1)) // head → advances
-        #expect(store.appliedCursor(for: conversationID(1)) == 9)
+        store.setFeed([conversation(1, lastActivity: 0), conversation(2, lastActivity: 500)])
+        store.apply(.chatEvents(conversationID: conversationID(1), events: [sentEvent(sequence: 1, message(9, at: 999))]))
+        #expect(store.conversations.first?.id == conversationID(1))   // moved to the front by activity
     }
 
-    @Test("resetCursor discards the frontier; seedAppliedCursors restores non-zero cursors")
-    func cursorResetAndSeed() {
+    @Test("setAppliedCursor never regresses; reset clears; seed restores non-zero cursors")
+    func cursorLifecycle() {
         var store = ConversationStore()
         store.setAppliedCursor(7, for: conversationID(1))
+        store.setAppliedCursor(3, for: conversationID(1))   // lower → ignored
+        #expect(store.appliedCursor(for: conversationID(1)) == 7)
+        store.setAppliedCursor(9, for: conversationID(1))   // higher → advances
+        #expect(store.appliedCursor(for: conversationID(1)) == 9)
         store.resetCursor(for: conversationID(1))
         #expect(store.appliedCursor(for: conversationID(1)) == 0)
         store.seedAppliedCursors([conversationID(1): 12, conversationID(2): 0])
         #expect(store.appliedCursor(for: conversationID(1)) == 12)
-        #expect(store.appliedCursor(for: conversationID(2)) == 0) // zero ignored
+        #expect(store.appliedCursor(for: conversationID(2)) == 0)   // zero ignored
     }
 
-    @Test("an edit of an old message does not advance the feed's last message")
-    func chatEventsEditDoesNotBumpLastMessage() {
+    @Test("reseatCursor forces the cursor regardless of monotonicity (failed-persist recovery)")
+    func reseatCursorForces() {
         var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 0)])
-        store.mergeMessages([message(5, "old", eventSequence: 5)], into: conversationID(1))
-        store.setLastMessage(message(5, "old", eventSequence: 5), in: conversationID(1))
-        store.apply(.chatEvents(conversationID: conversationID(1), events: [
-            DecodedChatEvent(sequence: 6, count: 1, mutations: [.edited(message(5, "edited", eventSequence: 6))])
-        ]))
-        #expect(store.conversations.first?.lastMessage?.id.value == 5)
-        #expect(store.messages(for: conversationID(1)).first?.content == .text("edited")) // transcript updates by LWW
+        store.setAppliedCursor(9, for: conversationID(1))
+        store.reseatCursor(3, for: conversationID(1))   // lowers it, unlike setAppliedCursor
+        #expect(store.appliedCursor(for: conversationID(1)) == 3)
     }
 
-    @Test("newMessages event appends and bumps the conversation's last activity")
-    func applyNewMessages() {
+    @Test("newMessages bumps the conversation's last activity")
+    func newMessagesBumpsActivity() {
         var store = ConversationStore()
         store.setFeed([conversation(1, lastActivity: 100), conversation(2, lastActivity: 200)])
         store.apply(.newMessages(conversationID: conversationID(1), messages: [message(5, "yo", at: 500)]))
-
-        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [5])
-        // conversation 1 moves to the front after its new activity
         #expect(store.conversations.first?.id == conversationID(1))
-        #expect(store.conversations.first?.lastMessage?.content == .text("yo"))
-    }
-
-    @Test("lastActivityChanged re-sorts the feed")
-    func applyLastActivityChanged() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100), conversation(2, lastActivity: 200)])
-        store.apply(.lastActivityChanged(conversationID: conversationID(1), date: Date(timeIntervalSince1970: 999)))
-        #expect(store.conversations.first?.id == conversationID(1))
-    }
-
-    @Test("metadataRefresh upserts a new conversation")
-    func applyMetadataRefreshInserts() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100)])
-        store.apply(.metadataRefresh(conversation(2, lastActivity: 999)))
-        #expect(store.conversations.count == 2)
-        #expect(store.conversations.first?.id == conversationID(2))
     }
 
     @Test("readPointersChanged advances a member's READ watermark monotonically")
-    func applyReadPointers() {
+    func readPointers() {
         let me = UUID()
         var store = ConversationStore()
         store.setFeed([Conversation(
@@ -203,473 +264,18 @@ struct ConversationStoreTests {
             lastMessage: nil,
             lastActivity: Date(timeIntervalSince1970: 0)
         )])
-
         store.apply(.readPointersChanged(conversationID: conversationID(1), pointers: [MemberReadPointer(userID: me, value: MessageID(value: 5))]))
         #expect(store.selfReadPointer(for: conversationID(1), selfUserID: me) == MessageID(value: 5))
-
-        // A stale watermark never moves it backward.
         store.apply(.readPointersChanged(conversationID: conversationID(1), pointers: [MemberReadPointer(userID: me, value: MessageID(value: 3))]))
-        #expect(store.selfReadPointer(for: conversationID(1), selfUserID: me) == MessageID(value: 5))
+        #expect(store.selfReadPointer(for: conversationID(1), selfUserID: me) == MessageID(value: 5))   // never backward
     }
 
-    @Test("readPointersChanged stores the read time when the watermark advances, and leaves it on a stale update")
-    func applyReadPointers_storesTimestamp() {
-        let me = UUID()
-        let readAt = Date(timeIntervalSince1970: 1_700_000_000)
+    @Test("hasPendingMessages reflects only the optimistic overlay")
+    func hasPending() {
         var store = ConversationStore()
-        store.setFeed([Conversation(
-            id: conversationID(1),
-            members: [ConversationMember(userID: me, displayName: "", readPointer: MessageID(value: 2))],
-            lastMessage: nil,
-            lastActivity: Date(timeIntervalSince1970: 0)
-        )])
-
-        store.apply(.readPointersChanged(conversationID: conversationID(1), pointers: [MemberReadPointer(userID: me, value: MessageID(value: 5), date: readAt)]))
-        #expect(store.conversations.first?.members.first?.readPointerTimestamp == readAt)
-
-        // A backward (stale) update is a no-op: the time stays put.
-        store.apply(.readPointersChanged(conversationID: conversationID(1), pointers: [MemberReadPointer(userID: me, value: MessageID(value: 3), date: Date(timeIntervalSince1970: 0))]))
-        #expect(store.conversations.first?.members.first?.readPointerTimestamp == readAt)
-    }
-
-    // MARK: - Feed preview from merge paths
-
-    private func cashMessage(_ id: UInt64) -> ConversationMessage {
-        ConversationMessage(
-            id: MessageID(value: id),
-            senderID: nil,
-            content: .cash(ExchangedFiat(nativeAmount: .usd(5.00), rate: .oneToOne)),
-            date: Date(timeIntervalSince1970: 0),
-            unreadSeq: 0,
-            eventSequence: id
-        )
-    }
-
-    @Test("a merged send-cash message newer than the preview becomes the feed's last message")
-    func mergeAdvancesPreviewToNewerCashMessage() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100)])
-        store.mergeMessages([message(3, "old text")], into: conversationID(1))
-        // The user's own cash send reaches the store via GetDelta catch-up — a merge-only path.
-        let cash = cashMessage(7)
-        store.applyDeltaBatch([cash], checkpoint: 7, into: conversationID(1))
-        #expect(store.conversations.first?.lastMessage == cash)
-    }
-
-    @Test("a merge seeds the preview of a conversation that has none")
-    func mergeSeedsMissingPreview() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100)])
-        store.mergeMessages([message(4, "first")], into: conversationID(1))
-        #expect(store.conversations.first?.lastMessage?.id.value == 4)
-    }
-
-    @Test("a paged-in older message does not regress the feed's last message")
-    func mergeDoesNotRegressPreview() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100)])
-        store.mergeMessages([message(9, "newest")], into: conversationID(1))
-        store.mergeMessages([message(2, "older history")], into: conversationID(1))
-        #expect(store.conversations.first?.lastMessage?.id.value == 9)
-    }
-
-    @Test("a merged tombstone is skipped — the newest visible message becomes the preview")
-    func mergeSkipsTombstoneForPreview() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100)])
-        store.mergeMessages([message(3, "old")], into: conversationID(1))
-        store.applyDeltaBatch([message(6, "visible", eventSequence: 6), deleted(7, eventSequence: 7)], checkpoint: 7, into: conversationID(1))
-        #expect(store.conversations.first?.lastMessage?.id.value == 6)
-    }
-
-    @Test("a merge advances the preview without re-sorting the feed — activity stays feed-owned")
-    func mergeDoesNotResortFeed() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100), conversation(2, lastActivity: 200)])
-        store.mergeMessages([message(5, "fresh", at: 500)], into: conversationID(1))
-        #expect(store.conversations.map(\.id) == [conversationID(2), conversationID(1)])
-        #expect(store.conversations.last?.lastMessage?.id.value == 5)
-    }
-
-    @Test("a stale re-delivered newMessages event does not regress the preview")
-    func staleNewMessagesDoesNotRegressPreview() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100)])
-        store.apply(.newMessages(conversationID: conversationID(1), messages: [message(10, "newest")]))
-        store.apply(.newMessages(conversationID: conversationID(1), messages: [message(8, "stale re-delivery")]))
-        #expect(store.conversations.first?.lastMessage?.id.value == 10)
-    }
-
-    @Test("a batch that sends and immediately deletes a message does not preview the deleted copy")
-    func sendPlusDeleteBatchDoesNotResurrectPreview() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100)])
-        store.mergeMessages([message(6, "visible", eventSequence: 6)], into: conversationID(1))
-        store.apply(.chatEvents(conversationID: conversationID(1), events: [
-            DecodedChatEvent(sequence: 7, count: 1, mutations: [.sent(message(7, "sent then deleted", eventSequence: 7))]),
-            DecodedChatEvent(sequence: 8, count: 1, mutations: [.deleted(deleted(7, eventSequence: 8))]),
-        ]))
-        #expect(store.conversations.first?.lastMessage?.id.value == 6)
-    }
-
-    @Test("an edit of the preview message refreshes its content without moving the row")
-    func editOfPreviewRefreshesContent() {
-        var store = ConversationStore()
-        store.setFeed([conversation(1, lastActivity: 100)])
-        store.mergeMessages([message(5, "old", eventSequence: 5)], into: conversationID(1))
-        store.apply(.chatEvents(conversationID: conversationID(1), events: [
-            DecodedChatEvent(sequence: 6, count: 1, mutations: [.edited(message(5, "edited", eventSequence: 6))]),
-        ]))
-        #expect(store.conversations.first?.lastMessage?.id.value == 5)
-        #expect(store.conversations.first?.lastMessage?.content == .text("edited"))
-    }
-
-    // MARK: - Optimistic send
-
-    @Test("A server-built message defaults to .sent with no client id; stableID is the server id")
-    func messageDefaultsAreSent() {
-        let m = message(7)
-        #expect(m.status == .sent)
-        #expect(m.clientMessageID == nil)
-        #expect(m.stableID == "7")
-    }
-
-    @Test("A pending message carries its client id as the stable identity")
-    func pendingMessageStableID() {
-        let id = UUID()
-        let m = ConversationMessage(
-            id: MessageID(value: .max), senderID: nil, content: .text("hi"),
-            date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-            status: .sending, clientMessageID: id
-        )
-        #expect(m.status == .sending)
-        #expect(m.stableID == id.uuidString)
-    }
-
-    @Test("insertPending shows the optimistic message after the confirmed ones; messages() ignores it")
-    func insertPendingDisplaysAfterConfirmed() {
-        var store = ConversationStore()
-        store.mergeMessages([message(1), message(2)], into: conversationID(1))
+        #expect(!store.hasPendingMessages(for: conversationID(1)))
         let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
-                                date: Date(timeIntervalSince1970: 99), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        #expect(store.displayedMessages(for: conversationID(1)).map(\.stableID) == ["1", "2", clientID.uuidString])
-        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [1, 2]) // confirmed-only, unchanged
-    }
-
-    @Test("markPending flips a pending message to failed")
-    func markPendingFailed() {
-        var store = ConversationStore()
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        store.markPending(clientMessageID: clientID, status: .failed, in: conversationID(1))
-        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1))?.status == .failed)
-    }
-
-    @Test("reconcile drops the pending copy and keeps the client id on the confirmed message")
-    func reconcileKeepsIdentity() {
-        var store = ConversationStore()
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        store.reconcile(clientMessageID: clientID, with: message(5, "c"), in: conversationID(1))
-
-        let displayed = store.displayedMessages(for: conversationID(1))
-        #expect(displayed.count == 1)
-        #expect(displayed.first?.id.value == 5)
-        #expect(displayed.first?.status == .sent)
-        #expect(displayed.first?.stableID == clientID.uuidString)   // identity preserved → no re-insert
-        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) == nil)
-    }
-
-    @Test("a stream echo of a reconciled message does not strip its client id")
-    func mergePreservesClientID() {
-        var store = ConversationStore()
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        store.reconcile(clientMessageID: clientID, with: message(5, "c"), in: conversationID(1))
-        // The event stream re-delivers the same server message with no client id.
-        store.mergeMessages([message(5, "c")], into: conversationID(1))
-
-        let displayed = store.displayedMessages(for: conversationID(1))
-        #expect(displayed.count == 1)
-        #expect(displayed.first?.stableID == clientID.uuidString)
-    }
-
-    @Test("An echo arriving before reconcile collapses onto the pending row (no duplicate, stable id)")
-    func echoBeforeReconcileCollapses() {
-        let me = UUID()
-        var store = ConversationStore()
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("c"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        // The stream echo (server id, no client id, same sender+content+time) lands before the RPC.
-        store.mergeMessages(
-            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("c"),
-                                 date: Date(timeIntervalSince1970: 1), unreadSeq: 0)],
-            into: conversationID(1)
-        )
-        let displayed = store.displayedMessages(for: conversationID(1))
-        #expect(displayed.count == 1)                               // collapsed, not duplicated
-        #expect(displayed.first?.id.value == 5)
-        #expect(displayed.first?.status == .sent)
-        #expect(displayed.first?.stableID == clientID.uuidString)   // identity preserved across the echo
-        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) == nil)
-    }
-
-    @Test("An echo reconciles a failed pending send, clearing the phantom (timed-out-but-persisted)")
-    func echoReconcilesFailedPending() {
-        let me = UUID()
-        var store = ConversationStore()
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("c"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        store.markPending(clientMessageID: clientID, status: .failed, in: conversationID(1))
-        // The send RPC timed out, but the server persisted + echoed the message.
-        store.mergeMessages(
-            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("c"),
-                                 date: Date(timeIntervalSince1970: 1), unreadSeq: 0)],
-            into: conversationID(1)
-        )
-        let displayed = store.displayedMessages(for: conversationID(1))
-        #expect(displayed.count == 1)                               // no permanent duplicate
-        #expect(displayed.first?.status == .sent)                   // no false "Not Delivered" phantom
-        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) == nil)
-    }
-
-    @Test("An unrelated old message with identical text does not reconcile a fresh pending send")
-    func oldHistoryDoesNotReconcile() {
-        let me = UUID()
-        var store = ConversationStore()
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
-                                date: Date(timeIntervalSince1970: 100_000), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        // A history page carries an old "hi" from the same sender, far outside the reconcile window.
-        store.mergeMessages(
-            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"),
-                                 date: Date(timeIntervalSince1970: 0), unreadSeq: 0)],
-            into: conversationID(1)
-        )
-        let displayed = store.displayedMessages(for: conversationID(1))
-        #expect(displayed.count == 2)                               // distinct messages, not collapsed
-        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
-    }
-
-    @Test("A counterpart message with identical text does not reconcile a pending self-send")
-    func counterpartMessageDoesNotReconcile() {
-        let me = UUID(), them = UUID()
-        var store = ConversationStore()
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        store.mergeMessages(
-            [ConversationMessage(id: MessageID(value: 5), senderID: them, content: .text("hi"),
-                                 date: Date(timeIntervalSince1970: 0), unreadSeq: 0)],
-            into: conversationID(1)
-        )
-        let displayed = store.displayedMessages(for: conversationID(1))
-        #expect(displayed.count == 2)                               // counterpart's "hi" + my pending "hi"
-        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
-    }
-
-    @Test("A re-delivered already-confirmed identical message does not absorb a fresh pending send")
-    func redeliveredConfirmedDoesNotAbsorbPending() {
-        let me = UUID()
-        var store = ConversationStore()
-        // An identical "hi" was sent earlier and confirmed at id 5.
-        store.mergeMessages(
-            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"),
-                                 date: Date(timeIntervalSince1970: 100), unreadSeq: 0)],
-            into: conversationID(1)
-        )
-        // A fresh "hi" is now in flight, within the reconcile window of the old one.
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
-                                date: Date(timeIntervalSince1970: 120), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        // The stream re-delivers the OLD confirmed "hi" (id 5, already known) — it must not steal the
-        // fresh pending row.
-        store.mergeMessages(
-            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"),
-                                 date: Date(timeIntervalSince1970: 100), unreadSeq: 0)],
-            into: conversationID(1)
-        )
-        #expect(store.pendingMessage(clientMessageID: clientID, in: conversationID(1)) != nil)
-        #expect(store.displayedMessages(for: conversationID(1)).count == 2)   // old confirmed + fresh pending
-    }
-
-    private func displayedTexts(_ store: ConversationStore, _ id: ConversationID) -> [String] {
-        store.displayedMessages(for: id).map { if case .text(let t) = $0.content { t } else { "" } }
-    }
-
-    @Test("A failed send keeps its chronological place when newer messages arrive")
-    func failedMessageHoldsChronologicalPosition() {
-        let me = UUID()
-        var store = ConversationStore()
-        store.mergeMessages([message(1, "a"), message(2, "b"), message(3, "c")], into: conversationID(1))
-        // Sent after seeing id 3, then it fails.
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("mine"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        store.markPending(clientMessageID: clientID, status: .failed, in: conversationID(1))
-        // A newer message arrives.
-        store.mergeMessages([message(4, "later")], into: conversationID(1))
-        // "mine" stays after id 3 (where it was sent), before the newer "later" — not dumped at the tail.
-        #expect(displayedTexts(store, conversationID(1)) == ["a", "b", "c", "mine", "later"])
-    }
-
-    @Test("Out-of-order reconcile keeps optimistic sends in send order")
-    func outOfOrderReconcileKeepsSendOrder() {
-        let me = UUID()
-        var store = ConversationStore()
-        store.mergeMessages([message(3, "x")], into: conversationID(1))
-        let clientA = UUID(), clientB = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("A"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientA),
-            into: conversationID(1)
-        )
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("B"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientB),
-            into: conversationID(1)
-        )
-        // B (sent second) reconciles first.
-        store.reconcile(clientMessageID: clientB, with: message(4, "B"), in: conversationID(1))
-        // A (sent first, still pending) stays above the just-confirmed B.
-        #expect(displayedTexts(store, conversationID(1)) == ["x", "A", "B"])
-    }
-
-    @Test("Out-of-order reconcile: the earlier send confirming first keeps send order")
-    func earlierSendReconcilingFirstKeepsSendOrder() {
-        let me = UUID()
-        var store = ConversationStore()
-        store.mergeMessages([message(3, "x")], into: conversationID(1))
-        let clientA = UUID(), clientB = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("A"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientA),
-            into: conversationID(1)
-        )
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("B"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientB),
-            into: conversationID(1)
-        )
-        // A (sent first) reconciles first — B must NOT jump above it.
-        store.reconcile(clientMessageID: clientA, with: message(4, "A"), in: conversationID(1))
-        #expect(displayedTexts(store, conversationID(1)) == ["x", "A", "B"])
-    }
-
-    @Test("An ambiguous echo of two identical-text in-flight sends is not cross-wired")
-    func ambiguousIdenticalSendsAreNotCrossWired() {
-        let me = UUID()
-        var store = ConversationStore()
-        let clientA = UUID(), clientB = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientA),
-            into: conversationID(1)
-        )
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: me, content: .text("hi"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientB),
-            into: conversationID(1)
-        )
-        // An echo of "hi" can't be told apart from either pending send — it must NOT reconcile.
-        store.mergeMessages(
-            [ConversationMessage(id: MessageID(value: 5), senderID: me, content: .text("hi"),
-                                 date: Date(timeIntervalSince1970: 0), unreadSeq: 0)],
-            into: conversationID(1)
-        )
-        #expect(store.pendingMessage(clientMessageID: clientA, in: conversationID(1)) != nil)
-        #expect(store.pendingMessage(clientMessageID: clientB, in: conversationID(1)) != nil)
-        // No two displayed rows share a stableID — no diff-corrupting duplicate identity.
-        let ids = store.displayedMessages(for: conversationID(1)).map(\.stableID)
-        #expect(Set(ids).count == ids.count)
-    }
-
-    // MARK: - Transcript trimming
-
-    @Test("trimMessages keeps only the newest N confirmed messages")
-    func trimKeepsNewest() {
-        var store = ConversationStore()
-        store.mergeMessages((1...10).map { message(UInt64($0)) }, into: conversationID(1))
-        store.trimMessages(for: conversationID(1), keepingNewest: 4)
-        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [7, 8, 9, 10])
-    }
-
-    @Test("trimMessages is a no-op when the thread is at or under the cap")
-    func trimNoOpUnderCap() {
-        var store = ConversationStore()
-        store.mergeMessages([message(1), message(2), message(3)], into: conversationID(1))
-        store.trimMessages(for: conversationID(1), keepingNewest: 5)
-        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [1, 2, 3])
-    }
-
-    @Test("trimMessages leaves pending sends and the applied cursor intact")
-    func trimPreservesPendingAndCursor() {
-        var store = ConversationStore()
-        store.setAppliedCursor(9, for: conversationID(1))
-        store.mergeMessages((1...6).map { message(UInt64($0)) }, into: conversationID(1))
-        let clientID = UUID()
-        store.insertPending(
-            ConversationMessage(id: MessageID(value: .max), senderID: nil, content: .text("c"),
-                                date: Date(timeIntervalSince1970: 0), unreadSeq: 0,
-                                status: .sending, clientMessageID: clientID),
-            into: conversationID(1)
-        )
-        store.trimMessages(for: conversationID(1), keepingNewest: 2)
-        #expect(store.messages(for: conversationID(1)).map(\.id.value) == [5, 6])              // confirmed trimmed
-        #expect(store.appliedCursor(for: conversationID(1)) == 9)                               // delta cursor intact
-        // The pending send survives and still rides after the trimmed confirmed tail.
-        #expect(store.displayedMessages(for: conversationID(1)).map(\.stableID) == ["5", "6", clientID.uuidString])
+        store.insertPending(pending(clientID, "c"), anchoredTo: 0, into: conversationID(1))
+        #expect(store.hasPendingMessages(for: conversationID(1)))
     }
 }

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -269,6 +269,22 @@ struct ConversationControllerTests {
         #expect(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [7])
     }
 
+    @Test("a confirmed send persists its client id to the cache (identity survives a DB round-trip)")
+    func sendPersistsClientID() async throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let me = UUID()
+        let mock = MockConversations()
+        mock.sendResult = ConversationMessage(id: MessageID(value: 7), senderID: me, content: .text("hi"), date: Date(timeIntervalSince1970: 0), unreadSeq: 0)
+        let controller = makeController(mock, selfUserID: me, database: database)
+
+        #expect(await controller.send("hi", to: ConversationID.test(1)))
+
+        let stored = try database.getConversationMessages(conversationID: ConversationID.test(1))
+        #expect(stored.map(\.id.value) == [7])
+        #expect(stored.first?.clientMessageID != nil)   // the send's client id round-tripped through the DB
+    }
+
     @Test("send shows the message immediately as sending, then sent on success")
     func sendOptimisticSuccess() async {
         let me = UUID()
@@ -776,46 +792,28 @@ struct ConversationControllerTests {
         #expect(pointer == MessageID(value: 2))
     }
 
-    // MARK: - Background transcript bound -
+    // MARK: - DB-backed transcript (no in-memory hold) -
 
-    private func backlog(_ ids: ClosedRange<Int>) -> [ConversationMessage] {
-        ids.map {
+    @Test("streamed messages persist to the DB and are read as a bounded window, not held in memory")
+    func streamedMessagesAreDBBackedAndWindowed() async throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let mock = MockConversations()
+        let controller = makeController(mock, database: database)
+        controller.start()
+        try await waitUntil { mock.streamOpened }
+
+        let backlog = (1...150).map {
             ConversationMessage(id: MessageID(value: UInt64($0)), senderID: nil, content: .text("m\($0)"), date: Date(timeIntervalSince1970: TimeInterval($0)), unreadSeq: UInt64($0))
         }
-    }
+        mock.emit(.newMessages(conversationID: ConversationID.test(1), messages: backlog))
 
-    @Test("a never-opened conversation's streamed backlog is bounded to the cached window")
-    func backgroundConversationTranscriptIsBounded() async throws {
-        let mock = MockConversations()
-        let controller = makeController(mock)
-        controller.start()
-        try await waitUntil { mock.streamOpened }
-
-        // .test(1) is the chat on screen; .test(2) is one the user never opens, so on-leave trim never
-        // fires for it and its whole streamed backlog would otherwise accrete in memory.
-        controller.visibleConversationID = ConversationID.test(1)
-        mock.emit(.newMessages(conversationID: ConversationID.test(2), messages: backlog(1...150)))
-
-        try await waitUntil { controller.messages(for: ConversationID.test(2)).count == 100 }
-        let bounded = controller.messages(for: ConversationID.test(2))
-        #expect(bounded.count == 100)              // capped to the cached window
-        #expect(bounded.first?.id.value == 51)     // newest 100 kept (51...150)
-        #expect(bounded.last?.id.value == 150)
-        controller.stop()
-    }
-
-    @Test("the conversation on screen is not capped, so a deep transcript keeps its loaded history")
-    func visibleConversationTranscriptIsNotBounded() async throws {
-        let mock = MockConversations()
-        let controller = makeController(mock)
-        controller.start()
-        try await waitUntil { mock.streamOpened }
-
-        controller.visibleConversationID = ConversationID.test(1)
-        mock.emit(.newMessages(conversationID: ConversationID.test(1), messages: backlog(1...150)))
-
-        try await waitUntil { controller.messages(for: ConversationID.test(1)).count == 150 }
-        #expect(controller.messages(for: ConversationID.test(1)).count == 150)   // visible chat uncapped
+        // The whole backlog lands in the DB (nothing dropped), but the accessor reads a bounded window.
+        try await waitUntil { ((try? database.messageCount(conversationID: ConversationID.test(1))) ?? 0) == 150 }
+        #expect(try database.messageCount(conversationID: ConversationID.test(1)) == 150)   // full history persisted
+        let window = controller.messages(for: ConversationID.test(1))
+        #expect(window.count == 100)              // read as a bounded window, not the whole 150
+        #expect(window.last?.id.value == 150)     // newest at the tail
         controller.stop()
     }
 }

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -775,4 +775,47 @@ struct ConversationControllerTests {
         let pointer = rehydrated.conversations.first?.selfReadPointer(for: selfUserID)
         #expect(pointer == MessageID(value: 2))
     }
+
+    // MARK: - Background transcript bound -
+
+    private func backlog(_ ids: ClosedRange<Int>) -> [ConversationMessage] {
+        ids.map {
+            ConversationMessage(id: MessageID(value: UInt64($0)), senderID: nil, content: .text("m\($0)"), date: Date(timeIntervalSince1970: TimeInterval($0)), unreadSeq: UInt64($0))
+        }
+    }
+
+    @Test("a never-opened conversation's streamed backlog is bounded to the cached window")
+    func backgroundConversationTranscriptIsBounded() async throws {
+        let mock = MockConversations()
+        let controller = makeController(mock)
+        controller.start()
+        try await waitUntil { mock.streamOpened }
+
+        // .test(1) is the chat on screen; .test(2) is one the user never opens, so on-leave trim never
+        // fires for it and its whole streamed backlog would otherwise accrete in memory.
+        controller.visibleConversationID = ConversationID.test(1)
+        mock.emit(.newMessages(conversationID: ConversationID.test(2), messages: backlog(1...150)))
+
+        try await waitUntil { controller.messages(for: ConversationID.test(2)).count == 100 }
+        let bounded = controller.messages(for: ConversationID.test(2))
+        #expect(bounded.count == 100)              // capped to the cached window
+        #expect(bounded.first?.id.value == 51)     // newest 100 kept (51...150)
+        #expect(bounded.last?.id.value == 150)
+        controller.stop()
+    }
+
+    @Test("the conversation on screen is not capped, so a deep transcript keeps its loaded history")
+    func visibleConversationTranscriptIsNotBounded() async throws {
+        let mock = MockConversations()
+        let controller = makeController(mock)
+        controller.start()
+        try await waitUntil { mock.streamOpened }
+
+        controller.visibleConversationID = ConversationID.test(1)
+        mock.emit(.newMessages(conversationID: ConversationID.test(1), messages: backlog(1...150)))
+
+        try await waitUntil { controller.messages(for: ConversationID.test(1)).count == 150 }
+        #expect(controller.messages(for: ConversationID.test(1)).count == 150)   // visible chat uncapped
+        controller.stop()
+    }
 }

--- a/FlipcashTests/Database/Database+ConversationsTests.swift
+++ b/FlipcashTests/Database/Database+ConversationsTests.swift
@@ -139,17 +139,24 @@ struct DatabaseConversationsTests {
         #expect(loaded == [message])
     }
 
-    @Test("Re-upserting a message id replaces the row instead of duplicating it")
+    @Test("Re-upserting a message id replaces the row with a newer version instead of duplicating it")
     func messageUpsertReplaces() throws {
         let (database, url) = try Database.makeTemp()
         defer { Database.removeTemp(at: url) }
         let id = ConversationID.test(1)
 
-        try database.upsertConversationMessages([textMessage(id: 1)], conversationID: id)
-        try database.upsertConversationMessages([textMessage(id: 1, at: 99)], conversationID: id)
+        // Last-writer-wins: a strictly-newer event_sequence replaces the row in place (no duplicate);
+        // an equal version is kept (covered by the identity tests below).
+        let first = ConversationMessage(id: MessageID(value: 1), senderID: otherID, content: .text("first"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 1, eventSequence: 1)
+        let newer = ConversationMessage(id: MessageID(value: 1), senderID: otherID, content: .text("second"),
+            date: Date(timeIntervalSince1970: 99), unreadSeq: 1, eventSequence: 2)
+        try database.upsertConversationMessages([first], conversationID: id)
+        try database.upsertConversationMessages([newer], conversationID: id)
 
         let loaded = try database.getConversationMessages(conversationID: id)
-        #expect(loaded == [textMessage(id: 1, at: 99)])
+        #expect(loaded.count == 1)          // no duplicate
+        #expect(loaded == [newer])          // newer version won
     }
 
     @Test("Sub-second message dates round-trip exactly")
@@ -170,58 +177,149 @@ struct DatabaseConversationsTests {
         #expect(try database.getConversationMessages(conversationID: id) == [message])
     }
 
-    @Test("Pruning keeps the newest window once the slack is exceeded")
-    func pruneKeepsNewestWindow() throws {
+    @Test("Retains all history — no prune")
+    func retainsAllHistory() throws {
         let (database, url) = try Database.makeTemp()
         defer { Database.removeTemp(at: url) }
         let id = ConversationID.test(1)
-        let overflow = Database.messageWindow + Database.messageWindowSlack + 10
+        let count = Database.messageWindow * 3
 
         try database.upsertConversationMessages(
-            (1...UInt64(overflow)).map { textMessage(id: $0) },
+            (1...UInt64(count)).map { textMessage(id: $0) },
             conversationID: id
         )
 
-        let kept = try database.getConversationMessages(conversationID: id)
-        #expect(kept.count == Database.messageWindow)
-        #expect(kept.first?.id.value == UInt64(overflow - Database.messageWindow + 1))
-        #expect(kept.last?.id.value == UInt64(overflow))
+        let all = try database.getConversationMessages(conversationID: id)
+        #expect(all.count == count)                    // nothing pruned
+        #expect(all.first?.id.value == 1)
+        #expect(all.last?.id.value == UInt64(count))
     }
 
-    @Test("No pruning within the hysteresis slack")
-    func pruneRespectsSlack() throws {
+    @Test("A windowed read returns the newest N, oldest-first")
+    func windowedReadReturnsNewest() throws {
         let (database, url) = try Database.makeTemp()
         defer { Database.removeTemp(at: url) }
         let id = ConversationID.test(1)
-        let withinSlack = Database.messageWindow + Database.messageWindowSlack
+        let count = 250
 
         try database.upsertConversationMessages(
-            (1...UInt64(withinSlack)).map { textMessage(id: $0) },
+            (1...UInt64(count)).map { textMessage(id: $0) },
             conversationID: id
         )
 
-        #expect(try database.getConversationMessages(conversationID: id).count == withinSlack)
+        let window = try database.getConversationMessages(conversationID: id, newest: Database.messageWindow)
+        #expect(window.count == Database.messageWindow)
+        #expect(window.first?.id.value == UInt64(count - Database.messageWindow + 1))   // oldest-first
+        #expect(window.last?.id.value == UInt64(count))                                  // newest at the tail
     }
 
-    @Test("Pruning leaves other conversations and the feed preview intact")
-    func pruneIsScopedAndPreviewSurvives() throws {
+    @Test("History is retained per conversation and the feed preview is the newest message")
+    func historyScopedAndPreviewSurvives() throws {
         let (database, url) = try Database.makeTemp()
         defer { Database.removeTemp(at: url) }
-        let pruned = ConversationID.test(1)
-        let untouched = ConversationID.test(2)
-        let overflow = Database.messageWindow + Database.messageWindowSlack + 1
+        let heavy = ConversationID.test(1)
+        let light = ConversationID.test(2)
+        let count = Database.messageWindow * 2
 
         try database.upsertConversation(conversation(byte: 1))
         try database.upsertConversation(conversation(byte: 2))
         try database.upsertConversationMessages(
-            (1...UInt64(overflow)).map { textMessage(id: $0) },
-            conversationID: pruned
+            (1...UInt64(count)).map { textMessage(id: $0) },
+            conversationID: heavy
         )
-        try database.upsertConversationMessages([textMessage(id: 1)], conversationID: untouched)
+        try database.upsertConversationMessages([textMessage(id: 1)], conversationID: light)
 
-        #expect(try database.getConversationMessages(conversationID: untouched).map(\.id.value) == [1])
+        #expect(try database.getConversationMessages(conversationID: heavy).count == count)   // retained
+        #expect(try database.getConversationMessages(conversationID: light).map(\.id.value) == [1])
         let previews = try database.getConversations().map(\.lastMessage?.id.value)
-        #expect(previews.contains(UInt64(overflow)))
+        #expect(previews.contains(UInt64(count)))
+    }
+
+    // MARK: - Identity + atomicity
+
+    @Test("clientMessageID round-trips through the cache")
+    func clientMessageIDRoundTrips() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let clientID = UUID()
+        let message = ConversationMessage(
+            id: MessageID(value: 5), senderID: selfID, content: .text("hi"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 5, clientMessageID: clientID
+        )
+        try database.upsertConversationMessages([message], conversationID: ConversationID.test(1))
+        #expect(try database.getConversationMessages(conversationID: ConversationID.test(1)).first?.clientMessageID == clientID)
+    }
+
+    @Test("equal eventSequence adopts a missing client id without changing content")
+    func equalSequenceAdoptsClientID() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        let stored = ConversationMessage(id: MessageID(value: 5), senderID: selfID, content: .text("hi"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 5, eventSequence: 3)
+        try database.upsertConversationMessages([stored], conversationID: id)
+        // An equal-version copy carrying the client id (a reconcile landing after the stream echo).
+        let clientID = UUID()
+        let echo = ConversationMessage(id: MessageID(value: 5), senderID: selfID, content: .text("hi"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 5, eventSequence: 3, clientMessageID: clientID)
+        try database.upsertConversationMessages([echo], conversationID: id)
+        let row = try database.getConversationMessages(conversationID: id).first
+        #expect(row?.clientMessageID == clientID)   // adopted
+        #expect(row?.content == .text("hi"))         // content unchanged
+    }
+
+    @Test("a newer version preserves the stored client id when it lacks one")
+    func newerVersionPreservesClientID() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        let clientID = UUID()
+        let stored = ConversationMessage(id: MessageID(value: 5), senderID: selfID, content: .text("hi"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 5, eventSequence: 3, clientMessageID: clientID)
+        try database.upsertConversationMessages([stored], conversationID: id)
+        // A newer edit arrives with no client id (the server never echoes it).
+        let edit = ConversationMessage(id: MessageID(value: 5), senderID: selfID, content: .text("edited"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 5, eventSequence: 4)
+        try database.upsertConversationMessages([edit], conversationID: id)
+        let row = try database.getConversationMessages(conversationID: id).first
+        #expect(row?.content == .text("edited"))    // newer content won
+        #expect(row?.clientMessageID == clientID)   // identity preserved
+    }
+
+    // Proves the batch + cursor both land on success. The rollback-on-partial-failure half of
+    // atomicity is guaranteed by the single `writer.transaction`, but isn't unit-exercisable without a
+    // DB fault-injection hook (which would be production test-support), so it stands by construction.
+    @Test("persistMessages writes the batch and advances the cursor together")
+    func persistMessagesAdvancesCursorAtomically() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversation(conversation(byte: 1))   // the cursor lives on the conversation row
+        try database.persistMessages([textMessage(id: 5), textMessage(id: 6)], cursor: 42, conversationID: id)
+        #expect(try database.getConversationMessages(conversationID: id).map(\.id.value) == [5, 6])
+        #expect(try database.getCatchupCursors()[id] == 42)
+    }
+
+    @Test("persistMessages does not write an unestablished (zero) cursor")
+    func persistMessagesSkipsZeroCursor() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversation(conversation(byte: 1))
+        try database.persistMessages([textMessage(id: 5)], cursor: 0, conversationID: id)
+        #expect(try database.getConversationMessages(conversationID: id).map(\.id.value) == [5])
+        #expect(try database.getCatchupCursors()[id] == nil)   // nothing written
+    }
+
+    @Test("catchupCursor round-trips the persisted cursor for one conversation")
+    func catchupCursorRoundTrips() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversation(conversation(byte: 1))
+        #expect(try database.catchupCursor(conversationID: id) == 0)   // none yet
+        try database.persistMessages([textMessage(id: 5)], cursor: 42, conversationID: id)
+        #expect(try database.catchupCursor(conversationID: id) == 42)
     }
 
     @Test("Messages are scoped to their conversation")

--- a/FlipcashTests/Database/Database+ConversationsTests.swift
+++ b/FlipcashTests/Database/Database+ConversationsTests.swift
@@ -182,7 +182,7 @@ struct DatabaseConversationsTests {
         let (database, url) = try Database.makeTemp()
         defer { Database.removeTemp(at: url) }
         let id = ConversationID.test(1)
-        let count = Database.messageWindow * 3
+        let count = 300
 
         try database.upsertConversationMessages(
             (1...UInt64(count)).map { textMessage(id: $0) },
@@ -207,10 +207,45 @@ struct DatabaseConversationsTests {
             conversationID: id
         )
 
-        let window = try database.getConversationMessages(conversationID: id, newest: Database.messageWindow)
-        #expect(window.count == Database.messageWindow)
-        #expect(window.first?.id.value == UInt64(count - Database.messageWindow + 1))   // oldest-first
-        #expect(window.last?.id.value == UInt64(count))                                  // newest at the tail
+        let window = try database.messagesWindow(conversationID: id, limit: 100)
+        #expect(window.count == 100)
+        #expect(window.first?.id.value == UInt64(count - 100 + 1))   // oldest-first
+        #expect(window.last?.id.value == UInt64(count))              // newest at the tail
+    }
+
+    @Test("An id-anchored read returns everything from the anchor to the newest")
+    func anchoredReadGrowsAtTheTail() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages(
+            (1...100).map { textMessage(id: $0) },
+            conversationID: id
+        )
+
+        let window = try database.messages(conversationID: id, from: 40)
+        #expect(window.first?.id.value == 40)     // anchor included
+        #expect(window.last?.id.value == 100)
+        // An arrival grows the window at the tail; the anchor row never slides out.
+        try database.upsertConversationMessages([textMessage(id: 101)], conversationID: id)
+        let grown = try database.messages(conversationID: id, from: 40)
+        #expect(grown.first?.id.value == 40)
+        #expect(grown.last?.id.value == 101)
+    }
+
+    @Test("olderAnchor steps back by N rows and clamps to the oldest available")
+    func olderAnchorSteps() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages(
+            (1...100).map { textMessage(id: $0) },
+            conversationID: id
+        )
+
+        #expect(try database.olderAnchor(conversationID: id, before: 60, step: 40) == 20)   // a full step
+        #expect(try database.olderAnchor(conversationID: id, before: 20, step: 40) == 1)    // clamps to oldest
+        #expect(try database.olderAnchor(conversationID: id, before: 1, step: 40) == nil)   // exhausted
     }
 
     @Test("History is retained per conversation and the feed preview is the newest message")
@@ -219,7 +254,7 @@ struct DatabaseConversationsTests {
         defer { Database.removeTemp(at: url) }
         let heavy = ConversationID.test(1)
         let light = ConversationID.test(2)
-        let count = Database.messageWindow * 2
+        let count = 200
 
         try database.upsertConversation(conversation(byte: 1))
         try database.upsertConversation(conversation(byte: 2))
@@ -479,10 +514,12 @@ struct DatabaseConversationsTests {
 
         #expect(try database.getConversations().map(\.id) == [ConversationID.test(1)])
         #expect(try database.getConversationMessages(conversationID: ConversationID.test(1)).map(\.id.value) == [1])
-        #expect(try database.getConversationMessages(conversationID: ConversationID.test(2)).isEmpty)
+        // Messages survive a feed replace: a stale feed snapshot (fetched before a brand-new chat's
+        // first message landed) must not wipe the transcript's source of truth.
+        #expect(try database.getConversationMessages(conversationID: ConversationID.test(2)).map(\.id.value) == [2])
     }
 
-    @Test("Replacing with an empty feed clears the cache")
+    @Test("Replacing with an empty feed clears the feed but retains messages")
     func emptyFeedReplaceClears() throws {
         let (database, url) = try Database.makeTemp()
         defer { Database.removeTemp(at: url) }
@@ -492,6 +529,49 @@ struct DatabaseConversationsTests {
         try database.replaceConversationFeed([])
 
         #expect(try database.getConversations().isEmpty)
+        #expect(try database.getConversationMessages(conversationID: ConversationID.test(1)).map(\.id.value) == [1])
+    }
+
+    @Test("persistMessages never regresses the persisted cursor")
+    func persistMessagesCursorIsMonotonic() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversation(conversation(byte: 1))
+        // A live event persisted cursor=50; an interleaved catch-up batch then lands checkpoint=30.
+        try database.persistMessages([textMessage(id: 5)], cursor: 50, conversationID: id)
+        try database.persistMessages([textMessage(id: 6)], cursor: 30, conversationID: id)
+        #expect(try database.catchupCursor(conversationID: id) == 50)   // regression ignored
+        try database.persistMessages([textMessage(id: 7)], cursor: 60, conversationID: id)
+        #expect(try database.catchupCursor(conversationID: id) == 60)   // forward still advances
+    }
+
+    @Test("newestMessage includes tombstones so a delete doesn't regress the buzz anchor")
+    func newestMessageIncludesTombstones() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages([textMessage(id: 1), textMessage(id: 2)], conversationID: id)
+        // The newest message is deleted in place (same id, higher event sequence).
+        let tombstone = ConversationMessage(id: MessageID(value: 2), senderID: otherID, content: .deleted,
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 2, eventSequence: 5)
+        try database.upsertConversationMessages([tombstone], conversationID: id)
+
+        #expect(try database.newestMessage(conversationID: id)?.id.value == 2)          // the tombstone itself
+        #expect(try database.newestMessage(conversationID: id)?.content == .deleted)
+        #expect(try database.latestMessage(conversationID: id)?.id.value == 1)          // preview falls back
+    }
+
+    @Test("deleteMessages drops a conversation's rows (the stale-epoch reset)")
+    func deleteMessagesDropsRows() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        try database.upsertConversationMessages([textMessage(id: 1)], conversationID: ConversationID.test(1))
+        try database.upsertConversationMessages([textMessage(id: 2)], conversationID: ConversationID.test(2))
+
+        try database.deleteMessages(conversationID: ConversationID.test(1))
+
         #expect(try database.getConversationMessages(conversationID: ConversationID.test(1)).isEmpty)
+        #expect(try database.getConversationMessages(conversationID: ConversationID.test(2)).map(\.id.value) == [2])
     }
 }

--- a/FlipcashTests/MessageLoaderTests.swift
+++ b/FlipcashTests/MessageLoaderTests.swift
@@ -1,0 +1,69 @@
+//
+//  MessageLoaderTests.swift
+//  FlipcashTests
+//
+
+import Testing
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("MessageLoader windowed DB reads")
+struct MessageLoaderTests {
+
+    private func makeController(_ database: Database) -> ConversationController {
+        ConversationController(
+            fetching: MockConversations(), messaging: MockConversations(), streaming: MockConversations(),
+            contactNaming: MockDMContactNaming(),
+            database: database,
+            owner: .generate()!, selfUserID: UUID(),
+            typingHeartbeatInterval: .seconds(3), incomingTypingExpiry: .seconds(10)
+        )
+    }
+
+    private func message(_ id: UInt64) -> ConversationMessage {
+        ConversationMessage(id: MessageID(value: id), senderID: nil, content: .text("m\(id)"), date: Date(timeIntervalSince1970: TimeInterval(id)), unreadSeq: id)
+    }
+
+    @Test("the initial window shows the newest page read from the DB")
+    func initialWindow() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages((1...200).map { message(UInt64($0)) }, conversationID: id)
+
+        let loader = MessageLoader(conversationID: id, controller: makeController(database))
+        let shown = loader.messages
+        #expect(shown.count == 60)              // the initial window, not the whole 200
+        #expect(shown.first?.id.value == 141)   // newest 60 (141...200), oldest-first
+        #expect(shown.last?.id.value == 200)
+    }
+
+    @Test("loadOlder grows the window over persisted history without a server fetch")
+    func loadOlderGrowsWindow() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages((1...200).map { message(UInt64($0)) }, conversationID: id)
+        let loader = MessageLoader(conversationID: id, controller: makeController(database))
+
+        loader.loadOlder()                      // 60 -> 100
+        #expect(loader.messages.count == 100)
+        #expect(loader.messages.first?.id.value == 101)
+        loader.loadOlder()                      // 100 -> 140
+        #expect(loader.messages.count == 140)
+        #expect(loader.messages.first?.id.value == 61)
+    }
+
+    @Test("a thread shorter than the window shows all of it")
+    func shortThread() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages((1...10).map { message(UInt64($0)) }, conversationID: id)
+
+        let loader = MessageLoader(conversationID: id, controller: makeController(database))
+        #expect(loader.messages.map(\.id.value) == Array(1...10).map(UInt64.init))
+    }
+}

--- a/FlipcashTests/MessageLoaderTests.swift
+++ b/FlipcashTests/MessageLoaderTests.swift
@@ -46,7 +46,7 @@ struct MessageLoaderTests {
         defer { Database.removeTemp(at: url) }
         let id = ConversationID.test(1)
         try database.upsertConversationMessages((1...200).map { message(UInt64($0)) }, conversationID: id)
-        let loader = MessageLoader(conversationID: id, controller: makeController(database))
+        let loader = MessageLoader(conversationID: id, controller: makeController(database), growthInterval: .zero)
 
         loader.loadOlder()                      // 60 -> 100
         #expect(loader.messages.count == 100)
@@ -54,6 +54,36 @@ struct MessageLoaderTests {
         loader.loadOlder()                      // 100 -> 140
         #expect(loader.messages.count == 140)
         #expect(loader.messages.first?.id.value == 61)
+    }
+
+    @Test("an arriving message grows the anchored window at the tail — the oldest revealed row never slides out")
+    func arrivalDoesNotSlideAnchoredWindow() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages((1...200).map { message(UInt64($0)) }, conversationID: id)
+        let loader = MessageLoader(conversationID: id, controller: makeController(database), growthInterval: .zero)
+
+        loader.loadOlder()                      // reader pages back: window anchored at 101
+        #expect(loader.messages.first?.id.value == 101)
+
+        // A message arrives while the reader is scrolled up.
+        try database.upsertConversationMessages([message(201)], conversationID: id)
+        let grown = loader.messages
+        #expect(grown.first?.id.value == 101)   // the revealed history is intact
+        #expect(grown.last?.id.value == 201)    // the arrival grew the tail
+    }
+
+    @Test("a scroll-tick burst of loadOlder grows the window by one step, not one per tick")
+    func loadOlderBurstIsDebounced() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages((1...200).map { message(UInt64($0)) }, conversationID: id)
+        let loader = MessageLoader(conversationID: id, controller: makeController(database))   // real interval
+
+        for _ in 0..<10 { loader.loadOlder() }   // scrollViewDidScroll fires per frame near the top
+        #expect(loader.messages.count == 100)     // one +40 step accepted, nine rejected
     }
 
     @Test("a thread shorter than the window shows all of it")

--- a/FlipcashUITests/Support/BaseUITestCase.swift
+++ b/FlipcashUITests/Support/BaseUITestCase.swift
@@ -173,9 +173,10 @@ class BaseUITestCase: XCTestCase {
     /// if the flow never completes — a swallowed miss leaves the alert
     /// covering the app and wedges every test that follows in the bundle.
     func allowContactsIfNeeded() {
-        // The in-app priming button; scoped to `app` so it never matches the
-        // system alert's own "Continue" (`springboard`, tapped below).
-        let appContinueButton = app.buttons["Continue"]
+        // The in-app priming button, targeted by identifier: a bare "Continue" label is ambiguous
+        // (the scan screen's camera prompt behind the sheet carries the same label), and scoping to
+        // `app` alone never matches the system alert's own "Continue" (`springboard`, tapped below).
+        let appContinueButton = app.buttons["contacts-continue-button"]
         guard appContinueButton.waitForExistence(timeout: 5) else { return }
         appContinueButton.tap()
 


### PR DESCRIPTION
The conversation screen re-mapped and re-laid-out the entire message history on the main thread over an in-memory store that was never pruned, so entering or leaving a dense chat froze the UI and the store grew unbounded for the session.

This makes the local database the source of truth for the transcript:

- The screen reads a bounded window from the database (the newest page), pages older on scroll, and maps it to display items off the main thread — a fresh open lays out a slice, not the whole thread.
- All message history is retained locally; history that used to re-fetch from the server every time is read from the database once it has been seen.
- The in-memory message store is retired entirely — it now holds only the feed, in-flight optimistic sends, and the catch-up cursor. Reconciliation, the feed preview, mark-read, and existence checks all run against the database.
- Bumps the local schema version, so cached conversations are deleted and rebuilt from the server on next login (messages re-page on demand).

Scroll position resets to the newest messages when you re-enter a chat (older re-pages on demand) — an accepted trade-off.

## Test plan
- [x] Enter and leave a dense conversation repeatedly — no freeze on either
- [x] Cash cards, receipts, date separators, grouping, links, and the typing indicator render correctly
- [x] Send, receive, and retry a failed send; page older history while messages arrive
- [x] Scroll up in a busy chat while the counterpart sends — the row being read stays put
- [x] Delete the newest message from the other side — no buzz, feed preview falls back
- [x] Feed previews and unread counts stay correct; brand-new chat's first message survives a feed refresh
- [x] Fresh install / re-login: transcript rebuilds from the server and pages correctly
- [x] AllTargets passes
