### PR TITLE
feat: morph send-cash button into the chat composer bar

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -10,11 +10,9 @@ import UIKit
 import FlipcashCore
 import FlipcashUI
 
-/// Hosts the fully-UIKit chat (transcript + bars) inside SwiftUI. SwiftUI supplies the already-mapped
-/// messages and hosts two bars — the Send Cash / Send Message action bar (pinned to the safe area)
-/// and the composer (pinned to the keyboard). All scroll, keyboard, and flow-under behavior lives in
-/// the UIKit screen. Both bars share `barModel`, so the swap animates through observation rather than
-/// `UIHostingController.rootView` reassignment (which can't carry it).
+/// Hosts the fully-UIKit chat (transcript + bar) inside SwiftUI. SwiftUI supplies the already-mapped
+/// messages and hosts the single bottom bar — Send Cash beside the composer — pinned to the keyboard
+/// layout guide. All scroll, keyboard, and flow-under behavior lives in the UIKit screen.
 struct ChatScreenRepresentable: UIViewControllerRepresentable {
 
     let items: [ChatItem]
@@ -32,46 +30,36 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     /// falling back to the system browser.
     let onOpenURL: (URL) -> Void
     let showsSendCash: Bool
-    let showsSendMessage: Bool
+    let chatExists: Bool
     let conversationID: ConversationID?
+    let symbol: String
     let onSendCash: () -> Void
     let conversationController: ConversationController
     let barModel: ConversationBarModel
 
     func makeUIViewController(context: Context) -> ChatScreenViewController {
-        let restingHost = UIHostingController(rootView: restingBar(coordinator: context.coordinator))
-        let keyboardHost = UIHostingController(rootView: keyboardBar(coordinator: context.coordinator))
-        restingHost.view.backgroundColor = .clear
-        keyboardHost.view.backgroundColor = .clear
-        let screen = ChatScreenViewController(
-            restingBar: restingHost.view,
-            keyboardBar: keyboardHost.view,
-            restingBarController: restingHost,
-            keyboardBarController: keyboardHost
-        )
+        let barHost = UIHostingController(rootView: bar(coordinator: context.coordinator))
+        barHost.view.backgroundColor = .clear
+        let screen = ChatScreenViewController(bar: barHost.view, barController: barHost)
         screen.onReachTop = onReachTop
         screen.onRetry = onRetry
         screen.onCashCardTap = onCashCardTap
         screen.onOpenURL = onOpenURL
         screen.update(items: items)
-        screen.setComposing(barModel.isComposing)
-        context.coordinator.restingHost = restingHost
-        context.coordinator.keyboardHost = keyboardHost
+        context.coordinator.barHost = barHost
         context.coordinator.screen = screen
         context.coordinator.lastMessageID = lastMessageID(of: items)
         return screen
     }
 
     func updateUIViewController(_ screen: ChatScreenViewController, context: Context) {
-        // Re-supply both bars with current inputs; SwiftUI diffs them, so the composer's draft and
+        // Re-supply the bar with current inputs; SwiftUI diffs it, so the composer's draft and
         // focus survive across updates.
-        context.coordinator.restingHost?.rootView = restingBar(coordinator: context.coordinator)
-        context.coordinator.keyboardHost?.rootView = keyboardBar(coordinator: context.coordinator)
+        context.coordinator.barHost?.rootView = bar(coordinator: context.coordinator)
         screen.onReachTop = onReachTop
         screen.onRetry = onRetry
         screen.onCashCardTap = onCashCardTap
         screen.onOpenURL = onOpenURL
-        screen.setComposing(barModel.isComposing)
 
         // Scroll only when the user's *own* message was just appended — a new trailing message id
         // (skipping any trailing receipt) that is from me. Received messages and prepended history
@@ -95,31 +83,25 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         lastMessage(of: items)?.id
     }
 
-    private func restingBar(coordinator: Coordinator) -> AnyView {
+    private func bar(coordinator: Coordinator) -> AnyView {
         AnyView(
-            ConversationActionBar(
+            ConversationBottomBar(
                 showsSendCash: showsSendCash,
-                showsSendMessage: showsSendMessage,
+                chatExists: chatExists,
+                conversationID: conversationID,
+                symbol: symbol,
                 onSendCash: onSendCash,
                 model: barModel
             )
-            .modifier(MeasuredBarHeight { coordinator.screen?.setRestingBarHeight($0) })
-        )
-    }
-
-    private func keyboardBar(coordinator: Coordinator) -> AnyView {
-        AnyView(
-            ConversationComposer(conversationID: conversationID, model: barModel)
-                .environment(conversationController)
-                .modifier(MeasuredBarHeight { coordinator.screen?.setKeyboardBarHeight($0) })
+            .environment(conversationController)
+            .modifier(MeasuredBarHeight { coordinator.screen?.setBarHeight($0) })
         )
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     @MainActor final class Coordinator {
-        var restingHost: UIHostingController<AnyView>?
-        var keyboardHost: UIHostingController<AnyView>?
+        var barHost: UIHostingController<AnyView>?
         weak var screen: ChatScreenViewController?
         var lastMessageID: String?
     }

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -25,6 +25,17 @@ import FlipcashUI
 /// appearance when the chat materializes, and the send-arrow pop.
 private let barMorphSpring = Animation.spring(duration: 0.35, bounce: 0.2)
 
+/// Metrics shared by the field and the button so their heights can't desync.
+/// Deliberately not `Metrics.buttonHeight`/`buttonRadius` — this bar's controls
+/// are field-sized, not standard-button-sized.
+private enum BarMetrics {
+    static let fieldMinHeight: CGFloat = 34
+    static let fieldVerticalPadding: CGFloat = 8
+    static let cornerRadius: CGFloat = 14
+    /// The height of every bar control: a single-line field plus its padding.
+    static let contentHeight: CGFloat = fieldMinHeight + fieldVerticalPadding * 2
+}
+
 /// The unified bottom bar: Send Cash (morphing) beside the message field.
 /// Full-width Send Cash alone until the chat exists server-side.
 struct ConversationBottomBar: View {
@@ -34,7 +45,7 @@ struct ConversationBottomBar: View {
     let conversationID: ConversationID?
     let symbol: String
     let onSendCash: () -> Void
-    @Bindable var model: ConversationBarModel
+    let model: ConversationBarModel
 
     var body: some View {
         let content = HStack(alignment: .bottom, spacing: 10) {
@@ -58,14 +69,8 @@ struct ConversationBottomBar: View {
 
         // Adjacent glass elements must share a sampling container on iOS 26 —
         // glass cannot sample other glass; spacing matches the HStack's.
-        return Group {
-            if #available(iOS 26, *) {
-                GlassEffectContainer(spacing: 10) { content }
-            } else {
-                content
-            }
-        }
-        .modifier(BarGradientBackground())
+        return GlassContainer(spacing: 10) { content }
+            .modifier(BarGradientBackground())
     }
 }
 
@@ -91,7 +96,7 @@ struct ConversationComposer: View {
                 .lineLimit(1...5)
                 .focused($isFocused)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .frame(minHeight: 34)
+                .frame(minHeight: BarMetrics.fieldMinHeight)
 
             if model.canSend {
                 Button(action: send) {
@@ -112,16 +117,10 @@ struct ConversationComposer: View {
         .animation(Self.sendButtonSpring, value: model.canSend)
         .padding(.leading, 14)
         .padding(.trailing, 8)
-        .padding(.vertical, 8)
+        .padding(.vertical, BarMetrics.fieldVerticalPadding)
 
-        // Liquid-glass background on iOS 26; ultra-thin material below.
-        return Group {
-            if #available(iOS 26, *) {
-                field.glassEffect(.regular.interactive(), in: .rect(cornerRadius: 14))
-            } else {
-                field.background(.ultraThinMaterial, in: .rect(cornerRadius: 14))
-            }
-        }
+        return field
+            .glassBackground(cornerRadius: BarMetrics.cornerRadius)
         // Focus is the single source of `isComposing` — the button morph and the
         // screen's interactive-dismiss gate both key off it. Losing focus
         // (keyboard swiped down) ends composing.
@@ -183,54 +182,41 @@ struct SendCashMorphButton: View {
     let fullWidth: Bool
     let action: () -> Void
 
-    /// Matches the composer field: 34pt min field height + 2×8pt padding.
-    private static let height: CGFloat = 50
-    private static let cornerRadius: CGFloat = 14
-
     var body: some View {
         Button(action: action) {
             HStack(spacing: 4) {
                 if !composing {
                     Text("Send")
+                        .font(.appTextMedium)
                         .transition(.opacity)
                 }
                 Text(symbol)
+                    // Same persistent Text — .interpolate animates the glyph
+                    // between sizes; swapping views would crossfade.
+                    .font(composing ? .appTextXL : .appTextMedium)
+                    .contentTransition(.interpolate)
             }
-            .font(.appTextMedium)
             .foregroundStyle(composing ? Color.textMain : Color.textAction)
             // The label must never reflow to "Se…" mid-morph; overflow is
             // clipped by the shape instead.
             .fixedSize()
             .padding(.horizontal, composing ? 0 : 20)
-            .frame(minWidth: Self.height)
+            .frame(minWidth: BarMetrics.contentHeight)
             .frame(maxWidth: fullWidth && !composing ? .infinity : nil)
-            .frame(height: Self.height)
+            .frame(height: BarMetrics.contentHeight)
         }
         .buttonStyle(.plain)
         // White fill above the glass base: fading it out is the white → glass
         // change, without ever swapping views.
         .background {
-            RoundedRectangle(cornerRadius: Self.cornerRadius)
+            RoundedRectangle(cornerRadius: BarMetrics.cornerRadius)
                 .fill(Color.action)
                 .opacity(composing ? 0 : 1)
         }
-        .modifier(GlassBase(cornerRadius: Self.cornerRadius))
-        .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
+        .glassBackground(cornerRadius: BarMetrics.cornerRadius)
+        .clipShape(RoundedRectangle(cornerRadius: BarMetrics.cornerRadius))
         .accessibilityLabel("Send Cash")
         .accessibilityIdentifier("send-cash-button")
-    }
-}
-
-/// Liquid-glass base on iOS 26; ultra-thin material below (the composer's split).
-private struct GlassBase: ViewModifier {
-    let cornerRadius: CGFloat
-
-    func body(content: Content) -> some View {
-        if #available(iOS 26, *) {
-            content.glassEffect(.regular.interactive(), in: .rect(cornerRadius: cornerRadius))
-        } else {
-            content.background(.ultraThinMaterial, in: .rect(cornerRadius: cornerRadius))
-        }
     }
 }
 
@@ -242,11 +228,11 @@ private struct GlassBase: ViewModifier {
             Spacer()
             HStack(spacing: 10) {
                 SendCashMorphButton(symbol: "€", composing: composing, fullWidth: false) {
-                    withAnimation(.spring(duration: 0.35, bounce: 0.2)) { composing.toggle() }
+                    withAnimation(barMorphSpring) { composing.toggle() }
                 }
-                RoundedRectangle(cornerRadius: 14)
+                RoundedRectangle(cornerRadius: BarMetrics.cornerRadius)
                     .fill(.white.opacity(0.1))
-                    .frame(height: 50)
+                    .frame(height: BarMetrics.contentHeight)
             }
             .padding(12)
         }

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -9,9 +9,9 @@ import SwiftUI
 import FlipcashCore
 import FlipcashUI
 
-/// Shared state for the action bar and the composer. They live in separately-anchored
-/// hosted views (safe area vs keyboard), so they share state through this model rather
-/// than a parent; each reads `isComposing` to animate its own fade.
+/// Shared state for the unified bottom bar: the message draft plus the
+/// focus-driven `isComposing` flag that drives the Send Cash morph and the
+/// screen's interactive-dismiss gate.
 @MainActor @Observable final class ConversationBarModel {
     var isComposing = false
     var draft = ""
@@ -21,49 +21,51 @@ import FlipcashUI
     }
 }
 
-/// Action bar ⇄ composer swap — the button group springs in/out (scaling
-/// from 95%) while the composer fades.
-private let barSwapSpring = Animation.spring(duration: 0.27, bounce: 0.31)
+/// Single spring driving the whole bar: the button morph, the composer's
+/// appearance when the chat materializes, and the send-arrow pop.
+let barMorphSpring = Animation.spring(duration: 0.35, bounce: 0.2)
 
-/// Send Cash alone until the chat exists, then Send Cash + Send Message.
-struct ConversationActionBar: View {
+/// The unified bottom bar: Send Cash (morphing) beside the message field.
+/// Full-width Send Cash alone until the chat exists server-side.
+struct ConversationBottomBar: View {
 
     let showsSendCash: Bool
-    let showsSendMessage: Bool
+    let chatExists: Bool
+    let conversationID: ConversationID?
+    let symbol: String
     let onSendCash: () -> Void
-    let model: ConversationBarModel
+    @Bindable var model: ConversationBarModel
 
     var body: some View {
-        HStack(spacing: 10) {
+        let content = HStack(alignment: .bottom, spacing: 10) {
             if showsSendCash {
-                Button("Send Cash", action: onSendCash)
-                    .buttonStyle(.filled)
+                SendCashMorphButton(
+                    symbol: symbol,
+                    composing: model.isComposing,
+                    fullWidth: !chatExists,
+                    action: onSendCash
+                )
             }
-            if showsSendMessage {
-                // Material-only frosted button (no fill) — matches the .filled
-                // metrics (full width, 60pt tall, 6pt radius, appTextMedium).
-                Button(action: { withAnimation(barSwapSpring) { model.isComposing = true } }) {
-                    Text("Send Message")
-                        .font(.appTextMedium)
-                        .foregroundStyle(Color.textMain)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: Metrics.buttonHeight)
-                }
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Metrics.buttonRadius))
-                .buttonStyle(.plain)
-                .transition(.scale(scale: 0.95).combined(with: .opacity))
+            if chatExists {
+                ConversationComposer(conversationID: conversationID, model: model)
+                    .transition(.opacity)
             }
         }
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 12)
         .padding(.top, 8)
         .padding(.bottom, 8)
-        .animation(barSwapSpring, value: showsSendMessage)
-        // Scales + fades out in place while composing. The bar is pinned to the safe
-        // area (in the UIKit screen), so it never rides the keyboard.
-        .scaleEffect(model.isComposing ? 0.95 : 1)
+        .animation(barMorphSpring, value: chatExists)
+
+        // Adjacent glass elements must share a sampling container on iOS 26 —
+        // glass cannot sample other glass; spacing matches the HStack's.
+        return Group {
+            if #available(iOS 26, *) {
+                GlassEffectContainer(spacing: 10) { content }
+            } else {
+                content
+            }
+        }
         .modifier(BarGradientBackground())
-        .opacity(model.isComposing ? 0 : 1)
-        .animation(barSwapSpring, value: model.isComposing)
     }
 }
 
@@ -120,19 +122,13 @@ struct ConversationComposer: View {
                 field.background(.ultraThinMaterial, in: .rect(cornerRadius: 14))
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.bottom, 8)
-        .modifier(BarGradientBackground())
-        .opacity(model.isComposing ? 1 : 0)
-        .animation(barSwapSpring, value: model.isComposing)
-        // Focus follows composing. The field is already mounted, so this is reliable —
-        // `.onAppear` would raise the keyboard on screen entry. Losing focus (keyboard
-        // swiped down) ends composing.
-        .onChange(of: model.isComposing) { _, composing in isFocused = composing }
+        // Focus is the single source of `isComposing` — the button morph and the
+        // screen's interactive-dismiss gate both key off it. Losing focus
+        // (keyboard swiped down) ends composing.
         .onChange(of: isFocused) { _, focused in
-            if !focused {
-                withAnimation(barSwapSpring) { model.isComposing = false }
-                if let conversationID { conversationController.stopSelfTyping(in: conversationID) }
+            withAnimation(barMorphSpring) { model.isComposing = focused }
+            if !focused, let conversationID {
+                conversationController.stopSelfTyping(in: conversationID)
             }
         }
         .onChange(of: model.draft) { _, text in
@@ -174,9 +170,11 @@ private struct BarGradientBackground: ViewModifier {
     }
 }
 
-/// The Send Cash button in its two shapes: a white "Send €" pill at rest, a
-/// compact glass "€" square while composing. One persistent view — the morph
-/// animates its properties (prefix text, fill, width, color) in lockstep.
+/// The Send Cash button, rendered as a white "Send €" pill at rest and a
+/// compact glass "€" square while composing.
+// One persistent view: the morph animates its properties (prefix text, fill,
+// width, color) in lockstep — splitting the two states into separate views
+// would crossfade instead of morphing.
 struct SendCashMorphButton: View {
 
     let symbol: String

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -173,3 +173,84 @@ private struct BarGradientBackground: ViewModifier {
         }
     }
 }
+
+/// The Send Cash button in its two shapes: a white "Send €" pill at rest, a
+/// compact glass "€" square while composing. One persistent view — the morph
+/// animates its properties (prefix text, fill, width, color) in lockstep.
+struct SendCashMorphButton: View {
+
+    let symbol: String
+    let composing: Bool
+    /// Spans the bar when the composer isn't available (no chat yet).
+    let fullWidth: Bool
+    let action: () -> Void
+
+    /// Matches the composer field: 34pt min field height + 2×8pt padding.
+    private static let height: CGFloat = 50
+    private static let cornerRadius: CGFloat = 14
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if !composing {
+                    Text("Send")
+                        .transition(.opacity)
+                }
+                Text(symbol)
+            }
+            .font(.appTextMedium)
+            .foregroundStyle(composing ? Color.textMain : Color.textAction)
+            // The label must never reflow to "Se…" mid-morph; overflow is
+            // clipped by the shape instead.
+            .fixedSize()
+            .padding(.horizontal, composing ? 0 : 20)
+            .frame(minWidth: Self.height)
+            .frame(maxWidth: fullWidth && !composing ? .infinity : nil)
+            .frame(height: Self.height)
+        }
+        .buttonStyle(.plain)
+        // White fill above the glass base: fading it out is the white → glass
+        // change, without ever swapping views.
+        .background {
+            RoundedRectangle(cornerRadius: Self.cornerRadius)
+                .fill(Color.action)
+                .opacity(composing ? 0 : 1)
+        }
+        .modifier(GlassBase(cornerRadius: Self.cornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
+        .accessibilityLabel("Send Cash")
+        .accessibilityIdentifier("send-cash-button")
+    }
+}
+
+/// Liquid-glass base on iOS 26; ultra-thin material below (the composer's split).
+private struct GlassBase: ViewModifier {
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content.glassEffect(.regular.interactive(), in: .rect(cornerRadius: cornerRadius))
+        } else {
+            content.background(.ultraThinMaterial, in: .rect(cornerRadius: cornerRadius))
+        }
+    }
+}
+
+#Preview("Morph") {
+    @Previewable @State var composing = false
+    ZStack {
+        Color.backgroundMain.ignoresSafeArea()
+        VStack {
+            Spacer()
+            HStack(spacing: 10) {
+                SendCashMorphButton(symbol: "€", composing: composing, fullWidth: false) {
+                    withAnimation(.spring(duration: 0.35, bounce: 0.2)) { composing.toggle() }
+                }
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(.white.opacity(0.1))
+                    .frame(height: 50)
+            }
+            .padding(12)
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -23,7 +23,7 @@ import FlipcashUI
 
 /// Single spring driving the whole bar: the button morph, the composer's
 /// appearance when the chat materializes, and the send-arrow pop.
-let barMorphSpring = Animation.spring(duration: 0.35, bounce: 0.2)
+private let barMorphSpring = Animation.spring(duration: 0.35, bounce: 0.2)
 
 /// The unified bottom bar: Send Cash (morphing) beside the message field.
 /// Full-width Send Cash alone until the chat exists server-side.
@@ -160,11 +160,11 @@ private struct BarGradientBackground: ViewModifier {
                 startPoint: .bottom,
                 endPoint: .top
             )
-            // Scope the bleed to the bottom edge only. The bar is the measured
-            // content of the transcript's bottom `.safeAreaInset`; an all-edges
-            // ignore makes the bar read as extending to the screen bottom, which
-            // collapses the scroll-content inset by the home-indicator height and
-            // drops the newest message under the bar.
+            // Scope the bleed to the bottom edge only. The bar is a measured,
+            // keyboard-guide-pinned hosted view; an all-edges ignore makes the
+            // bar read as extending to the screen bottom, which collapses the
+            // scroll-content inset by the home-indicator height and drops the
+            // newest message under the bar.
             .ignoresSafeArea(edges: .bottom)
         }
     }

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -25,12 +25,12 @@ nonisolated enum ConversationContext: Hashable {
     case contact(ResolvedContact)
 }
 
-/// A DM conversation: an iMessage-style transcript over a Send Cash / Send
-/// Message action bar. Reads live messages from `ConversationController`,
-/// which owns the single event stream. For a contact without a chat the
-/// transcript stays empty and only Send Cash shows; once the first payment
-/// creates the chat, the chat ID resolves live from the synced directory and
-/// Send Message appears.
+/// A DM conversation: an iMessage-style transcript over a unified bottom bar
+/// (Send Cash beside the composer). Reads live messages from
+/// `ConversationController`, which owns the single event stream. For a
+/// contact without a chat the transcript stays empty and only Send Cash
+/// shows; once the first payment creates the chat, the chat ID resolves live
+/// from the synced directory and the composer appears.
 struct ConversationScreen: View {
 
     let context: ConversationContext
@@ -148,8 +148,9 @@ struct ConversationScreen: View {
             onCashCardTap: openCurrencyInfo,
             onOpenURL: openLink,
             showsSendCash: sendTarget != nil,
-            showsSendMessage: chatExists,
+            chatExists: chatExists,
             conversationID: conversationID,
+            symbol: ratesController.balanceCurrency.compactSymbol,
             onSendCash: sendCash,
             conversationController: conversationController,
             barModel: barModel

--- a/Flipcash/Core/Screens/Onboarding/NotificationPermissionDeniedScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/NotificationPermissionDeniedScreen.swift
@@ -90,23 +90,10 @@ private struct NotificationToggleRow: View {
             .font(.system(size: 14, weight: .medium))
             .allowsHitTesting(false)
             .padding(12)
-            .modifier(NotificationToggleBackground())
+            .glassBackground(cornerRadius: 20)
     }
 }
 
-// MARK: - Notification Toggle Background -
-
-private struct NotificationToggleBackground: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(iOS 26, *) {
-            content
-                .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 20))
-        } else {
-            content
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
-        }
-    }
-}
 
 // MARK: - Previews -
 

--- a/Flipcash/Core/Screens/Onboarding/NotificationPermissionScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/NotificationPermissionScreen.swift
@@ -103,23 +103,10 @@ private struct NotificationBannerPreview: View {
             }
         }
         .padding(12)
-        .modifier(NotificationBannerBackground())
+        .glassBackground(cornerRadius: 20)
     }
 }
 
-// MARK: - Notification Banner Background -
-
-private struct NotificationBannerBackground: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(iOS 26, *) {
-            content
-                .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 20))
-        } else {
-            content
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
-        }
-    }
-}
 
 // MARK: - Previews -
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/CurrencyCode.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/CurrencyCode.swift
@@ -247,6 +247,15 @@ extension CurrencyCode {
     public var singleCharacterCurrencySymbols: String? {
         (CurrencyCode.lookupTable[self] ?? []).first { $0.count == 1 }
     }
+
+    /// Returns the most compact display symbol for this currency, falling back
+    /// to the uppercased currency code when no locale defines a symbol.
+    public var compactSymbol: String {
+        let shortest = (CurrencyCode.lookupTable[self] ?? []).min { lhs, rhs in
+            (lhs.count, lhs) < (rhs.count, rhs)
+        }
+        return shortest ?? rawValue.uppercased()
+    }
 }
 
 // MARK: - Identifiable -

--- a/FlipcashCore/Sources/FlipcashCore/Models/CurrencyCode.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/CurrencyCode.swift
@@ -215,11 +215,11 @@ extension CurrencyCode {
 
 extension CurrencyCode {
     
-    private static let lookupTable: [CurrencyCode: Set<String>] = {
+    private static let lookupTable: [CurrencyCode: [String]] = {
         var container: [CurrencyCode: Set<String>] = [:]
         Locale.availableIdentifiers.forEach {
             let locale = Locale(identifier: $0)
-            
+
             guard
                 let currencyCode = locale.currency?.identifier,
                 let currency = try? CurrencyCode(currencyCode: currencyCode),
@@ -227,7 +227,7 @@ extension CurrencyCode {
             else {
                 return
             }
-            
+
             if var set = container[currency] {
                 set.insert(symbol)
                 container[currency] = set
@@ -235,21 +235,23 @@ extension CurrencyCode {
                 container[currency] = [symbol]
             }
         }
-        return container
+        // Sorted once here so every per-case read is a plain array lookup and
+        // equal-length symbols resolve deterministically.
+        return container.mapValues { $0.sorted { ($0.count, $0) < ($1.count, $1) } }
     }()
-    
+
     public var currencySymbols: [String] {
-        (CurrencyCode.lookupTable[self] ?? []).sorted { ($0.count, $0) < ($1.count, $1) }
+        CurrencyCode.lookupTable[self] ?? []
     }
 
     public var singleCharacterCurrencySymbols: String? {
-        (CurrencyCode.lookupTable[self] ?? []).first { $0.count == 1 }
+        currencySymbols.first { $0.count == 1 }
     }
 
-    /// Returns the most compact display symbol for this currency, falling back
-    /// to the uppercased currency code when no locale defines a symbol.
+    /// Returns the single-character display symbol for this currency, falling
+    /// back to `"$"` when no locale defines one.
     public var compactSymbol: String {
-        currencySymbols.first ?? rawValue.uppercased()
+        singleCharacterCurrencySymbols ?? "$"
     }
 }
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/CurrencyCode.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/CurrencyCode.swift
@@ -239,11 +239,9 @@ extension CurrencyCode {
     }()
     
     public var currencySymbols: [String] {
-        (CurrencyCode.lookupTable[self] ?? []).sorted { lhs, rhs in
-            lhs.count < rhs.count
-        }
+        (CurrencyCode.lookupTable[self] ?? []).sorted { ($0.count, $0) < ($1.count, $1) }
     }
-    
+
     public var singleCharacterCurrencySymbols: String? {
         (CurrencyCode.lookupTable[self] ?? []).first { $0.count == 1 }
     }
@@ -251,10 +249,7 @@ extension CurrencyCode {
     /// Returns the most compact display symbol for this currency, falling back
     /// to the uppercased currency code when no locale defines a symbol.
     public var compactSymbol: String {
-        let shortest = (CurrencyCode.lookupTable[self] ?? []).min { lhs, rhs in
-            (lhs.count, lhs) < (rhs.count, rhs)
-        }
-        return shortest ?? rawValue.uppercased()
+        currencySymbols.first ?? rawValue.uppercased()
     }
 }
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/CurrencyCodeTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/CurrencyCodeTests.swift
@@ -1,0 +1,31 @@
+//
+//  CurrencyCodeTests.swift
+//  FlipcashCoreTests
+//
+
+import Testing
+@testable import FlipcashCore
+
+@Suite("CurrencyCode Tests")
+struct CurrencyCodeTests {
+
+    @Test("Compact symbol is the shortest locale symbol")
+    func compactSymbol_symbolCurrency_returnsShortestSymbol() {
+        #expect(CurrencyCode.eur.compactSymbol == "€")
+        #expect(CurrencyCode.usd.compactSymbol == "$")
+    }
+
+    @Test("Compact symbol tie-break is deterministic")
+    func compactSymbol_equalLengthSymbols_isDeterministic() {
+        // JPY has two 1-char symbols across locales (¥ U+00A5, ￥ U+FFE5);
+        // the lexicographic tie-break must always pick the same one.
+        #expect(CurrencyCode.jpy.compactSymbol == "¥")
+    }
+
+    @Test("Compact symbol is never empty")
+    func compactSymbol_allCases_nonEmpty() {
+        for currency in CurrencyCode.allCases {
+            #expect(!currency.compactSymbol.isEmpty)
+        }
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/CurrencyCodeTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/CurrencyCodeTests.swift
@@ -9,8 +9,8 @@ import Testing
 @Suite("CurrencyCode Tests")
 struct CurrencyCodeTests {
 
-    @Test("Compact symbol is the shortest locale symbol")
-    func compactSymbol_symbolCurrency_returnsShortestSymbol() {
+    @Test("Compact symbol is the single-character locale symbol")
+    func compactSymbol_symbolCurrency_returnsSingleCharacterSymbol() {
         #expect(CurrencyCode.eur.compactSymbol == "€")
         #expect(CurrencyCode.usd.compactSymbol == "$")
     }
@@ -20,6 +20,12 @@ struct CurrencyCodeTests {
         // JPY has two 1-char symbols across locales (¥ U+00A5, ￥ U+FFE5);
         // the lexicographic tie-break must always pick the same one.
         #expect(CurrencyCode.jpy.compactSymbol == "¥")
+    }
+
+    @Test("Compact symbol falls back to dollar sign")
+    func compactSymbol_noSingleCharacterSymbol_fallsBackToDollarSign() {
+        // CHF's locale symbols ("CHF", "Fr.") are all multi-character.
+        #expect(CurrencyCode.chf.compactSymbol == "$")
     }
 
     @Test("Compact symbol is never empty")

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -10,47 +10,34 @@ import UIKit
 import SwiftUI
 import FlipcashCore
 
-/// The full chat screen, entirely in UIKit: the transcript fills the view and two injected bars
-/// float over its bottom (so content flows under them). The owner supplies both — a resting Send Cash
-/// / Send Message bar pinned to the safe area, and a composer pinned to the keyboard guide — so this
-/// screen stays agnostic about *what* the bars are and only owns layout + keyboard handling.
+/// The full chat screen, entirely in UIKit: the transcript fills the view and one injected bar
+/// floats over its bottom (so content flows under it). The bar is pinned to the keyboard layout
+/// guide, which rests at the bottom safe area when the keyboard is down and rides it when shown —
+/// one bar covers both states. This screen stays agnostic about *what* the bar is and only owns
+/// layout + keyboard handling.
 ///
 /// Keyboard handling is deliberately *not* hand-rolled. The host's safe area already grows to
-/// include the keyboard, so the keyboard bar is pinned to the keyboard layout guide (it rides the
-/// keyboard for free) and the transcript only reserves the active bar's own height — the safe area
-/// supplies the keyboard. Doing both ourselves was what double-counted the keyboard. The resting bar
-/// pins to the safe area so it never rides the keyboard.
+/// include the keyboard, so the bar rides the keyboard for free and the transcript only reserves
+/// the bar's own height — the safe area supplies the keyboard. Doing both ourselves was what
+/// double-counted the keyboard.
 public final class ChatScreenViewController: UIViewController {
 
     private let transcript = ChatViewController()
-    private let restingBar: UIView
-    private let keyboardBar: UIView
-    private let restingBarController: UIViewController?
-    private let keyboardBarController: UIViewController?
-    /// Each bar's height is driven by its *measured* SwiftUI height, so the frame matches its content
-    /// exactly — a hosting controller's intrinsic size mis-measures multiline growth and lets the
-    /// composer overflow below its frame, under the keyboard.
-    private var restingBarHeightConstraint: NSLayoutConstraint!
-    private var keyboardBarHeightConstraint: NSLayoutConstraint!
-    /// Which bar the transcript reserves bottom inset for; the composer can grow tall.
-    private var isComposing = false
+    private let bar: UIView
+    private let barController: UIViewController?
+    /// The bar's height is driven by its *measured* SwiftUI height, so the frame matches its
+    /// content exactly — a hosting controller's intrinsic size mis-measures multiline growth and
+    /// lets the composer overflow below its frame, under the keyboard.
+    private var barHeightConstraint: NSLayoutConstraint!
 
     /// - Parameters:
-    ///   - restingBar: pinned over the transcript's bottom safe area; does not ride the keyboard.
-    ///   - keyboardBar: pinned to the keyboard layout guide; rides the keyboard.
-    ///   - restingBarController/keyboardBarController: the view controllers owning each bar, when
-    ///     hosted (e.g. a `UIHostingController` for a SwiftUI bar). Adopted as children so their
-    ///     lifecycle and environment work. Pass `nil` for a plain `UIView` bar.
-    public init(
-        restingBar: UIView,
-        keyboardBar: UIView,
-        restingBarController: UIViewController? = nil,
-        keyboardBarController: UIViewController? = nil
-    ) {
-        self.restingBar = restingBar
-        self.keyboardBar = keyboardBar
-        self.restingBarController = restingBarController
-        self.keyboardBarController = keyboardBarController
+    ///   - bar: pinned to the keyboard layout guide; rides the keyboard.
+    ///   - barController: the view controller owning the bar, when hosted (e.g. a
+    ///     `UIHostingController` for a SwiftUI bar). Adopted as a child so its lifecycle and
+    ///     environment work. Pass `nil` for a plain `UIView` bar.
+    public init(bar: UIView, barController: UIViewController? = nil) {
+        self.bar = bar
+        self.barController = barController
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -92,12 +79,7 @@ public final class ChatScreenViewController: UIViewController {
             transcript.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
 
-        // Resting bar first, then the keyboard bar on top — when the keyboard is down they overlap at
-        // the bottom and the keyboard bar (non-interactive then) must not occlude the buttons.
-        restingBarHeightConstraint = addBar(restingBar, controller: restingBarController, pinnedTo: view.safeAreaLayoutGuide.bottomAnchor)
-        keyboardBarHeightConstraint = addBar(keyboardBar, controller: keyboardBarController, pinnedTo: view.keyboardLayoutGuide.topAnchor)
-
-        applyBarInteraction()
+        barHeightConstraint = addBar(bar, controller: barController, pinnedTo: view.keyboardLayoutGuide.topAnchor)
     }
 
     /// Adds a hosted bar pinned to the view's width and the given bottom anchor; returns its height
@@ -132,34 +114,10 @@ public final class ChatScreenViewController: UIViewController {
         host.setContentScrollView(transcript.collectionView, for: .top)
     }
 
-    /// Set the resting bar's height to its measured SwiftUI content height.
-    public func setRestingBarHeight(_ height: CGFloat) {
-        guard restingBarHeightConstraint != nil, restingBarHeightConstraint.constant != height else { return }
-        restingBarHeightConstraint.constant = height
-    }
-
-    /// Set the keyboard bar's height to its measured SwiftUI content height. Pinned at the bottom to
-    /// the keyboard guide, so growing the constant grows the bar *upward* — it can never push content
-    /// below the keyboard.
-    public func setKeyboardBarHeight(_ height: CGFloat) {
-        guard keyboardBarHeightConstraint != nil, keyboardBarHeightConstraint.constant != height else { return }
-        keyboardBarHeightConstraint.constant = height
-    }
-
-    /// Switch which bar the transcript reserves bottom inset for, and which one takes touches.
-    public func setComposing(_ composing: Bool) {
-        guard isComposing != composing else { return }
-        isComposing = composing
-        applyBarInteraction()
-        view.setNeedsLayout()
-    }
-
-    /// Only the active bar takes touches. The bars overlap at the bottom when the keyboard is down,
-    /// and a hosting controller's view doesn't pass touches through on `.allowsHitTesting(false)`
-    /// alone — disabling the inactive bar at the UIKit layer reliably lets the active one receive them.
-    private func applyBarInteraction() {
-        restingBar.isUserInteractionEnabled = !isComposing
-        keyboardBar.isUserInteractionEnabled = isComposing
+    /// Set the bar's height to its measured SwiftUI content height.
+    public func setBarHeight(_ height: CGFloat) {
+        guard barHeightConstraint != nil, barHeightConstraint.constant != height else { return }
+        barHeightConstraint.constant = height
     }
 
     // MARK: - Data passthrough
@@ -171,10 +129,10 @@ public final class ChatScreenViewController: UIViewController {
 
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        // Reserve only the active bar's own height. On-device the system already grows the collection
+        // Reserve only the bar's own height. On-device the system already grows the collection
         // view's adjusted content inset by the keyboard when it's up, so adding the keyboard here
         // too (via the bar's risen position) double-counts it and overscrolls by a whole keyboard.
-        transcript.setBottomInset(isComposing ? keyboardBar.frame.height : restingBar.frame.height)
+        transcript.setBottomInset(bar.frame.height)
     }
 }
 #endif

--- a/FlipcashUI/Sources/FlipcashUI/Views/Containers/GlassBackground.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Containers/GlassBackground.swift
@@ -1,0 +1,19 @@
+//
+//  GlassBackground.swift
+//  FlipcashUI
+//
+
+import SwiftUI
+
+extension View {
+    /// Applies the app's standard glass surface: Liquid Glass on iOS 26,
+    /// an ultra-thin material below.
+    @ViewBuilder
+    public func glassBackground(cornerRadius: CGFloat) -> some View {
+        if #available(iOS 26, *) {
+            glassEffect(.regular.interactive(), in: .rect(cornerRadius: cornerRadius))
+        } else {
+            background(.ultraThinMaterial, in: .rect(cornerRadius: cornerRadius))
+        }
+    }
+}

--- a/FlipcashUITests/Support/Screens/ConversationUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/ConversationUIScreen.swift
@@ -18,8 +18,7 @@ struct ConversationUIScreen {
 
     // MARK: - Elements
 
-    var sendCashButton: XCUIElement { app.buttons["Send Cash"] }
-    var sendMessageButton: XCUIElement { app.buttons["Send Message"] }
+    var sendCashButton: XCUIElement { app.buttons["send-cash-button"] }
     var messageField: XCUIElement { app.textFields["Message"] }
 
     /// The composer's send arrow. A dedicated identifier avoids the same-labelled
@@ -37,9 +36,8 @@ struct ConversationUIScreen {
         testCase.waitAndTap(sendCashButton)
     }
 
-    /// Opens the composer, types `text`, and sends it.
+    /// Focuses the always-visible composer, types `text`, and sends it.
     func sendMessage(_ text: String, from testCase: BaseUITestCase) {
-        testCase.waitAndTap(sendMessageButton)
         testCase.waitUntilHittableAndTap(messageField)
         messageField.typeText(text)
         testCase.waitAndTap(composerSendButton)


### PR DESCRIPTION
The chat bottom bar is now a single bar: the message field is always visible, with the Send Cash button beside it showing the local currency symbol ("Send €"). Focusing the field morphs the button into a compact glass square — the background fades from white to glass, the frame shrinks, and the "Send" characters animate out while the symbol persists and grows to 22pt. Dismissing the keyboard morphs it back.

- One keyboard-anchored bar replaces the resting/composer bar pair, so the two-bar crossfade and its interaction juggling are gone
- The button is one persistent view animating its properties; the symbol comes from the balance currency, defaulting to $ when a currency has no single-character symbol
- Contacts without a chat get the full-width Send button; the field animates in once the first payment creates the chat
- Glass styling consolidated into one shared background modifier, also adopted by the notification permission screens

Test plan:
- [x] In a DM, tap the message field: "Send €" morphs into the glass "€" square; swipe the keyboard down and it morphs back
- [x] Tap the glass "€" while composing: amount entry opens
- [x] Send a message and send cash from the unified bar
- [x] Contact without a chat: full-width Send button, field appears after the first payment
- [x] Balance currency without a single-character symbol (e.g. CHF) shows "Send $"