### PR TITLE
feat: integrate Coinbase liquidity pool via user flag

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/Wallet/TransactionSigning.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Wallet/TransactionSigning.swift
@@ -26,9 +26,7 @@ protocol TransactionSigning: AnyObject {
     /// transaction is delivered later via `deeplinkEvents`.
     func sendUsdcToUsdfSignRequest(
         usdc: FlipcashCore.TokenAmount,
-        swapId: SwapId,
-        displayName: String,
-        liquidityPool: UserFlags.UsdcLiquidityPool
+        swapId: SwapId
     ) async throws
 }
 

--- a/Flipcash/Core/Controllers/Deep Links/Wallet/TransactionSigning.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Wallet/TransactionSigning.swift
@@ -27,7 +27,8 @@ protocol TransactionSigning: AnyObject {
     func sendUsdcToUsdfSignRequest(
         usdc: FlipcashCore.TokenAmount,
         swapId: SwapId,
-        displayName: String
+        displayName: String,
+        liquidityPool: UserFlags.UsdcLiquidityPool
     ) async throws
 }
 

--- a/Flipcash/Core/Controllers/Deep Links/Wallet/WalletConnection.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Wallet/WalletConnection.swift
@@ -45,6 +45,7 @@ public final class WalletConnection {
     private let box: Box
     let owner: AccountCluster
     private let rpc: any SolanaRPC
+    private let preferredLiquidityPool: () -> UserFlags.UsdcLiquidityPool
 
     /// Awaiting continuation for `connect()` / `handshake()`. Resumed by
     /// `didConnect` on success or by the errorCode branch of `didReceiveURL`
@@ -60,9 +61,14 @@ public final class WalletConnection {
 
     // MARK: - Init -
 
-    init(owner: AccountCluster, rpc: any SolanaRPC = SolanaJSONRPCClient()) {
+    init(
+        owner: AccountCluster,
+        rpc: any SolanaRPC = SolanaJSONRPCClient(),
+        preferredLiquidityPool: @escaping () -> UserFlags.UsdcLiquidityPool
+    ) {
         self.owner = owner
         self.rpc = rpc
+        self.preferredLiquidityPool = preferredLiquidityPool
 
         var continuation: AsyncStream<DeeplinkEvent>.Continuation!
         self.deeplinkEvents = AsyncStream { continuation = $0 }
@@ -303,9 +309,7 @@ public final class WalletConnection {
     /// comes back via `didReceiveURL` → `deeplinkEvents`.
     func sendUsdcToUsdfSignRequest(
         usdc: FlipcashCore.TokenAmount,
-        swapId: SwapId,
-        displayName: String,
-        liquidityPool: UserFlags.UsdcLiquidityPool
+        swapId: SwapId
     ) async throws {
         guard let connectedSession = Keychain.connectedWalletSession else {
             logger.error("Sign request without a connected wallet session")
@@ -321,7 +325,7 @@ public final class WalletConnection {
         let externalWallet = try FlipcashCore.PublicKey(base58: connectedSession.walletPublicKey.base58)
         let flipcashOwner = owner.authorityPublicKey
 
-        let swapPool = try await resolveFundSwapPool(liquidityPool)
+        let swapPool = try await resolveFundSwapPool(preferredLiquidityPool())
 
         let instructions = SwapInstructionBuilder.buildUsdcToUsdfSwapInstructions(
             sender: externalWallet,
@@ -376,7 +380,6 @@ public final class WalletConnection {
         logger.info("Requested USDC→USDF deposit swap", metadata: [
             "amount": "\(amount.nativeAmount.formatted())",
             "swapId": "\(swapId.publicKey.base58)",
-            "name": "\(displayName)",
             "pool": "\(poolLabel)",
         ])
     }
@@ -390,7 +393,7 @@ public final class WalletConnection {
     ) async throws -> FundSwapPool {
         switch liquidityPool {
         case .unknown, .flipcash:
-            return .usdf(.usdf)
+            return .usdf
         case .coinbaseStableSwapper:
             guard let poolAddress = CoinbaseStableSwapperProgram.derivePoolAddress() else {
                 logger.error("Failed to derive Coinbase pool address")
@@ -606,5 +609,5 @@ private extension FlipcashCore.Keychain {
 // MARK: - Mock -
 
 extension WalletConnection {
-    static let mock = WalletConnection(owner: .mock)
+    static let mock = WalletConnection(owner: .mock, preferredLiquidityPool: { .unknown })
 }

--- a/Flipcash/Core/Controllers/Deep Links/Wallet/WalletConnection.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Wallet/WalletConnection.swift
@@ -304,7 +304,8 @@ public final class WalletConnection {
     func sendUsdcToUsdfSignRequest(
         usdc: FlipcashCore.TokenAmount,
         swapId: SwapId,
-        displayName: String
+        displayName: String,
+        liquidityPool: UserFlags.UsdcLiquidityPool
     ) async throws {
         guard let connectedSession = Keychain.connectedWalletSession else {
             logger.error("Sign request without a connected wallet session")
@@ -320,11 +321,13 @@ public final class WalletConnection {
         let externalWallet = try FlipcashCore.PublicKey(base58: connectedSession.walletPublicKey.base58)
         let flipcashOwner = owner.authorityPublicKey
 
+        let swapPool = try await resolveFundSwapPool(liquidityPool)
+
         let instructions = SwapInstructionBuilder.buildUsdcToUsdfSwapInstructions(
             sender: externalWallet,
             owner: flipcashOwner,
             amount: usdc.quarks,
-            pool: .usdf,
+            pool: swapPool,
             swapId: swapId.publicKey,
             destination: .vmDeposit
         )
@@ -363,13 +366,47 @@ public final class WalletConnection {
             throw Error.invalidURL
         }
 
+        let poolLabel = switch swapPool {
+        case .usdf: "flipcash"
+        case .coinbaseStableSwapper: "coinbaseStableSwapper"
+        }
+
         Analytics.walletRequestAmount(amount: amount.nativeAmount)
         openExternalWallet(url)
         logger.info("Requested USDC→USDF deposit swap", metadata: [
             "amount": "\(amount.nativeAmount.formatted())",
             "swapId": "\(swapId.publicKey.base58)",
             "name": "\(displayName)",
+            "pool": "\(poolLabel)",
         ])
+    }
+
+    /// Resolves which pool the funding swap routes through. The Coinbase
+    /// pool's fee recipient lives on the on-chain pool account, so that
+    /// variant fetches and parses it; a failed fetch fails the deposit rather
+    /// than falling back to the legacy pool.
+    func resolveFundSwapPool(
+        _ liquidityPool: UserFlags.UsdcLiquidityPool
+    ) async throws -> FundSwapPool {
+        switch liquidityPool {
+        case .unknown, .flipcash:
+            return .usdf(.usdf)
+        case .coinbaseStableSwapper:
+            guard let poolAddress = CoinbaseStableSwapperProgram.derivePoolAddress() else {
+                logger.error("Failed to derive Coinbase pool address")
+                throw Error.poolAccountUnavailable
+            }
+            guard
+                let accountData = try await rpc.getAccountData(poolAddress.publicKey, commitment: .finalized),
+                let poolAccount = CoinbaseStableSwapperProgram.PoolAccount(accountData: accountData)
+            else {
+                logger.error("Failed to resolve Coinbase pool account", metadata: [
+                    "pool": "\(poolAddress.publicKey.base58)",
+                ])
+                throw Error.poolAccountUnavailable
+            }
+            return .coinbaseStableSwapper(feeRecipient: poolAccount.feeRecipient)
+        }
     }
 }
 
@@ -508,9 +545,12 @@ public enum WalletConnectionError: Error, LocalizedError {
 }
 
 extension WalletConnection {
-    enum Error: Swift.Error {
+    enum Error: Swift.Error, Equatable {
         case noSession
         case invalidURL
+        /// The Coinbase pool account could not be fetched or parsed, so the
+        /// swap's fee recipient is unknown.
+        case poolAccountUnavailable
     }
 }
 

--- a/Flipcash/Core/Controllers/Deep Links/Wallet/WalletConnection.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Wallet/WalletConnection.swift
@@ -325,6 +325,10 @@ public final class WalletConnection {
         let externalWallet = try FlipcashCore.PublicKey(base58: connectedSession.walletPublicKey.base58)
         let flipcashOwner = owner.authorityPublicKey
 
+        // The blockhash fetch runs as a child task so it overlaps the pool
+        // resolution's own network round-trip.
+        async let recentBlockhash = rpc.getLatestBlockhash(commitment: .finalized)
+
         let swapPool = try await resolveFundSwapPool(preferredLiquidityPool())
 
         let instructions = SwapInstructionBuilder.buildUsdcToUsdfSwapInstructions(
@@ -336,11 +340,9 @@ public final class WalletConnection {
             destination: .vmDeposit
         )
 
-        let recentBlockhash = try await rpc.getLatestBlockhash(commitment: .finalized)
-
         let transaction = SolanaTransaction(
             payer: externalWallet,
-            recentBlockhash: recentBlockhash,
+            recentBlockhash: try await recentBlockhash,
             instructions: instructions
         )
 

--- a/Flipcash/Core/Screens/Main/AddMoney/AddMoneyAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/AddMoneyAmountViewModel.swift
@@ -163,12 +163,13 @@ final class AddMoneyAmountViewModel {
     ) {
         Analytics.addMoneyAmountConfirmed(method: .phantom, exchangedFiat: amount)
         let operation = PhantomDepositOperation(walletConnection: walletConnection)
+        let liquidityPool = session.userFlags?.preferredOnrampUsdcLiquidityPool ?? .unknown
         depositTask = Task { [weak self, operation] in
             self?.actionButtonState = .loading
             defer { self?.actionButtonState = .normal }
             do {
                 // The wallet was connected on the education screen — sign only.
-                try await operation.signAndSubmit(amount: amount)
+                try await operation.signAndSubmit(amount: amount, liquidityPool: liquidityPool)
                 onProceed(.init(amount: amount, method: .phantom, depositRef: operation.submittedSignature))
             } catch is CancellationError {
                 // User dismissed the Phantom flow — silent.

--- a/Flipcash/Core/Screens/Main/AddMoney/AddMoneyAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/AddMoneyAmountViewModel.swift
@@ -163,13 +163,12 @@ final class AddMoneyAmountViewModel {
     ) {
         Analytics.addMoneyAmountConfirmed(method: .phantom, exchangedFiat: amount)
         let operation = PhantomDepositOperation(walletConnection: walletConnection)
-        let liquidityPool = session.userFlags?.preferredOnrampUsdcLiquidityPool ?? .unknown
         depositTask = Task { [weak self, operation] in
             self?.actionButtonState = .loading
             defer { self?.actionButtonState = .normal }
             do {
                 // The wallet was connected on the education screen — sign only.
-                try await operation.signAndSubmit(amount: amount, liquidityPool: liquidityPool)
+                try await operation.signAndSubmit(amount: amount)
                 onProceed(.init(amount: amount, method: .phantom, depositRef: operation.submittedSignature))
             } catch is CancellationError {
                 // User dismissed the Phantom flow — silent.

--- a/Flipcash/Core/Screens/Main/AddMoney/PhantomDepositOperation.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/PhantomDepositOperation.swift
@@ -56,8 +56,8 @@ final class PhantomDepositOperation {
 
     /// Has Phantom sign the USDC→USDF swap and submits it to chain. Requires
     /// a live session from a prior `connect()`; it does not re-handshake.
-    func signAndSubmit(amount: ExchangedFiat, liquidityPool: UserFlags.UsdcLiquidityPool) async throws {
-        let task = Task { try await runSignAndSubmit(amount, liquidityPool: liquidityPool) }
+    func signAndSubmit(amount: ExchangedFiat) async throws {
+        let task = Task { try await runSignAndSubmit(amount) }
         runTask = task
         defer { runTask = nil }
         return try await withTaskCancellationHandler {
@@ -92,7 +92,7 @@ final class PhantomDepositOperation {
         }
     }
 
-    private func runSignAndSubmit(_ amount: ExchangedFiat, liquidityPool: UserFlags.UsdcLiquidityPool) async throws {
+    private func runSignAndSubmit(_ amount: ExchangedFiat) async throws {
         // Reset state on any exit.
         defer { state = .idle }
 
@@ -101,9 +101,7 @@ final class PhantomDepositOperation {
         state = .awaitingExternal(.phantomSign)
         try await walletConnection.sendUsdcToUsdfSignRequest(
             usdc: amount.onChainAmount,
-            swapId: swapId,
-            displayName: "USDF",
-            liquidityPool: liquidityPool
+            swapId: swapId
         )
         Analytics.addMoneyPaymentInvoked(method: .phantom, exchangedFiat: amount)
 

--- a/Flipcash/Core/Screens/Main/AddMoney/PhantomDepositOperation.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/PhantomDepositOperation.swift
@@ -165,6 +165,19 @@ final class PhantomDepositOperation {
                 "signature": "\(signature.base58)",
                 "swapId": "\(swapId.publicKey.base58)",
             ])
+        } catch let SolanaRPCError.responseError(response) {
+            // The node refused the transaction at its preflight — commonly an
+            // expired blockhash after a slow Phantom approval — so nothing was
+            // submitted and the user can simply retry.
+            logger.error("Chain submission rejected at preflight", metadata: [
+                "code": "\(response.code ?? -1)",
+                "message": "\(response.message ?? "nil")",
+                "swapId": "\(swapId.publicKey.base58)",
+            ])
+            throw DepositError.externalRejected(
+                title: "Transaction Failed",
+                subtitle: "The transaction simulation failed. Check your Phantom wallet and try again."
+            )
         } catch {
             logger.error("Chain submission failed", metadata: [
                 "error": "\(error)",

--- a/Flipcash/Core/Screens/Main/AddMoney/PhantomDepositOperation.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/PhantomDepositOperation.swift
@@ -56,8 +56,8 @@ final class PhantomDepositOperation {
 
     /// Has Phantom sign the USDC→USDF swap and submits it to chain. Requires
     /// a live session from a prior `connect()`; it does not re-handshake.
-    func signAndSubmit(amount: ExchangedFiat) async throws {
-        let task = Task { try await runSignAndSubmit(amount) }
+    func signAndSubmit(amount: ExchangedFiat, liquidityPool: UserFlags.UsdcLiquidityPool) async throws {
+        let task = Task { try await runSignAndSubmit(amount, liquidityPool: liquidityPool) }
         runTask = task
         defer { runTask = nil }
         return try await withTaskCancellationHandler {
@@ -92,7 +92,7 @@ final class PhantomDepositOperation {
         }
     }
 
-    private func runSignAndSubmit(_ amount: ExchangedFiat) async throws {
+    private func runSignAndSubmit(_ amount: ExchangedFiat, liquidityPool: UserFlags.UsdcLiquidityPool) async throws {
         // Reset state on any exit.
         defer { state = .idle }
 
@@ -102,7 +102,8 @@ final class PhantomDepositOperation {
         try await walletConnection.sendUsdcToUsdfSignRequest(
             usdc: amount.onChainAmount,
             swapId: swapId,
-            displayName: "USDF"
+            displayName: "USDF",
+            liquidityPool: liquidityPool
         )
         Analytics.addMoneyPaymentInvoked(method: .phantom, exchangedFiat: amount)
 

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -269,7 +269,9 @@ final class SessionAuthenticator {
             userID: initializedAccount.userID
         )
 
-        let walletConnection = WalletConnection(owner: owner)
+        let walletConnection = WalletConnection(owner: owner, preferredLiquidityPool: { [weak session] in
+            session?.userFlags?.preferredOnrampUsdcLiquidityPool ?? .unknown
+        })
 
         return SessionContainer(
             session: session,

--- a/FlipcashCore/Sources/FlipcashCore/Models/FundSwapPool.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/FundSwapPool.swift
@@ -1,0 +1,15 @@
+//
+//  FundSwapPool.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+/// The liquidity pool a client-built USDC→USDF funding swap routes through.
+public enum FundSwapPool: Equatable, Sendable {
+    /// The legacy Flipcash USDF liquidity pool.
+    case usdf(LiquidityPool)
+    /// The Coinbase Stable Swapper pool; `feeRecipient` is read from the
+    /// on-chain pool account.
+    case coinbaseStableSwapper(feeRecipient: PublicKey)
+}

--- a/FlipcashCore/Sources/FlipcashCore/Models/FundSwapPool.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/FundSwapPool.swift
@@ -7,8 +7,8 @@ import Foundation
 
 /// The liquidity pool a client-built USDC→USDF funding swap routes through.
 public enum FundSwapPool: Equatable, Sendable {
-    /// The legacy Flipcash USDF liquidity pool.
-    case usdf(LiquidityPool)
+    /// The legacy Flipcash USDF liquidity pool (`LiquidityPool.usdf`).
+    case usdf
     /// The Coinbase Stable Swapper pool; `feeRecipient` is read from the
     /// on-chain pool account.
     case coinbaseStableSwapper(feeRecipient: PublicKey)

--- a/FlipcashCore/Sources/FlipcashCore/Models/UserFlags.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/UserFlags.swift
@@ -32,6 +32,9 @@ public struct UserFlags: Codable, Sendable {
     /// When `false`, a locally collected, unverified email is acceptable.
     public let requireCoinbaseEmailVerification: Bool
 
+    /// Which liquidity pool client-built USDC→USDF on-ramp swaps route through.
+    public let preferredOnrampUsdcLiquidityPool: UsdcLiquidityPool
+
     public var hasPreferredOnrampProvider: Bool {
         preferredOnrampProvider != .unknown
     }
@@ -64,6 +67,14 @@ extension UserFlags {
         case base
     }
 
+    /// The liquidity pool client-built USDC on-ramp swaps route through;
+    /// `unknown` resolves to the legacy Flipcash pool.
+    public enum UsdcLiquidityPool: Int, Codable, Sendable {
+        case unknown
+        case flipcash
+        case coinbaseStableSwapper
+    }
+
     init(_ proto: Flipcash_Account_V1_UserFlags) {
         self.init(
             isRegistered: proto.isRegisteredAccount,
@@ -89,8 +100,24 @@ extension UserFlags {
                 mint: .usdf
             ),
             enablePhoneNumberSend: proto.enablePhoneNumberSend,
-            requireCoinbaseEmailVerification: proto.requireCoinbaseEmailVerification
+            requireCoinbaseEmailVerification: proto.requireCoinbaseEmailVerification,
+            preferredOnrampUsdcLiquidityPool: UsdcLiquidityPool(proto.preferredOnRampUsdcLiquidityPool)
         )
+    }
+}
+
+extension UserFlags.UsdcLiquidityPool {
+    init(_ proto: Flipcash_Account_V1_UserFlags.UsdcLiquidityPool) {
+        switch proto {
+        case .unknownUsdcLiquidityPool:
+            self = .unknown
+        case .flipcash:
+            self = .flipcash
+        case .coinbaseStableSwapper:
+            self = .coinbaseStableSwapper
+        case .UNRECOGNIZED:
+            self = .unknown
+        }
     }
 }
 

--- a/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CoinbaseStableSwapperProgram+PDAs.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CoinbaseStableSwapperProgram+PDAs.swift
@@ -45,4 +45,41 @@ extension CoinbaseStableSwapperProgram {
             program: address
         )
     }
+
+    /// The pool-side accounts a `Swap` instruction targets for a mint pair.
+    public struct SwapAccounts: Equatable, Sendable {
+        public let pool: PublicKey
+        public let inVault: PublicKey
+        public let outVault: PublicKey
+        public let inVaultTokenAccount: PublicKey
+        public let outVaultTokenAccount: PublicKey
+        public let whitelist: PublicKey
+    }
+
+    /// Derives every pool-side account `Swap` needs for the given mint pair,
+    /// or `nil` when any derivation fails.
+    public static func deriveSwapAccounts(
+        fromMint: PublicKey,
+        toMint: PublicKey
+    ) -> SwapAccounts? {
+        guard
+            let pool = derivePoolAddress(),
+            let inVault = deriveTokenVaultAddress(pool: pool.publicKey, mint: fromMint),
+            let outVault = deriveTokenVaultAddress(pool: pool.publicKey, mint: toMint),
+            let inVaultTokenAccount = deriveVaultTokenAccountAddress(vault: inVault.publicKey),
+            let outVaultTokenAccount = deriveVaultTokenAccountAddress(vault: outVault.publicKey),
+            let whitelist = deriveWhitelistAddress()
+        else {
+            return nil
+        }
+
+        return SwapAccounts(
+            pool: pool.publicKey,
+            inVault: inVault.publicKey,
+            outVault: outVault.publicKey,
+            inVaultTokenAccount: inVaultTokenAccount.publicKey,
+            outVaultTokenAccount: outVaultTokenAccount.publicKey,
+            whitelist: whitelist.publicKey
+        )
+    }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CoinbaseStableSwapperProgram.PoolAccount.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CoinbaseStableSwapperProgram.PoolAccount.swift
@@ -19,14 +19,8 @@ extension CoinbaseStableSwapperProgram {
         /// Parses the raw pool account data, returning `nil` when the data is
         /// too short or the fee recipient bytes are not a valid public key.
         public init?(accountData: Data) {
-            let offset = Self.feeRecipientOffset
-            guard accountData.count >= offset + 32 else {
-                return nil
-            }
-
-            let start = accountData.index(accountData.startIndex, offsetBy: offset)
-            let end = accountData.index(start, offsetBy: 32)
-            guard let feeRecipient = try? PublicKey(Data(accountData[start..<end])) else {
+            var payload = accountData.tail(from: Self.feeRecipientOffset)
+            guard let feeRecipient = try? PublicKey(payload.consume(PublicKey.length)) else {
                 return nil
             }
 

--- a/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CoinbaseStableSwapperProgram.PoolAccount.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/Programs/CoinbaseStableSwapperProgram.PoolAccount.swift
@@ -1,0 +1,36 @@
+//
+//  CoinbaseStableSwapperProgram.PoolAccount.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+extension CoinbaseStableSwapperProgram {
+
+    /// The on-chain liquidity pool account.
+    ///
+    /// Layout: `[8 discriminator][32 operations_authority][32 pause_authority][32 fee_recipient]...`
+    public struct PoolAccount: Equatable, Sendable {
+
+        public let feeRecipient: PublicKey
+
+        private static let feeRecipientOffset = 8 + 32 + 32
+
+        /// Parses the raw pool account data, returning `nil` when the data is
+        /// too short or the fee recipient bytes are not a valid public key.
+        public init?(accountData: Data) {
+            let offset = Self.feeRecipientOffset
+            guard accountData.count >= offset + 32 else {
+                return nil
+            }
+
+            let start = accountData.index(accountData.startIndex, offsetBy: offset)
+            let end = accountData.index(start, offsetBy: 32)
+            guard let feeRecipient = try? PublicKey(Data(accountData[start..<end])) else {
+                return nil
+            }
+
+            self.feeRecipient = feeRecipient
+        }
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Solana/RPC/SolanaRPC.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/RPC/SolanaRPC.swift
@@ -13,12 +13,20 @@ private let logger = Logger(label: "flipcash.solana-rpc")
 // MARK: - SolanaRPC -
 
 /// The narrow Solana JSON-RPC surface the app consumes today: fetch the
-/// latest blockhash, simulate a signed transaction before submitting it, and
-/// submit a signed transaction. Designed for use from any isolation context;
-/// callers are expected to hop to `@MainActor` themselves for UI updates.
+/// latest blockhash, fetch an account's raw data, simulate a signed
+/// transaction before submitting it, and submit a signed transaction.
+/// Designed for use from any isolation context; callers are expected to hop
+/// to `@MainActor` themselves for UI updates.
 public protocol SolanaRPC: Sendable {
 
     func getLatestBlockhash(commitment: SolanaCommitment) async throws -> Hash
+
+    /// Returns the raw data of an on-chain account, or `nil` when the
+    /// account does not exist.
+    func getAccountData(
+        _ account: PublicKey,
+        commitment: SolanaCommitment
+    ) async throws -> Data?
 
     func sendTransaction(
         _ base64Transaction: String,
@@ -65,6 +73,17 @@ public struct SolanaJSONRPCClient: SolanaRPC {
             params: GetLatestBlockhashParams(commitment: commitment)
         )
         return try Hash(base58: response.value.blockhash)
+    }
+
+    public func getAccountData(
+        _ account: PublicKey,
+        commitment: SolanaCommitment
+    ) async throws -> Data? {
+        let response: RPCContextValue<GetAccountInfoValue?> = try await call(
+            method: "getAccountInfo",
+            params: GetAccountInfoParams(account: account.base58, commitment: commitment)
+        )
+        return response.value?.data
     }
 
     public func sendTransaction(
@@ -193,6 +212,46 @@ private struct GetLatestBlockhashParams: Encodable, Sendable {
 
 private struct GetLatestBlockhashValue: Decodable, Sendable {
     let blockhash: String
+}
+
+// MARK: - getAccountInfo -
+
+private struct GetAccountInfoParams: Encodable, Sendable {
+    let account: String
+    let commitment: SolanaCommitment
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(account)
+        try container.encode(ConfigObject(commitment: commitment))
+    }
+
+    private struct ConfigObject: Encodable, Sendable {
+        let commitment: SolanaCommitment
+        let encoding = "base64"
+    }
+}
+
+private struct GetAccountInfoValue: Decodable, Sendable {
+    let data: Data
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+
+    init(from decoder: Decoder) throws {
+        // `data` arrives as a two-element array: ["<base64>", "base64"].
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        var dataContainer = try container.nestedUnkeyedContainer(forKey: .data)
+        let base64 = try dataContainer.decode(String.self)
+        guard let decoded = Data(base64Encoded: base64) else {
+            throw DecodingError.dataCorruptedError(
+                in: dataContainer,
+                debugDescription: "Account data is not valid base64"
+            )
+        }
+        self.data = decoded
+    }
 }
 
 // MARK: - sendTransaction -

--- a/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+StatelessSwap.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+StatelessSwap.swift
@@ -68,33 +68,11 @@ extension SwapInstructionBuilder {
         }
 
         // Coinbase Stable Swapper PDAs.
-        guard let pool = CoinbaseStableSwapperProgram.derivePoolAddress() else {
-            fatalError("Failed to derive Coinbase pool address")
-        }
-        guard let inVault = CoinbaseStableSwapperProgram.deriveTokenVaultAddress(
-            pool: pool.publicKey,
-            mint: fromMint.address
+        guard let swapAccounts = CoinbaseStableSwapperProgram.deriveSwapAccounts(
+            fromMint: fromMint.address,
+            toMint: toMint.address
         ) else {
-            fatalError("Failed to derive Coinbase in-vault address")
-        }
-        guard let outVault = CoinbaseStableSwapperProgram.deriveTokenVaultAddress(
-            pool: pool.publicKey,
-            mint: toMint.address
-        ) else {
-            fatalError("Failed to derive Coinbase out-vault address")
-        }
-        guard let inVaultTokenAccount = CoinbaseStableSwapperProgram.deriveVaultTokenAccountAddress(
-            vault: inVault.publicKey
-        ) else {
-            fatalError("Failed to derive Coinbase in-vault token account")
-        }
-        guard let outVaultTokenAccount = CoinbaseStableSwapperProgram.deriveVaultTokenAccountAddress(
-            vault: outVault.publicKey
-        ) else {
-            fatalError("Failed to derive Coinbase out-vault token account")
-        }
-        guard let whitelist = CoinbaseStableSwapperProgram.deriveWhitelistAddress() else {
-            fatalError("Failed to derive Coinbase whitelist address")
+            fatalError("Failed to derive Coinbase swap accounts")
         }
 
         // Fee recipient's source-mint ATA — fee is paid in the from-mint.
@@ -151,11 +129,11 @@ extension SwapInstructionBuilder {
         //    lose value.
         instructions.append(
             CoinbaseStableSwapperProgram.Swap(
-                pool: pool.publicKey,
-                inVault: inVault.publicKey,
-                outVault: outVault.publicKey,
-                inVaultTokenAccount: inVaultTokenAccount.publicKey,
-                outVaultTokenAccount: outVaultTokenAccount.publicKey,
+                pool: swapAccounts.pool,
+                inVault: swapAccounts.inVault,
+                outVault: swapAccounts.outVault,
+                inVaultTokenAccount: swapAccounts.inVaultTokenAccount,
+                outVaultTokenAccount: swapAccounts.outVaultTokenAccount,
                 userFromTokenAccount: ownerFromAta.publicKey,
                 toTokenAccount: ownerToVmDepositAta.publicKey,
                 feeRecipientTokenAccount: feeRecipientFromAta.publicKey,
@@ -163,7 +141,7 @@ extension SwapInstructionBuilder {
                 fromMint: fromMint.address,
                 toMint: toMint.address,
                 user: owner,
-                whitelist: whitelist.publicKey,
+                whitelist: swapAccounts.whitelist,
                 amountIn: amount,
                 minAmountOut: amount
             ).instruction()

--- a/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+UsdcToUsdf.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+UsdcToUsdf.swift
@@ -117,15 +117,15 @@ extension SwapInstructionBuilder {
 
         // 7. Swap (sender's USDC ATA → sender's USDF ATA)
         switch pool {
-        case .usdf(let pool):
+        case .usdf:
             instructions.append(
                 UsdfProgram.Swap(
                     amount: amount,
                     usdfToOther: false,
                     user: sender,
-                    pool: pool.address,
-                    usdfVault: pool.usdfVault,
-                    otherVault: pool.otherVault,
+                    pool: LiquidityPool.usdf.address,
+                    usdfVault: LiquidityPool.usdf.usdfVault,
+                    otherVault: LiquidityPool.usdf.otherVault,
                     userUsdfToken: senderUsdfAta.address,
                     userOtherToken: senderUsdcAta.address
                 ).instruction()

--- a/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+UsdcToUsdf.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+UsdcToUsdf.swift
@@ -22,7 +22,7 @@ extension SwapInstructionBuilder {
     ///   - sender: The sender/payer of the transaction (Phantom wallet)
     ///   - owner: The owner for deriving timelock swap accounts (Flipcash user)
     ///   - amount: Amount of USDC to swap (in quarks)
-    ///   - pool: The liquidity pool to use for the swap
+    ///   - pool: The liquidity pool to swap through
     ///   - swapId: Unique identifier for the swap (used in memo)
     ///   - destination: Which of the owner's USDF accounts receives the swapped
     ///     USDF. Defaults to `.swapPda`.
@@ -31,7 +31,7 @@ extension SwapInstructionBuilder {
         sender: PublicKey,
         owner: PublicKey,
         amount: UInt64,
-        pool: LiquidityPool,
+        pool: FundSwapPool,
         swapId: PublicKey,
         destination: UsdfSwapDestination = .swapPda
     ) -> [Instruction] {
@@ -115,19 +115,61 @@ extension SwapInstructionBuilder {
             MemoProgram.Memo(message: swapId.base58).instruction()
         )
 
-        // 7. Usdf::Swap (sender's USDC ATA → sender's USDF ATA)
-        instructions.append(
-            UsdfProgram.Swap(
-                amount: amount,
-                usdfToOther: false,
-                user: sender,
-                pool: pool.address,
-                usdfVault: pool.usdfVault,
-                otherVault: pool.otherVault,
-                userUsdfToken: senderUsdfAta.address,
-                userOtherToken: senderUsdcAta.address
-            ).instruction()
-        )
+        // 7. Swap (sender's USDC ATA → sender's USDF ATA)
+        switch pool {
+        case .usdf(let pool):
+            instructions.append(
+                UsdfProgram.Swap(
+                    amount: amount,
+                    usdfToOther: false,
+                    user: sender,
+                    pool: pool.address,
+                    usdfVault: pool.usdfVault,
+                    otherVault: pool.otherVault,
+                    userUsdfToken: senderUsdfAta.address,
+                    userOtherToken: senderUsdcAta.address
+                ).instruction()
+            )
+
+        case .coinbaseStableSwapper(let feeRecipient):
+            guard let swapAccounts = CoinbaseStableSwapperProgram.deriveSwapAccounts(
+                fromMint: .usdc,
+                toMint: .usdf
+            ) else {
+                fatalError("Failed to derive Coinbase swap accounts")
+            }
+            // Fee is paid in the from-mint, so the recipient's USDC ATA.
+            guard let feeRecipientUsdcAta = PublicKey.deriveAssociatedAccount(
+                from: feeRecipient,
+                mint: .usdc
+            ) else {
+                fatalError("Failed to derive fee recipient USDC ATA")
+            }
+
+            // `minAmountOut: amount` enforces a 1:1 rate — the Coinbase Stable
+            // Swapper is a stable pair, so any slippage indicates a
+            // misconfigured pool and the swap should fail rather than
+            // silently lose value.
+            instructions.append(
+                CoinbaseStableSwapperProgram.Swap(
+                    pool: swapAccounts.pool,
+                    inVault: swapAccounts.inVault,
+                    outVault: swapAccounts.outVault,
+                    inVaultTokenAccount: swapAccounts.inVaultTokenAccount,
+                    outVaultTokenAccount: swapAccounts.outVaultTokenAccount,
+                    userFromTokenAccount: senderUsdcAta.address,
+                    toTokenAccount: senderUsdfAta.address,
+                    feeRecipientTokenAccount: feeRecipientUsdcAta.publicKey,
+                    feeRecipient: feeRecipient,
+                    fromMint: .usdc,
+                    toMint: .usdf,
+                    user: sender,
+                    whitelist: swapAccounts.whitelist,
+                    amountIn: amount,
+                    minAmountOut: amount
+                ).instruction()
+            )
+        }
 
         // 8. Token::Transfer (sender's USDF ATA → destination USDF ATA)
         instructions.append(

--- a/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+UsdfToUsdc.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+UsdfToUsdc.swift
@@ -42,33 +42,11 @@ extension SwapInstructionBuilder {
         }
 
         // Coinbase Stable Swapper PDAs
-        guard let pool = CoinbaseStableSwapperProgram.derivePoolAddress() else {
-            fatalError("Failed to derive Coinbase pool address")
-        }
-        guard let inVault = CoinbaseStableSwapperProgram.deriveTokenVaultAddress(
-            pool: pool.publicKey,
-            mint: fromMintMetadata.address
+        guard let swapAccounts = CoinbaseStableSwapperProgram.deriveSwapAccounts(
+            fromMint: fromMintMetadata.address,
+            toMint: toMintMetadata.address
         ) else {
-            fatalError("Failed to derive Coinbase in-vault address")
-        }
-        guard let outVault = CoinbaseStableSwapperProgram.deriveTokenVaultAddress(
-            pool: pool.publicKey,
-            mint: toMintMetadata.address
-        ) else {
-            fatalError("Failed to derive Coinbase out-vault address")
-        }
-        guard let inVaultTokenAccount = CoinbaseStableSwapperProgram.deriveVaultTokenAccountAddress(
-            vault: inVault.publicKey
-        ) else {
-            fatalError("Failed to derive Coinbase in-vault token account")
-        }
-        guard let outVaultTokenAccount = CoinbaseStableSwapperProgram.deriveVaultTokenAccountAddress(
-            vault: outVault.publicKey
-        ) else {
-            fatalError("Failed to derive Coinbase out-vault token account")
-        }
-        guard let whitelist = CoinbaseStableSwapperProgram.deriveWhitelistAddress() else {
-            fatalError("Failed to derive Coinbase whitelist address")
+            fatalError("Failed to derive Coinbase swap accounts")
         }
 
         // Fee recipient's from-mint ATA (USDF ATA owned by poolFeeRecipient)
@@ -151,11 +129,11 @@ extension SwapInstructionBuilder {
         //    Swaps USDF in the swap-authority's ATA for USDC into the destination-owner's ATA.
         instructions.append(
             CoinbaseStableSwapperProgram.Swap(
-                pool: pool.publicKey,
-                inVault: inVault.publicKey,
-                outVault: outVault.publicKey,
-                inVaultTokenAccount: inVaultTokenAccount.publicKey,
-                outVaultTokenAccount: outVaultTokenAccount.publicKey,
+                pool: swapAccounts.pool,
+                inVault: swapAccounts.inVault,
+                outVault: swapAccounts.outVault,
+                inVaultTokenAccount: swapAccounts.inVaultTokenAccount,
+                outVaultTokenAccount: swapAccounts.outVaultTokenAccount,
                 userFromTokenAccount: createSwapAuthorityFromMintAta.address,
                 toTokenAccount: createDestinationOwnerToMintAta.address,
                 feeRecipientTokenAccount: feeRecipientFromMintAta.publicKey,
@@ -163,7 +141,7 @@ extension SwapInstructionBuilder {
                 fromMint: fromMintMetadata.address,
                 toMint: toMintMetadata.address,
                 user: swapAuthority,
-                whitelist: whitelist.publicKey,
+                whitelist: swapAccounts.whitelist,
                 amountIn: amount,
                 minAmountOut: minOutput
             ).instruction()

--- a/FlipcashCore/Tests/FlipcashCoreTests/CoinbaseStableSwapperPoolAccountTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/CoinbaseStableSwapperPoolAccountTests.swift
@@ -18,21 +18,15 @@ struct CoinbaseStableSwapperPoolAccountTests {
         return data
     }
 
-    @Test("Parses the fee recipient at offset 72")
-    func initAccountData_validLayout_parsesFeeRecipient() throws {
+    @Test(
+        "Parses the fee recipient at offset 72, with or without trailing fields",
+        arguments: [0, 128]
+    )
+    func initAccountData_validLayout_parsesFeeRecipient(trailing: Int) throws {
         let feeRecipientBytes = [UInt8](repeating: 7, count: 32)
         let account = try #require(
-            CoinbaseStableSwapperProgram.PoolAccount(accountData: Self.accountData(feeRecipient: feeRecipientBytes))
-        )
-        #expect(account.feeRecipient == (try PublicKey(feeRecipientBytes)))
-    }
-
-    @Test("Tolerates trailing fields beyond the fee recipient")
-    func initAccountData_trailingFields_parsesFeeRecipient() throws {
-        let feeRecipientBytes = [UInt8](repeating: 9, count: 32)
-        let account = try #require(
             CoinbaseStableSwapperProgram.PoolAccount(
-                accountData: Self.accountData(feeRecipient: feeRecipientBytes, trailing: 128)
+                accountData: Self.accountData(feeRecipient: feeRecipientBytes, trailing: trailing)
             )
         )
         #expect(account.feeRecipient == (try PublicKey(feeRecipientBytes)))

--- a/FlipcashCore/Tests/FlipcashCoreTests/CoinbaseStableSwapperPoolAccountTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/CoinbaseStableSwapperPoolAccountTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("CoinbaseStableSwapperProgram.PoolAccount")
+struct CoinbaseStableSwapperPoolAccountTests {
+
+    /// Minimum account length: 8 discriminator + 32 ops authority
+    /// + 32 pause authority + 32 fee recipient.
+    private static let minimumLength = 8 + 32 + 32 + 32
+
+    private static func accountData(feeRecipient: [UInt8], trailing: Int = 0) -> Data {
+        var data = Data(repeating: 0xAA, count: 8)          // discriminator
+        data.append(Data(repeating: 0xBB, count: 32))       // operations authority
+        data.append(Data(repeating: 0xCC, count: 32))       // pause authority
+        data.append(Data(feeRecipient))
+        data.append(Data(repeating: 0xDD, count: trailing))
+        return data
+    }
+
+    @Test("Parses the fee recipient at offset 72")
+    func initAccountData_validLayout_parsesFeeRecipient() throws {
+        let feeRecipientBytes = [UInt8](repeating: 7, count: 32)
+        let account = try #require(
+            CoinbaseStableSwapperProgram.PoolAccount(accountData: Self.accountData(feeRecipient: feeRecipientBytes))
+        )
+        #expect(account.feeRecipient == (try PublicKey(feeRecipientBytes)))
+    }
+
+    @Test("Tolerates trailing fields beyond the fee recipient")
+    func initAccountData_trailingFields_parsesFeeRecipient() throws {
+        let feeRecipientBytes = [UInt8](repeating: 9, count: 32)
+        let account = try #require(
+            CoinbaseStableSwapperProgram.PoolAccount(
+                accountData: Self.accountData(feeRecipient: feeRecipientBytes, trailing: 128)
+            )
+        )
+        #expect(account.feeRecipient == (try PublicKey(feeRecipientBytes)))
+    }
+
+    @Test("Rejects account data shorter than the fee recipient bounds")
+    func initAccountData_shortData_returnsNil() {
+        let short = Data(repeating: 0xAA, count: Self.minimumLength - 1)
+        #expect(CoinbaseStableSwapperProgram.PoolAccount(accountData: short) == nil)
+    }
+
+    @Test("Ignores slice offsets — parses relative to the data's start")
+    func initAccountData_dataSlice_parsesRelativeToStart() throws {
+        let feeRecipientBytes = [UInt8](repeating: 5, count: 32)
+        var padded = Data(repeating: 0xFF, count: 16)
+        padded.append(Self.accountData(feeRecipient: feeRecipientBytes))
+        let slice = padded[16...]
+
+        let account = try #require(CoinbaseStableSwapperProgram.PoolAccount(accountData: slice))
+        #expect(account.feeRecipient == (try PublicKey(feeRecipientBytes)))
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/SolanaRPCDecodingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SolanaRPCDecodingTests.swift
@@ -123,8 +123,13 @@ struct SolanaRPCDecodingTests {
         }
         """
         let account = try PublicKey([UInt8](repeating: 1, count: 32))
-        await #expect(throws: SolanaRPCError.self) {
+        do {
             _ = try await Self.client(serving: body).getAccountData(account, commitment: .finalized)
+            Issue.record("getAccountData should have thrown")
+        } catch SolanaRPCError.decoding {
+            // Expected — malformed base64 surfaces as a decode failure.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
     }
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/SolanaRPCDecodingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SolanaRPCDecodingTests.swift
@@ -65,6 +65,69 @@ struct SolanaRPCDecodingTests {
         #expect(signature.base58 == Self.signatureB58)
     }
 
+    // MARK: - getAccountInfo
+
+    @Test("getAccountData decodes the base64 payload from value.data")
+    func getAccountData_decodesBase64Payload() async throws {
+        let payload = Data([0x01, 0x02, 0x03, 0x04])
+        let body = """
+        {
+          "jsonrpc": "2.0",
+          "result": {
+            "context": { "slot": 1 },
+            "value": {
+              "data": ["\(payload.base64EncodedString())", "base64"],
+              "executable": false,
+              "lamports": 1000000,
+              "owner": "11111111111111111111111111111111",
+              "rentEpoch": 0
+            }
+          },
+          "id": 1
+        }
+        """
+        let account = try PublicKey([UInt8](repeating: 1, count: 32))
+        let data = try await Self.client(serving: body).getAccountData(account, commitment: .finalized)
+        #expect(data == payload)
+    }
+
+    @Test("getAccountData returns nil when the account does not exist (value is null)")
+    func getAccountData_returnsNil_whenAccountMissing() async throws {
+        let body = """
+        {
+          "jsonrpc": "2.0",
+          "result": {
+            "context": { "slot": 1 },
+            "value": null
+          },
+          "id": 1
+        }
+        """
+        let account = try PublicKey([UInt8](repeating: 1, count: 32))
+        let data = try await Self.client(serving: body).getAccountData(account, commitment: .finalized)
+        #expect(data == nil)
+    }
+
+    @Test("getAccountData throws decoding when the payload is not valid base64")
+    func getAccountData_throwsDecoding_whenPayloadIsMalformed() async throws {
+        let body = """
+        {
+          "jsonrpc": "2.0",
+          "result": {
+            "context": { "slot": 1 },
+            "value": {
+              "data": ["not-base-64!!", "base64"]
+            }
+          },
+          "id": 1
+        }
+        """
+        let account = try PublicKey([UInt8](repeating: 1, count: 32))
+        await #expect(throws: SolanaRPCError.self) {
+            _ = try await Self.client(serving: body).getAccountData(account, commitment: .finalized)
+        }
+    }
+
     // MARK: - simulateTransaction — success
 
     @Test("simulateTransaction returns logs when err is null")

--- a/FlipcashCore/Tests/FlipcashCoreTests/SolanaTransactionEncodingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SolanaTransactionEncodingTests.swift
@@ -37,7 +37,7 @@ struct SolanaTransactionEncodingTests {
             sender: Self.sender,
             owner: Self.owner,
             amount: Self.amount,
-            pool: .usdf(.usdf),
+            pool: .usdf,
             swapId: Self.swapId
         )
 
@@ -56,7 +56,7 @@ struct SolanaTransactionEncodingTests {
             sender: Self.sender,
             owner: Self.owner,
             amount: Self.amount,
-            pool: .usdf(.usdf),
+            pool: .usdf,
             swapId: Self.swapId
         )
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/SolanaTransactionEncodingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SolanaTransactionEncodingTests.swift
@@ -37,7 +37,7 @@ struct SolanaTransactionEncodingTests {
             sender: Self.sender,
             owner: Self.owner,
             amount: Self.amount,
-            pool: .usdf,
+            pool: .usdf(.usdf),
             swapId: Self.swapId
         )
 
@@ -56,7 +56,7 @@ struct SolanaTransactionEncodingTests {
             sender: Self.sender,
             owner: Self.owner,
             amount: Self.amount,
-            pool: .usdf,
+            pool: .usdf(.usdf),
             swapId: Self.swapId
         )
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
@@ -23,7 +23,7 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
 
     private static func makeInstructions(
         amount: UInt64 = SwapInstructionBuilderUsdcToUsdfTests.amount,
-        pool: FundSwapPool = .usdf(.usdf),
+        pool: FundSwapPool = .usdf,
         destination: UsdfSwapDestination = .swapPda
     ) -> [Instruction] {
         SwapInstructionBuilder.buildUsdcToUsdfSwapInstructions(

--- a/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
@@ -245,16 +245,21 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
         #expect(Self.makeCoinbaseInstructions().count == 8)
     }
 
-    @Test("Coinbase variant only replaces the swap — instruction 6 is CoinbaseStableSwapper, the rest match the legacy layout")
-    func coinbase_onlyReplacesSwapInstruction() {
-        let coinbase = Self.makeCoinbaseInstructions()
-        let legacy = Self.makeDepositInstructions()
-        #expect(coinbase[6].program == CoinbaseStableSwapperProgram.address)
-        for index in [0, 1, 2, 3, 4, 5, 7] {
-            #expect(coinbase[index].program == legacy[index].program)
-            #expect(coinbase[index].accounts.map(\.publicKey) == legacy[index].accounts.map(\.publicKey))
-            #expect(coinbase[index].data == legacy[index].data)
-        }
+    @Test("Coinbase variant replaces instruction 6 with the CoinbaseStableSwapper swap")
+    func coinbase_swapInstructionProgram() {
+        #expect(Self.makeCoinbaseInstructions()[6].program == CoinbaseStableSwapperProgram.address)
+    }
+
+    @Test(
+        "Coinbase variant matches the legacy layout at every non-swap instruction",
+        arguments: [0, 1, 2, 3, 4, 5, 7]
+    )
+    func coinbase_nonSwapInstruction_matchesLegacy(index: Int) {
+        let coinbase = Self.makeCoinbaseInstructions()[index]
+        let legacy = Self.makeDepositInstructions()[index]
+        #expect(coinbase.program == legacy.program)
+        #expect(coinbase.accounts.map(\.publicKey) == legacy.accounts.map(\.publicKey))
+        #expect(coinbase.data == legacy.data)
     }
 
     @Test("Coinbase swap accounts: pool PDAs, sender ATAs, fee recipient, whitelist")

--- a/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderUsdcToUsdfTests.swift
@@ -22,14 +22,17 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
     private static let amount: UInt64 = 20_000_000
 
     private static func makeInstructions(
-        amount: UInt64 = SwapInstructionBuilderUsdcToUsdfTests.amount
+        amount: UInt64 = SwapInstructionBuilderUsdcToUsdfTests.amount,
+        pool: FundSwapPool = .usdf(.usdf),
+        destination: UsdfSwapDestination = .swapPda
     ) -> [Instruction] {
         SwapInstructionBuilder.buildUsdcToUsdfSwapInstructions(
             sender: sender,
             owner: owner,
             amount: amount,
-            pool: .usdf,
-            swapId: swapId
+            pool: pool,
+            swapId: swapId,
+            destination: destination
         )
     }
 
@@ -164,14 +167,7 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
     private static func makeDepositInstructions(
         amount: UInt64 = SwapInstructionBuilderUsdcToUsdfTests.amount
     ) -> [Instruction] {
-        SwapInstructionBuilder.buildUsdcToUsdfSwapInstructions(
-            sender: sender,
-            owner: owner,
-            amount: amount,
-            pool: .usdf,
-            swapId: swapId,
-            destination: .vmDeposit
-        )
+        makeInstructions(amount: amount, destination: .vmDeposit)
     }
 
     /// The owner's USDF VM Deposit ATA — derived exactly as the builder does:
@@ -228,5 +224,79 @@ struct SwapInstructionBuilderUsdcToUsdfTests {
     func deposit_addressDiffersFromSwapPda() throws {
         let swapPdaAta = try #require(MintMetadata.usdf.timelockSwapAccounts(owner: Self.owner)).ata.publicKey
         #expect(Self.usdfDepositAta() != swapPdaAta)
+    }
+
+    // MARK: - Coinbase Stable Swapper pool
+
+    private static let feeRecipient = testKey(4)
+
+    private static func makeCoinbaseInstructions(
+        amount: UInt64 = SwapInstructionBuilderUsdcToUsdfTests.amount
+    ) -> [Instruction] {
+        makeInstructions(
+            amount: amount,
+            pool: .coinbaseStableSwapper(feeRecipient: feeRecipient),
+            destination: .vmDeposit
+        )
+    }
+
+    @Test("Coinbase variant still produces exactly 8 instructions")
+    func coinbase_produces8Instructions() {
+        #expect(Self.makeCoinbaseInstructions().count == 8)
+    }
+
+    @Test("Coinbase variant only replaces the swap — instruction 6 is CoinbaseStableSwapper, the rest match the legacy layout")
+    func coinbase_onlyReplacesSwapInstruction() {
+        let coinbase = Self.makeCoinbaseInstructions()
+        let legacy = Self.makeDepositInstructions()
+        #expect(coinbase[6].program == CoinbaseStableSwapperProgram.address)
+        for index in [0, 1, 2, 3, 4, 5, 7] {
+            #expect(coinbase[index].program == legacy[index].program)
+            #expect(coinbase[index].accounts.map(\.publicKey) == legacy[index].accounts.map(\.publicKey))
+            #expect(coinbase[index].data == legacy[index].data)
+        }
+    }
+
+    @Test("Coinbase swap accounts: pool PDAs, sender ATAs, fee recipient, whitelist")
+    func coinbase_swapAccounts() throws {
+        let instructions = Self.makeCoinbaseInstructions()
+        let ix = instructions[6]
+
+        let pool = try #require(CoinbaseStableSwapperProgram.derivePoolAddress()).publicKey
+        let inVault = try #require(CoinbaseStableSwapperProgram.deriveTokenVaultAddress(pool: pool, mint: .usdc)).publicKey
+        let outVault = try #require(CoinbaseStableSwapperProgram.deriveTokenVaultAddress(pool: pool, mint: .usdf)).publicKey
+        let inVaultTokenAccount = try #require(CoinbaseStableSwapperProgram.deriveVaultTokenAccountAddress(vault: inVault)).publicKey
+        let outVaultTokenAccount = try #require(CoinbaseStableSwapperProgram.deriveVaultTokenAccountAddress(vault: outVault)).publicKey
+        let whitelist = try #require(CoinbaseStableSwapperProgram.deriveWhitelistAddress()).publicKey
+        let senderUsdcAta = instructions[4].accounts[1].publicKey
+        let senderUsdfAta = instructions[2].accounts[1].publicKey
+        let feeRecipientUsdcAta = try #require(
+            PublicKey.deriveAssociatedAccount(from: Self.feeRecipient, mint: .usdc)
+        ).publicKey
+
+        // Account list order documented on CoinbaseStableSwapperProgram.Swap.
+        #expect(ix.accounts[0].publicKey == pool)
+        #expect(ix.accounts[1].publicKey == inVault)
+        #expect(ix.accounts[2].publicKey == outVault)
+        #expect(ix.accounts[3].publicKey == inVaultTokenAccount)
+        #expect(ix.accounts[4].publicKey == outVaultTokenAccount)
+        #expect(ix.accounts[5].publicKey == senderUsdcAta)
+        #expect(ix.accounts[6].publicKey == senderUsdfAta)
+        #expect(ix.accounts[7].publicKey == feeRecipientUsdcAta)
+        #expect(ix.accounts[8].publicKey == Self.feeRecipient)
+        #expect(ix.accounts[9].publicKey == PublicKey.usdc)
+        #expect(ix.accounts[10].publicKey == PublicKey.usdf)
+        #expect(ix.accounts[11].publicKey == Self.sender)
+        #expect(ix.accounts[11].isSigner)
+        #expect(ix.accounts[12].publicKey == whitelist)
+    }
+
+    @Test("Coinbase swap data: discriminator + amountIn(8 LE) + minAmountOut(8 LE), both equal to amount")
+    func coinbase_dataLayout() {
+        let ix = Self.makeCoinbaseInstructions(amount: 20_000_000)[6]
+        #expect(ix.data.count == 8 + 8 + 8)
+        #expect(Array(ix.data.prefix(8)) == CoinbaseStableSwapperProgram.Swap.discriminator)
+        #expect(UInt64(bytes: Array(ix.data[8..<16])) == 20_000_000)
+        #expect(UInt64(bytes: Array(ix.data[16..<24])) == 20_000_000)
     }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/UserFlagsUsdcLiquidityPoolTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/UserFlagsUsdcLiquidityPoolTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import FlipcashCore
+import FlipcashAPI
+
+@Suite("UserFlags.preferredOnrampUsdcLiquidityPool")
+struct UserFlagsUsdcLiquidityPoolTests {
+
+    @Test(
+        "Maps preferredOnRampUsdcLiquidityPool from the proto",
+        arguments: [
+            (Flipcash_Account_V1_UserFlags.UsdcLiquidityPool.unknownUsdcLiquidityPool, UserFlags.UsdcLiquidityPool.unknown),
+            (.flipcash, .flipcash),
+            (.coinbaseStableSwapper, .coinbaseStableSwapper),
+            (.UNRECOGNIZED(99), .unknown),
+        ]
+    )
+    func preferredOnrampUsdcLiquidityPool_mapsFromProto(
+        proto: Flipcash_Account_V1_UserFlags.UsdcLiquidityPool,
+        expected: UserFlags.UsdcLiquidityPool
+    ) {
+        let flags = UserFlags(Flipcash_Account_V1_UserFlags.with { $0.preferredOnRampUsdcLiquidityPool = proto })
+        #expect(flags.preferredOnrampUsdcLiquidityPool == expected)
+    }
+
+    @Test("Unset proto defaults to unknown")
+    func unsetProto_defaultsToUnknown() {
+        let flags = UserFlags(Flipcash_Account_V1_UserFlags())
+        #expect(flags.preferredOnrampUsdcLiquidityPool == .unknown)
+    }
+}

--- a/FlipcashTests/Database/Database+ProfileTests.swift
+++ b/FlipcashTests/Database/Database+ProfileTests.swift
@@ -23,7 +23,8 @@ struct DatabaseProfileTests {
         withdrawalFeeAmount: TokenAmount(quarks: 50_000, mint: .usdf),
         minimumHolderValue: TokenAmount(quarks: 100_000, mint: .usdf),
         enablePhoneNumberSend: true,
-        requireCoinbaseEmailVerification: true
+        requireCoinbaseEmailVerification: true,
+        preferredOnrampUsdcLiquidityPool: .coinbaseStableSwapper
     )
 
     /// Restricted account: no onramp providers, unset timeout, zero fees.
@@ -39,7 +40,8 @@ struct DatabaseProfileTests {
         withdrawalFeeAmount: .zero(mint: .usdf),
         minimumHolderValue: .zero(mint: .usdf),
         enablePhoneNumberSend: false,
-        requireCoinbaseEmailVerification: false
+        requireCoinbaseEmailVerification: false,
+        preferredOnrampUsdcLiquidityPool: .unknown
     )
 
     // MARK: - Empty (fresh install) -
@@ -106,5 +108,6 @@ struct DatabaseProfileTests {
         #expect(restored.newCurrencyFeeAmount == original.newCurrencyFeeAmount)
         #expect(restored.withdrawalFeeAmount == original.withdrawalFeeAmount)
         #expect(restored.minimumHolderValue == original.minimumHolderValue)
+        #expect(restored.preferredOnrampUsdcLiquidityPool == original.preferredOnrampUsdcLiquidityPool)
     }
 }

--- a/FlipcashTests/PhantomDepositOperationTests.swift
+++ b/FlipcashTests/PhantomDepositOperationTests.swift
@@ -69,6 +69,30 @@ struct PhantomDepositOperationTests {
         #expect(op.state == .idle)
     }
 
+    @Test("A node preflight rejection at submit surfaces the retry dialog, not the generic failure")
+    func submit_preflightRejected_throwsExternalRejectedWithRetryCopy() async throws {
+        let wallet = MockTransactionSigning()
+        let rpc = MockSolanaRPC()
+        rpc.sendHandler = { _ in
+            throw SolanaRPCError.responseError(
+                SolanaRPCResponseError(code: -32002, message: "Transaction simulation failed", data: nil)
+            )
+        }
+        let op = PhantomDepositOperation(walletConnection: wallet, rpc: rpc)
+
+        let task = Task { try await op.signAndSubmit(amount: .tenUSDF, liquidityPool: .unknown) }
+        try await waitUntil(op) { $0.state == .awaitingExternal(.phantomSign) }
+        wallet.yieldDeeplinkEvent(.signed(Self.validSignedTransactionBase58))
+
+        await #expect(throws: DepositError.externalRejected(
+            title: "Transaction Failed",
+            subtitle: "The transaction simulation failed. Check your Phantom wallet and try again."
+        )) {
+            try await task.value
+        }
+        #expect(op.state == .idle)
+    }
+
     @Test("Sign user-cancel throws userCancelled")
     func signUserCancelled_throws() async throws {
         let wallet = MockTransactionSigning()

--- a/FlipcashTests/PhantomDepositOperationTests.swift
+++ b/FlipcashTests/PhantomDepositOperationTests.swift
@@ -27,7 +27,7 @@ struct PhantomDepositOperationTests {
         #expect(op.state == .idle)
 
         // Amount screen: sign + submit.
-        let task = Task { try await op.signAndSubmit(amount: .tenUSDF, liquidityPool: .unknown) }
+        let task = Task { try await op.signAndSubmit(amount: .tenUSDF) }
         try await waitUntil(op) { $0.state == .awaitingExternal(.phantomSign) }
         wallet.yieldDeeplinkEvent(.signed(Self.validSignedTransactionBase58))
         try await task.value
@@ -47,7 +47,7 @@ struct PhantomDepositOperationTests {
         rpc.sendHandler = { _ in .mock }
         let op = PhantomDepositOperation(walletConnection: wallet, rpc: rpc)
 
-        let task = Task { try await op.signAndSubmit(amount: .tenUSDF, liquidityPool: .unknown) }
+        let task = Task { try await op.signAndSubmit(amount: .tenUSDF) }
         try await waitUntil(op) { $0.state == .awaitingExternal(.phantomSign) }
         wallet.yieldDeeplinkEvent(.signed(Self.validSignedTransactionBase58))
         try await task.value
@@ -80,7 +80,7 @@ struct PhantomDepositOperationTests {
         }
         let op = PhantomDepositOperation(walletConnection: wallet, rpc: rpc)
 
-        let task = Task { try await op.signAndSubmit(amount: .tenUSDF, liquidityPool: .unknown) }
+        let task = Task { try await op.signAndSubmit(amount: .tenUSDF) }
         try await waitUntil(op) { $0.state == .awaitingExternal(.phantomSign) }
         wallet.yieldDeeplinkEvent(.signed(Self.validSignedTransactionBase58))
 
@@ -98,7 +98,7 @@ struct PhantomDepositOperationTests {
         let wallet = MockTransactionSigning()
         let op = PhantomDepositOperation(walletConnection: wallet, rpc: MockSolanaRPC())
 
-        let task = Task { try await op.signAndSubmit(amount: .tenUSDF, liquidityPool: .unknown) }
+        let task = Task { try await op.signAndSubmit(amount: .tenUSDF) }
         try await waitUntil(op) { $0.state == .awaitingExternal(.phantomSign) }
         wallet.yieldDeeplinkEvent(.userCancelled)
 
@@ -125,7 +125,7 @@ private extension PhantomDepositOperationTests {
             sender: PublicKey.mock,
             owner: PublicKey.mock,
             amount: 1_000_000,
-            pool: .usdf(.usdf),
+            pool: .usdf,
             swapId: PublicKey.mock,
             destination: .vmDeposit
         )

--- a/FlipcashTests/PhantomDepositOperationTests.swift
+++ b/FlipcashTests/PhantomDepositOperationTests.swift
@@ -27,7 +27,7 @@ struct PhantomDepositOperationTests {
         #expect(op.state == .idle)
 
         // Amount screen: sign + submit.
-        let task = Task { try await op.signAndSubmit(amount: .tenUSDF) }
+        let task = Task { try await op.signAndSubmit(amount: .tenUSDF, liquidityPool: .unknown) }
         try await waitUntil(op) { $0.state == .awaitingExternal(.phantomSign) }
         wallet.yieldDeeplinkEvent(.signed(Self.validSignedTransactionBase58))
         try await task.value
@@ -47,7 +47,7 @@ struct PhantomDepositOperationTests {
         rpc.sendHandler = { _ in .mock }
         let op = PhantomDepositOperation(walletConnection: wallet, rpc: rpc)
 
-        let task = Task { try await op.signAndSubmit(amount: .tenUSDF) }
+        let task = Task { try await op.signAndSubmit(amount: .tenUSDF, liquidityPool: .unknown) }
         try await waitUntil(op) { $0.state == .awaitingExternal(.phantomSign) }
         wallet.yieldDeeplinkEvent(.signed(Self.validSignedTransactionBase58))
         try await task.value
@@ -74,7 +74,7 @@ struct PhantomDepositOperationTests {
         let wallet = MockTransactionSigning()
         let op = PhantomDepositOperation(walletConnection: wallet, rpc: MockSolanaRPC())
 
-        let task = Task { try await op.signAndSubmit(amount: .tenUSDF) }
+        let task = Task { try await op.signAndSubmit(amount: .tenUSDF, liquidityPool: .unknown) }
         try await waitUntil(op) { $0.state == .awaitingExternal(.phantomSign) }
         wallet.yieldDeeplinkEvent(.userCancelled)
 
@@ -101,7 +101,7 @@ private extension PhantomDepositOperationTests {
             sender: PublicKey.mock,
             owner: PublicKey.mock,
             amount: 1_000_000,
-            pool: .usdf,
+            pool: .usdf(.usdf),
             swapId: PublicKey.mock,
             destination: .vmDeposit
         )

--- a/FlipcashTests/SessionTests.swift
+++ b/FlipcashTests/SessionTests.swift
@@ -662,7 +662,8 @@ struct SessionOfflineCacheTests {
             withdrawalFeeAmount: TokenAmount(quarks: 50_000, mint: .usdf),
             minimumHolderValue: .zero(mint: .usdf),
             enablePhoneNumberSend: false,
-            requireCoinbaseEmailVerification: false
+            requireCoinbaseEmailVerification: false,
+            preferredOnrampUsdcLiquidityPool: .unknown
         )
     }
 
@@ -724,7 +725,8 @@ struct SessionCanSendTests {
             withdrawalFeeAmount: .zero(mint: .usdf),
             minimumHolderValue: .zero(mint: .usdf),
             enablePhoneNumberSend: enablePhoneNumberSend,
-            requireCoinbaseEmailVerification: false
+            requireCoinbaseEmailVerification: false,
+            preferredOnrampUsdcLiquidityPool: .unknown
         )
     }
 

--- a/FlipcashTests/TestSupport/MockSolanaRPC.swift
+++ b/FlipcashTests/TestSupport/MockSolanaRPC.swift
@@ -15,6 +15,7 @@ final class MockSolanaRPC: SolanaRPC, @unchecked Sendable {
     nonisolated(unsafe) var simulateHandler: (@Sendable (String) async throws -> SolanaSimulationResult)?
     nonisolated(unsafe) var sendHandler: (@Sendable (String) async throws -> Signature)?
     nonisolated(unsafe) var blockhashHandler: (@Sendable (SolanaCommitment) async throws -> Hash)?
+    nonisolated(unsafe) var accountDataHandler: (@Sendable (PublicKey) async throws -> Data?)?
 
     init() {}
 
@@ -23,6 +24,16 @@ final class MockSolanaRPC: SolanaRPC, @unchecked Sendable {
             return try await handler(commitment)
         }
         return Hash.mock
+    }
+
+    func getAccountData(
+        _ account: PublicKey,
+        commitment: SolanaCommitment
+    ) async throws -> Data? {
+        if let handler = accountDataHandler {
+            return try await handler(account)
+        }
+        return nil
     }
 
     func simulateTransaction(

--- a/FlipcashTests/TestSupport/MockSolanaRPC.swift
+++ b/FlipcashTests/TestSupport/MockSolanaRPC.swift
@@ -16,6 +16,7 @@ final class MockSolanaRPC: SolanaRPC, @unchecked Sendable {
     nonisolated(unsafe) var sendHandler: (@Sendable (String) async throws -> Signature)?
     nonisolated(unsafe) var blockhashHandler: (@Sendable (SolanaCommitment) async throws -> Hash)?
     nonisolated(unsafe) var accountDataHandler: (@Sendable (PublicKey) async throws -> Data?)?
+    nonisolated(unsafe) private(set) var accountDataRequests: [PublicKey] = []
 
     init() {}
 
@@ -30,6 +31,7 @@ final class MockSolanaRPC: SolanaRPC, @unchecked Sendable {
         _ account: PublicKey,
         commitment: SolanaCommitment
     ) async throws -> Data? {
+        accountDataRequests.append(account)
         if let handler = accountDataHandler {
             return try await handler(account)
         }

--- a/FlipcashTests/TestSupport/MockTransactionSigning.swift
+++ b/FlipcashTests/TestSupport/MockTransactionSigning.swift
@@ -17,7 +17,7 @@ final class MockTransactionSigning: TransactionSigning {
     private let continuation: AsyncStream<WalletConnection.DeeplinkEvent>.Continuation
 
     private(set) var handshakeCallCount = 0
-    private(set) var sendSignRequestCalls: [(usdc: FlipcashCore.TokenAmount, swapId: SwapId, displayName: String)] = []
+    private(set) var sendSignRequestCalls: [(usdc: FlipcashCore.TokenAmount, swapId: SwapId, displayName: String, liquidityPool: UserFlags.UsdcLiquidityPool)] = []
 
     var handshakeHandler: (() async throws -> Void)?
     var sendSignRequestHandler: ((FlipcashCore.TokenAmount, SwapId, String) async throws -> Void)?
@@ -36,9 +36,10 @@ final class MockTransactionSigning: TransactionSigning {
     func sendUsdcToUsdfSignRequest(
         usdc: FlipcashCore.TokenAmount,
         swapId: SwapId,
-        displayName: String
+        displayName: String,
+        liquidityPool: UserFlags.UsdcLiquidityPool
     ) async throws {
-        sendSignRequestCalls.append((usdc, swapId, displayName))
+        sendSignRequestCalls.append((usdc, swapId, displayName, liquidityPool))
         try await sendSignRequestHandler?(usdc, swapId, displayName)
     }
 

--- a/FlipcashTests/TestSupport/MockTransactionSigning.swift
+++ b/FlipcashTests/TestSupport/MockTransactionSigning.swift
@@ -17,10 +17,10 @@ final class MockTransactionSigning: TransactionSigning {
     private let continuation: AsyncStream<WalletConnection.DeeplinkEvent>.Continuation
 
     private(set) var handshakeCallCount = 0
-    private(set) var sendSignRequestCalls: [(usdc: FlipcashCore.TokenAmount, swapId: SwapId, displayName: String, liquidityPool: UserFlags.UsdcLiquidityPool)] = []
+    private(set) var sendSignRequestCalls: [(usdc: FlipcashCore.TokenAmount, swapId: SwapId)] = []
 
     var handshakeHandler: (() async throws -> Void)?
-    var sendSignRequestHandler: ((FlipcashCore.TokenAmount, SwapId, String) async throws -> Void)?
+    var sendSignRequestHandler: ((FlipcashCore.TokenAmount, SwapId) async throws -> Void)?
 
     init() {
         let (stream, continuation) = AsyncStream<WalletConnection.DeeplinkEvent>.makeStream()
@@ -35,12 +35,10 @@ final class MockTransactionSigning: TransactionSigning {
 
     func sendUsdcToUsdfSignRequest(
         usdc: FlipcashCore.TokenAmount,
-        swapId: SwapId,
-        displayName: String,
-        liquidityPool: UserFlags.UsdcLiquidityPool
+        swapId: SwapId
     ) async throws {
-        sendSignRequestCalls.append((usdc, swapId, displayName, liquidityPool))
-        try await sendSignRequestHandler?(usdc, swapId, displayName)
+        sendSignRequestCalls.append((usdc, swapId))
+        try await sendSignRequestHandler?(usdc, swapId)
     }
 
     /// Simulates Phantom returning a deeplink callback. Yielding `.signed`

--- a/FlipcashTests/TestSupport/UserFlags+Fixtures.swift
+++ b/FlipcashTests/TestSupport/UserFlags+Fixtures.swift
@@ -24,7 +24,8 @@ extension UserFlags {
             withdrawalFeeAmount: .zero(mint: .usdf),
             minimumHolderValue: .zero(mint: .usdf),
             enablePhoneNumberSend: false,
-            requireCoinbaseEmailVerification: requireCoinbaseEmailVerification
+            requireCoinbaseEmailVerification: requireCoinbaseEmailVerification,
+            preferredOnrampUsdcLiquidityPool: .unknown
         )
     }
 }

--- a/FlipcashTests/TestSupport/WithdrawViewModel+TestSupport.swift
+++ b/FlipcashTests/TestSupport/WithdrawViewModel+TestSupport.swift
@@ -41,7 +41,8 @@ enum WithdrawViewModelTestHelpers {
             withdrawalFeeAmount: TokenAmount(quarks: withdrawalFeeQuarks, mint: .usdf),
             minimumHolderValue: .zero(mint: .usdf),
             enablePhoneNumberSend: false,
-            requireCoinbaseEmailVerification: false
+            requireCoinbaseEmailVerification: false,
+            preferredOnrampUsdcLiquidityPool: .unknown
         )
 
         return WithdrawViewModel(
@@ -133,7 +134,8 @@ enum WithdrawViewModelTestHelpers {
                 withdrawalFeeAmount: TokenAmount(quarks: withdrawalFeeQuarks, mint: .usdf),
                 minimumHolderValue: .zero(mint: .usdf),
                 enablePhoneNumberSend: false,
-                requireCoinbaseEmailVerification: false
+                requireCoinbaseEmailVerification: false,
+                preferredOnrampUsdcLiquidityPool: .unknown
             )
         }
         let stored = try #require(container.session.balance(for: .usdf))

--- a/FlipcashTests/WalletConnectionPoolResolutionTests.swift
+++ b/FlipcashTests/WalletConnectionPoolResolutionTests.swift
@@ -1,0 +1,128 @@
+//
+//  WalletConnectionPoolResolutionTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+@testable import Flipcash
+import FlipcashCore
+
+@MainActor
+@Suite("WalletConnection.resolveFundSwapPool")
+struct WalletConnectionPoolResolutionTests {
+
+    private nonisolated static func poolAccountData(feeRecipient: [UInt8]) -> Data {
+        var data = Data(repeating: 0, count: 8 + 32 + 32)
+        data.append(Data(feeRecipient))
+        return data
+    }
+
+    @Test(
+        "Legacy flag values resolve to the legacy pool without touching the network",
+        arguments: [UserFlags.UsdcLiquidityPool.unknown, .flipcash]
+    )
+    func resolveFundSwapPool_legacyFlag_returnsLegacyPoolWithoutFetching(
+        flag: UserFlags.UsdcLiquidityPool
+    ) async throws {
+        let rpc = MockSolanaRPC()
+        let fetchCount = CallCounter()
+        rpc.accountDataHandler = { _ in
+            fetchCount.increment()
+            return nil
+        }
+
+        let connection = WalletConnection(owner: .mock, rpc: rpc)
+        let pool = try await connection.resolveFundSwapPool(flag)
+
+        #expect(pool == .usdf(.usdf))
+        #expect(fetchCount.value == 0)
+    }
+
+    @Test("Coinbase flag fetches the pool account and parses its fee recipient")
+    func resolveFundSwapPool_coinbaseFlag_parsesFeeRecipientFromPoolAccount() async throws {
+        let feeRecipientBytes = [UInt8](repeating: 7, count: 32)
+        let requestedAccount = RequestedAccountBox()
+        let rpc = MockSolanaRPC()
+        rpc.accountDataHandler = { account in
+            requestedAccount.store(account)
+            return Self.poolAccountData(feeRecipient: feeRecipientBytes)
+        }
+
+        let connection = WalletConnection(owner: .mock, rpc: rpc)
+        let pool = try await connection.resolveFundSwapPool(.coinbaseStableSwapper)
+
+        let expectedPoolAddress = try #require(CoinbaseStableSwapperProgram.derivePoolAddress()).publicKey
+        #expect(requestedAccount.value == expectedPoolAddress)
+        #expect(pool == .coinbaseStableSwapper(feeRecipient: try PublicKey(feeRecipientBytes)))
+    }
+
+    @Test("Missing pool account fails the resolution instead of falling back")
+    func resolveFundSwapPool_missingPoolAccount_throwsPoolAccountUnavailable() async throws {
+        let rpc = MockSolanaRPC()
+        rpc.accountDataHandler = { _ in nil }
+
+        let connection = WalletConnection(owner: .mock, rpc: rpc)
+        await #expect(throws: WalletConnection.Error.poolAccountUnavailable) {
+            _ = try await connection.resolveFundSwapPool(.coinbaseStableSwapper)
+        }
+    }
+
+    @Test("Malformed pool account data fails the resolution instead of falling back")
+    func resolveFundSwapPool_malformedPoolAccount_throwsPoolAccountUnavailable() async throws {
+        let rpc = MockSolanaRPC()
+        rpc.accountDataHandler = { _ in Data(repeating: 0, count: 10) }
+
+        let connection = WalletConnection(owner: .mock, rpc: rpc)
+        await #expect(throws: WalletConnection.Error.poolAccountUnavailable) {
+            _ = try await connection.resolveFundSwapPool(.coinbaseStableSwapper)
+        }
+    }
+
+    @Test("An RPC failure propagates instead of being swallowed")
+    func resolveFundSwapPool_rpcFailure_rethrows() async throws {
+        let rpc = MockSolanaRPC()
+        rpc.accountDataHandler = { _ in throw URLError(.notConnectedToInternet) }
+
+        let connection = WalletConnection(owner: .mock, rpc: rpc)
+        await #expect(throws: URLError.self) {
+            _ = try await connection.resolveFundSwapPool(.coinbaseStableSwapper)
+        }
+    }
+}
+
+/// Minimal thread-safe capture boxes for values observed inside `@Sendable`
+/// mock handlers.
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+}
+
+private final class RequestedAccountBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var account: PublicKey?
+
+    var value: PublicKey? {
+        lock.lock()
+        defer { lock.unlock() }
+        return account
+    }
+
+    func store(_ value: PublicKey) {
+        lock.lock()
+        account = value
+        lock.unlock()
+    }
+}

--- a/FlipcashTests/WalletConnectionPoolResolutionTests.swift
+++ b/FlipcashTests/WalletConnectionPoolResolutionTests.swift
@@ -18,6 +18,10 @@ struct WalletConnectionPoolResolutionTests {
         return data
     }
 
+    private static func makeConnection(rpc: MockSolanaRPC) -> WalletConnection {
+        WalletConnection(owner: .mock, rpc: rpc, preferredLiquidityPool: { .unknown })
+    }
+
     @Test(
         "Legacy flag values resolve to the legacy pool without touching the network",
         arguments: [UserFlags.UsdcLiquidityPool.unknown, .flipcash]
@@ -26,34 +30,23 @@ struct WalletConnectionPoolResolutionTests {
         flag: UserFlags.UsdcLiquidityPool
     ) async throws {
         let rpc = MockSolanaRPC()
-        let fetchCount = CallCounter()
-        rpc.accountDataHandler = { _ in
-            fetchCount.increment()
-            return nil
-        }
 
-        let connection = WalletConnection(owner: .mock, rpc: rpc)
-        let pool = try await connection.resolveFundSwapPool(flag)
+        let pool = try await Self.makeConnection(rpc: rpc).resolveFundSwapPool(flag)
 
-        #expect(pool == .usdf(.usdf))
-        #expect(fetchCount.value == 0)
+        #expect(pool == .usdf)
+        #expect(rpc.accountDataRequests.isEmpty)
     }
 
     @Test("Coinbase flag fetches the pool account and parses its fee recipient")
     func resolveFundSwapPool_coinbaseFlag_parsesFeeRecipientFromPoolAccount() async throws {
         let feeRecipientBytes = [UInt8](repeating: 7, count: 32)
-        let requestedAccount = RequestedAccountBox()
         let rpc = MockSolanaRPC()
-        rpc.accountDataHandler = { account in
-            requestedAccount.store(account)
-            return Self.poolAccountData(feeRecipient: feeRecipientBytes)
-        }
+        rpc.accountDataHandler = { _ in Self.poolAccountData(feeRecipient: feeRecipientBytes) }
 
-        let connection = WalletConnection(owner: .mock, rpc: rpc)
-        let pool = try await connection.resolveFundSwapPool(.coinbaseStableSwapper)
+        let pool = try await Self.makeConnection(rpc: rpc).resolveFundSwapPool(.coinbaseStableSwapper)
 
         let expectedPoolAddress = try #require(CoinbaseStableSwapperProgram.derivePoolAddress()).publicKey
-        #expect(requestedAccount.value == expectedPoolAddress)
+        #expect(rpc.accountDataRequests == [expectedPoolAddress])
         #expect(pool == .coinbaseStableSwapper(feeRecipient: try PublicKey(feeRecipientBytes)))
     }
 
@@ -62,20 +55,8 @@ struct WalletConnectionPoolResolutionTests {
         let rpc = MockSolanaRPC()
         rpc.accountDataHandler = { _ in nil }
 
-        let connection = WalletConnection(owner: .mock, rpc: rpc)
         await #expect(throws: WalletConnection.Error.poolAccountUnavailable) {
-            _ = try await connection.resolveFundSwapPool(.coinbaseStableSwapper)
-        }
-    }
-
-    @Test("Malformed pool account data fails the resolution instead of falling back")
-    func resolveFundSwapPool_malformedPoolAccount_throwsPoolAccountUnavailable() async throws {
-        let rpc = MockSolanaRPC()
-        rpc.accountDataHandler = { _ in Data(repeating: 0, count: 10) }
-
-        let connection = WalletConnection(owner: .mock, rpc: rpc)
-        await #expect(throws: WalletConnection.Error.poolAccountUnavailable) {
-            _ = try await connection.resolveFundSwapPool(.coinbaseStableSwapper)
+            _ = try await Self.makeConnection(rpc: rpc).resolveFundSwapPool(.coinbaseStableSwapper)
         }
     }
 
@@ -84,45 +65,8 @@ struct WalletConnectionPoolResolutionTests {
         let rpc = MockSolanaRPC()
         rpc.accountDataHandler = { _ in throw URLError(.notConnectedToInternet) }
 
-        let connection = WalletConnection(owner: .mock, rpc: rpc)
         await #expect(throws: URLError.self) {
-            _ = try await connection.resolveFundSwapPool(.coinbaseStableSwapper)
+            _ = try await Self.makeConnection(rpc: rpc).resolveFundSwapPool(.coinbaseStableSwapper)
         }
-    }
-}
-
-/// Minimal thread-safe capture boxes for values observed inside `@Sendable`
-/// mock handlers.
-private final class CallCounter: @unchecked Sendable {
-    private let lock = NSLock()
-    private var count = 0
-
-    var value: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return count
-    }
-
-    func increment() {
-        lock.lock()
-        count += 1
-        lock.unlock()
-    }
-}
-
-private final class RequestedAccountBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var account: PublicKey?
-
-    var value: PublicKey? {
-        lock.lock()
-        defer { lock.unlock() }
-        return account
-    }
-
-    func store(_ value: PublicKey) {
-        lock.lock()
-        account = value
-        lock.unlock()
     }
 }

--- a/FlipcashTests/WithdrawViewModelTests.swift
+++ b/FlipcashTests/WithdrawViewModelTests.swift
@@ -329,7 +329,8 @@ struct WithdrawViewModelTests {
                 withdrawalFeeAmount: TokenAmount(quarks: withdrawalFeeQuarks, mint: .usdf),
                 minimumHolderValue: .zero(mint: .usdf),
                 enablePhoneNumberSend: false,
-                requireCoinbaseEmailVerification: false
+                requireCoinbaseEmailVerification: false,
+                preferredOnrampUsdcLiquidityPool: .unknown
             )
         }
         let stored = try #require(container.session.balance(for: mint))


### PR DESCRIPTION
Phantom deposits now honor the server's preferred USDC liquidity pool flag: when it selects the Coinbase Stable Swapper, the swap is built against the Coinbase program with the fee recipient read from the on-chain pool account; otherwise the legacy pool is used, as before. Every other flow already swaps through the Coinbase pool server-side.

A failed pool fetch fails the deposit — no silent fallback. A node preflight rejection now shows a "check your Phantom wallet and try again" dialog instead of the generic failure.

## Test plan

- [x] Phantom deposit with the Coinbase flag set completes end to end
- [x] Phantom deposit with the flag unset routes through the legacy pool
- [x] Preflight rejection shows the retry dialog