### PR TITLE
chore: update to latest core and payments protos

### DIFF
--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/blob_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/blob_v1_model.pb.swift
@@ -100,6 +100,9 @@ public enum Flipcash_Blob_V1_RejectionReason: SwiftProtobuf.Enum, Swift.CaseIter
 
   /// server-side processing error
   case `internal` // = 6
+
+  /// blob contains privacy metadata that was not stripped
+  case privacyMetadata // = 7
   case UNRECOGNIZED(Int)
 
   public init() {
@@ -115,6 +118,7 @@ public enum Flipcash_Blob_V1_RejectionReason: SwiftProtobuf.Enum, Swift.CaseIter
     case 4: self = .tooLarge
     case 5: self = .corrupt
     case 6: self = .internal
+    case 7: self = .privacyMetadata
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
@@ -128,6 +132,7 @@ public enum Flipcash_Blob_V1_RejectionReason: SwiftProtobuf.Enum, Swift.CaseIter
     case .tooLarge: return 4
     case .corrupt: return 5
     case .internal: return 6
+    case .privacyMetadata: return 7
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -141,6 +146,7 @@ public enum Flipcash_Blob_V1_RejectionReason: SwiftProtobuf.Enum, Swift.CaseIter
     .tooLarge,
     .corrupt,
     .internal,
+    .privacyMetadata,
   ]
 
 }
@@ -305,6 +311,121 @@ public struct Flipcash_Blob_V1_ImageMetadata: Sendable {
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+}
+
+/// One logical piece of media — a chat image, a profile picture — carried as the
+/// set of renditions it is stored as. Distinct from Blob: a Blob is ONE stored
+/// object, while a Media is the several stored objects that together represent
+/// the same content at different qualities/sizes.
+///
+/// Wherever a surface attaches media, it embeds this type: the client uploads a
+/// single ORIGINAL and the server derives the rest, identically everywhere.
+public struct Flipcash_Blob_V1_Media: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The renditions of this media, each an independently-stored blob. When a
+  /// client attaches media (e.g. SendMessage, SetProfilePicture) it supplies
+  /// exactly one ORIGINAL rendition (its blob_id); the server fills that
+  /// rendition's metadata and appends any derived renditions (e.g. a
+  /// downscaled DISPLAY and a THUMBNAIL).
+  public var renditions: [Flipcash_Blob_V1_Rendition] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// A single stored variant of a Media.
+public struct Flipcash_Blob_V1_Rendition: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The intended use of this rendition within the media.
+  public var role: Flipcash_Blob_V1_Rendition.Role = .unknown
+
+  /// Handle to the blob holding this rendition's bytes. Client-set on the
+  /// ORIGINAL when attaching the media; server-set for derived renditions.
+  public var blobID: Flipcash_Blob_V1_BlobId {
+    get {_blobID ?? Flipcash_Blob_V1_BlobId()}
+    set {_blobID = newValue}
+  }
+  /// Returns true if `blobID` has been explicitly set.
+  public var hasBlobID: Bool {self._blobID != nil}
+  /// Clears the value of `blobID`. Subsequent reads from it will return its default value.
+  public mutating func clearBlobID() {self._blobID = nil}
+
+  /// Server-authoritative blob metadata (mime type, size, download URL, and
+  /// the image dimensions/preview), resolved from the blob record. Omitted on
+  /// the request that attaches the media and populated on returned copies.
+  ///
+  /// If unavailable at the time the media is retrieved, the client can use
+  /// GetBlobs to query for the blob metadata.
+  public var blob: Flipcash_Blob_V1_BlobMetadata {
+    get {_blob ?? Flipcash_Blob_V1_BlobMetadata()}
+    set {_blob = newValue}
+  }
+  /// Returns true if `blob` has been explicitly set.
+  public var hasBlob: Bool {self._blob != nil}
+  /// Clears the value of `blob`. Subsequent reads from it will return its default value.
+  public mutating func clearBlob() {self._blob = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public enum Role: SwiftProtobuf.Enum, Swift.CaseIterable {
+    public typealias RawValue = Int
+    case unknown // = 0
+
+    /// full-quality source the client uploaded
+    case original // = 1
+
+    /// downscaled/compressed for inline display
+    case display // = 2
+
+    /// tiny preview (grid cell, avatar, ...)
+    case thumbnail // = 3
+    case UNRECOGNIZED(Int)
+
+    public init() {
+      self = .unknown
+    }
+
+    public init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .unknown
+      case 1: self = .original
+      case 2: self = .display
+      case 3: self = .thumbnail
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    public var rawValue: Int {
+      switch self {
+      case .unknown: return 0
+      case .original: return 1
+      case .display: return 2
+      case .thumbnail: return 3
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Flipcash_Blob_V1_Rendition.Role] = [
+      .unknown,
+      .original,
+      .display,
+      .thumbnail,
+    ]
+
+  }
+
+  public init() {}
+
+  fileprivate var _blobID: Flipcash_Blob_V1_BlobId? = nil
+  fileprivate var _blob: Flipcash_Blob_V1_BlobMetadata? = nil
 }
 
 /// The constraints the server enforces on uploads, surfaced so clients can
@@ -598,12 +719,35 @@ public struct Flipcash_Blob_V1_AccessContext: Sendable {
     set {scope = .chat(newValue)}
   }
 
+  /// The caller is accessing these blobs from this user's public profile.
+  /// Authorized iff the blob is a rendition of that user's CURRENT profile
+  /// picture — a profile grants nothing else, and a superseded picture's
+  /// renditions stop resolving through it.
+  ///
+  /// A caller never needs this for its OWN profile picture, since it owns
+  /// those blobs.
+  public var profile: Flipcash_Common_V1_UserId {
+    get {
+      if case .profile(let v)? = scope {return v}
+      return Flipcash_Common_V1_UserId()
+    }
+    set {scope = .profile(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_Scope: Equatable, Sendable {
     /// The caller is accessing these blobs from within this chat. Authorized
     /// iff the caller is a member of the chat and the blob was shared into it.
     case chat(Flipcash_Common_V1_ChatId)
+    /// The caller is accessing these blobs from this user's public profile.
+    /// Authorized iff the blob is a rendition of that user's CURRENT profile
+    /// picture — a profile grants nothing else, and a superseded picture's
+    /// renditions stop resolving through it.
+    ///
+    /// A caller never needs this for its OWN profile picture, since it owns
+    /// those blobs.
+    case profile(Flipcash_Common_V1_UserId)
 
   }
 
@@ -619,7 +763,7 @@ extension Flipcash_Blob_V1_BlobStatus: SwiftProtobuf._ProtoNameProviding {
 }
 
 extension Flipcash_Blob_V1_RejectionReason: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0REJECTION_REASON_UNKNOWN\0\u{1}REJECTION_REASON_MODERATION\0\u{1}REJECTION_REASON_UNSUPPORTED_TYPE\0\u{1}REJECTION_REASON_MISMATCHED_TYPE\0\u{1}REJECTION_REASON_TOO_LARGE\0\u{1}REJECTION_REASON_CORRUPT\0\u{1}REJECTION_REASON_INTERNAL\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0REJECTION_REASON_UNKNOWN\0\u{1}REJECTION_REASON_MODERATION\0\u{1}REJECTION_REASON_UNSUPPORTED_TYPE\0\u{1}REJECTION_REASON_MISMATCHED_TYPE\0\u{1}REJECTION_REASON_TOO_LARGE\0\u{1}REJECTION_REASON_CORRUPT\0\u{1}REJECTION_REASON_INTERNAL\0\u{1}REJECTION_REASON_PRIVACY_METADATA\0")
 }
 
 extension Flipcash_Blob_V1_BlobId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -860,6 +1004,84 @@ extension Flipcash_Blob_V1_ImageMetadata: SwiftProtobuf.Message, SwiftProtobuf._
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
+}
+
+extension Flipcash_Blob_V1_Media: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Media"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}renditions\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.renditions) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.renditions.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.renditions, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Blob_V1_Media, rhs: Flipcash_Blob_V1_Media) -> Bool {
+    if lhs.renditions != rhs.renditions {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Blob_V1_Rendition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Rendition"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}role\0\u{3}blob_id\0\u{1}blob\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.role) }()
+      case 2: try { try decoder.decodeSingularMessageField(value: &self._blobID) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._blob) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.role != .unknown {
+      try visitor.visitSingularEnumField(value: self.role, fieldNumber: 1)
+    }
+    try { if let v = self._blobID {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    } }()
+    try { if let v = self._blob {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Blob_V1_Rendition, rhs: Flipcash_Blob_V1_Rendition) -> Bool {
+    if lhs.role != rhs.role {return false}
+    if lhs._blobID != rhs._blobID {return false}
+    if lhs._blob != rhs._blob {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Blob_V1_Rendition.Role: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}ORIGINAL\0\u{1}DISPLAY\0\u{1}THUMBNAIL\0")
 }
 
 extension Flipcash_Blob_V1_UploadPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -1166,7 +1388,7 @@ extension Flipcash_Blob_V1_RejectionMetadata: SwiftProtobuf.Message, SwiftProtob
 
 extension Flipcash_Blob_V1_AccessContext: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AccessContext"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}chat\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}chat\0\u{1}profile\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1187,6 +1409,19 @@ extension Flipcash_Blob_V1_AccessContext: SwiftProtobuf.Message, SwiftProtobuf._
           self.scope = .chat(v)
         }
       }()
+      case 2: try {
+        var v: Flipcash_Common_V1_UserId?
+        var hadOneofValue = false
+        if let current = self.scope {
+          hadOneofValue = true
+          if case .profile(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.scope = .profile(v)
+        }
+      }()
       default: break
       }
     }
@@ -1197,9 +1432,17 @@ extension Flipcash_Blob_V1_AccessContext: SwiftProtobuf.Message, SwiftProtobuf._
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
     // https://github.com/apple/swift-protobuf/issues/1182
-    try { if case .chat(let v)? = self.scope {
+    switch self.scope {
+    case .chat?: try {
+      guard case .chat(let v)? = self.scope else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    } }()
+    }()
+    case .profile?: try {
+      guard case .profile(let v)? = self.scope else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case nil: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/messaging_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/messaging_v1_model.pb.swift
@@ -318,7 +318,10 @@ public struct Flipcash_Messaging_V1_MediaContent: Sendable {
 
   /// The media items attached to this message. A single item today; raising
   /// this cap later enables albums (each item self-describes its kind).
-  public var items: [Flipcash_Messaging_V1_MediaItem] = []
+  ///
+  /// On SendMessage the client supplies exactly one ORIGINAL rendition per
+  /// item; the server fills its metadata and appends the derived renditions.
+  public var items: [Flipcash_Blob_V1_Media] = []
 
   /// Optional caption rendered alongside the media
   public var caption: Flipcash_Messaging_V1_TextContent {
@@ -335,114 +338,6 @@ public struct Flipcash_Messaging_V1_MediaContent: Sendable {
   public init() {}
 
   fileprivate var _caption: Flipcash_Messaging_V1_TextContent? = nil
-}
-
-/// One logical media item, carried as its set of renditions (quality/size variants).
-public struct Flipcash_Messaging_V1_MediaItem: Sendable {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  /// The renditions of this media, each an independently-stored blob. On
-  /// SendMessage the client supplies exactly one ORIGINAL rendition (its
-  /// blob_id); the server fills metadata and appends any derived renditions
-  /// (e.g. a downscaled DISPLAY and a THUMBNAIL).
-  public var renditions: [Flipcash_Messaging_V1_MediaItemRendition] = []
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
-/// A single stored variant of a MediaItem
-public struct Flipcash_Messaging_V1_MediaItemRendition: Sendable {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  /// The intended use of this rendition within the item.
-  public var role: Flipcash_Messaging_V1_MediaItemRendition.Role = .unknown
-
-  /// Handle to the blob holding this rendition's bytes. Client-set on the
-  /// ORIGINAL at send time; server-set for derived renditions.
-  public var blobID: Flipcash_Blob_V1_BlobId {
-    get {_blobID ?? Flipcash_Blob_V1_BlobId()}
-    set {_blobID = newValue}
-  }
-  /// Returns true if `blobID` has been explicitly set.
-  public var hasBlobID: Bool {self._blobID != nil}
-  /// Clears the value of `blobID`. Subsequent reads from it will return its default value.
-  public mutating func clearBlobID() {self._blobID = nil}
-
-  /// Server-authoritative blob metadata (mime type, size, download URL, and
-  /// the image dimensions/preview), resolved from the blob record. Omitted on
-  /// SendMessage and populated on stored/returned messages.
-  ///
-  /// If unavailable at time of message retrieval, client can use the blob
-  /// service to query for the blob metadata.
-  public var blob: Flipcash_Blob_V1_BlobMetadata {
-    get {_blob ?? Flipcash_Blob_V1_BlobMetadata()}
-    set {_blob = newValue}
-  }
-  /// Returns true if `blob` has been explicitly set.
-  public var hasBlob: Bool {self._blob != nil}
-  /// Clears the value of `blob`. Subsequent reads from it will return its default value.
-  public mutating func clearBlob() {self._blob = nil}
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public enum Role: SwiftProtobuf.Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case unknown // = 0
-
-    /// full-quality source the client uploaded
-    case original // = 1
-
-    /// downscaled/compressed for inline display
-    case display // = 2
-
-    /// tiny grid preview
-    case thumbnail // = 3
-    case UNRECOGNIZED(Int)
-
-    public init() {
-      self = .unknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .original
-      case 2: self = .display
-      case 3: self = .thumbnail
-      default: self = .UNRECOGNIZED(rawValue)
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .original: return 1
-      case .display: return 2
-      case .thumbnail: return 3
-      case .UNRECOGNIZED(let i): return i
-      }
-    }
-
-    // The compiler won't synthesize support with the UNRECOGNIZED case.
-    public static let allCases: [Flipcash_Messaging_V1_MediaItemRendition.Role] = [
-      .unknown,
-      .original,
-      .display,
-      .thumbnail,
-    ]
-
-  }
-
-  public init() {}
-
-  fileprivate var _blobID: Flipcash_Blob_V1_BlobId? = nil
-  fileprivate var _blob: Flipcash_Blob_V1_BlobMetadata? = nil
 }
 
 /// System message content
@@ -1507,84 +1402,6 @@ extension Flipcash_Messaging_V1_MediaContent: SwiftProtobuf.Message, SwiftProtob
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
-}
-
-extension Flipcash_Messaging_V1_MediaItem: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".MediaItem"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}renditions\0")
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.renditions) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.renditions.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.renditions, fieldNumber: 1)
-    }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Flipcash_Messaging_V1_MediaItem, rhs: Flipcash_Messaging_V1_MediaItem) -> Bool {
-    if lhs.renditions != rhs.renditions {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-extension Flipcash_Messaging_V1_MediaItemRendition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".MediaItemRendition"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}role\0\u{3}blob_id\0\u{1}blob\0")
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularEnumField(value: &self.role) }()
-      case 2: try { try decoder.decodeSingularMessageField(value: &self._blobID) }()
-      case 3: try { try decoder.decodeSingularMessageField(value: &self._blob) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    if self.role != .unknown {
-      try visitor.visitSingularEnumField(value: self.role, fieldNumber: 1)
-    }
-    try { if let v = self._blobID {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    } }()
-    try { if let v = self._blob {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    } }()
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Flipcash_Messaging_V1_MediaItemRendition, rhs: Flipcash_Messaging_V1_MediaItemRendition) -> Bool {
-    if lhs.role != rhs.role {return false}
-    if lhs._blobID != rhs._blobID {return false}
-    if lhs._blob != rhs._blob {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-extension Flipcash_Messaging_V1_MediaItemRendition.Role: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}ORIGINAL\0\u{1}DISPLAY\0\u{1}THUMBNAIL\0")
 }
 
 extension Flipcash_Messaging_V1_SystemContent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_model.pb.swift
@@ -53,12 +53,31 @@ public struct Flipcash_Profile_V1_UserProfile: Sendable {
   /// Clears the value of `emailAddress`. Subsequent reads from it will return its default value.
   public mutating func clearEmailAddress() {self._emailAddress = nil}
 
+  /// The user's profile picture, as the set of renditions it is stored as —
+  /// typically a DISPLAY for the profile view and a THUMBNAIL for avatars in
+  /// member rows and chat lists.
+  ///
+  /// Unset when the user has not set a picture. Set it with SetProfilePicture.
+  ///
+  /// To fetch the bytes of ANOTHER user's picture, the caller does not own
+  /// these blobs, so a GetBlobs call must carry a blob.v1.AccessContext whose
+  /// `profile` scope names this user. A caller reading its own needs none.
+  public var profilePicture: Flipcash_Blob_V1_Media {
+    get {_profilePicture ?? Flipcash_Blob_V1_Media()}
+    set {_profilePicture = newValue}
+  }
+  /// Returns true if `profilePicture` has been explicitly set.
+  public var hasProfilePicture: Bool {self._profilePicture != nil}
+  /// Clears the value of `profilePicture`. Subsequent reads from it will return its default value.
+  public mutating func clearProfilePicture() {self._profilePicture = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _phoneNumber: Flipcash_Phone_V1_PhoneNumber? = nil
   fileprivate var _emailAddress: Flipcash_Email_V1_EmailAddress? = nil
+  fileprivate var _profilePicture: Flipcash_Blob_V1_Media? = nil
 }
 
 public struct Flipcash_Profile_V1_SocialProfile: Sendable {
@@ -165,7 +184,7 @@ fileprivate let _protobuf_package = "flipcash.profile.v1"
 
 extension Flipcash_Profile_V1_UserProfile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UserProfile"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}display_name\0\u{3}social_profiles\0\u{3}phone_number\0\u{3}email_address\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}display_name\0\u{3}social_profiles\0\u{3}phone_number\0\u{3}email_address\0\u{3}profile_picture\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -177,6 +196,7 @@ extension Flipcash_Profile_V1_UserProfile: SwiftProtobuf.Message, SwiftProtobuf.
       case 2: try { try decoder.decodeRepeatedMessageField(value: &self.socialProfiles) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._phoneNumber) }()
       case 4: try { try decoder.decodeSingularMessageField(value: &self._emailAddress) }()
+      case 5: try { try decoder.decodeSingularMessageField(value: &self._profilePicture) }()
       default: break
       }
     }
@@ -199,6 +219,9 @@ extension Flipcash_Profile_V1_UserProfile: SwiftProtobuf.Message, SwiftProtobuf.
     try { if let v = self._emailAddress {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
     } }()
+    try { if let v = self._profilePicture {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -207,6 +230,7 @@ extension Flipcash_Profile_V1_UserProfile: SwiftProtobuf.Message, SwiftProtobuf.
     if lhs.socialProfiles != rhs.socialProfiles {return false}
     if lhs._phoneNumber != rhs._phoneNumber {return false}
     if lhs._emailAddress != rhs._emailAddress {return false}
+    if lhs._profilePicture != rhs._profilePicture {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.grpc.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.grpc.swift
@@ -46,6 +46,19 @@ public enum Flipcash_Profile_V1_Profile: Sendable {
                 type: .unary
             )
         }
+        /// Namespace for "SetProfilePicture" metadata.
+        public enum SetProfilePicture: Sendable {
+            /// Request type for "SetProfilePicture".
+            public typealias Input = Flipcash_Profile_V1_SetProfilePictureRequest
+            /// Response type for "SetProfilePicture".
+            public typealias Output = Flipcash_Profile_V1_SetProfilePictureResponse
+            /// Descriptor for "SetProfilePicture".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "flipcash.profile.v1.Profile"),
+                method: "SetProfilePicture",
+                type: .unary
+            )
+        }
         /// Namespace for "LinkSocialAccount" metadata.
         public enum LinkSocialAccount: Sendable {
             /// Request type for "LinkSocialAccount".
@@ -76,6 +89,7 @@ public enum Flipcash_Profile_V1_Profile: Sendable {
         public static let descriptors: [GRPCCore.MethodDescriptor] = [
             GetProfile.descriptor,
             SetDisplayName.descriptor,
+            SetProfilePicture.descriptor,
             LinkSocialAccount.descriptor,
             UnlinkSocialAccount.descriptor
         ]
@@ -133,6 +147,35 @@ extension Flipcash_Profile_V1_Profile {
             deserializer: some GRPCCore.MessageDeserializer<Flipcash_Profile_V1_SetDisplayNameResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetDisplayNameResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "SetProfilePicture" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > SetProfilePicture sets the caller's profile picture to a blob they have
+        /// > already uploaded via BlobStorage, replacing any picture already set.
+        /// > 
+        /// > The client uploads only the ORIGINAL — InitiateExternalUpload, PUT/POST
+        /// > the bytes, then (optionally) CompleteExternalUpload — and passes the
+        /// > resulting BlobId here once the blob is READY. The server derives the
+        /// > DISPLAY and THUMBNAIL renditions itself and returns the full set.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Flipcash_Profile_V1_SetProfilePictureRequest` message.
+        ///   - serializer: A serializer for `Flipcash_Profile_V1_SetProfilePictureRequest` messages.
+        ///   - deserializer: A deserializer for `Flipcash_Profile_V1_SetProfilePictureResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func setProfilePicture<Result>(
+            request: GRPCCore.ClientRequest<Flipcash_Profile_V1_SetProfilePictureRequest>,
+            serializer: some GRPCCore.MessageSerializer<Flipcash_Profile_V1_SetProfilePictureRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Flipcash_Profile_V1_SetProfilePictureResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetProfilePictureResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
 
         /// Call the "LinkSocialAccount" method.
@@ -251,6 +294,46 @@ extension Flipcash_Profile_V1_Profile {
             try await self.client.unary(
                 request: request,
                 descriptor: Flipcash_Profile_V1_Profile.Method.SetDisplayName.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "SetProfilePicture" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > SetProfilePicture sets the caller's profile picture to a blob they have
+        /// > already uploaded via BlobStorage, replacing any picture already set.
+        /// > 
+        /// > The client uploads only the ORIGINAL — InitiateExternalUpload, PUT/POST
+        /// > the bytes, then (optionally) CompleteExternalUpload — and passes the
+        /// > resulting BlobId here once the blob is READY. The server derives the
+        /// > DISPLAY and THUMBNAIL renditions itself and returns the full set.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Flipcash_Profile_V1_SetProfilePictureRequest` message.
+        ///   - serializer: A serializer for `Flipcash_Profile_V1_SetProfilePictureRequest` messages.
+        ///   - deserializer: A deserializer for `Flipcash_Profile_V1_SetProfilePictureResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func setProfilePicture<Result>(
+            request: GRPCCore.ClientRequest<Flipcash_Profile_V1_SetProfilePictureRequest>,
+            serializer: some GRPCCore.MessageSerializer<Flipcash_Profile_V1_SetProfilePictureRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Flipcash_Profile_V1_SetProfilePictureResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetProfilePictureResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Flipcash_Profile_V1_Profile.Method.SetProfilePicture.descriptor,
                 serializer: serializer,
                 deserializer: deserializer,
                 options: options,
@@ -381,6 +464,41 @@ extension Flipcash_Profile_V1_Profile.ClientProtocol {
         )
     }
 
+    /// Call the "SetProfilePicture" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > SetProfilePicture sets the caller's profile picture to a blob they have
+    /// > already uploaded via BlobStorage, replacing any picture already set.
+    /// > 
+    /// > The client uploads only the ORIGINAL — InitiateExternalUpload, PUT/POST
+    /// > the bytes, then (optionally) CompleteExternalUpload — and passes the
+    /// > resulting BlobId here once the blob is READY. The server derives the
+    /// > DISPLAY and THUMBNAIL renditions itself and returns the full set.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Flipcash_Profile_V1_SetProfilePictureRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func setProfilePicture<Result>(
+        request: GRPCCore.ClientRequest<Flipcash_Profile_V1_SetProfilePictureRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetProfilePictureResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.setProfilePicture(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Flipcash_Profile_V1_SetProfilePictureRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Flipcash_Profile_V1_SetProfilePictureResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
     /// Call the "LinkSocialAccount" method.
     ///
     /// > Source IDL Documentation:
@@ -495,6 +613,45 @@ extension Flipcash_Profile_V1_Profile.ClientProtocol {
             metadata: metadata
         )
         return try await self.setDisplayName(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "SetProfilePicture" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > SetProfilePicture sets the caller's profile picture to a blob they have
+    /// > already uploaded via BlobStorage, replacing any picture already set.
+    /// > 
+    /// > The client uploads only the ORIGINAL — InitiateExternalUpload, PUT/POST
+    /// > the bytes, then (optionally) CompleteExternalUpload — and passes the
+    /// > resulting BlobId here once the blob is READY. The server derives the
+    /// > DISPLAY and THUMBNAIL renditions itself and returns the full set.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func setProfilePicture<Result>(
+        _ message: Flipcash_Profile_V1_SetProfilePictureRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetProfilePictureResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Flipcash_Profile_V1_SetProfilePictureRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.setProfilePicture(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.pb.swift
@@ -187,6 +187,123 @@ public struct Flipcash_Profile_V1_SetDisplayNameResponse: Sendable {
   public init() {}
 }
 
+public struct Flipcash_Profile_V1_SetProfilePictureRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The blob holding the ORIGINAL image the caller uploaded. It must be owned
+  /// by the caller and READY; the server derives the remaining renditions from
+  /// it. A blob may back at most one profile picture — reuse is not implied.
+  public var blobID: Flipcash_Blob_V1_BlobId {
+    get {_blobID ?? Flipcash_Blob_V1_BlobId()}
+    set {_blobID = newValue}
+  }
+  /// Returns true if `blobID` has been explicitly set.
+  public var hasBlobID: Bool {self._blobID != nil}
+  /// Clears the value of `blobID`. Subsequent reads from it will return its default value.
+  public mutating func clearBlobID() {self._blobID = nil}
+
+  public var auth: Flipcash_Common_V1_Auth {
+    get {_auth ?? Flipcash_Common_V1_Auth()}
+    set {_auth = newValue}
+  }
+  /// Returns true if `auth` has been explicitly set.
+  public var hasAuth: Bool {self._auth != nil}
+  /// Clears the value of `auth`. Subsequent reads from it will return its default value.
+  public mutating func clearAuth() {self._auth = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _blobID: Flipcash_Blob_V1_BlobId? = nil
+  fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
+}
+
+public struct Flipcash_Profile_V1_SetProfilePictureResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var result: Flipcash_Profile_V1_SetProfilePictureResponse.Result = .ok
+
+  /// The caller's new profile picture, including the renditions the server
+  /// derived. Set only when result == OK.
+  public var profilePicture: Flipcash_Blob_V1_Media {
+    get {_profilePicture ?? Flipcash_Blob_V1_Media()}
+    set {_profilePicture = newValue}
+  }
+  /// Returns true if `profilePicture` has been explicitly set.
+  public var hasProfilePicture: Bool {self._profilePicture != nil}
+  /// Clears the value of `profilePicture`. Subsequent reads from it will return its default value.
+  public mutating func clearProfilePicture() {self._profilePicture = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public enum Result: SwiftProtobuf.Enum, Swift.CaseIterable {
+    public typealias RawValue = Int
+    case ok // = 0
+    case denied // = 1
+
+    /// no such blob, or it is not owned by the caller
+    case blobNotFound // = 2
+
+    /// blob is still PENDING/PROCESSING; retry once READY
+    case blobNotReady // = 3
+
+    /// blob failed validation or moderation; terminal for this id, so the client must upload again
+    case blobRejected // = 4
+
+    /// blob is READY but unusable as a picture (e.g. not an image)
+    case invalidBlob // = 5
+    case UNRECOGNIZED(Int)
+
+    public init() {
+      self = .ok
+    }
+
+    public init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .ok
+      case 1: self = .denied
+      case 2: self = .blobNotFound
+      case 3: self = .blobNotReady
+      case 4: self = .blobRejected
+      case 5: self = .invalidBlob
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    public var rawValue: Int {
+      switch self {
+      case .ok: return 0
+      case .denied: return 1
+      case .blobNotFound: return 2
+      case .blobNotReady: return 3
+      case .blobRejected: return 4
+      case .invalidBlob: return 5
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Flipcash_Profile_V1_SetProfilePictureResponse.Result] = [
+      .ok,
+      .denied,
+      .blobNotFound,
+      .blobNotReady,
+      .blobRejected,
+      .invalidBlob,
+    ]
+
+  }
+
+  public init() {}
+
+  fileprivate var _profilePicture: Flipcash_Blob_V1_Media? = nil
+}
+
 public struct Flipcash_Profile_V1_LinkSocialAccountRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -560,6 +677,88 @@ extension Flipcash_Profile_V1_SetDisplayNameResponse: SwiftProtobuf.Message, Swi
 
 extension Flipcash_Profile_V1_SetDisplayNameResponse.Result: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}INVALID_DISPLAY_NAME\0\u{1}DENIED\0")
+}
+
+extension Flipcash_Profile_V1_SetProfilePictureRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SetProfilePictureRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}blob_id\0\u{2}\u{9}auth\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._blobID) }()
+      case 10: try { try decoder.decodeSingularMessageField(value: &self._auth) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._blobID {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    try { if let v = self._auth {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Profile_V1_SetProfilePictureRequest, rhs: Flipcash_Profile_V1_SetProfilePictureRequest) -> Bool {
+    if lhs._blobID != rhs._blobID {return false}
+    if lhs._auth != rhs._auth {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Profile_V1_SetProfilePictureResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SetProfilePictureResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}result\0\u{3}profile_picture\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.result) }()
+      case 2: try { try decoder.decodeSingularMessageField(value: &self._profilePicture) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.result != .ok {
+      try visitor.visitSingularEnumField(value: self.result, fieldNumber: 1)
+    }
+    try { if let v = self._profilePicture {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Profile_V1_SetProfilePictureResponse, rhs: Flipcash_Profile_V1_SetProfilePictureResponse) -> Bool {
+    if lhs.result != rhs.result {return false}
+    if lhs._profilePicture != rhs._profilePicture {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Profile_V1_SetProfilePictureResponse.Result: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}DENIED\0\u{1}BLOB_NOT_FOUND\0\u{1}BLOB_NOT_READY\0\u{1}BLOB_REJECTED\0\u{1}INVALID_BLOB\0")
 }
 
 extension Flipcash_Profile_V1_LinkSocialAccountRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/resolver_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/resolver_v1_model.pb.swift
@@ -37,10 +37,19 @@ public struct Flipcash_Resolver_V1_Identifier: Sendable {
     set {kind = .phone(newValue)}
   }
 
+  public var userID: Flipcash_Common_V1_UserId {
+    get {
+      if case .userID(let v)? = kind {return v}
+      return Flipcash_Common_V1_UserId()
+    }
+    set {kind = .userID(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_Kind: Equatable, Sendable {
     case phone(Flipcash_Phone_V1_PhoneNumber)
+    case userID(Flipcash_Common_V1_UserId)
 
   }
 
@@ -80,7 +89,7 @@ fileprivate let _protobuf_package = "flipcash.resolver.v1"
 
 extension Flipcash_Resolver_V1_Identifier: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Identifier"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phone\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phone\0\u{3}user_id\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -101,6 +110,19 @@ extension Flipcash_Resolver_V1_Identifier: SwiftProtobuf.Message, SwiftProtobuf.
           self.kind = .phone(v)
         }
       }()
+      case 2: try {
+        var v: Flipcash_Common_V1_UserId?
+        var hadOneofValue = false
+        if let current = self.kind {
+          hadOneofValue = true
+          if case .userID(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.kind = .userID(v)
+        }
+      }()
       default: break
       }
     }
@@ -111,9 +133,17 @@ extension Flipcash_Resolver_V1_Identifier: SwiftProtobuf.Message, SwiftProtobuf.
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
     // https://github.com/apple/swift-protobuf/issues/1182
-    try { if case .phone(let v)? = self.kind {
+    switch self.kind {
+    case .phone?: try {
+      guard case .phone(let v)? = self.kind else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    } }()
+    }()
+    case .userID?: try {
+      guard case .userID(let v)? = self.kind else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case nil: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/blob/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/blob/v1/model.proto
@@ -97,6 +97,50 @@ message ImageMetadata {
     string blurhash = 3 [(validate.rules).string.max_len = 64];
 }
 
+// One logical piece of media — a chat image, a profile picture — carried as the
+// set of renditions it is stored as. Distinct from Blob: a Blob is ONE stored
+// object, while a Media is the several stored objects that together represent
+// the same content at different qualities/sizes.
+//
+// Wherever a surface attaches media, it embeds this type: the client uploads a
+// single ORIGINAL and the server derives the rest, identically everywhere.
+message Media {
+    // The renditions of this media, each an independently-stored blob. When a
+    // client attaches media (e.g. SendMessage, SetProfilePicture) it supplies
+    // exactly one ORIGINAL rendition (its blob_id); the server fills that
+    // rendition's metadata and appends any derived renditions (e.g. a
+    // downscaled DISPLAY and a THUMBNAIL).
+    repeated Rendition renditions = 1 [(validate.rules).repeated = {
+        min_items: 1
+    }];
+}
+
+// A single stored variant of a Media.
+message Rendition {
+    // The intended use of this rendition within the media.
+    Role role = 1 [(validate.rules).enum = {
+        not_in: [0]
+    }];
+    enum Role {
+        UNKNOWN   = 0;
+        ORIGINAL  = 1; // full-quality source the client uploaded
+        DISPLAY   = 2; // downscaled/compressed for inline display
+        THUMBNAIL = 3; // tiny preview (grid cell, avatar, ...)
+    }
+
+    // Handle to the blob holding this rendition's bytes. Client-set on the
+    // ORIGINAL when attaching the media; server-set for derived renditions.
+    BlobId blob_id = 2 [(validate.rules).message.required = true];
+
+    // Server-authoritative blob metadata (mime type, size, download URL, and
+    // the image dimensions/preview), resolved from the blob record. Omitted on
+    // the request that attaches the media and populated on returned copies.
+    //
+    // If unavailable at the time the media is retrieved, the client can use
+    // GetBlobs to query for the blob metadata.
+    BlobMetadata blob = 3;
+}
+
 // The constraints the server enforces on uploads, surfaced so clients can
 // validate and resize/transcode before reserving an upload. Advisory and
 // cacheable; InitiateExternalUpload remains authoritative. Constraints can
@@ -247,6 +291,7 @@ enum RejectionReason {
     REJECTION_REASON_TOO_LARGE        = 4; // stored bytes exceeded the per-type ceiling
     REJECTION_REASON_CORRUPT          = 5; // bytes unreadable; failed to decode or transcode
     REJECTION_REASON_INTERNAL         = 6; // server-side processing error
+    REJECTION_REASON_PRIVACY_METADATA = 7; // blob contains privacy metadata that was not stripped
 }
 
 // AccessContext names the surface a caller is accessing blobs THROUGH on a
@@ -268,5 +313,14 @@ message AccessContext {
         // The caller is accessing these blobs from within this chat. Authorized
         // iff the caller is a member of the chat and the blob was shared into it.
         common.v1.ChatId chat = 1 [(validate.rules).message.required = true];
+
+        // The caller is accessing these blobs from this user's public profile.
+        // Authorized iff the blob is a rendition of that user's CURRENT profile
+        // picture — a profile grants nothing else, and a superseded picture's
+        // renditions stop resolving through it.
+        //
+        // A caller never needs this for its OWN profile picture, since it owns
+        // those blobs.
+        common.v1.UserId profile = 2 [(validate.rules).message.required = true];
     }
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/messaging/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/messaging/v1/model.proto
@@ -147,50 +147,16 @@ message ReplyContent {
 message MediaContent {
     // The media items attached to this message. A single item today; raising
     // this cap later enables albums (each item self-describes its kind).
-    repeated MediaItem items = 1 [(validate.rules).repeated = {
+    //
+    // On SendMessage the client supplies exactly one ORIGINAL rendition per
+    // item; the server fills its metadata and appends the derived renditions.
+    repeated blob.v1.Media items = 1 [(validate.rules).repeated = {
         min_items: 1
         max_items: 1
     }];
 
     // Optional caption rendered alongside the media
     TextContent caption = 2;
-}
-
-// One logical media item, carried as its set of renditions (quality/size variants).
-message MediaItem {
-    // The renditions of this media, each an independently-stored blob. On
-    // SendMessage the client supplies exactly one ORIGINAL rendition (its
-    // blob_id); the server fills metadata and appends any derived renditions
-    // (e.g. a downscaled DISPLAY and a THUMBNAIL).
-    repeated MediaItemRendition renditions = 1 [(validate.rules).repeated = {
-        min_items: 1
-    }];
-}
-
-// A single stored variant of a MediaItem
-message MediaItemRendition {
-    // The intended use of this rendition within the item.
-    Role role = 1 [(validate.rules).enum = {
-        not_in: [0]
-    }];
-    enum Role {
-        UNKNOWN   = 0;
-        ORIGINAL  = 1; // full-quality source the client uploaded
-        DISPLAY   = 2; // downscaled/compressed for inline display
-        THUMBNAIL = 3; // tiny grid preview
-    }
-
-    // Handle to the blob holding this rendition's bytes. Client-set on the
-    // ORIGINAL at send time; server-set for derived renditions.
-    blob.v1.BlobId blob_id = 2 [(validate.rules).message.required = true];
-
-    // Server-authoritative blob metadata (mime type, size, download URL, and
-    // the image dimensions/preview), resolved from the blob record. Omitted on
-    // SendMessage and populated on stored/returned messages.
-    //
-    // If unavailable at time of message retrieval, client can use the blob
-    // service to query for the blob metadata.
-    blob.v1.BlobMetadata blob = 3;
 }
 
 // System message content

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/model.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/g
 option java_package = "com.codeinc.flipcash.gen.profile.v1";
 option objc_class_prefix = "FPBProfileV1";
 
+import "blob/v1/model.proto";
 import "email/v1/model.proto";
 import "phone/v1/model.proto";
 import "validate/validate.proto";
@@ -31,6 +32,17 @@ message UserProfile {
     // Email address linked to this user. This is private and will only be returned
     // when the requesting user asks for their own profile
     email.v1.EmailAddress email_address = 4;
+
+    // The user's profile picture, as the set of renditions it is stored as —
+    // typically a DISPLAY for the profile view and a THUMBNAIL for avatars in
+    // member rows and chat lists.
+    //
+    // Unset when the user has not set a picture. Set it with SetProfilePicture.
+    //
+    // To fetch the bytes of ANOTHER user's picture, the caller does not own
+    // these blobs, so a GetBlobs call must carry a blob.v1.AccessContext whose
+    // `profile` scope names this user. A caller reading its own needs none.
+    blob.v1.Media profile_picture = 5;
 }
 
 message SocialProfile {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/profile_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/profile_service.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/g
 option java_package = "com.codeinc.flipcash.gen.profile.v1";
 option objc_class_prefix = "FPBProfileV1";
 
+import "blob/v1/model.proto";
 import "common/v1/common.proto";
 import "profile/v1/model.proto";
 import "validate/validate.proto";
@@ -14,6 +15,15 @@ service Profile {
 	rpc GetProfile(GetProfileRequest) returns (GetProfileResponse);
 
 	rpc SetDisplayName(SetDisplayNameRequest) returns (SetDisplayNameResponse);
+
+	// SetProfilePicture sets the caller's profile picture to a blob they have
+	// already uploaded via BlobStorage, replacing any picture already set.
+	//
+	// The client uploads only the ORIGINAL — InitiateExternalUpload, PUT/POST
+	// the bytes, then (optionally) CompleteExternalUpload — and passes the
+	// resulting BlobId here once the blob is READY. The server derives the
+	// DISPLAY and THUMBNAIL renditions itself and returns the full set.
+	rpc SetProfilePicture(SetProfilePictureRequest) returns (SetProfilePictureResponse);
 
 	// LinkSocialAccount links a social account to a user
 	rpc LinkSocialAccount(LinkSocialAccountRequest) returns (LinkSocialAccountResponse);
@@ -60,6 +70,31 @@ message SetDisplayNameResponse {
 		INVALID_DISPLAY_NAME = 1;
 		DENIED               = 2;
 	}
+}
+
+message SetProfilePictureRequest {
+	// The blob holding the ORIGINAL image the caller uploaded. It must be owned
+	// by the caller and READY; the server derives the remaining renditions from
+	// it. A blob may back at most one profile picture — reuse is not implied.
+	blob.v1.BlobId blob_id = 1 [(validate.rules).message.required = true];
+
+	common.v1.Auth auth = 10 [(validate.rules).message.required = true];
+}
+
+message SetProfilePictureResponse {
+	Result result = 1;
+	enum Result {
+		OK             = 0;
+		DENIED         = 1;
+		BLOB_NOT_FOUND = 2; // no such blob, or it is not owned by the caller
+		BLOB_NOT_READY = 3; // blob is still PENDING/PROCESSING; retry once READY
+		BLOB_REJECTED  = 4; // blob failed validation or moderation; terminal for this id, so the client must upload again
+		INVALID_BLOB   = 5; // blob is READY but unusable as a picture (e.g. not an image)
+	}
+
+	// The caller's new profile picture, including the renditions the server
+	// derived. Set only when result == OK.
+	blob.v1.Media profile_picture = 2;
 }
 
 message LinkSocialAccountRequest {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/resolver/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/resolver/v1/model.proto
@@ -16,7 +16,8 @@ message Identifier {
     oneof kind {
         option (validate.required) = true;
 
-        phone.v1.PhoneNumber phone = 1;
+        phone.v1.PhoneNumber phone   = 1;
+        common.v1.UserId     user_id = 2;
     }
 }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Payments/Generated/transaction_v1_ocp_transaction_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Payments/Generated/transaction_v1_ocp_transaction_service.pb.swift
@@ -886,64 +886,92 @@ public struct Ocp_Transaction_V1_StatefulSwapRequest: Sendable {
     }
 
     /// Client parameters for starting swaps against the Reserve contract
-    public struct ReserveSwapClientParameters: Sendable {
+    public struct ReserveSwapClientParameters: @unchecked Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
 
       /// The unique ID for this swap randomly generated on client
       public var id: Ocp_Common_V1_SwapId {
-        get {_id ?? Ocp_Common_V1_SwapId()}
-        set {_id = newValue}
+        get {_storage._id ?? Ocp_Common_V1_SwapId()}
+        set {_uniqueStorage()._id = newValue}
       }
       /// Returns true if `id` has been explicitly set.
-      public var hasID: Bool {self._id != nil}
+      public var hasID: Bool {_storage._id != nil}
       /// Clears the value of `id`. Subsequent reads from it will return its default value.
-      public mutating func clearID() {self._id = nil}
+      public mutating func clearID() {_uniqueStorage()._id = nil}
 
       /// The source mint that will be swapped from
       public var fromMint: Ocp_Common_V1_SolanaAccountId {
-        get {_fromMint ?? Ocp_Common_V1_SolanaAccountId()}
-        set {_fromMint = newValue}
+        get {_storage._fromMint ?? Ocp_Common_V1_SolanaAccountId()}
+        set {_uniqueStorage()._fromMint = newValue}
       }
       /// Returns true if `fromMint` has been explicitly set.
-      public var hasFromMint: Bool {self._fromMint != nil}
+      public var hasFromMint: Bool {_storage._fromMint != nil}
       /// Clears the value of `fromMint`. Subsequent reads from it will return its default value.
-      public mutating func clearFromMint() {self._fromMint = nil}
+      public mutating func clearFromMint() {_uniqueStorage()._fromMint = nil}
 
       /// The destination mint that will be swapped to
       public var toMint: Ocp_Common_V1_SolanaAccountId {
-        get {_toMint ?? Ocp_Common_V1_SolanaAccountId()}
-        set {_toMint = newValue}
+        get {_storage._toMint ?? Ocp_Common_V1_SolanaAccountId()}
+        set {_uniqueStorage()._toMint = newValue}
       }
       /// Returns true if `toMint` has been explicitly set.
-      public var hasToMint: Bool {self._toMint != nil}
+      public var hasToMint: Bool {_storage._toMint != nil}
       /// Clears the value of `toMint`. Subsequent reads from it will return its default value.
-      public mutating func clearToMint() {self._toMint = nil}
+      public mutating func clearToMint() {_uniqueStorage()._toMint = nil}
 
       /// The amount to swap from the source mint in quarks.
-      public var swapAmount: UInt64 = 0
+      public var swapAmount: UInt64 {
+        get {_storage._swapAmount}
+        set {_uniqueStorage()._swapAmount = newValue}
+      }
 
       /// Where "amount" of "from_mint" will be sent from to the VM swap PDA
-      public var fundingSource: Ocp_Transaction_V1_FundingSource = .unknown
+      public var fundingSource: Ocp_Transaction_V1_FundingSource {
+        get {_storage._fundingSource}
+        set {_uniqueStorage()._fundingSource = newValue}
+      }
 
       /// The ID of the "transaction" to lookup funding state.
       ///
       /// For FUNDING_SOURCE_SUBMIT_INTENT, this value is the base58 encoded intent ID.
       /// For FUNDING_SOURCE_EXTERNAL_WALLET, this value is the base58 encoded transaction signature.
       /// For FUNDING_SOURCE_COINBASE_ONRAMP, this value is the order ID
-      public var fundingID: String = String()
+      public var fundingID: String {
+        get {_storage._fundingID}
+        set {_uniqueStorage()._fundingID = newValue}
+      }
 
       /// The fee amount to pay for this swap
-      public var feeAmount: UInt64 = 0
+      ///
+      /// Note: Amounts are coordinated outside this RPC for user verifications
+      ///       and validated in this RPC.
+      public var feeAmount: UInt64 {
+        get {_storage._feeAmount}
+        set {_uniqueStorage()._feeAmount = newValue}
+      }
+
+      /// Verified exchange data for flows that require a specific fiat value
+      /// over the full amount (swap + fee). For intent fundings, it's expected
+      /// that this exchange data will be used.
+      ///
+      /// Required for the following flows:
+      ///  - Initializing a new reserve currency outside of the core mint
+      public var fullAmountExchangeData: Ocp_Transaction_V1_VerifiedExchangeData {
+        get {_storage._fullAmountExchangeData ?? Ocp_Transaction_V1_VerifiedExchangeData()}
+        set {_uniqueStorage()._fullAmountExchangeData = newValue}
+      }
+      /// Returns true if `fullAmountExchangeData` has been explicitly set.
+      public var hasFullAmountExchangeData: Bool {_storage._fullAmountExchangeData != nil}
+      /// Clears the value of `fullAmountExchangeData`. Subsequent reads from it will return its default value.
+      public mutating func clearFullAmountExchangeData() {_uniqueStorage()._fullAmountExchangeData = nil}
 
       public var unknownFields = SwiftProtobuf.UnknownStorage()
 
       public init() {}
 
-      fileprivate var _id: Ocp_Common_V1_SwapId? = nil
-      fileprivate var _fromMint: Ocp_Common_V1_SolanaAccountId? = nil
-      fileprivate var _toMint: Ocp_Common_V1_SolanaAccountId? = nil
+      fileprivate var _storage = _StorageClass.defaultInstance
     }
 
     /// Client parameters for starting swaps against the Coinbase Stable Swaper program
@@ -1140,7 +1168,7 @@ public struct Ocp_Transaction_V1_StatefulSwapResponse: Sendable {
     ///  4. [Optional] Memo::Memo
     ///  5. AssociatedTokenAccount::CreateIdempotent (open Core Mint temporary account)
     ///  6. VM::TransferForSwap (Core Mint VM swap ATA -> Core Mint temporary account)
-    ///  6. Reserve::BuyAndDepositIntoVm (bounded buy depositing to_mint tokens into the to_mint VM)
+    ///  7. Reserve::BuyAndDepositIntoVm (bounded buy depositing to_mint tokens into the to_mint VM)
     ///  8. Token::CloseAccount (closes Core Mint temporary account)
     ///  9. VM::CloseSwapAccountIfEmpty (closes Core Mint VM swap ATA if empty)
     ///
@@ -1247,7 +1275,7 @@ public struct Ocp_Transaction_V1_StatefulSwapResponse: Sendable {
     ///
     /// Supported Solana transaction version: v0
     ///
-    /// Instruction format:
+    /// Instruction format (paying with Core Mint):
     ///  1. System::AdvanceNonce
     ///  2. [Optional] ComputeBudget::SetComputeUnitLimit
     ///  3. [Optional] ComputeBudget::SetComputeUnitPrice
@@ -1260,6 +1288,20 @@ public struct Ocp_Transaction_V1_StatefulSwapResponse: Sendable {
     /// 10. VM::TransferForSwapWithFee (Core Mint VM swap ATA -> owner's Core Mint ATA (swap amount) and fee destination (fee amount))
     /// 11. Reserve::BuyTokens (limited buy transferring to_mint tokens into the to_mint VM Deposit ATA)
     /// 12. Token::CloseAccount (closes owner's Core Mint ATA)
+    ///
+    /// Instruction format (all other cases):
+    ///  1. System::AdvanceNonce
+    ///  2. [Optional] ComputeBudget::SetComputeUnitLimit
+    ///  3. [Optional] ComputeBudget::SetComputeUnitPrice
+    ///  4. [Optional] Memo::Memo
+    ///  5. AssociatedTokenAccount::CreateIdempotent (open treasury's from_mint ATA)
+    ///  6. VM::TransferForSwapWithFee (from_mint VM swap ATA -> treasury's from_mint ATA (swap + fee amount))
+    ///  7. Reserve::SellTokens (limited sell of the full swap + fee amount, transferring the Core Mint value into the fee destination)
+    ///  8. Reserve::BuyTokens (limited buy funded by the treasury's Core Mint ATA, transferring to_mint tokens into the to_mint VM Deposit ATA)
+    ///
+    /// Note: The currency, VM and to_mint VM Deposit ATA will be initialized prior to
+    ///       executing this transaction. Atomicity cannot be guaranteed due to transaction
+    ///       size limits, which will be revisited when the v1 transaction format is released.
     ///
     /// Note: Client should verify that the new currency's mint address matches that derived
     ///       from using these server parameters.
@@ -1355,6 +1397,21 @@ public struct Ocp_Transaction_V1_StatefulSwapResponse: Sendable {
       /// Clears the value of `feeDestination`. Subsequent reads from it will return its default value.
       public mutating func clearFeeDestination() {self._feeDestination = nil}
 
+      /// Server-controlled treasury for flows that require it
+      public var treasury: Ocp_Common_V1_SolanaAccountId {
+        get {_treasury ?? Ocp_Common_V1_SolanaAccountId()}
+        set {_treasury = newValue}
+      }
+      /// Returns true if `treasury` has been explicitly set.
+      public var hasTreasury: Bool {self._treasury != nil}
+      /// Clears the value of `treasury`. Subsequent reads from it will return its default value.
+      public mutating func clearTreasury() {self._treasury = nil}
+
+      /// The amount of core mint tokens used for purchase. Client should
+      /// validate this is as expected based on a pre-coordinated amount
+      /// accepted by the user.
+      public var treasuryPurchaseAmount: UInt64 = 0
+
       public var unknownFields = SwiftProtobuf.UnknownStorage()
 
       public init() {}
@@ -1365,6 +1422,7 @@ public struct Ocp_Transaction_V1_StatefulSwapResponse: Sendable {
       fileprivate var _authority: Ocp_Common_V1_SolanaAccountId? = nil
       fileprivate var _seed: Ocp_Common_V1_SolanaAccountId? = nil
       fileprivate var _feeDestination: Ocp_Common_V1_SolanaAccountId? = nil
+      fileprivate var _treasury: Ocp_Common_V1_SolanaAccountId? = nil
     }
 
     /// Server parameters when executing stateful swap flows against the
@@ -4421,63 +4479,118 @@ extension Ocp_Transaction_V1_StatefulSwapRequest.Initiate: SwiftProtobuf.Message
 
 extension Ocp_Transaction_V1_StatefulSwapRequest.Initiate.ReserveSwapClientParameters: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Ocp_Transaction_V1_StatefulSwapRequest.Initiate.protoMessageName + ".ReserveSwapClientParameters"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}from_mint\0\u{3}to_mint\0\u{3}swap_amount\0\u{3}funding_source\0\u{3}funding_id\0\u{3}fee_amount\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}from_mint\0\u{3}to_mint\0\u{3}swap_amount\0\u{3}funding_source\0\u{3}funding_id\0\u{3}fee_amount\0\u{3}full_amount_exchange_data\0")
+
+  fileprivate class _StorageClass {
+    var _id: Ocp_Common_V1_SwapId? = nil
+    var _fromMint: Ocp_Common_V1_SolanaAccountId? = nil
+    var _toMint: Ocp_Common_V1_SolanaAccountId? = nil
+    var _swapAmount: UInt64 = 0
+    var _fundingSource: Ocp_Transaction_V1_FundingSource = .unknown
+    var _fundingID: String = String()
+    var _feeAmount: UInt64 = 0
+    var _fullAmountExchangeData: Ocp_Transaction_V1_VerifiedExchangeData? = nil
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _id = source._id
+      _fromMint = source._fromMint
+      _toMint = source._toMint
+      _swapAmount = source._swapAmount
+      _fundingSource = source._fundingSource
+      _fundingID = source._fundingID
+      _feeAmount = source._feeAmount
+      _fullAmountExchangeData = source._fullAmountExchangeData
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularMessageField(value: &self._id) }()
-      case 2: try { try decoder.decodeSingularMessageField(value: &self._fromMint) }()
-      case 3: try { try decoder.decodeSingularMessageField(value: &self._toMint) }()
-      case 4: try { try decoder.decodeSingularUInt64Field(value: &self.swapAmount) }()
-      case 5: try { try decoder.decodeSingularEnumField(value: &self.fundingSource) }()
-      case 6: try { try decoder.decodeSingularStringField(value: &self.fundingID) }()
-      case 7: try { try decoder.decodeSingularUInt64Field(value: &self.feeAmount) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularMessageField(value: &_storage._id) }()
+        case 2: try { try decoder.decodeSingularMessageField(value: &_storage._fromMint) }()
+        case 3: try { try decoder.decodeSingularMessageField(value: &_storage._toMint) }()
+        case 4: try { try decoder.decodeSingularUInt64Field(value: &_storage._swapAmount) }()
+        case 5: try { try decoder.decodeSingularEnumField(value: &_storage._fundingSource) }()
+        case 6: try { try decoder.decodeSingularStringField(value: &_storage._fundingID) }()
+        case 7: try { try decoder.decodeSingularUInt64Field(value: &_storage._feeAmount) }()
+        case 8: try { try decoder.decodeSingularMessageField(value: &_storage._fullAmountExchangeData) }()
+        default: break
+        }
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    try { if let v = self._id {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    } }()
-    try { if let v = self._fromMint {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    } }()
-    try { if let v = self._toMint {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    } }()
-    if self.swapAmount != 0 {
-      try visitor.visitSingularUInt64Field(value: self.swapAmount, fieldNumber: 4)
-    }
-    if self.fundingSource != .unknown {
-      try visitor.visitSingularEnumField(value: self.fundingSource, fieldNumber: 5)
-    }
-    if !self.fundingID.isEmpty {
-      try visitor.visitSingularStringField(value: self.fundingID, fieldNumber: 6)
-    }
-    if self.feeAmount != 0 {
-      try visitor.visitSingularUInt64Field(value: self.feeAmount, fieldNumber: 7)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      try { if let v = _storage._id {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      } }()
+      try { if let v = _storage._fromMint {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      } }()
+      try { if let v = _storage._toMint {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      } }()
+      if _storage._swapAmount != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._swapAmount, fieldNumber: 4)
+      }
+      if _storage._fundingSource != .unknown {
+        try visitor.visitSingularEnumField(value: _storage._fundingSource, fieldNumber: 5)
+      }
+      if !_storage._fundingID.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._fundingID, fieldNumber: 6)
+      }
+      if _storage._feeAmount != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._feeAmount, fieldNumber: 7)
+      }
+      try { if let v = _storage._fullAmountExchangeData {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Ocp_Transaction_V1_StatefulSwapRequest.Initiate.ReserveSwapClientParameters, rhs: Ocp_Transaction_V1_StatefulSwapRequest.Initiate.ReserveSwapClientParameters) -> Bool {
-    if lhs._id != rhs._id {return false}
-    if lhs._fromMint != rhs._fromMint {return false}
-    if lhs._toMint != rhs._toMint {return false}
-    if lhs.swapAmount != rhs.swapAmount {return false}
-    if lhs.fundingSource != rhs.fundingSource {return false}
-    if lhs.fundingID != rhs.fundingID {return false}
-    if lhs.feeAmount != rhs.feeAmount {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._id != rhs_storage._id {return false}
+        if _storage._fromMint != rhs_storage._fromMint {return false}
+        if _storage._toMint != rhs_storage._toMint {return false}
+        if _storage._swapAmount != rhs_storage._swapAmount {return false}
+        if _storage._fundingSource != rhs_storage._fundingSource {return false}
+        if _storage._fundingID != rhs_storage._fundingID {return false}
+        if _storage._feeAmount != rhs_storage._feeAmount {return false}
+        if _storage._fullAmountExchangeData != rhs_storage._fullAmountExchangeData {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -4826,7 +4939,7 @@ extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveExisti
 
 extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveNewCurrencyServerParameter: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.protoMessageName + ".ReserveNewCurrencyServerParameter"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payer\0\u{1}nonce\0\u{1}blockhash\0\u{1}alts\0\u{3}compute_unit_limit\0\u{3}compute_unit_price\0\u{3}memo_value\0\u{1}authority\0\u{1}name\0\u{1}symbol\0\u{1}seed\0\u{3}sell_fee_bps\0\u{3}vm_lock_duration_in_days\0\u{3}fee_destination\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payer\0\u{1}nonce\0\u{1}blockhash\0\u{1}alts\0\u{3}compute_unit_limit\0\u{3}compute_unit_price\0\u{3}memo_value\0\u{1}authority\0\u{1}name\0\u{1}symbol\0\u{1}seed\0\u{3}sell_fee_bps\0\u{3}vm_lock_duration_in_days\0\u{3}fee_destination\0\u{1}treasury\0\u{3}treasury_purchase_amount\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4848,6 +4961,8 @@ extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveNewCur
       case 12: try { try decoder.decodeSingularUInt32Field(value: &self.sellFeeBps) }()
       case 13: try { try decoder.decodeSingularUInt32Field(value: &self.vmLockDurationInDays) }()
       case 14: try { try decoder.decodeSingularMessageField(value: &self._feeDestination) }()
+      case 15: try { try decoder.decodeSingularMessageField(value: &self._treasury) }()
+      case 16: try { try decoder.decodeSingularUInt64Field(value: &self.treasuryPurchaseAmount) }()
       default: break
       }
     }
@@ -4900,6 +5015,12 @@ extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveNewCur
     try { if let v = self._feeDestination {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
     } }()
+    try { if let v = self._treasury {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+    } }()
+    if self.treasuryPurchaseAmount != 0 {
+      try visitor.visitSingularUInt64Field(value: self.treasuryPurchaseAmount, fieldNumber: 16)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -4918,6 +5039,8 @@ extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveNewCur
     if lhs.sellFeeBps != rhs.sellFeeBps {return false}
     if lhs.vmLockDurationInDays != rhs.vmLockDurationInDays {return false}
     if lhs._feeDestination != rhs._feeDestination {return false}
+    if lhs._treasury != rhs._treasury {return false}
+    if lhs.treasuryPurchaseAmount != rhs.treasuryPurchaseAmount {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/FlipcashAPI/Sources/FlipcashAPI/Payments/proto/transaction/v1/ocp_transaction_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Payments/proto/transaction/v1/ocp_transaction_service.proto
@@ -355,7 +355,18 @@ message StatefulSwapRequest {
             }];
 
             // The fee amount to pay for this swap
+            //
+            // Note: Amounts are coordinated outside this RPC for user verifications
+            //       and validated in this RPC.
             uint64 fee_amount = 7;
+
+            // Verified exchange data for flows that require a specific fiat value
+            // over the full amount (swap + fee). For intent fundings, it's expected
+            // that this exchange data will be used.
+            //
+            // Required for the following flows:
+            //  - Initializing a new reserve currency outside of the core mint
+            VerifiedExchangeData full_amount_exchange_data = 8;
         }
 
          // Client parameters for starting swaps against the Coinbase Stable Swaper program
@@ -458,7 +469,7 @@ message StatefulSwapResponse {
         //  4. [Optional] Memo::Memo
         //  5. AssociatedTokenAccount::CreateIdempotent (open Core Mint temporary account)
         //  6. VM::TransferForSwap (Core Mint VM swap ATA -> Core Mint temporary account)
-        //  6. Reserve::BuyAndDepositIntoVm (bounded buy depositing to_mint tokens into the to_mint VM)
+        //  7. Reserve::BuyAndDepositIntoVm (bounded buy depositing to_mint tokens into the to_mint VM)
         //  8. Token::CloseAccount (closes Core Mint temporary account)
         //  9. VM::CloseSwapAccountIfEmpty (closes Core Mint VM swap ATA if empty)
         //
@@ -524,7 +535,7 @@ message StatefulSwapResponse {
         //
         // Supported Solana transaction version: v0
         //
-        // Instruction format:
+        // Instruction format (paying with Core Mint):
         //  1. System::AdvanceNonce
         //  2. [Optional] ComputeBudget::SetComputeUnitLimit
         //  3. [Optional] ComputeBudget::SetComputeUnitPrice
@@ -537,6 +548,20 @@ message StatefulSwapResponse {
         // 10. VM::TransferForSwapWithFee (Core Mint VM swap ATA -> owner's Core Mint ATA (swap amount) and fee destination (fee amount))
         // 11. Reserve::BuyTokens (limited buy transferring to_mint tokens into the to_mint VM Deposit ATA)
         // 12. Token::CloseAccount (closes owner's Core Mint ATA)
+        //
+        // Instruction format (all other cases):
+        //  1. System::AdvanceNonce
+        //  2. [Optional] ComputeBudget::SetComputeUnitLimit
+        //  3. [Optional] ComputeBudget::SetComputeUnitPrice
+        //  4. [Optional] Memo::Memo
+        //  5. AssociatedTokenAccount::CreateIdempotent (open treasury's from_mint ATA)
+        //  6. VM::TransferForSwapWithFee (from_mint VM swap ATA -> treasury's from_mint ATA (swap + fee amount))
+        //  7. Reserve::SellTokens (limited sell of the full swap + fee amount, transferring the Core Mint value into the fee destination)
+        //  8. Reserve::BuyTokens (limited buy funded by the treasury's Core Mint ATA, transferring to_mint tokens into the to_mint VM Deposit ATA)
+        //
+        // Note: The currency, VM and to_mint VM Deposit ATA will be initialized prior to
+        //       executing this transaction. Atomicity cannot be guaranteed due to transaction
+        //       size limits, which will be revisited when the v1 transaction format is released.
         //
         // Note: Client should verify that the new currency's mint address matches that derived
         //       from using these server parameters.
@@ -591,6 +616,14 @@ message StatefulSwapResponse {
 
             // Destination account where fee should be paid
             common.v1.SolanaAccountId fee_destination = 14 [(validate.rules).message.required = true];
+
+            // Server-controlled treasury for flows that require it
+            common.v1.SolanaAccountId treasury = 15;
+
+            // The amount of core mint tokens used for purchase. Client should
+            // validate this is as expected based on a pre-coordinated amount
+            // accepted by the user.
+            uint64 treasury_purchase_amount = 16;
         }
 
         // Server parameters when executing stateful swap flows against the


### PR DESCRIPTION
Routine sync from the upstream proto repos, kept as a standalone PR ahead of upcoming feature work.

What came in upstream:

- Chat media's per-message item and rendition types were promoted to a shared blob-level Media type, used identically wherever a surface attaches media
- New SetProfilePicture RPC, a profile picture field on user profiles, a profile blob-access scope for fetching other users' picture bytes, and a privacy-metadata rejection reason
- The identity resolver can now look up by user id in addition to phone number
- Stateful swaps: reserve-currency flows gain verified exchange data covering the full amount (swap plus fee), and treasury server parameters

Everything is additive from the client's perspective — nothing references the renamed media types and no exhaustive switches are affected, so no wrapper changes are needed.

## Test plan

- [x] App builds
- [x] FlipcashTests and FlipcashCoreTests pass