### PR TITLE
feat: add haptic feedback when slide-to-send commits

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Views/Controls/SwipeControl.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Controls/SwipeControl.swift
@@ -71,6 +71,7 @@ public struct SwipeControl: View {
             .animation(nil, value: state)
         }
         .opacity(isEnabled ? 1 : Layout.disabledOpacity)
+        .sensoryFeedback(.impact(weight: .heavy), trigger: state) { _, newState in newState == .loading }
         .accessibilityRepresentation {
             Button(text) {
                 Task {


### PR DESCRIPTION
Adds a firm haptic tap the moment the Slide to Send control commits and the send fires — once the knob is dragged past the threshold. It fires once per commit, not while dragging, and only on the actual slide gesture.

## Test plan
- [x] On a physical device, slide the knob all the way to send and feel the haptic the instant it locks in and the spinner appears
- [x] Confirm nothing fires mid-drag or on a partial drag that snaps back
