### PR TITLE
feat: add contact profile card to the start of short chats

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -29,6 +29,9 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     /// Fired when the user taps a URL in a message. The owner routes it through the deep-link handler,
     /// falling back to the system browser.
     let onOpenURL: (URL) -> Void
+    /// Fired when the user taps the profile card's call to action. The owner opens the
+    /// counterpart's contact card (or the add-contact sheet), same as tapping the nav title.
+    let onContactAction: () -> Void
     let showsSendCash: Bool
     let chatExists: Bool
     let conversationID: ConversationID?
@@ -45,6 +48,7 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         screen.onRetry = onRetry
         screen.onCashCardTap = onCashCardTap
         screen.onOpenURL = onOpenURL
+        screen.onContactAction = onContactAction
         screen.update(items: items)
         context.coordinator.barHost = barHost
         context.coordinator.screen = screen
@@ -60,6 +64,7 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         screen.onRetry = onRetry
         screen.onCashCardTap = onCashCardTap
         screen.onOpenURL = onOpenURL
+        screen.onContactAction = onContactAction
 
         // Scroll only when the user's *own* message was just appended — a new trailing message id
         // (skipping any trailing receipt) that is from me. Received messages and prepended history

--- a/Flipcash/Core/Screens/Conversation/ContactCardView.swift
+++ b/Flipcash/Core/Screens/Conversation/ContactCardView.swift
@@ -25,6 +25,29 @@ enum ContactCard: Identifiable {
         case .unknown(let contact): return "unknown-\(contact.identifier)"
         }
     }
+
+    /// The presentable card for a counterpart: the address-book card when
+    /// they're a synced contact (nil if the record can't be read, e.g. deleted
+    /// since sync), otherwise the "Add to Contacts" sheet seeded with their
+    /// number. `nil` when neither is available.
+    static func make(contact: ResolvedContact?, addablePhone: String?) -> ContactCard? {
+        if let contactId = contact?.contactId {
+            let keys = [CNContactViewController.descriptorForRequiredKeys()]
+            guard let fetched = try? CNContactStore().unifiedContact(
+                withIdentifier: contactId,
+                keysToFetch: keys
+            ) else { return nil }
+            return .existing(fetched)
+        }
+        if let addablePhone {
+            let unknown = CNMutableContact()
+            unknown.phoneNumbers = [
+                CNLabeledValue(label: CNLabelPhoneNumberMobile, value: CNPhoneNumber(stringValue: addablePhone))
+            ]
+            return .unknown(unknown)
+        }
+        return nil
+    }
 }
 
 /// The native iOS contact card (`CNContactViewController`), hosted in a

--- a/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
@@ -23,14 +23,23 @@ final class ConversationLoadCoordinator {
     let conversationID: ConversationID
     private let controller: ConversationController
     private let session: Session
+    /// Supplies the counterpart's profile card, resolved live — it runs inside the observation
+    /// scope, so whatever it reads (the contact directory, the conversation) re-triggers mapping.
+    private let profileCard: @MainActor () -> ChatProfileCard
 
     @ObservationIgnored private var lastInputs: Inputs?
     @ObservationIgnored private var mapTask: Task<Void, Never>?
 
-    init(conversationID: ConversationID, controller: ConversationController, session: Session) {
+    init(
+        conversationID: ConversationID,
+        controller: ConversationController,
+        session: Session,
+        profileCard: @escaping @MainActor () -> ChatProfileCard
+    ) {
         self.conversationID = conversationID
         self.controller = controller
         self.session = session
+        self.profileCard = profileCard
         self.loader = MessageLoader(conversationID: conversationID, controller: controller)
 
         // First paint is synchronous so an open never flashes an empty transcript; every later
@@ -80,6 +89,9 @@ final class ConversationLoadCoordinator {
             counterpartReadDate: read?.date,
             suppressReceiptFor: controller.settlingSendID,
             isTyping: controller.isCounterpartTyping(in: conversationID),
+            // The card heads only a short transcript — long or paged histories drop it; the
+            // nav title opens the same contact card.
+            profileCard: loader.isEntireHistory(windowCount: window.count) ? profileCard() : nil,
             branding: branding
         )
     }
@@ -98,6 +110,9 @@ final class ConversationLoadCoordinator {
         if inputs.isTyping {
             items.append(.typingIndicator)
         }
+        if let card = inputs.profileCard {
+            items.insert(.profileCard(card), at: 0)
+        }
         return items
     }
 
@@ -111,6 +126,7 @@ final class ConversationLoadCoordinator {
         var counterpartReadDate: Date?
         var suppressReceiptFor: String?
         var isTyping: Bool
+        var profileCard: ChatProfileCard?
         var branding: [PublicKey: Branding]
 
         struct Branding: Equatable, Sendable {

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 import UIKit
 import Combine
-import Contacts
-import ContactsUI
 import FlipcashCore
 import FlipcashUI
 
@@ -23,6 +21,17 @@ private let logger = Logger(label: "flipcash.conversation")
 nonisolated enum ConversationContext: Hashable {
     case existing(ConversationID)
     case contact(ResolvedContact)
+
+    /// Resolves the counterpart's synced contact from the directory — the one
+    /// rule the nav title, transcript profile card, and profile page share.
+    func resolvedContact(in directory: [ResolvedContact]) -> ResolvedContact? {
+        switch self {
+        case .contact(let contact):
+            directory.first { $0.contactId == contact.contactId && $0.phoneE164 == contact.phoneE164 } ?? contact
+        case .existing(let conversationID):
+            directory.first { $0.dmChatID == conversationID.data }
+        }
+    }
 }
 
 /// A DM conversation: an iMessage-style transcript over a unified bottom bar
@@ -58,13 +67,7 @@ struct ConversationScreen: View {
     /// so a `dmChatID` stored after the first payment flows in. Falls back to
     /// the pushed snapshot when the directory hasn't resolved yet.
     private var contact: ResolvedContact? {
-        let directory = contactSyncController.resolvedContacts.onFlipcash
-        switch context {
-        case .contact(let contact):
-            return directory.first { $0.id == contact.id } ?? contact
-        case .existing(let conversationID):
-            return directory.first { $0.dmChatID == conversationID.data }
-        }
+        context.resolvedContact(in: contactSyncController.resolvedContacts.onFlipcash)
     }
 
     private var conversationID: ConversationID? {
@@ -147,6 +150,7 @@ struct ConversationScreen: View {
             onRetry: retry,
             onCashCardTap: openCurrencyInfo,
             onOpenURL: openLink,
+            onContactAction: openContactCard,
             showsSendCash: sendTarget != nil,
             chatExists: chatExists,
             conversationID: conversationID,
@@ -281,26 +285,11 @@ struct ConversationScreen: View {
         conversationController.visibleConversationID = id
     }
 
-    /// Opens the native iOS contact card for the counterpart. An address-book
-    /// contact shows their card (fetched with the descriptor
-    /// `CNContactViewController` requires; nothing is shown if it can't be read,
-    /// e.g. deleted since sync). A non-contact with a known number opens the
-    /// "Add to Contacts" sheet seeded with that number.
+    /// Opens the native iOS contact card for the counterpart: their
+    /// address-book card when they're a contact, otherwise the "Add to
+    /// Contacts" sheet seeded with their number.
     private func openContactCard() {
-        if let contactId = contact?.contactId {
-            let keys = [CNContactViewController.descriptorForRequiredKeys()]
-            guard let fetched = try? CNContactStore().unifiedContact(
-                withIdentifier: contactId,
-                keysToFetch: keys
-            ) else { return }
-            presentedCard = .existing(fetched)
-        } else if let phone = addableContactPhone {
-            let unknown = CNMutableContact()
-            unknown.phoneNumbers = [
-                CNLabeledValue(label: CNLabelPhoneNumberMobile, value: CNPhoneNumber(stringValue: phone))
-            ]
-            presentedCard = .unknown(unknown)
-        }
+        presentedCard = ContactCard.make(contact: contact, addablePhone: addableContactPhone)
     }
 
     private func sendCash() {
@@ -350,9 +339,42 @@ struct ConversationScreen: View {
             coordinator = ConversationLoadCoordinator(
                 conversationID: id,
                 controller: conversationController,
-                session: session
+                session: session,
+                profileCard: { [context, contactSyncController, conversationController] in
+                    Self.profileCard(
+                        context: context,
+                        conversationID: id,
+                        directory: contactSyncController.resolvedContacts.onFlipcash,
+                        controller: conversationController
+                    )
+                }
             )
         }
+    }
+
+    /// The transcript's profile card for the counterpart, resolved live from the directory the
+    /// same way the nav title is: the synced contact when there is one, otherwise the counterpart's
+    /// formatted number flagged as an unknown contact.
+    private static func profileCard(
+        context: ConversationContext,
+        conversationID: ConversationID,
+        directory: [ResolvedContact],
+        controller: ConversationController
+    ) -> ChatProfileCard {
+        if let contact = context.resolvedContact(in: directory) {
+            return ChatProfileCard(
+                name: contact.displayName,
+                avatarID: contact.contactId,
+                imageData: contact.imageData,
+                counterpart: .contact(phone: contact.nationalPhone)
+            )
+        }
+        return ChatProfileCard(
+            name: controller.displayName(forConversationID: conversationID),
+            avatarID: conversationID.description,
+            imageData: nil,
+            counterpart: .unknown
+        )
     }
 
     /// After returning from the amount screen for a contact's first payment,

--- a/Flipcash/Core/Screens/Conversation/MessageLoader.swift
+++ b/Flipcash/Core/Screens/Conversation/MessageLoader.swift
@@ -37,6 +37,13 @@ final class MessageLoader {
         controller.windowedMessages(for: conversationID, startingAt: startID, limit: Self.initialWindow)
     }
 
+    /// Whether a rendered window of `windowCount` messages is the entire locally-known history:
+    /// nothing paged back and the window under its limit. The count is passed in because
+    /// `messages` is a DB read the caller already holds.
+    func isEntireHistory(windowCount: Int) -> Bool {
+        startID == nil && windowCount < Self.initialWindow
+    }
+
     /// Reveals an older step: moves the anchor back over already-persisted history, or pages the next
     /// older batch from the server (which persists it) once the local history is exhausted.
     func loadOlder() {

--- a/Flipcash/Core/Screens/Send/FullContactAccessCard.swift
+++ b/Flipcash/Core/Screens/Send/FullContactAccessCard.swift
@@ -22,7 +22,7 @@ struct FullContactAccessCard: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: 48, height: 48)
-                    .foregroundStyle(Color.iconWarning)
+                    .foregroundStyle(Color.warning)
                     .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 4) {

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatItem.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatItem.swift
@@ -17,12 +17,15 @@ public enum ChatItem: Hashable, Sendable, Codable, Identifiable {
     case dateSeparator(id: String, text: String)
     /// A leading-aligned typing bubble pinned at the transcript tail while the counterpart types.
     case typingIndicator
+    /// The counterpart's profile card at the head of a short transcript.
+    case profileCard(ChatProfileCard)
 
     public var id: String {
         switch self {
         case .message(let message): message.id
         case .dateSeparator(let id, _): id
         case .typingIndicator: "typing-indicator"
+        case .profileCard: "profile-card"
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatProfileCard.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatProfileCard.swift
@@ -1,0 +1,35 @@
+//
+//  ChatProfileCard.swift
+//  FlipcashCore
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+
+/// What the transcript's profile-card row shows about the counterpart: their avatar, title line,
+/// and how they relate to the address book (which drives the subtitle and the call to action).
+public struct ChatProfileCard: Hashable, Sendable, Codable {
+    /// Title line: the contact's name, or their formatted number when they're not a contact.
+    public var name: String
+    /// Stable identity for the avatar (monogram color + image cache key).
+    public var avatarID: String
+    /// The contact's address-book thumbnail; nil renders the monogram placeholder.
+    public var imageData: Data?
+    public var counterpart: Counterpart
+
+    /// How the counterpart relates to the address book.
+    public enum Counterpart: Hashable, Sendable, Codable {
+        /// In the address book: the subtitle is their number and the CTA views their contact card.
+        case contact(phone: String)
+        /// Not in the address book: an "Unknown Contact" subtitle and a CTA that adds them.
+        case unknown
+    }
+
+    public init(name: String, avatarID: String, imageData: Data?, counterpart: Counterpart) {
+        self.name = name
+        self.avatarID = avatarID
+        self.imageData = imageData
+        self.counterpart = counterpart
+    }
+}

--- a/FlipcashTests/Chat/ChatCashCardSizingTests.swift
+++ b/FlipcashTests/Chat/ChatCashCardSizingTests.swift
@@ -45,6 +45,12 @@ struct ChatCashCardSizingTests {
     @Test("Date separator, text, and receipt-carrying rows self-size (.auto)")
     func otherRows_areAuto() {
         let items: [ChatItem] = [
+            .profileCard(ChatProfileCard(
+                name: "Ted Livingston",
+                avatarID: "ted",
+                imageData: nil,
+                counterpart: .contact(phone: "519 802-3885")
+            )),
             .dateSeparator(id: "sep", text: "Today 1:00 PM"),
             .message(ChatMessage(id: "1", text: "hello", sender: .other)),
             .message(ChatMessage(id: "2", text: "sent", sender: .me, receipt: "Delivered")),

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem+Differentiable.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem+Differentiable.swift
@@ -27,6 +27,8 @@ extension ChatItem {
         switch self {
         case .typingIndicator:
             ChatTypingIndicatorCell.reuseIdentifier
+        case .profileCard:
+            ChatProfileCardCell.reuseIdentifier
         case .dateSeparator:
             ChatDateSeparatorCell.reuseIdentifier
         case .message(let message):

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatProfileCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatProfileCardCell.swift
@@ -1,0 +1,116 @@
+//
+//  ChatProfileCardCell.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+import SwiftUI
+import FlipcashCore
+
+/// The counterpart's profile card at the head of a short transcript: avatar, name, and a
+/// call to action that opens their contact card — or adds them, when they're not a contact.
+/// SwiftUI content hosted in the cell so the avatar is the same `ContactAvatarView` the
+/// navigation title renders.
+public final class ChatProfileCardCell: UICollectionViewCell {
+
+    public static let reuseIdentifier = "ChatProfileCardCell"
+
+    public func configure(with card: ChatProfileCard, onContactAction: @escaping () -> Void) {
+        contentConfiguration = UIHostingConfiguration {
+            ProfileCardView(card: card, onContactAction: onContactAction)
+        }
+        .margins(.all, 0)
+    }
+}
+
+/// The card body. The pill leads to the same place the navigation title does, so the card is a
+/// bigger door to an existing room.
+private struct ProfileCardView: View {
+
+    let card: ChatProfileCard
+    let onContactAction: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ContactAvatarView(
+                id: card.avatarID,
+                displayName: card.name,
+                imageData: card.imageData,
+                size: 80
+            )
+            .accessibilityHidden(true)
+
+            Text(card.name)
+                .font(.appTextLarge)
+                .foregroundStyle(Color.textMain)
+                .lineLimit(1)
+                .padding(.top, 12)
+
+            ProfileCardSubtitle(counterpart: card.counterpart)
+                .font(.appTextSmall)
+                .padding(.top, 4)
+
+            ContactActionPill(counterpart: card.counterpart, action: onContactAction)
+                .padding(.top, 16)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 20)
+        // Min, not fixed: the app fonts scale with Dynamic Type, so the card grows past its
+        // design height at accessibility sizes instead of clipping.
+        .frame(width: 230)
+        .frame(minHeight: 250)
+        .background {
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.08))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 8)
+    }
+
+}
+
+/// The line under the name: the contact's number, or the "Unknown Contact" flag.
+private struct ProfileCardSubtitle: View {
+
+    let counterpart: ChatProfileCard.Counterpart
+
+    var body: some View {
+        switch counterpart {
+        case .contact(let phone):
+            Text(phone)
+                .foregroundStyle(Color.textSecondary)
+        case .unknown:
+            Text("Unknown Contact")
+                .foregroundStyle(Color.warning)
+        }
+    }
+}
+
+#Preview("Known / unknown") {
+    VStack(spacing: 12) {
+        ProfileCardView(
+            card: ChatProfileCard(
+                name: "Ted Livingston",
+                avatarID: "ted",
+                imageData: nil,
+                counterpart: .contact(phone: "519 802-3885")
+            ),
+            onContactAction: {}
+        )
+        ProfileCardView(
+            card: ChatProfileCard(
+                name: "519 802-3885",
+                avatarID: "unknown",
+                imageData: nil,
+                counterpart: .unknown
+            ),
+            onContactAction: {}
+        )
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.backgroundMain)
+}
+#endif

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -64,6 +64,11 @@ public final class ChatScreenViewController: UIViewController {
         set { transcript.onOpenURL = newValue }
     }
 
+    public var onContactAction: (() -> Void)? {
+        get { transcript.onContactAction }
+        set { transcript.onContactAction = newValue }
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor(Color.backgroundMain)

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -17,11 +17,11 @@ import FlipcashCore
 /// it pulls nothing. The owner calls `update(messages:)`; there is no network, no database,
 /// and no shared state inside.
 ///
-/// All scroll positioning is ChatLayout's: the `keepContentOffsetAtBottomOnBatchUpdates` /
-/// `keepContentAtBottomOfVisibleArea` settings keep the view anchored to the newest message as
-/// content is appended, prepended, and self-sizes, and `restoreContentOffset(_:)` against the
-/// last item's bottom edge does the explicit scroll-to-bottom. This controller never computes a
-/// content offset by hand — doing so lands short while tall cells are still at their estimate.
+/// All scroll positioning is ChatLayout's: `keepContentOffsetAtBottomOnBatchUpdates` keeps the
+/// view anchored to the newest message as content is appended, prepended, and self-sizes, and
+/// `restoreContentOffset(_:)` against the last item's bottom edge does the explicit
+/// scroll-to-bottom. Content shorter than the viewport top-aligns. This controller never computes
+/// a content offset by hand — doing so lands short while tall cells are still at their estimate.
 public final class ChatViewController: UICollectionViewController {
 
     /// Called whenever the user is near the top, to request the next older page. Fired
@@ -38,6 +38,10 @@ public final class ChatViewController: UICollectionViewController {
 
     /// Called when the user taps a URL in a text bubble; the owner opens it.
     public var onOpenURL: ((URL) -> Void)?
+
+    /// Called when the user taps the profile card's call to action; the owner opens the
+    /// counterpart's contact card (or the add-contact sheet), same as the nav title.
+    public var onContactAction: (() -> Void)?
 
     /// The widest a bubble may grow, as a share of the collection view's width.
     private static let maxBubbleWidthFraction: CGFloat = 0.78
@@ -82,10 +86,10 @@ public final class ChatViewController: UICollectionViewController {
         chatLayout.delegate = self
         chatLayout.settings.interItemSpacing = 8
         // ChatLayout owns the bottom anchoring: stay pinned to the newest message across batch
-        // updates (so an append at the bottom follows and a prepend preserves position), and sit
-        // content at the bottom when it's shorter than the viewport.
+        // updates (so an append at the bottom follows and a prepend preserves position). Content
+        // shorter than the viewport top-aligns — the profile card sits under the nav bar with
+        // messages flowing beneath it, iMessage-style.
         chatLayout.keepContentOffsetAtBottomOnBatchUpdates = true
-        chatLayout.keepContentAtBottomOfVisibleArea = true
         chatLayout.processOnlyVisibleItemsOnAnimatedBatchUpdates = false
         // Estimated size lets ChatLayout place off-screen rows without measuring them; the
         // native cell self-sizes to its true height, so the estimate never clips content.
@@ -115,6 +119,7 @@ public final class ChatViewController: UICollectionViewController {
         collectionView.register(ChatCashCardCell.self, forCellWithReuseIdentifier: ChatCashCardCell.reuseIdentifier)
         collectionView.register(ChatDateSeparatorCell.self, forCellWithReuseIdentifier: ChatDateSeparatorCell.reuseIdentifier)
         collectionView.register(ChatTypingIndicatorCell.self, forCellWithReuseIdentifier: ChatTypingIndicatorCell.reuseIdentifier)
+        collectionView.register(ChatProfileCardCell.self, forCellWithReuseIdentifier: ChatProfileCardCell.reuseIdentifier)
         collectionView.reloadData()
     }
 
@@ -215,6 +220,10 @@ public final class ChatViewController: UICollectionViewController {
         switch item {
         case .typingIndicator:
             break
+        case .profileCard(let card):
+            (cell as! ChatProfileCardCell).configure(with: card) { [weak self] in
+                self?.onContactAction?()
+            }
         case .dateSeparator(_, let text):
             (cell as! ChatDateSeparatorCell).configure(text: text)
         case .message(let message):
@@ -418,9 +427,7 @@ extension ChatViewController {
             case .cash:
                 return nil
             }
-        case .dateSeparator:
-            return nil
-        case .typingIndicator:
+        case .dateSeparator, .typingIndicator, .profileCard:
             return nil
         }
 

--- a/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
@@ -18,7 +18,7 @@ extension ShapeStyle where Self == Color {
     public static var textError: Color                   { Color(r: 255, g: 131, b: 131) }
     public static var textSuccess: Color                 { Color(r: 73 , g: 213, b: 23) }
     public static var textWarning: Color                 { Color(r: 255, g: 243, b: 131) }
-    public static var iconWarning: Color                 { Color(r: 255, g: 169, b: 57)  }
+    public static var warning: Color                     { Color(r: 255, g: 169, b: 57)  }
 
     public static var action: Color                      { Color.white }
     public static var actionDisabled: Color              { Color(r: 30,  g: 30,  b: 30) }

--- a/FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift
@@ -47,6 +47,7 @@ public enum SystemSymbol: String {
     case circleDotted = "circle.dotted"
     case circleCheck = "checkmark.circle.fill"
     case circlePerson = "person.circle"
+    case personBadgePlus = "person.badge.plus"
     
     case arrowUp = "arrow.up"
     case arrowDown = "arrow.down"

--- a/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactActionPill.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactActionPill.swift
@@ -1,0 +1,55 @@
+//
+//  ContactActionPill.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import SwiftUI
+import FlipcashCore
+
+/// The counterpart call to action shared by the chat profile card and the profile page:
+/// "View in Contacts" for a synced contact, "Add Contact" for an unknown one.
+public struct ContactActionPill: View {
+
+    let counterpart: ChatProfileCard.Counterpart
+    let action: () -> Void
+
+    public init(counterpart: ChatProfileCard.Counterpart, action: @escaping () -> Void) {
+        self.counterpart = counterpart
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            ContactActionLabel(counterpart: counterpart)
+                .font(.appTextSmall)
+                .foregroundStyle(Color.textMain)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background {
+                    Capsule().fill(Color.white.opacity(0.1))
+                }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// The pill's label: view the existing contact, or add the unknown one.
+private struct ContactActionLabel: View {
+
+    let counterpart: ChatProfileCard.Counterpart
+
+    var body: some View {
+        switch counterpart {
+        case .contact:
+            Text("View in Contacts")
+        case .unknown:
+            Label {
+                Text("Add Contact")
+            } icon: {
+                Image.system(.personBadgePlus)
+            }
+        }
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactAvatarView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactAvatarView.swift
@@ -38,7 +38,9 @@ public struct ContactAvatarView: View {
                         switch Self.monogram(for: displayName) {
                         case .initials(let text):
                             Text(text)
-                                .font(.appTextMedium)
+                                // Scales with the avatar, preserving the default (44pt) avatar's
+                                // 16pt monogram proportions at any size.
+                                .font(.default(size: size * 16 / 44, weight: .bold))
                                 .foregroundStyle(Color.textMain)
                         case .placeholder:
                             PeopleSilhouette(size: size)

--- a/NotificationContent/NotificationTranscriptView.swift
+++ b/NotificationContent/NotificationTranscriptView.swift
@@ -35,10 +35,11 @@ struct NotificationTranscriptView: View {
                             case .dateSeparator(_, let text):
                                 NotificationDateSeparator(text: text)
                                     .transition(.opacity)
-                            case .typingIndicator:
-                                // Typing is live, ephemeral state — it has no place in a
-                                // static notification snapshot and the preview mapping never
-                                // emits it. Handled only for exhaustiveness.
+                            case .typingIndicator, .profileCard:
+                                // Typing is live, ephemeral state and the profile card is
+                                // in-app chrome — neither belongs in a static notification
+                                // snapshot and the preview mapping never emits them. Handled
+                                // only for exhaustiveness.
                                 EmptyView()
                             }
                         }


### PR DESCRIPTION
Short conversations now open with a profile card for the counterpart: their avatar, name, and number — or an orange "Unknown Contact" tag when they're not in the address book — plus a pill that opens the same contact card the nav title does ("View in Contacts" / "Add Contact"). The card shows while the whole history fits in the first page and drops out once the reader pages back into older history.

Short transcripts also lay out from the top now (iMessage-style) instead of pinning to the bottom; opening a chat still lands on the newest message, and all bottom-anchoring behavior for long chats is unchanged.

Also renames the orange warning color to a generic name now that it colors text too.

## Test plan
- [x] Short chat with a synced contact shows the card; "View in Contacts" opens their card
- [x] Chat with an unknown number shows the orange tag; "Add Contact" opens the add sheet, and adding them flips the card in place
- [x] Long chat (60+ messages) shows no card; paging back into history keeps it hidden
- [x] Empty chat (contact without a conversation yet) shows just the card at the top
- [x] Opening any chat still lands on the newest message; sending and receiving still pin to the bottom