### PR TITLE
feat: add time, unread badge, and unknown-contact tag to Send rows

### DIFF
--- a/Flipcash/Core/Screens/Send/AddMoreContactsFooter.swift
+++ b/Flipcash/Core/Screens/Send/AddMoreContactsFooter.swift
@@ -27,7 +27,7 @@ struct AddMoreContactsFooter: View {
                 // Decorative — the whole row is the tap target, like the
                 // contact rows' "Invite" pill.
                 Text("Settings")
-                    .pill(.prominent)
+                    .chip(.prominent)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())

--- a/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
+++ b/Flipcash/Core/Screens/Send/RecipientPickerScreen.swift
@@ -373,14 +373,26 @@ private struct RecipientPickerList: View {
 
 // MARK: - Rows -
 
+/// Where a picker row's accessory sits, which in turn sets how wide the subtitle
+/// runs.
+private enum RecipientRowAccessoryPlacement {
+    /// Centered in a full-height trailing column; the subtitle stays in the
+    /// column beside it — the invite rows.
+    case trailingColumn
+    /// On the title's line (Messages/Mail style); the subtitle spans the row's
+    /// full width below — the merged on-Flipcash feed.
+    case titleLine
+}
+
 /// The chrome every picker row shares: a full-row button with avatar,
-/// title/subtitle, and a trailing accessory.
+/// title/subtitle, and an accessory.
 private struct RecipientRowScaffold<Trailing: View>: View {
 
     let avatarID: String
     let title: String
     let subtitle: String?
     let imageData: Data?
+    var accessoryPlacement: RecipientRowAccessoryPlacement = .trailingColumn
     let accessibilityLabel: String
     let onTap: () -> Void
     @ViewBuilder let trailing: Trailing
@@ -391,7 +403,8 @@ private struct RecipientRowScaffold<Trailing: View>: View {
                 avatarID: avatarID,
                 title: title,
                 subtitle: subtitle,
-                imageData: imageData
+                imageData: imageData,
+                accessoryPlacement: accessoryPlacement
             ) {
                 trailing
             }
@@ -400,15 +413,16 @@ private struct RecipientRowScaffold<Trailing: View>: View {
     }
 }
 
-/// The visual content of a picker row: avatar, title/subtitle, and a trailing
-/// accessory. Shared by the tappable `RecipientRowScaffold` and the `ShareLink`
-/// invite-fallback row.
+/// The visual content of a picker row: avatar, title/subtitle, and an accessory
+/// placed per `accessoryPlacement`. Shared by the tappable `RecipientRowScaffold`
+/// and the `ShareLink` invite-fallback row.
 private struct RecipientRowBody<Trailing: View>: View {
 
     let avatarID: String
     let title: String
     let subtitle: String?
     let imageData: Data?
+    var accessoryPlacement: RecipientRowAccessoryPlacement = .trailingColumn
     @ViewBuilder let trailing: Trailing
 
     var body: some View {
@@ -420,10 +434,16 @@ private struct RecipientRowBody<Trailing: View>: View {
                 size: 44
             )
             VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.appTextMedium)
-                    .foregroundStyle(Color.textMain)
-                    .lineLimit(1)
+                HStack(alignment: .top, spacing: 6) {
+                    Text(title)
+                        .font(.appTextMedium)
+                        .foregroundStyle(Color.textMain)
+                        .lineLimit(1)
+                    if accessoryPlacement == .titleLine {
+                        Spacer(minLength: 12)
+                        trailing
+                    }
+                }
                 if let subtitle {
                     Text(subtitle)
                         .font(.appTextSmall)
@@ -436,8 +456,10 @@ private struct RecipientRowBody<Trailing: View>: View {
             // Cross-fade the subtitle when it changes — notably the "Typing…" ⇄ last-message swap, but
             // also a fresh message preview replacing the previous one.
             .animation(.easeInOut(duration: 0.2), value: subtitle)
-            Spacer(minLength: 12)
-            trailing
+            if accessoryPlacement == .trailingColumn {
+                Spacer(minLength: 12)
+                trailing
+            }
         }
         .contentShape(Rectangle())
     }
@@ -509,6 +531,11 @@ private struct RecipientListItemRow: View {
         item.conversation?.hasUnread(for: conversationController.selfUserID) ?? false
     }
 
+    /// A chat whose counterpart isn't a synced address-book contact.
+    private var isUnknown: Bool {
+        item.contact == nil
+    }
+
     private var avatarID: String {
         switch item {
         case .contact(let contact), .matched(let contact, _):
@@ -520,7 +547,8 @@ private struct RecipientListItemRow: View {
 
     private var accessibilityLabel: String {
         let base = subtitle.map { "\(title), \($0)" } ?? title
-        return hasUnread ? "\(base), unread messages" : base
+        let named = isUnknown ? "\(base), Unknown Contact" : base
+        return hasUnread ? "\(named), unread messages" : named
     }
 
     var body: some View {
@@ -529,22 +557,49 @@ private struct RecipientListItemRow: View {
             title: title,
             subtitle: subtitle,
             imageData: item.contact?.imageData,
+            accessoryPlacement: .titleLine,
             accessibilityLabel: accessibilityLabel,
             onTap: onTap
         ) {
-            Image(systemName: "chevron.right")
-                .font(.appTextSmall)
-                .foregroundStyle(Color.textSecondary)
+            RecipientRowAccessory(
+                timestamp: item.sortDate,
+                isUnknown: isUnknown,
+                hasUnread: hasUnread
+            )
         }
-        .overlay(alignment: .leading) {
+    }
+}
+
+/// A merged recipient row's title-line accessory: a relative timestamp — or an
+/// "Unknown Contact" pill for a chat with someone not in the address book —
+/// followed by an unread badge or a disclosure chevron.
+private struct RecipientRowAccessory: View {
+
+    let timestamp: Date
+    let isUnknown: Bool
+    let hasUnread: Bool
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if isUnknown {
+                Text("Unknown Contact")
+                    .fixedSize(horizontal: true, vertical: false)
+                    .pill()
+            } else {
+                Text(timestamp.formattedRelatively(useTimeForToday: true))
+                    .font(.appTextSmall)
+                    .foregroundStyle(hasUnread ? Color.unreadIndicator : Color.textSecondary)
+            }
             if hasUnread {
-                // Offset into the row's leading inset so the dot sits in the
-                // margin left of the avatar.
                 Circle()
                     .fill(Color.unreadIndicator)
-                    .frame(width: 10, height: 10)
-                    .offset(x: -15)
-                    .accessibilityHidden(true)
+                    .frame(width: 9, height: 9)
+            } else {
+                Image(systemName: "chevron.right")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 9, height: 12)
+                    .foregroundStyle(Color.textSecondary)
             }
         }
     }
@@ -593,11 +648,11 @@ private struct RecipientRow: View {
     }
 }
 
-/// The trailing "Invite" pill on a "Not on Flipcash Yet" row.
+/// The trailing "Invite" chip on a "Not on Flipcash Yet" row.
 private struct InvitePill: View {
     var body: some View {
         Text("Invite")
-            .pill(.standard)
+            .chip(.standard)
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/Chip.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/Chip.swift
@@ -1,0 +1,45 @@
+//
+//  Chip.swift
+//  FlipcashUI
+//
+
+import SwiftUI
+
+/// Visual style for a compact chip label (small text on a rounded-rect fill).
+public enum ChipStyle {
+    /// Subtle row-fill background — e.g. the "Invite" affordance.
+    case standard
+    /// Solid white fill — e.g. the "Settings" affordance.
+    case prominent
+
+    var textColor: Color {
+        switch self {
+        case .standard:  .textMain
+        case .prominent: .backgroundMain
+        }
+    }
+
+    var fillColor: Color {
+        switch self {
+        case .standard:  .backgroundRow
+        case .prominent: .textMain
+        }
+    }
+}
+
+public extension View {
+    /// Styles the receiver as a compact rounded-rect chip. Used for the
+    /// non-interactive affordance inside a tappable row (the whole row is the
+    /// tap target), e.g. "Invite" and "Settings".
+    func chip(_ style: ChipStyle) -> some View {
+        self
+            .font(.appTextSmall)
+            .foregroundStyle(style.textColor)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background {
+                RoundedRectangle(cornerRadius: Metrics.buttonRadius)
+                    .fill(style.fillColor)
+            }
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/Pill.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/Pill.swift
@@ -5,41 +5,18 @@
 
 import SwiftUI
 
-/// Visual style for a compact pill label (small text on a rounded fill).
-public enum PillStyle {
-    /// Subtle row-fill background — e.g. the "Invite" affordance.
-    case standard
-    /// Solid white fill — e.g. the "Settings" affordance.
-    case prominent
-
-    var textColor: Color {
-        switch self {
-        case .standard:  .textMain
-        case .prominent: .backgroundMain
-        }
-    }
-
-    var fillColor: Color {
-        switch self {
-        case .standard:  .backgroundRow
-        case .prominent: .textMain
-        }
-    }
-}
-
 public extension View {
-    /// Styles the receiver as a compact pill. Used for the non-interactive pill
-    /// affordance inside a tappable row (the whole row is the tap target), e.g.
-    /// "Invite" and "Settings".
-    func pill(_ style: PillStyle) -> some View {
+    /// Styles the receiver as a fully-rounded pill with muted text — e.g. the
+    /// "Unknown Contact" tag on a recipient row.
+    func pill() -> some View {
         self
             .font(.appTextSmall)
-            .foregroundStyle(style.textColor)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
+            .foregroundStyle(Color.textSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
             .background {
-                RoundedRectangle(cornerRadius: Metrics.buttonRadius)
-                    .fill(style.fillColor)
+                Capsule()
+                    .fill(Color.backgroundRow)
             }
     }
 }


### PR DESCRIPTION
Restyles the on-Flipcash rows in the Send picker to a Messages-style layout. On the title line each row now shows the relative time — or an "Unknown Contact" tag for a chat with someone who isn't in your address book — followed by an unread badge when unread or a disclosure chevron. The message preview spans the full row width below, and the unread dot moves out of the leading margin into that trailing group.

Also renames the mis-named `.pill` style helper to `.chip` (the rounded-rect used by Invite and Settings) and adds a new `.pill()` capsule, so the name matches the shape.

## Test plan
- [x] On-Flipcash rows show a relative time + chevron when read, and a blue time + unread dot when unread
- [x] A chat with someone not in your contacts shows the "Unknown Contact" capsule
- [x] Message previews run the full width of the row
- [x] "Not on Flipcash Yet" invite rows are unchanged