### PR TITLE
feat: create currencies with other currencies

### DIFF
--- a/Flipcash/Core/Screens/Main/AddMoney/AddMoneyGate.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/AddMoneyGate.swift
@@ -15,12 +15,32 @@ protocol USDFReserveReading: AnyObject {
 extension Session: USDFReserveReading {}
 
 
-/// True when the user's USDF reserves can't cover `launchCost` (purchase +
-/// fee). Must agree with the wizard's `reserveBalance` affordability check.
+/// Read access to every balance the launch gate weighs.
 @MainActor
-func shouldAddMoneyBeforeLaunch(session: some USDFReserveReading, launchCost: TokenAmount) -> Bool {
-    guard let balance = session.balance(for: .usdf) else { return true }
-    return balance.usdf.value < launchCost.decimalValue
+protocol LaunchBalanceReading: AnyObject {
+    var balances: [StoredBalance] { get }
+}
+
+extension Session: LaunchBalanceReading {}
+
+/// True when `balance` alone can pay `launchCost`. USDF compares exactly (the
+/// server has no tolerance on the core path, so display-rounding must not widen
+/// it); a launchpad balance compares its display-rounded USD sell value, which
+/// mirrors the server's ± half-cent acceptance window.
+@MainActor
+func canPayLaunchCost(_ balance: StoredBalance, launchCost: TokenAmount) -> Bool {
+    if balance.mint == .usdf {
+        return balance.usdf.value >= launchCost.decimalValue
+    }
+    return balance.usdf.value.rounded(to: CurrencyCode.usd.maximumFractionDigits) >= launchCost.decimalValue
+}
+
+/// True when no single balance can pay `launchCost` (purchase + fee), so the
+/// user must add money before launching. Shares `canPayLaunchCost` with the
+/// payment picker's row enablement, so the gate and picker never disagree.
+@MainActor
+func shouldAddMoneyBeforeLaunch(session: some LaunchBalanceReading, launchCost: TokenAmount) -> Bool {
+    !session.balances.contains { canPayLaunchCost($0, launchCost: launchCost) }
 }
 
 /// The balance inputs the give/send cash gate needs — `USDFReserveReading`

--- a/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
@@ -134,6 +134,7 @@ final class BuyConfirmationViewModel {
             actionButtonState = .normal
             router.pushAny(BuyFlowPath.processing(
                 swapId: swapId,
+                targetMint: targetMint,
                 currencyName: targetName,
                 amount: amountToBuy,
                 swapType: swapType

--- a/Flipcash/Core/Screens/Main/Buy/BuyFlowDestinationView.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyFlowDestinationView.swift
@@ -36,10 +36,11 @@ struct BuyFlowDestinationView: View {
                 pinnedState: pinnedState
             )
 
-        case .processing(let swapId, let currencyName, let amount, let swapType):
+        case .processing(let swapId, let targetMint, let currencyName, let amount, let swapType):
             SwapProcessingScreen(
                 swapId: swapId,
                 swapType: swapType,
+                targetMint: targetMint,
                 currencyName: currencyName,
                 amount: amount
             )

--- a/Flipcash/Core/Screens/Main/Buy/BuyFlowPath.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyFlowPath.swift
@@ -26,5 +26,5 @@ enum BuyFlowPath: Hashable, Sendable {
         paymentAmount: ExchangedFiat,
         pinnedState: VerifiedState
     )
-    case processing(swapId: SwapId, currencyName: String, amount: ExchangedFiat, swapType: SwapType)
+    case processing(swapId: SwapId, targetMint: PublicKey, currencyName: String, amount: ExchangedFiat, swapType: SwapType)
 }

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -33,9 +33,9 @@ struct CurrencyCreationWizardScreen: View {
     @State private var isShowingPhotoPicker = false
     @State private var isShowingFilePicker = false
 
-    /// Non-nil while the Reserves-funded launch is in flight. Drives a
-    /// `fullScreenCover` that presents `CurrencyLaunchProcessingScreen`.
-    @State private var reservesLaunchContext: ReservesLaunchContext?
+    /// Non-nil while a launch is in flight. Drives a `fullScreenCover` that
+    /// presents `CurrencyLaunchProcessingScreen`.
+    @State private var launchContext: LaunchContext?
     /// Mint from an earlier attempt whose buy failed inline. On a
     /// `nameExists` retry, reuse it so only the buy reruns. Bound to
     /// `name` — renaming invalidates.
@@ -46,11 +46,13 @@ struct CurrencyCreationWizardScreen: View {
         let name: String
     }
 
-    private struct ReservesLaunchContext: Identifiable, Hashable {
+    private struct LaunchContext: Identifiable, Hashable {
         let swapId: SwapId
         let launchedMint: PublicKey
         let currencyName: String
         let amount: ExchangedFiat
+        /// The token that paid the launch cost, for analytics.
+        let paymentMint: PublicKey
 
         var id: String { swapId.publicKey.base58 }
     }
@@ -94,10 +96,9 @@ struct CurrencyCreationWizardScreen: View {
         )
     }
 
-    /// True while the reserves-funded launch is preflighting or its processing
-    /// cover is up.
+    /// True while a launch is preflighting or its processing cover is up.
     private var isPayInFlight: Bool {
-        isValidating || reservesLaunchContext != nil
+        isValidating || launchContext != nil
     }
 
     enum Field: Hashable {
@@ -106,10 +107,18 @@ struct CurrencyCreationWizardScreen: View {
     }
 
     enum WizardStep: Int, CaseIterable {
-        case name = 0, icon, description, billCreation, confirmation
+        case name = 0, icon, description, billCreation, confirmation, paymentSelection
 
         var next: WizardStep? { WizardStep(rawValue: rawValue + 1) }
         var previous: WizardStep? { WizardStep(rawValue: rawValue - 1) }
+
+        /// Whether this step joins the progress bar. The payment picker shows a
+        /// title instead, so it opts out — the bar's total derives from this, not
+        /// a hard-coded count.
+        var showsProgressBar: Bool { self != .paymentSelection }
+
+        /// Number of steps the progress bar counts.
+        static let progressStepCount = allCases.filter(\.showsProgressBar).count
     }
 
     enum Direction {
@@ -179,10 +188,27 @@ struct CurrencyCreationWizardScreen: View {
                         onBuy: onPayToCreateTap
                     )
                     .transition(direction.slide)
+
+                case .paymentSelection:
+                    PaymentSelectionStep(
+                        viewModel: CurrencyPaymentSelectionViewModel(
+                            launchCost: totalLaunchCost.onChainAmount,
+                            // The launch flow prices everything in USD — the
+                            // rows must match the "$20" the CTA promised.
+                            displayRate: .oneToOne,
+                            session: session,
+                            ratesController: ratesController
+                        ),
+                        isLaunching: isPayInFlight,
+                        onConfirm: { launchAndBuy(payment: $0) }
+                    )
+                    .transition(direction.slide)
                 }
             }
         }
         .dialog(item: $errorDialog)
+        // The picker step names itself; the creation steps show the progress bar.
+        .navigationTitle(step.showsProgressBar ? "" : "Select Payment Currency")
         .toolbarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled()
@@ -193,11 +219,13 @@ struct CurrencyCreationWizardScreen: View {
                         .foregroundStyle(Color.textMain)
                 }
             }
-            ToolbarItem(placement: .principal) {
-                CreationProgressBar(
-                    current: step.rawValue + 1,
-                    total: WizardStep.allCases.count
-                )
+            if step.showsProgressBar {
+                ToolbarItem(placement: .principal) {
+                    CreationProgressBar(
+                        current: step.rawValue + 1,
+                        total: WizardStep.progressStepCount
+                    )
+                }
             }
             if step == .billCreation {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -219,13 +247,14 @@ struct CurrencyCreationWizardScreen: View {
         ) { result in
             handleFileImport(result)
         }
-        .fullScreenCover(item: $reservesLaunchContext) { context in
+        .fullScreenCover(item: $launchContext) { context in
             NavigationStack {
                 CurrencyLaunchProcessingScreen(
                     swapId: context.swapId,
                     launchedMint: context.launchedMint,
                     currencyName: context.currencyName,
-                    launchAmount: context.amount
+                    launchAmount: context.amount,
+                    paymentMint: context.paymentMint
                 )
                 .environment(\.dismissParentContainer, {
                     // Sheet dismiss unmounts the wizard, taking the
@@ -244,7 +273,7 @@ struct CurrencyCreationWizardScreen: View {
             switch newStep {
             case .name: focusedField = .name
             case .description: focusedField = .description
-            case .icon, .billCreation, .confirmation: focusedField = nil
+            case .icon, .billCreation, .confirmation, .paymentSelection: focusedField = nil
             }
         }
     }
@@ -465,30 +494,55 @@ struct CurrencyCreationWizardScreen: View {
     }
 
     private func launchAndBuyWithReserves() {
+        performLaunch(paymentMint: .usdf) {
+            guard let pin = await ratesController.currentPinnedState(
+                for: launchAmount.nativeAmount.currency,
+                mint: launchAmount.mint
+            ) else { return nil }
+            return { mint in
+                try await session.buyNewCurrency(
+                    amount: launchAmount,
+                    feeAmount: launchFee,
+                    verifiedState: pin,
+                    mint: mint
+                )
+            }
+        }
+    }
+
+    /// Shared launch scaffold: guards the wizard's attestations, resolves the
+    /// funding proof via `prepareBuy`, launches the currency, buys the first
+    /// tokens with the yielded closure, and routes every error to a dialog. On
+    /// a `nameExists` collision it reuses a prior attempt's mint and reruns only
+    /// the buy. `prepareBuy` returns `nil` when the proof can't be resolved.
+    private func performLaunch(
+        paymentMint: PublicKey,
+        prepareBuy: @escaping () async -> ((PublicKey) async throws -> SwapId)?
+    ) {
         validationTask?.cancel()
         validationTask = Task {
             isValidating = true
             defer { isValidating = false }
 
-            let launchAmount = self.launchAmount
-            let launchFee = self.launchFee
             let totalLaunchCost = self.totalLaunchCost
+            let launchAmount = self.launchAmount
             let displayName = state.currencyName
 
+            // These two guards can fail while the "Ready To Create?" dialog is
+            // still tearing down — a locally-bound `.dialog(item:)` presented in
+            // that window is silently dropped, so route them through
+            // `session.dialogItem` (rendered in `DialogWindow` above any sheet).
             guard let nameAttestation = state.nameAttestation,
                   let iconAttestation = state.iconAttestation,
                   let descriptionAttestation = state.descriptionAttestation,
                   let iconData = state.encodedIconData else {
                 logger.error("Confirmation reached without required attestations or icon")
-                presentGenericErrorDialog()
+                session.dialogItem = .error(title: "Something Went Wrong", subtitle: "Please try again")
                 return
             }
 
-            guard let verifiedState = await ratesController.currentPinnedState(
-                for: launchAmount.nativeAmount.currency,
-                mint: launchAmount.mint
-            ) else {
-                presentGenericErrorDialog()
+            guard let buy = await prepareBuy() else {
+                session.dialogItem = .error(title: "Rate Unavailable", subtitle: "Couldn't get a fresh rate. Please try again.")
                 return
             }
 
@@ -505,12 +559,7 @@ struct CurrencyCreationWizardScreen: View {
                     iconAttestation: iconAttestation
                 )
                 launchedMint = mint
-                swapId = try await session.buyNewCurrency(
-                    amount: launchAmount,
-                    feeAmount: launchFee,
-                    verifiedState: verifiedState,
-                    mint: mint
-                )
+                swapId = try await buy(mint)
             } catch ErrorLaunchCurrency.denied {
                 logger.error("Launch denied after preflight attestations passed")
                 ErrorReporting.captureError(ErrorLaunchCurrency.denied)
@@ -521,31 +570,26 @@ struct CurrencyCreationWizardScreen: View {
                 return
             } catch ErrorLaunchCurrency.nameExists {
                 // Recover when a prior attempt minted the same name but its
-                // buyNewCurrency step failed — reuse the mint and try the buy
-                // directly so the user isn't stranded on a server-confirmed
-                // name collision.
+                // buy step failed — reuse the mint and rerun the buy directly
+                // so the user isn't stranded on a server-confirmed collision.
                 if let existing = createdMint, existing.name == displayName {
                     logger.info("Launch nameExists — reusing mint from prior attempt", metadata: [
                         "mint": "\(existing.mint.base58)",
                     ])
                     do {
-                        let retrySwapId = try await session.buyNewCurrency(
-                            amount: launchAmount,
-                            feeAmount: launchFee,
-                            verifiedState: verifiedState,
-                            mint: existing.mint
-                        )
-                        reservesLaunchContext = ReservesLaunchContext(
+                        let retrySwapId = try await buy(existing.mint)
+                        launchContext = LaunchContext(
                             swapId: retrySwapId,
                             launchedMint: existing.mint,
                             currencyName: displayName,
-                            amount: launchAmount
+                            amount: launchAmount,
+                            paymentMint: paymentMint
                         )
                     } catch Session.Error.insufficientBalance {
                         presentInsufficientFundsDialog(totalLaunchCost: totalLaunchCost)
                     } catch {
                         if Task.isCancelled { return }
-                        logger.error("Reserves-funded buy retry failed", metadata: [
+                        logger.error("Buy retry failed", metadata: [
                             "error": "\(error)",
                             "mint": "\(existing.mint.base58)",
                         ])
@@ -576,7 +620,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 if Task.isCancelled { return }
                 captureCreatedMint(launchedMint, name: displayName)
-                logger.error("Reserves-funded launch failed", metadata: [
+                logger.error("Launch failed", metadata: [
                     "error": "\(error)",
                     "mint": "\(launchedMint?.base58 ?? "nil")",
                 ])
@@ -587,12 +631,40 @@ struct CurrencyCreationWizardScreen: View {
 
             // Submission accepted — record the mint and present the processing screen.
             captureCreatedMint(launchedMint, name: displayName)
-            reservesLaunchContext = ReservesLaunchContext(
+            launchContext = LaunchContext(
                 swapId: swapId,
                 launchedMint: launchedMint!,
                 currencyName: displayName,
-                amount: launchAmount
+                amount: launchAmount,
+                paymentMint: paymentMint
             )
+        }
+    }
+
+    private func launchAndBuyWithCurrency(payment: StoredBalance) {
+        performLaunch(paymentMint: payment.mint) {
+            // Pin the payment currency's USD proof and derive the swap/fee split
+            // at the commit moment — quarks are tied to this exact proof.
+            guard let pin = await ratesController.currentPinnedState(for: .usd, mint: payment.mint),
+                  let supply = pin.supplyFromBonding,
+                  let split = LaunchPaymentSplit.compute(
+                      purchaseUSD: launchAmount.nativeAmount.value,
+                      feeUSD: launchFee.nativeAmount.value,
+                      rate: pin.rate,
+                      paymentMint: payment.mint,
+                      supplyQuarks: supply,
+                      balanceUSD: payment.usdf
+                  )
+            else { return nil }
+            return { mint in
+                try await session.buyNewCurrency(
+                    amount: split.swap,
+                    feeAmount: split.fee,
+                    with: payment.mint,
+                    verifiedState: pin,
+                    mint: mint
+                )
+            }
         }
     }
 
@@ -613,16 +685,25 @@ struct CurrencyCreationWizardScreen: View {
 
     // MARK: - Pay-to-Create dispatch
 
-    /// "Pay X to Create" tap handler — launches from reserves, or routes to
-    /// Add Money when the balance no longer covers the cost (checked at "Get
+    /// "Pay X to Create" tap handler — advances to the payment-currency picker,
+    /// or routes to Add Money when no balance covers the cost (checked at "Get
     /// Started", so that only fires if it dropped mid-flow).
     private func onPayToCreateTap() {
-        if !shouldAddMoneyBeforeLaunch(session: session, launchCost: totalLaunchCost.onChainAmount) {
-            launchAndBuyWithReserves()
-        } else {
+        if shouldAddMoneyBeforeLaunch(session: session, launchCost: totalLaunchCost.onChainAmount) {
             session.dialogItem = .noBalance(subtitle: AddMoneyContext.createCurrency.noBalanceSubtitle) {
                 router.presentAddMoney(.createCurrency, source: .buyShortfall)
             }
+        } else {
+            advance()
+        }
+    }
+
+    /// Routes a chosen payment currency to the matching launch path.
+    private func launchAndBuy(payment: StoredBalance) {
+        if payment.mint == .usdf {
+            launchAndBuyWithReserves()
+        } else {
+            launchAndBuyWithCurrency(payment: payment)
         }
     }
 
@@ -892,6 +973,55 @@ private struct ConfirmationStep: View {
             .padding(.bottom, 20)
         }
         .padding(.horizontal, 20)
+    }
+}
+
+// MARK: - PaymentSelectionStep
+
+private struct PaymentSelectionStep: View {
+    @State private var viewModel: CurrencyPaymentSelectionViewModel
+    let isLaunching: Bool
+    let onConfirm: (StoredBalance) -> Void
+
+    init(
+        viewModel: CurrencyPaymentSelectionViewModel,
+        isLaunching: Bool,
+        onConfirm: @escaping (StoredBalance) -> Void
+    ) {
+        self._viewModel = State(initialValue: viewModel)
+        self.isLaunching = isLaunching
+        self.onConfirm = onConfirm
+    }
+
+    var body: some View {
+        @Bindable var viewModel = viewModel
+        List {
+            Section {
+                ForEach(viewModel.rows) { row in
+                    let eligible = viewModel.isEligible(row)
+                    let isUSDF = row.stored.mint == .usdf
+                    // The confirmed row's chevron becomes the in-flight loader —
+                    // the app never shows a full-screen loader.
+                    let isPaying = isLaunching && viewModel.confirmedMint == row.stored.mint
+                    CurrencyBalanceRow(
+                        exchangedBalance: row,
+                        accessibilityIdentifier: isUSDF ? "launch-payment-row-usdf" : "launch-payment-row",
+                        accessory: isPaying ? .loader : .chevron,
+                        amountStyle: .pill,
+                        usesSymbol: isUSDF
+                    ) {
+                        viewModel.select(row, onConfirm: onConfirm)
+                    }
+                    .disabled(!eligible || isLaunching)
+                    .opacity(eligible ? 1 : 0.4)
+                }
+            }
+            .listRowInsets(EdgeInsets())
+            .listSectionSeparator(.hidden, edges: .top)
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .dialog(item: $viewModel.dialogItem)
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingScreen.swift
@@ -17,12 +17,13 @@ struct CurrencyLaunchProcessingScreen: View {
 
     // MARK: - Init -
 
-    init(swapId: SwapId, launchedMint: PublicKey, currencyName: String, launchAmount: ExchangedFiat) {
+    init(swapId: SwapId, launchedMint: PublicKey, currencyName: String, launchAmount: ExchangedFiat, paymentMint: PublicKey) {
         _viewModel = State(wrappedValue: CurrencyLaunchProcessingViewModel(
             swapId: swapId,
             launchedMint: launchedMint,
             currencyName: currencyName,
-            launchAmount: launchAmount
+            launchAmount: launchAmount,
+            paymentMint: paymentMint
         ))
     }
 

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyLaunchProcessingViewModel.swift
@@ -26,6 +26,9 @@ class CurrencyLaunchProcessingViewModel {
     let currencyName: String
     let launchAmount: ExchangedFiat
     let launchedMint: PublicKey
+    /// The token that paid the launch cost — distinguishes the reserves and
+    /// currency analytics events.
+    let paymentMint: PublicKey
 
     // MARK: - Private -
 
@@ -33,11 +36,12 @@ class CurrencyLaunchProcessingViewModel {
 
     // MARK: - Init -
 
-    init(swapId: SwapId, launchedMint: PublicKey, currencyName: String, launchAmount: ExchangedFiat) {
+    init(swapId: SwapId, launchedMint: PublicKey, currencyName: String, launchAmount: ExchangedFiat, paymentMint: PublicKey) {
         self.swapId = swapId
         self.launchedMint = launchedMint
         self.currencyName = currencyName
         self.launchAmount = launchAmount
+        self.paymentMint = paymentMint
     }
 
     // MARK: - Copy -
@@ -78,7 +82,7 @@ class CurrencyLaunchProcessingViewModel {
     var isSuccess: Bool  { displayState == .success }
 
     var analyticsEvent: Analytics.CurrencyLaunchEvent {
-        .launchWithReserves
+        paymentMint == .usdf ? .launchWithReserves : .launchWithCurrency
     }
 
     // MARK: - Actions -
@@ -121,20 +125,20 @@ class CurrencyLaunchProcessingViewModel {
                 // doesn't race the streamed wallet update.
                 if await awaitBalance(session: session) {
                     displayState = .success
-                    Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, exchangedFiat: launchAmount, successful: true)
+                    Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, paymentMint: paymentMint, exchangedFiat: launchAmount, successful: true)
                 } else {
                     reportLaunchFailure(state: metadata.state, reason: "Launched currency balance did not land within budget")
                     displayState = .failed
-                    Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, exchangedFiat: launchAmount, successful: false)
+                    Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, paymentMint: paymentMint, exchangedFiat: launchAmount, successful: false)
                 }
             case .failed, .cancelled:
                 reportLaunchFailure(state: metadata.state, reason: "Launch swap completed with failure state")
                 displayState = .failed
-                Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, exchangedFiat: launchAmount, successful: false)
+                Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, paymentMint: paymentMint, exchangedFiat: launchAmount, successful: false)
             case .unknown, .created, .funding, .funded, .submitting, .cancelling:
                 reportLaunchFailure(state: metadata.state, reason: "Launch swap timed out in intermediate state")
                 displayState = .failed
-                Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, exchangedFiat: launchAmount, successful: false)
+                Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, paymentMint: paymentMint, exchangedFiat: launchAmount, successful: false)
             }
         } catch is CancellationError {
             // Task was cancelled (e.g., by SwiftUI during navigation
@@ -144,7 +148,7 @@ class CurrencyLaunchProcessingViewModel {
             // No swap state was ever fetched within the poll budget
             logger.error("Launch swap polling failed", metadata: ["error": "\(error)"])
             displayState = .failed
-            Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, exchangedFiat: launchAmount, successful: false, error: error)
+            Analytics.currencyLaunch(event: analyticsEvent, launchedMint: launchedMint, paymentMint: paymentMint, exchangedFiat: launchAmount, successful: false, error: error)
         }
 
         isPolling = false
@@ -285,5 +289,4 @@ extension CurrencyLaunchProcessingViewModel {
         case success
         case failed
     }
-
 }

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyPaymentSelectionViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyPaymentSelectionViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  CurrencyPaymentSelectionViewModel.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+@Observable
+@MainActor
+final class CurrencyPaymentSelectionViewModel {
+
+    var dialogItem: DialogItem?
+    /// The row the user confirmed paying with — its chevron becomes the
+    /// in-flight loader while the launch preflights.
+    private(set) var confirmedMint: PublicKey?
+
+    @ObservationIgnored let launchCost: TokenAmount
+    @ObservationIgnored private let displayRate: Rate?
+    @ObservationIgnored private let session: Session
+    @ObservationIgnored private let ratesController: RatesController
+
+    /// - Parameter displayRate: Fixed display rate for flows anchored to a
+    ///   single currency (the launch flow prices everything in USD); nil
+    ///   follows the user's balance currency.
+    init(launchCost: TokenAmount, displayRate: Rate? = nil, session: Session, ratesController: RatesController) {
+        self.launchCost = launchCost
+        self.displayRate = displayRate
+        self.session = session
+        self.ratesController = ratesController
+    }
+
+    /// Spendable payment sources; zero-value balances are hidden (nothing to pay with).
+    var rows: [ExchangedBalance] {
+        let rate = displayRate ?? ratesController.rateForBalanceCurrency()
+        return session.balances(for: rate).filter { $0.exchangedFiat.hasDisplayableValue() }
+    }
+
+    /// Whether `row` alone can pay the launch cost — drives row enablement.
+    func isEligible(_ row: ExchangedBalance) -> Bool {
+        canPayLaunchCost(row.stored, launchCost: launchCost)
+    }
+
+    /// Raises the "Ready To Create?" confirmation; `onConfirm` runs only if the
+    /// user taps "Pay To Create Currency". Ineligible rows never reach here.
+    func select(_ row: ExchangedBalance, onConfirm: @escaping (StoredBalance) -> Void) {
+        guard isEligible(row) else { return }
+        dialogItem = .info(
+            title: "Ready To Create?",
+            subtitle: "You won't be able to change the name once your currency is created"
+        ) {
+            .standard("Pay To Create Currency") { [weak self] in
+                self?.confirmedMint = row.stored.mint
+                onConfirm(row.stored)
+            };
+            .dismiss(kind: .subtle)
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingScreen.swift
@@ -2,9 +2,6 @@
 //  SwapProcessingScreen.swift
 //  Flipcash
 //
-//  Created by Claude.
-//  Copyright © 2025 Code Inc. All rights reserved.
-//
 
 import SwiftUI
 import FlipcashUI
@@ -19,10 +16,11 @@ struct SwapProcessingScreen: View {
 
     // MARK: - Init -
 
-    init(swapId: SwapId, swapType: SwapType, currencyName: String, amount: ExchangedFiat) {
+    init(swapId: SwapId, swapType: SwapType, targetMint: PublicKey? = nil, currencyName: String, amount: ExchangedFiat) {
         _viewModel = State(wrappedValue: SwapProcessingViewModel(
             swapId: swapId,
             swapType: swapType,
+            targetMint: targetMint,
             currencyName: currencyName,
             amount: amount
         ))

--- a/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingViewModel.swift
@@ -2,9 +2,6 @@
 //  SwapProcessingViewModel.swift
 //  Flipcash
 //
-//  Created by Claude.
-//  Copyright © 2025 Code Inc. All rights reserved.
-//
 
 import SwiftUI
 import FlipcashCore
@@ -93,14 +90,18 @@ class SwapProcessingViewModel {
 
     private let swapId: SwapId
     private let swapType: SwapType
+    /// The token being bought — analytics-only; nil on the sell path, where
+    /// `amount.mint` already names the subject token.
+    private let targetMint: PublicKey?
     private let currencyName: String
     private let amount: ExchangedFiat
 
     // MARK: - Init -
 
-    init(swapId: SwapId, swapType: SwapType, currencyName: String, amount: ExchangedFiat) {
+    init(swapId: SwapId, swapType: SwapType, targetMint: PublicKey? = nil, currencyName: String, amount: ExchangedFiat) {
         self.swapId = swapId
         self.swapType = swapType
+        self.targetMint = targetMint
         self.currencyName = currencyName
         self.amount = amount
     }
@@ -183,9 +184,9 @@ class SwapProcessingViewModel {
     private func trackTransaction(successful: Bool) {
         switch swapType {
         case .buyWithReserves:
-            Analytics.tokenPurchase(method: .purchaseWithReserves, exchangedFiat: amount, successful: successful)
+            Analytics.tokenPurchase(method: .purchaseWithReserves, targetMint: targetMint, exchangedFiat: amount, successful: successful)
         case .buyWithCurrency:
-            Analytics.tokenPurchase(method: .purchaseWithCurrency, exchangedFiat: amount, successful: successful)
+            Analytics.tokenPurchase(method: .purchaseWithCurrency, targetMint: targetMint, exchangedFiat: amount, successful: successful)
         case .sell:
             Analytics.tokenSell(exchangedFiat: amount, successful: successful)
         }

--- a/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
+++ b/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
@@ -80,6 +80,7 @@ struct SelectCurrencyScreen: View {
 enum CurrencyRowAccessory {
     case chevron
     case check(isSelected: Bool)
+    case loader
 }
 
 struct CurrencyBalanceRow: View {
@@ -206,6 +207,10 @@ private struct AccessoryView: View {
                 .foregroundStyle(Color.textSecondary)
         case .check(let isSelected):
             CheckView(active: isSelected)
+        case .loader:
+            ProgressView()
+                .progressViewStyle(.circular)
+                .tint(Color.textSecondary)
         }
     }
 }

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -766,6 +766,61 @@ class Session {
         return metadata.swapId
     }
 
+    /// Buys the first tokens on a newly-launched currency paying with another
+    /// launchpad currency, given the swap and fee legs in the payment token.
+    @discardableResult
+    func buyNewCurrency(
+        amount: ExchangedFiat,
+        feeAmount: ExchangedFiat,
+        with paymentMint: PublicKey,
+        verifiedState: VerifiedState,
+        mint: PublicKey,
+        swapId: SwapId = .generate()
+    ) async throws -> SwapId {
+        let fullAmount = amount.adding(feeAmount)
+        guard fullAmount.onChainAmount.quarks > 0 else {
+            throw Error.invalidAmount
+        }
+
+        try assertFresh(verifiedState, operation: "buyNewCurrencyWithCurrency",
+                        currency: fullAmount.nativeAmount.currency, mint: paymentMint)
+
+        // Defensive: the picker's eligibility gate should have prevented this.
+        // Unlike buy(with:), don't silently recompute here — a recompute would
+        // break the swap/fee split the server re-values; the split helper
+        // already balance-caps the total.
+        if let balance = balance(for: paymentMint), fullAmount.onChainAmount.quarks > balance.quarks {
+            logger.error("New-currency currency buy exceeds balance — gating should have prevented this", metadata: [
+                "fullQuarks": "\(fullAmount.onChainAmount.quarks)",
+                "balanceQuarks": "\(balance.quarks)",
+                "paymentMint": "\(paymentMint.base58)",
+            ])
+            throw Error.insufficientBalance
+        }
+
+        let paymentToken = try await fetchMintMetadata(mint: paymentMint)
+
+        logger.info("Buying new currency with currency", metadata: [
+            "amount": "\(amount.nativeAmount.formatted())",
+            "feeAmount": "\(feeAmount.nativeAmount.formatted())",
+            "paymentSymbol": "\(paymentToken.symbol)",
+            "mint": "\(mint.base58)",
+        ])
+
+        let metadata = try await client.buyNewCurrency(
+            swapId: swapId,
+            amount: amount,
+            feeAmount: feeAmount,
+            verifiedState: verifiedState,
+            paymentToken: paymentToken.metadata,
+            mint: mint,
+            owner: owner
+        )
+
+        updatePostTransaction()
+        return metadata.swapId
+    }
+
     @discardableResult
     func sell(amount: ExchangedFiat, verifiedState: VerifiedState, in mint: PublicKey) async throws -> SwapId {
         try assertFresh(verifiedState, operation: "sell", currency: amount.nativeAmount.currency, mint: mint)

--- a/Flipcash/Utilities/Events.swift
+++ b/Flipcash/Utilities/Events.swift
@@ -91,6 +91,7 @@ extension Analytics {
 
     enum CurrencyLaunchEvent: String, AnalyticsEvent {
         case launchWithReserves = "Currency Launch With Reserves"
+        case launchWithCurrency = "Currency Launch With Currency"
     }
 
     enum DeeplinkEvent: String, AnalyticsEvent {
@@ -281,13 +282,20 @@ extension Analytics {
 // MARK: - Token Transactions -
 
 extension Analytics {
-    static func tokenPurchase(method: TokenTransactionEvent, exchangedFiat: ExchangedFiat, successful: Bool, error: Error? = nil) {
-        let properties: [Property: AnalyticsValue] = [
+    /// `Mint` is the token being purchased; `Payment Mint` is the token the
+    /// buyer spent (USDF for reserves buys), taken from `exchangedFiat`.
+    /// A nil `targetMint` omits `Mint` — `exchangedFiat` is payment-denominated,
+    /// so no truthful substitute exists.
+    static func tokenPurchase(method: TokenTransactionEvent, targetMint: PublicKey?, exchangedFiat: ExchangedFiat, successful: Bool, error: Error? = nil) {
+        var properties: [Property: AnalyticsValue] = [
             .state: successful ? String.success : String.failure,
-            .mint: exchangedFiat.mint.base58,
+            .paymentMint: exchangedFiat.mint.base58,
             .fiat: exchangedFiat.nativeAmount.doubleValue,
             .currency: exchangedFiat.currencyRate.currency.rawValue,
         ]
+        if let targetMint {
+            properties[.mint] = targetMint.base58
+        }
         track(event: method, properties: properties, error: error)
     }
 
@@ -306,10 +314,13 @@ extension Analytics {
 // MARK: - Currency Launch -
 
 extension Analytics {
-    static func currencyLaunch(event: CurrencyLaunchEvent, launchedMint: PublicKey, exchangedFiat: ExchangedFiat, successful: Bool, error: Error? = nil) {
+    /// `Mint` is the launched currency; `Payment Mint` is the token that paid
+    /// the launch cost.
+    static func currencyLaunch(event: CurrencyLaunchEvent, launchedMint: PublicKey, paymentMint: PublicKey, exchangedFiat: ExchangedFiat, successful: Bool, error: Error? = nil) {
         let properties: [Property: AnalyticsValue] = [
             .state: successful ? String.success : String.failure,
             .mint: launchedMint.base58,
+            .paymentMint: paymentMint.base58,
             .fiat: exchangedFiat.nativeAmount.doubleValue,
             .currency: exchangedFiat.currencyRate.currency.rawValue,
         ]
@@ -360,6 +371,7 @@ extension Analytics {
         case method            = "Method"
         case quarks            = "Quarks"
         case mint              = "Mint"
+        case paymentMint       = "Payment Mint"
         case fiat              = "Fiat"
         case currency          = "Currency"
         case fx                = "Exchange Rate"

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Transaction.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Transaction.swift
@@ -220,6 +220,31 @@ extension Client {
         }
     }
 
+    /// Buys the first tokens on a newly-launched currency, funded by another
+    /// launchpad currency rather than USDF reserves.
+    @discardableResult
+    public func buyNewCurrency(
+        swapId: SwapId,
+        amount: ExchangedFiat,
+        feeAmount: ExchangedFiat,
+        verifiedState: VerifiedState,
+        paymentToken: MintMetadata,
+        mint: PublicKey,
+        owner: AccountCluster
+    ) async throws -> SwapMetadata {
+        try await withCheckedThrowingContinuation { c in
+            transactionService.buyNewCurrency(
+                swapId: swapId,
+                amount: amount,
+                feeAmount: feeAmount,
+                verifiedState: verifiedState,
+                paymentToken: paymentToken,
+                mint: mint,
+                owner: owner
+            ) { c.resume(with: $0) }
+        }
+    }
+
     // MARK: - Status -
     
     public func pollIntentMetadata(owner: KeyPair, intentID: PublicKey, maxAttempts: Int = 50) async throws -> IntentMetadata {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentFundSwap.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/IntentFundSwap.swift
@@ -2,9 +2,6 @@
 //  IntentFundSwap.swift
 //  FlipcashCore
 //
-//  Created by Claude.
-//  Copyright © 2025 Code Inc. All rights reserved.
-//
 
 import Foundation
 import FlipcashAPI
@@ -68,15 +65,7 @@ extension IntentFundSwap {
                 $0.destinationOwner = destinationOwner.solanaAccountID
                 $0.mint = amount.mint.solanaAccountID
 
-                $0.clientExchangeData = .with {
-                    $0.mint = amount.mint.solanaAccountID
-                    $0.quarks = amount.onChainAmount.quarks
-                    $0.nativeAmount = amount.nativeAmount.doubleValue
-                    $0.coreMintFiatExchangeRate = verifiedState.rateProto
-                    if let reserveProto = verifiedState.reserveProto {
-                        $0.launchpadCurrencyReserveState = reserveProto
-                    }
-                }
+                $0.clientExchangeData = .init(amount: amount, verifiedState: verifiedState)
 
                 $0.isWithdrawal = true
                 $0.isIndirectSend = false

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/VerifiedExchangeData+Build.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Intents/VerifiedExchangeData+Build.swift
@@ -1,0 +1,23 @@
+//
+//  VerifiedExchangeData+Build.swift
+//  FlipcashCore
+//
+
+import Foundation
+import FlipcashAPI
+
+extension Ocp_Transaction_V1_VerifiedExchangeData {
+    /// The client's signed valuation of `amount`, carrying the rate proof and,
+    /// for launchpad mints, the reserve-state proof the server re-values against.
+    init(amount: ExchangedFiat, verifiedState: VerifiedState) {
+        self = .with {
+            $0.mint = amount.mint.solanaAccountID
+            $0.quarks = amount.onChainAmount.quarks
+            $0.nativeAmount = amount.nativeAmount.doubleValue
+            $0.coreMintFiatExchangeRate = verifiedState.rateProto
+            if let reserveProto = verifiedState.reserveProto {
+                $0.launchpadCurrencyReserveState = reserveProto
+            }
+        }
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/SwapService.swift
@@ -46,10 +46,15 @@ final class SwapService: Sendable {
         owner: KeyPair,
         isNewCurrencyLaunch: Bool = false,
         kind: VerifiedSwapMetadata.ClientParameters.Kind = .reserve,
+        fullAmountExchangeData: VerifiedSwapMetadata.FullAmountExchangeData? = nil,
+        expectedTreasuryPurchaseQuarks: UInt64? = nil,
         completion: @escaping @Sendable (Result<SwapMetadata, ErrorSwap>) -> Void
     ) {
         let fromMint = direction.sourceMint.address
         let toMint = direction.destinationMint.address
+        // Captured for the treasury-funded launch builder, which needs the
+        // payment mint's VM + launchpad accounts.
+        let paymentTokenMetadata = direction.sourceMint
         let resolvedFeeAmount = feeAmount ?? TokenAmount(quarks: 0, mint: fromMint)
         logger.info("Starting swap", metadata: [
             "swapId": "\(swapId.publicKey.base58)",
@@ -142,7 +147,8 @@ final class SwapService: Sendable {
             amount: amount,
             feeAmount: resolvedFeeAmount,
             fundingSource: fundingSource,
-            kind: kind
+            kind: kind,
+            fullAmountExchangeData: fullAmountExchangeData
         )
 
         // Swap authority signs the transaction. For standard swaps the server
@@ -266,17 +272,42 @@ final class SwapService: Sendable {
                     )
                     pendingSwap.withLock { $0.serverParameters = serverParameters }
 
-                    // Build the atomic launch-and-first-buy transaction. The owner
-                    // is also the swap_authority for new-currency flows, so only
-                    // one signature is required.
+                    // Build the first-buy transaction in the format the server
+                    // compiled — it declares treasury funding by including the
+                    // treasury account; its absence means the reserves format.
+                    // Either way the owner is also the swap_authority for
+                    // new-currency flows, so only one client signature is needed.
                     let transaction: SolanaTransaction
                     do {
-                        transaction = try TransactionBuilder.swapNewCurrency(
-                            responseParams: params,
-                            authority: owner.publicKey,
-                            swapAmount: amount.quarks,
-                            feeAmount: resolvedFeeAmount.quarks
-                        )
+                        if let treasury = params.treasury {
+                            // The proto requires validating the treasury's spend
+                            // against the pre-coordinated amount the user accepted.
+                            guard params.treasuryPurchaseAmount == expectedTreasuryPurchaseQuarks else {
+                                logger.error("Treasury purchase amount does not match accepted amount", metadata: [
+                                    "treasuryPurchaseAmount": "\(params.treasuryPurchaseAmount)",
+                                    "expected": "\(expectedTreasuryPurchaseQuarks.map(String.init) ?? "nil")",
+                                ])
+                                reference.cancel()
+                                completion(.failure(.invalidSwap(reasons: [])))
+                                return
+                            }
+                            transaction = try TransactionBuilder.swapNewCurrencyTreasuryFunded(
+                                responseParams: params,
+                                treasury: treasury,
+                                treasuryPurchaseAmount: params.treasuryPurchaseAmount,
+                                authority: owner.publicKey,
+                                paymentToken: paymentTokenMetadata,
+                                swapAmount: amount.quarks,
+                                feeAmount: resolvedFeeAmount.quarks
+                            )
+                        } else {
+                            transaction = try TransactionBuilder.swapNewCurrency(
+                                responseParams: params,
+                                authority: owner.publicKey,
+                                swapAmount: amount.quarks,
+                                feeAmount: resolvedFeeAmount.quarks
+                            )
+                        }
                     } catch {
                         logger.error("Failed to build swap transaction", metadata: ["error": "\(error)"])
                         reference.cancel()

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/TransactionService.swift
@@ -463,6 +463,102 @@ final class TransactionService: Sendable {
         }
     }
 
+    /// A buy of a freshly-launched currency, funded by another launchpad
+    /// currency (Phase 1 launchpad→launchpad swap + Phase 2 via IntentFundSwap).
+    /// The swap+fee total is valued at the exact USD launch cost on the wire;
+    /// the payment pool's sell fee is absorbed by the swap treasury.
+    func buyNewCurrency(
+        swapId: SwapId,
+        amount: ExchangedFiat,
+        feeAmount: ExchangedFiat,
+        verifiedState: VerifiedState,
+        paymentToken: MintMetadata,
+        mint: PublicKey,
+        owner: AccountCluster,
+        completion: @Sendable @escaping (Result<SwapMetadata, ErrorSwap>) -> Void
+    ) {
+        guard let fundingIntentID = PublicKey.generate() else {
+            completion(.failure(.unknown))
+            return
+        }
+        guard let paymentVmAuthority = paymentToken.vmMetadata?.authority else {
+            logger.error("Payment token missing VM authority", metadata: [
+                "symbol": "\(paymentToken.symbol)",
+                "mint": "\(paymentToken.address.base58)",
+            ])
+            completion(.failure(.unknown))
+            return
+        }
+        let ownerKeyPair = owner.authority.keyPair
+        // Derived, not passed: the wire total is exactly the two legs summed.
+        let fullAmount = amount.adding(feeAmount)
+        // The swap leg is valued at the exact USD purchase component; the core
+        // mint is a USD stablecoin, so the treasury must spend exactly this many
+        // core quarks on the buy. Validated against the server's parameters.
+        let expectedTreasuryPurchaseQuarks = TokenAmount(
+            wholeTokens: amount.usdfValue.value,
+            mint: .usdf
+        ).quarks
+
+        logger.info("Starting new-currency buy with currency", metadata: [
+            "amount": "\(amount.nativeAmount.formatted())",
+            "feeAmount": "\(feeAmount.nativeAmount.formatted())",
+            "fullAmount": "\(fullAmount.nativeAmount.formatted())",
+            "paymentSymbol": "\(paymentToken.symbol)",
+            "mint": "\(mint.base58)",
+            "swapId": "\(swapId.publicKey.base58)",
+        ])
+
+        // Phase 1: Create swap state on the server
+        swapService.swap(
+            swapId: swapId,
+            direction: .swap(from: paymentToken, to: .launchStub(address: mint)),
+            amount: amount.onChainAmount,
+            feeAmount: feeAmount.onChainAmount,
+            fundingSource: .submitIntent(id: fundingIntentID),
+            owner: ownerKeyPair,
+            isNewCurrencyLaunch: true,
+            fullAmountExchangeData: .init(amount: fullAmount, verifiedState: verifiedState),
+            expectedTreasuryPurchaseQuarks: expectedTreasuryPurchaseQuarks
+        ) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let metadata):
+                logger.info("New-currency currency swap state created", metadata: [
+                    "swapId": "\(metadata.swapId.publicKey.base58)",
+                ])
+
+                // Phase 2: Fund the payment token's VM swap PDA via IntentFundSwap.
+                let fundingIntent = IntentFundSwap(
+                    intentID: fundingIntentID,
+                    swapId: metadata.swapId,
+                    sourceCluster: owner.use(mint: paymentToken.address, timeAuthority: paymentVmAuthority),
+                    amount: fullAmount,
+                    verifiedState: verifiedState,
+                    fromMint: paymentToken,
+                    toMint: .launchStub(address: mint)
+                )
+
+                self.submit(intent: fundingIntent, owner: ownerKeyPair) { fundingResult in
+                    switch fundingResult {
+                    case .success:
+                        logger.info("New-currency currency buy completed", metadata: [
+                            "intentId": "\(fundingIntentID.base58)",
+                        ])
+                        completion(.success(metadata))
+                    case .failure(let error):
+                        logger.error("Failed to fund new-currency currency swap", metadata: ["error": "\(error)"])
+                        completion(.failure(.fundingIntent(error)))
+                    }
+                }
+
+            case .failure(let error):
+                logger.error("Failed to start new-currency currency swap", metadata: ["error": "\(error)"])
+                completion(.failure(error))
+            }
+        }
+    }
+
     /// Runs a stateless USDC ↔ USDF swap via Coinbase Stable Swapper. Used by
     /// the on-app-open auto-sweep.
     func statelessSwap(

--- a/FlipcashCore/Sources/FlipcashCore/Models/LaunchPaymentSplit.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/LaunchPaymentSplit.swift
@@ -1,0 +1,54 @@
+//
+//  LaunchPaymentSplit.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+/// Splits a fixed-USD launch cost into the swap and fee legs a launchpad-funded
+/// currency creation pays, denominated in the payment token's quarks.
+public enum LaunchPaymentSplit {
+
+    /// Returns the swap and fee legs, or `nil` when the balance can't seat the
+    /// split. Natives are the exact USD components (the wire's full-amount
+    /// valuation must equal the fixed USD total); quarks are curve-derived and
+    /// the total is capped to `balanceUSD` so rounding can't overshoot reserves.
+    ///
+    /// `rate` and `balanceUSD` are USD; the caller unwraps the pin's reserve
+    /// supply before calling.
+    public static func compute(
+        purchaseUSD: Decimal,
+        feeUSD: Decimal,
+        rate: Rate,
+        paymentMint: PublicKey,
+        supplyQuarks: UInt64,
+        balanceUSD: FiatAmount
+    ) -> (swap: ExchangedFiat, fee: ExchangedFiat)? {
+        guard
+            let feeLeg = ExchangedFiat.compute(
+                fromEntered: .usd(feeUSD), rate: rate, mint: paymentMint, supplyQuarks: supplyQuarks
+            ),
+            let totalLeg = ExchangedFiat.compute(
+                fromEntered: .usd(purchaseUSD + feeUSD), rate: rate, mint: paymentMint,
+                supplyQuarks: supplyQuarks, balance: balanceUSD
+            )
+        else { return nil }
+
+        let feeQuarks = feeLeg.onChainAmount.quarks
+        let totalQuarks = totalLeg.onChainAmount.quarks
+        guard totalQuarks >= feeQuarks else { return nil }
+        let swapQuarks = totalQuarks - feeQuarks
+
+        let fee = ExchangedFiat(
+            onChainAmount: TokenAmount(quarks: feeQuarks, mint: paymentMint),
+            nativeAmount: .usd(feeUSD),
+            currencyRate: rate
+        )
+        let swap = ExchangedFiat(
+            onChainAmount: TokenAmount(quarks: swapQuarks, mint: paymentMint),
+            nativeAmount: .usd(purchaseUSD),
+            currencyRate: rate
+        )
+        return (swap, fee)
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Models/SwapModels.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/SwapModels.swift
@@ -156,6 +156,18 @@ public struct VerifiedSwapMetadata: Sendable {
         self.serverParameters = serverParameters
     }
     
+    /// The signed full-amount valuation a launchpad-funded new-currency launch
+    /// carries so the server can re-value the payment token against its reserve.
+    public struct FullAmountExchangeData: Sendable {
+        public let amount: ExchangedFiat
+        public let verifiedState: VerifiedState
+
+        public init(amount: ExchangedFiat, verifiedState: VerifiedState) {
+            self.amount = amount
+            self.verifiedState = verifiedState
+        }
+    }
+
     public struct ClientParameters: Sendable {
         public let id: SwapId
         public let fromMint: PublicKey
@@ -164,6 +176,7 @@ public struct VerifiedSwapMetadata: Sendable {
         public let feeAmount: TokenAmount
         public let fundingSource: FundingSource
         public let kind: Kind
+        public let fullAmountExchangeData: FullAmountExchangeData?
 
         public enum Kind: Sendable, Hashable {
             /// Reserve-swap path (buy/sell bonded tokens, new currency launch).
@@ -179,7 +192,8 @@ public struct VerifiedSwapMetadata: Sendable {
             amount: TokenAmount,
             feeAmount: TokenAmount? = nil,
             fundingSource: FundingSource,
-            kind: Kind = .reserve
+            kind: Kind = .reserve,
+            fullAmountExchangeData: FullAmountExchangeData? = nil
         ) {
             self.id = id
             self.fromMint = fromMint
@@ -188,6 +202,7 @@ public struct VerifiedSwapMetadata: Sendable {
             self.feeAmount = feeAmount ?? TokenAmount(quarks: 0, mint: fromMint)
             self.fundingSource = fundingSource
             self.kind = kind
+            self.fullAmountExchangeData = fullAmountExchangeData
         }
     }
     
@@ -216,6 +231,9 @@ extension VerifiedSwapMetadata.ClientParameters {
 
         let fundingSource = FundingSource(proto.fundingSource, fundingID: proto.fundingID)
 
+        // The full-amount valuation is only ever set client-side for the
+        // outbound Initiate; the server echo the client parses back doesn't
+        // need it.
         self.init(
             id: swapId,
             fromMint: fromMint,
@@ -235,6 +253,9 @@ extension VerifiedSwapMetadata.ClientParameters {
             $0.feeAmount = feeAmount.quarks
             $0.fundingSource = fundingSource.protoSource
             $0.fundingID = fundingSource.fundingID
+            if let full = fullAmountExchangeData {
+                $0.fullAmountExchangeData = .init(amount: full.amount, verifiedState: full.verifiedState)
+            }
         }
     }
 }
@@ -499,6 +520,12 @@ public struct SwapResponseServerParameters {
         public let sellFeeBps: UInt32
         public let vmLockDurationInDays: UInt32
         public let feeDestination: PublicKey
+        /// Server-controlled treasury funding the first buy. Present only for
+        /// launches paid with another launchpad currency.
+        public let treasury: PublicKey?
+        /// Core-mint quarks the treasury spends on the purchase. The client
+        /// must validate this equals the user-accepted purchase amount.
+        public let treasuryPurchaseAmount: UInt64
 
         public init(
             payer: PublicKey,
@@ -514,7 +541,9 @@ public struct SwapResponseServerParameters {
             seed: PublicKey,
             sellFeeBps: UInt32,
             vmLockDurationInDays: UInt32,
-            feeDestination: PublicKey
+            feeDestination: PublicKey,
+            treasury: PublicKey? = nil,
+            treasuryPurchaseAmount: UInt64 = 0
         ) {
             self.payer = payer
             self.nonce = nonce
@@ -530,6 +559,8 @@ public struct SwapResponseServerParameters {
             self.sellFeeBps = sellFeeBps
             self.vmLockDurationInDays = vmLockDurationInDays
             self.feeDestination = feeDestination
+            self.treasury = treasury
+            self.treasuryPurchaseAmount = treasuryPurchaseAmount
         }
     }
 }
@@ -572,6 +603,14 @@ extension SwapResponseServerParameters.ReserveNewCurrency {
             return nil
         }
 
+        let treasury: PublicKey?
+        if proto.hasTreasury {
+            guard let parsed = try? PublicKey(proto.treasury.value) else { return nil }
+            treasury = parsed
+        } else {
+            treasury = nil
+        }
+
         let alts = proto.alts.compactMap { AddressLookupTable($0) }
 
         self.init(
@@ -588,7 +627,9 @@ extension SwapResponseServerParameters.ReserveNewCurrency {
             seed: seed,
             sellFeeBps: proto.sellFeeBps,
             vmLockDurationInDays: proto.vmLockDurationInDays,
-            feeDestination: feeDestination
+            feeDestination: feeDestination,
+            treasury: treasury,
+            treasuryPurchaseAmount: proto.treasuryPurchaseAmount
         )
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+NewCurrency.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/SwapInstructionBuilder+NewCurrency.swift
@@ -260,4 +260,177 @@ extension SwapInstructionBuilder {
 
         return instructions
     }
+
+    /// Builds the first-buy instruction list for a new launchpad currency paid
+    /// with another launchpad currency. The buyer's payment tokens (swap + fee)
+    /// flow to the server-controlled treasury, the treasury sells them into
+    /// Core Mint, and the treasury funds the buy with `treasuryPurchaseAmount`
+    /// Core Mint quarks — guaranteeing the purchase value regardless of
+    /// payment-mint price movement. Mirrors ocp-server's
+    /// `ReserveTreasuryFundedCreateAndBuySwapHandler.MakeInstructions`: unlike
+    /// the reserves format there are no Initialize/Memo/Close instructions, and
+    /// the compute-budget instructions are unconditional.
+    static func newCurrencyLaunchTreasuryFunded(
+        serverParams: SwapResponseServerParameters.ReserveNewCurrency,
+        treasury: PublicKey,
+        treasuryPurchaseAmount: UInt64,
+        authority: PublicKey,
+        paymentToken: MintMetadata,
+        swapAmount: UInt64,
+        feeAmount: UInt64
+    ) throws -> [Instruction] {
+        let coreMint = MintMetadata.usdf
+
+        guard let sourceVM = paymentToken.vmMetadata else {
+            throw SwapTransactionBuildError.missingMintMetadata(symbol: paymentToken.symbol)
+        }
+        guard let sourceLaunchpad = paymentToken.launchpadMetadata else {
+            throw SwapTransactionBuildError.missingMintMetadata(symbol: paymentToken.symbol)
+        }
+        guard let sourceSwapAccounts = paymentToken.timelockSwapAccounts(owner: authority) else {
+            throw SwapTransactionBuildError.missingMintMetadata(symbol: paymentToken.symbol)
+        }
+
+        // Derive the new currency's launchpad PDAs from server params.
+        guard let (targetMint, _) = LaunchpadMint.deriveMint(
+            authority: serverParams.authority,
+            name: serverParams.name,
+            seed: serverParams.seed
+        ) else {
+            fatalError("Failed to derive target mint PDA")
+        }
+
+        guard let (currency, _) = LaunchpadMint.deriveCurrency(mint: targetMint) else {
+            fatalError("Failed to derive currency PDA")
+        }
+
+        guard let (pool, _) = LaunchpadMint.derivePool(currency: currency) else {
+            fatalError("Failed to derive pool PDA")
+        }
+
+        guard let (vaultA, _) = LaunchpadMint.deriveVault(pool: pool, mint: targetMint) else {
+            fatalError("Failed to derive vault A PDA")
+        }
+
+        guard let (vaultB, _) = LaunchpadMint.deriveVault(pool: pool, mint: coreMint.address) else {
+            fatalError("Failed to derive vault B PDA")
+        }
+
+        // Buyer's deposit PDA + ATA on the new target-mint VM — where the
+        // bought tokens land.
+        guard let lockDuration = Byte(exactly: serverParams.vmLockDurationInDays) else {
+            throw SwapTransactionBuildError.invalidServerParameter("vmLockDurationInDays")
+        }
+        guard let buyerVMDepositPda = PublicKey.deriveDepositAccount(
+            owner: authority,
+            mint: targetMint,
+            timeAuthority: serverParams.authority,
+            lockout: lockDuration
+        ) else {
+            fatalError("Failed to derive buyer VM deposit PDA")
+        }
+        guard let buyerTargetVMDepositATA = PublicKey.deriveAssociatedAccount(
+            from: buyerVMDepositPda.publicKey,
+            mint: targetMint
+        ) else {
+            fatalError("Failed to derive buyer target VM deposit ATA")
+        }
+
+        // Treasury's Core Mint ATA funds the buy; it already exists on-chain.
+        guard let treasuryCoreMintATA = PublicKey.deriveAssociatedAccount(
+            from: treasury,
+            mint: coreMint.address
+        ) else {
+            fatalError("Failed to derive treasury Core Mint ATA")
+        }
+
+        // Treasury's payment-mint ATA receives the swap + fee, created here.
+        let createTreasuryFromMintATA = AssociatedTokenProgram.CreateIdempotent(
+            subsidizer: serverParams.payer,
+            owner: treasury,
+            mint: paymentToken.address
+        )
+
+        var instructions: [Instruction] = []
+
+        // 1. System::AdvanceNonce
+        instructions.append(
+            SystemProgram.AdvanceNonce(
+                nonce: serverParams.nonce,
+                authority: serverParams.payer
+            ).instruction()
+        )
+
+        // 2. ComputeBudget::SetComputeUnitLimit
+        instructions.append(
+            ComputeBudgetProgram.SetComputeUnitLimit(
+                units: serverParams.computeUnitLimit
+            ).instruction()
+        )
+
+        // 3. ComputeBudget::SetComputeUnitPrice
+        instructions.append(
+            ComputeBudgetProgram.SetComputeUnitPrice(
+                microLamports: serverParams.computeUnitPrice
+            ).instruction()
+        )
+
+        // 4. ATA::CreateIdempotent — treasury's payment-mint ATA
+        instructions.append(createTreasuryFromMintATA.instruction())
+
+        // 5. VM::TransferForSwapWithFee — the entire swap and fee amount is
+        //    collected by the treasury (both destinations), then converted into
+        //    Core Mint by the sell below.
+        instructions.append(
+            VMProgram.TransferForSwapWithFee(
+                vmAuthority: sourceVM.authority,
+                vm: sourceVM.vm,
+                swapper: authority,
+                swapPda: sourceSwapAccounts.pda.publicKey,
+                swapAta: sourceSwapAccounts.ata.publicKey,
+                swapDestination: createTreasuryFromMintATA.address,
+                feeDestination: createTreasuryFromMintATA.address,
+                swapAmount: swapAmount,
+                feeAmount: feeAmount,
+                bump: sourceSwapAccounts.pda.bump
+            ).instruction()
+        )
+
+        // 6. Reserve::SellTokens — treasury sells the collected payment tokens;
+        //    the Core Mint proceeds go to the fee destination.
+        instructions.append(
+            CurrencyCreatorProgram.SellTokens(
+                seller: treasury,
+                pool: sourceLaunchpad.liquidityPool,
+                targetMint: paymentToken.address,
+                baseMint: coreMint.address,
+                vaultTarget: sourceLaunchpad.mintVault,
+                vaultBase: sourceLaunchpad.coreMintVault,
+                sellerTarget: createTreasuryFromMintATA.address,
+                sellerBase: serverParams.feeDestination,
+                inAmount: swapAmount + feeAmount,
+                minAmountOut: 0
+            ).instruction()
+        )
+
+        // 7. Reserve::BuyTokens — treasury funds the first buy with the
+        //    pre-coordinated Core Mint amount, depositing the minted tokens
+        //    into the buyer's target-mint VM deposit ATA.
+        instructions.append(
+            CurrencyCreatorProgram.BuyTokens(
+                buyer: treasury,
+                pool: pool,
+                targetMint: targetMint,
+                baseMint: coreMint.address,
+                vaultA: vaultA,
+                vaultB: vaultB,
+                buyerTarget: buyerTargetVMDepositATA.publicKey,
+                buyerBase: treasuryCoreMintATA.publicKey,
+                amount: treasuryPurchaseAmount,
+                minOutAmount: 0
+            ).instruction()
+        )
+
+        return instructions
+    }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Solana/TransactionBuilder.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/TransactionBuilder.swift
@@ -170,4 +170,33 @@ extension TransactionBuilder {
             instructions: instructions
         )
     }
+
+    /// Builds the first-buy transaction for a new launchpad currency paid with
+    /// another launchpad currency, funded through the server's treasury.
+    static func swapNewCurrencyTreasuryFunded(
+        responseParams: SwapResponseServerParameters.ReserveNewCurrency,
+        treasury: PublicKey,
+        treasuryPurchaseAmount: UInt64,
+        authority: PublicKey,
+        paymentToken: MintMetadata,
+        swapAmount: UInt64,
+        feeAmount: UInt64
+    ) throws -> SolanaTransaction {
+        let instructions = try SwapInstructionBuilder.newCurrencyLaunchTreasuryFunded(
+            serverParams: responseParams,
+            treasury: treasury,
+            treasuryPurchaseAmount: treasuryPurchaseAmount,
+            authority: authority,
+            paymentToken: paymentToken,
+            swapAmount: swapAmount,
+            feeAmount: feeAmount
+        )
+
+        return SolanaTransaction(
+            payer: responseParams.payer,
+            recentBlockhash: responseParams.blockhash,
+            addressLookupTables: responseParams.alts,
+            instructions: instructions
+        )
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/LaunchPaymentSplitTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/LaunchPaymentSplitTests.swift
@@ -1,0 +1,91 @@
+//
+//  LaunchPaymentSplitTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("LaunchPaymentSplit")
+struct LaunchPaymentSplitTests {
+
+    // Supply chosen so ~2000 tokens ≈ $20 of curve value (matches the buy tests).
+    private static let supply: UInt64 = 50_000 * 10_000_000_000
+    private static let ampleBalance = FiatAmount.usd(1_000)
+
+    @Test("The summed legs value to exactly the fixed USD total")
+    func totalNativeIsExact() throws {
+        let split = try #require(LaunchPaymentSplit.compute(
+            purchaseUSD: 10, feeUSD: 10, rate: .oneToOne, paymentMint: .jeffy,
+            supplyQuarks: Self.supply, balanceUSD: Self.ampleBalance
+        ))
+        // The wire's full-amount valuation is the sum of the legs; the server
+        // rejects anything but exactly $20.00 (a float `!=` compare).
+        let total = split.swap.adding(split.fee)
+
+        #expect(total.nativeAmount == FiatAmount.usd(20))
+        #expect(total.nativeAmount.doubleValue == 20.0)
+    }
+
+    @Test("Fee quarks re-value to ~the fee USD within a half cent")
+    func feeQuarksValueWithinTolerance() throws {
+        let split = try #require(LaunchPaymentSplit.compute(
+            purchaseUSD: 10, feeUSD: 10, rate: .oneToOne, paymentMint: .jeffy,
+            supplyQuarks: Self.supply, balanceUSD: Self.ampleBalance
+        ))
+        // Re-value the fee quarks the way the server does (curve sell, feeBps 0).
+        let revalued = ExchangedFiat.compute(
+            onChainAmount: split.fee.onChainAmount, rate: .oneToOne, supplyQuarks: Self.supply
+        )
+        let delta = (revalued.nativeAmount.value - 10 as Decimal).magnitude
+        #expect(delta <= Decimal(string: "0.005")!)
+    }
+
+    @Test("The total leg is capped to the balance's USD value")
+    func totalCapsToBalance() throws {
+        let cappedUSD = FiatAmount.usd(12)
+        let split = try #require(LaunchPaymentSplit.compute(
+            purchaseUSD: 10, feeUSD: 10, rate: .oneToOne, paymentMint: .jeffy,
+            supplyQuarks: Self.supply, balanceUSD: cappedUSD
+        ))
+        let total = split.swap.onChainAmount.quarks + split.fee.onChainAmount.quarks
+
+        let expectedCapped = try #require(ExchangedFiat.compute(
+            fromEntered: .usd(12), rate: .oneToOne, mint: .jeffy, supplyQuarks: Self.supply
+        )).onChainAmount.quarks
+        #expect(total == expectedCapped)
+    }
+
+    @Test("A balance displaying $20.00 seats the capped split inside the server's ±half-cent window", arguments: [
+        UInt64(50_000) * 10_000_000_000,
+        UInt64(5_000_000) * 10_000_000_000, // deeper on the curve — nonlinear region
+    ])
+    func boundaryBalanceStaysInWindow(supply: UInt64) throws {
+        // Raw value $19.996 rounds to a displayed $20.00 — eligible by rule 5.
+        let boundary = try #require(ExchangedFiat.compute(
+            fromEntered: .usd(Decimal(string: "19.996")!),
+            rate: .oneToOne, mint: .jeffy, supplyQuarks: supply
+        ))
+        let balanceUSD = ExchangedFiat.compute(
+            onChainAmount: boundary.onChainAmount, rate: .oneToOne, supplyQuarks: supply
+        ).nativeAmount
+
+        let split = try #require(LaunchPaymentSplit.compute(
+            purchaseUSD: 10, feeUSD: 10, rate: .oneToOne, paymentMint: .jeffy,
+            supplyQuarks: supply, balanceUSD: balanceUSD
+        ))
+
+        // Capped total never exceeds the holding, yet still re-values (the way
+        // the server does) within ±$0.005 of the exact $20 the wire declares.
+        let totalQuarks = split.swap.onChainAmount.quarks + split.fee.onChainAmount.quarks
+        #expect(totalQuarks <= boundary.onChainAmount.quarks)
+
+        let revalued = ExchangedFiat.compute(
+            onChainAmount: TokenAmount(quarks: totalQuarks, mint: .jeffy),
+            rate: .oneToOne, supplyQuarks: supply
+        )
+        let delta = (revalued.nativeAmount.value - 20 as Decimal).magnitude
+        #expect(delta <= Decimal(string: "0.005")!)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderNewCurrencyTreasuryTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SwapInstructionBuilderNewCurrencyTreasuryTests.swift
@@ -1,0 +1,198 @@
+//
+//  SwapInstructionBuilderNewCurrencyTreasuryTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+import FlipcashAPI
+@testable import FlipcashCore
+
+@Suite("SwapInstructionBuilder treasury-funded new-currency launch")
+struct SwapInstructionBuilderNewCurrencyTreasuryTests {
+
+    private static func key(_ seed: UInt8) -> PublicKey {
+        try! PublicKey([UInt8](repeating: seed, count: 32))
+    }
+
+    private static let payer     = key(1)
+    private static let nonce     = key(2)
+    private static let authority = key(4)
+    private static let treasury  = key(7)
+    private static let feeDestination = key(8)
+
+    private static let paymentMint = MintMetadata(
+        address: key(10),
+        decimals: 10,
+        name: "PAY",
+        symbol: "PAY",
+        description: "",
+        imageURL: nil,
+        vmMetadata: VMMetadata(
+            vm: key(11),
+            authority: key(12),
+            lockDurationInDays: 21
+        ),
+        launchpadMetadata: LaunchpadMetadata(
+            currencyConfig: key(13),
+            liquidityPool: key(14),
+            seed: key(15),
+            authority: key(12),
+            mintVault: key(16),
+            coreMintVault: key(17),
+            coreMintFees: nil,
+            supplyFromBonding: 50_000,
+            sellFeeBps: 100
+        )
+    )
+
+    private static func makeServerParams() -> SwapResponseServerParameters.ReserveNewCurrency {
+        SwapResponseServerParameters.ReserveNewCurrency(
+            payer: payer,
+            nonce: nonce,
+            blockhash: try! Hash([UInt8](repeating: 99, count: 32)),
+            alts: [],
+            computeUnitLimit: 250_000,
+            computeUnitPrice: 10_000,
+            memoValue: "",
+            authority: authority,
+            name: "Test Coin",
+            symbol: "VALUE",
+            seed: key(20),
+            sellFeeBps: 100,
+            vmLockDurationInDays: 21,
+            feeDestination: feeDestination,
+            treasury: treasury,
+            treasuryPurchaseAmount: 10_000_000
+        )
+    }
+
+    private func build(swapAmount: UInt64 = 900, feeAmount: UInt64 = 100) throws -> [Instruction] {
+        try SwapInstructionBuilder.newCurrencyLaunchTreasuryFunded(
+            serverParams: Self.makeServerParams(),
+            treasury: Self.treasury,
+            treasuryPurchaseAmount: 10_000_000,
+            authority: Self.authority,
+            paymentToken: Self.paymentMint,
+            swapAmount: swapAmount,
+            feeAmount: feeAmount
+        )
+    }
+
+    @Test("Builds the 7-instruction treasury format in server order — no Initialize, Memo, or Close")
+    func instructionOrder() throws {
+        let instructions = try build()
+
+        #expect(instructions.count == 7)
+        #expect(instructions[0].program == SystemProgram.address)
+        #expect(instructions[1].program == ComputeBudgetProgram.address)
+        #expect(instructions[2].program == ComputeBudgetProgram.address)
+        #expect(instructions[3].program == AssociatedTokenProgram.address)
+        #expect(instructions[4].program == VMProgram.address)
+        #expect(instructions[5].program == CurrencyCreatorProgram.address)
+        #expect(instructions[6].program == CurrencyCreatorProgram.address)
+    }
+
+    @Test("The treasury's payment-mint ATA collects both the swap and the fee")
+    func transferLeg() throws {
+        let instructions = try build(swapAmount: 900, feeAmount: 100)
+
+        let treasuryAta = try AssociatedTokenProgram.CreateIdempotent(instruction: instructions[3])
+        #expect(treasuryAta.owner == Self.treasury)
+        #expect(treasuryAta.mint == Self.paymentMint.address)
+        #expect(treasuryAta.subsidizer == Self.payer)
+
+        let transfer = try VMProgram.TransferForSwapWithFee(instruction: instructions[4])
+        #expect(transfer.swapAmount == 900)
+        #expect(transfer.feeAmount == 100)
+        #expect(transfer.vmAuthority == Self.paymentMint.vmMetadata?.authority)
+        #expect(transfer.vm == Self.paymentMint.vmMetadata?.vm)
+        #expect(transfer.swapper == Self.authority)
+        #expect(transfer.swapDestination == treasuryAta.address)
+        #expect(transfer.feeDestination == treasuryAta.address)
+    }
+
+    @Test("SellTokens sells the full swap+fee from the treasury, proceeds to the fee destination")
+    func sellLeg() throws {
+        let instructions = try build(swapAmount: 900, feeAmount: 100)
+
+        let treasuryAta = try AssociatedTokenProgram.CreateIdempotent(instruction: instructions[3])
+        let sell = try CurrencyCreatorProgram.SellTokens(instruction: instructions[5])
+
+        #expect(sell.inAmount == 1_000)
+        #expect(sell.minAmountOut == 0)
+        #expect(sell.seller == Self.treasury)
+        #expect(sell.pool == Self.paymentMint.launchpadMetadata?.liquidityPool)
+        #expect(sell.targetMint == Self.paymentMint.address)
+        #expect(sell.baseMint == MintMetadata.usdf.address)
+        #expect(sell.vaultTarget == Self.paymentMint.launchpadMetadata?.mintVault)
+        #expect(sell.vaultBase == Self.paymentMint.launchpadMetadata?.coreMintVault)
+        #expect(sell.sellerTarget == treasuryAta.address)
+        #expect(sell.sellerBase == Self.feeDestination)
+    }
+
+    @Test("BuyTokens is treasury-funded with exactly the pre-coordinated core quarks")
+    func buyLeg() throws {
+        let instructions = try build()
+
+        let buy = try CurrencyCreatorProgram.BuyTokens(instruction: instructions[6])
+
+        #expect(buy.amount == 10_000_000)
+        #expect(buy.minOutAmount == 0)
+        #expect(buy.buyer == Self.treasury)
+        #expect(buy.baseMint == MintMetadata.usdf.address)
+
+        let treasuryCoreAta = try #require(PublicKey.deriveAssociatedAccount(
+            from: Self.treasury,
+            mint: MintMetadata.usdf.address
+        ))
+        #expect(buy.buyerBase == treasuryCoreAta.publicKey)
+    }
+
+    @Test("Server params parse the treasury fields when present, nil treasury when absent")
+    func paramsParseTreasury() throws {
+        var proto = Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveNewCurrencyServerParameter()
+        proto.payer = Self.payer.solanaAccountID
+        proto.nonce = Self.nonce.solanaAccountID
+        proto.blockhash = .with { $0.value = Data(repeating: 99, count: 32) }
+        proto.authority = Self.authority.solanaAccountID
+        proto.seed = Self.key(20).solanaAccountID
+        proto.feeDestination = Self.feeDestination.solanaAccountID
+        proto.treasury = Self.treasury.solanaAccountID
+        proto.treasuryPurchaseAmount = 10_000_000
+
+        let parsed = try #require(SwapResponseServerParameters.ReserveNewCurrency(proto))
+        #expect(parsed.treasury == Self.treasury)
+        #expect(parsed.treasuryPurchaseAmount == 10_000_000)
+
+        proto.clearTreasury()
+        let withoutTreasury = try #require(SwapResponseServerParameters.ReserveNewCurrency(proto))
+        #expect(withoutTreasury.treasury == nil)
+    }
+
+    @Test("Missing payment-mint metadata throws missingMintMetadata")
+    func missingMetadata_throws() {
+        let bare = MintMetadata(
+            address: Self.paymentMint.address,
+            decimals: 10,
+            name: "PAY",
+            symbol: "PAY",
+            description: "",
+            imageURL: nil,
+            vmMetadata: Self.paymentMint.vmMetadata,
+            launchpadMetadata: nil
+        )
+
+        #expect(throws: SwapTransactionBuildError.missingMintMetadata(symbol: "PAY")) {
+            try SwapInstructionBuilder.newCurrencyLaunchTreasuryFunded(
+                serverParams: Self.makeServerParams(),
+                treasury: Self.treasury,
+                treasuryPurchaseAmount: 10_000_000,
+                authority: Self.authority,
+                paymentToken: bare,
+                swapAmount: 900,
+                feeAmount: 100
+            )
+        }
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/VerifiedExchangeDataBuildTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/VerifiedExchangeDataBuildTests.swift
@@ -1,0 +1,61 @@
+//
+//  VerifiedExchangeDataBuildTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+import FlipcashAPI
+@testable import FlipcashCore
+
+@Suite("VerifiedExchangeData builder")
+struct VerifiedExchangeDataBuildTests {
+
+    @Test("Encodes mint, quarks, native, rate, and reserve proof")
+    func encodesAllFields() {
+        let pin = VerifiedState(
+            rateProto: .makeTest(currencyCode: "USD", rate: 1.0),
+            reserveProto: .makeTest(mint: .jeffy, supplyFromBonding: 50_000 * 10_000_000_000)
+        )
+        let amount = ExchangedFiat.compute(
+            onChainAmount: TokenAmount(quarks: 2_000 * 10_000_000_000, mint: .jeffy),
+            rate: pin.rate,
+            supplyQuarks: pin.supplyFromBonding
+        )
+
+        let proto = Ocp_Transaction_V1_VerifiedExchangeData(amount: amount, verifiedState: pin)
+
+        #expect(proto.quarks == amount.onChainAmount.quarks)
+        #expect(proto.nativeAmount == amount.nativeAmount.doubleValue)
+        #expect(proto.mint == amount.mint.solanaAccountID)
+        #expect(proto.hasLaunchpadCurrencyReserveState)
+    }
+
+    @Test("Omits reserve proof for the core-mint path")
+    func omitsReserveForCoreMint() {
+        let pin = VerifiedState(rateProto: .makeTest(currencyCode: "USD", rate: 1.0))
+        let amount = ExchangedFiat(nativeAmount: .usd(20), rate: pin.rate)
+
+        let proto = Ocp_Transaction_V1_VerifiedExchangeData(amount: amount, verifiedState: pin)
+
+        #expect(!proto.hasLaunchpadCurrencyReserveState)
+    }
+}
+
+private extension Ocp_Currency_V1_VerifiedCoreMintFiatExchangeRate {
+    static func makeTest(currencyCode: String, rate: Double) -> Self {
+        var proto = Self()
+        proto.exchangeRate.currencyCode = currencyCode
+        proto.exchangeRate.exchangeRate = rate
+        return proto
+    }
+}
+
+private extension Ocp_Currency_V1_VerifiedLaunchpadCurrencyReserveState {
+    static func makeTest(mint: PublicKey, supplyFromBonding: UInt64 = 0) -> Self {
+        var proto = Self()
+        proto.reserveState.mint = mint.solanaAccountID
+        proto.reserveState.supplyFromBonding = supplyFromBonding
+        return proto
+    }
+}

--- a/FlipcashTests/AddMoneyGateTests.swift
+++ b/FlipcashTests/AddMoneyGateTests.swift
@@ -58,6 +58,70 @@ struct AddMoneyGateTests {
         #expect(shouldAddMoneyBeforeLaunch(session: session, launchCost: launchCost) == false)
     }
 
+    /// A launchpad `StoredBalance` whose curve sell value covers/undershoots the cost.
+    /// Supply ≈ 50k tokens; ~2000 tokens ≈ $20 of curve value (matches the buy tests).
+    private func makeLaunchpadBalance(quarks: UInt64) throws -> StoredBalance {
+        try StoredBalance(
+            quarks: quarks,
+            symbol: "JEFFY",
+            name: "Jeffy",
+            supplyFromBonding: 50_000 * 10_000_000_000,
+            sellFeeBps: 100,
+            mint: .jeffy,
+            vmAuthority: nil,
+            updatedAt: Date(),
+            imageURL: nil,
+            costBasis: 0
+        )
+    }
+
+    @Test("Launch proceeds when a launchpad currency covers the cost")
+    func launch_launchpadCovers_proceeds() throws {
+        let session = MockSession()
+        session.extraBalances = [try makeLaunchpadBalance(quarks: 3_000 * 10_000_000_000)]
+        #expect(shouldAddMoneyBeforeLaunch(session: session, launchCost: launchCost) == false)
+    }
+
+    @Test("Launch adds money when the only launchpad balance is short")
+    func launch_launchpadShort_addsMoney() throws {
+        let session = MockSession()
+        session.extraBalances = [try makeLaunchpadBalance(quarks: 100 * 10_000_000_000)]
+        #expect(shouldAddMoneyBeforeLaunch(session: session, launchCost: launchCost) == true)
+    }
+
+    @Test("USDF eligibility is exact — a dust-short balance can't pay")
+    func launch_usdfDustShort_addsMoney() throws {
+        let session = MockSession()
+        session.usdfReserveBalance = try makeUSDFBalance(quarks: 19_999_999) // $19.999999
+        #expect(shouldAddMoneyBeforeLaunch(session: session, launchCost: launchCost) == true)
+    }
+
+    @Test("A launchpad balance that displays $20.00 can pay; one displaying $19.99 cannot")
+    func launch_boundaryDisplays() throws {
+        let supply: UInt64 = 50_000 * 10_000_000_000
+
+        // $19.996 raw rounds to a displayed $20.00 — inside the server's
+        // ±half-cent acceptance window, so the row must be payable.
+        let displaysTwenty = try #require(ExchangedFiat.compute(
+            fromEntered: .usd(Decimal(string: "19.996")!),
+            rate: .oneToOne, mint: .jeffy, supplyQuarks: supply
+        ))
+        #expect(canPayLaunchCost(
+            try makeLaunchpadBalance(quarks: displaysTwenty.onChainAmount.quarks),
+            launchCost: launchCost
+        ) == true)
+
+        // $19.99 raw displays as $19.99 — short, and outside the window.
+        let displaysShort = try #require(ExchangedFiat.compute(
+            fromEntered: .usd(Decimal(string: "19.99")!),
+            rate: .oneToOne, mint: .jeffy, supplyQuarks: supply
+        ))
+        #expect(canPayLaunchCost(
+            try makeLaunchpadBalance(quarks: displaysShort.onChainAmount.quarks),
+            launchCost: launchCost
+        ) == false)
+    }
+
     // MARK: - Give / send cash
 
     @Test("Give gate proceeds when a community currency is on hand")

--- a/FlipcashTests/CurrencyCreation/CurrencyPaymentSelectionViewModelTests.swift
+++ b/FlipcashTests/CurrencyCreation/CurrencyPaymentSelectionViewModelTests.swift
@@ -1,0 +1,92 @@
+//
+//  CurrencyPaymentSelectionViewModelTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+@testable import Flipcash
+
+@Suite("CurrencyPaymentSelectionViewModel")
+@MainActor
+struct CurrencyPaymentSelectionViewModelTests {
+
+    private static let jeffySupply: UInt64 = 50_000 * 10_000_000_000
+
+    /// $20 launch cost — the default new-currency total.
+    private static let launchCost = TokenAmount(quarks: 20_000_000, mint: .usdf)
+
+    private static func makeContainer(
+        holdings: [SessionContainer.Holding],
+        currency: CurrencyCode = .usd,
+        fx: Double = 1.0
+    ) throws -> SessionContainer {
+        let container = try SessionContainer.makeTest(holdings: holdings)
+        container.ratesController.configureTestRates(
+            balanceCurrency: currency,
+            rates: [Rate(fx: Decimal(fx), currency: currency)]
+        )
+        return container
+    }
+
+    private static func makeViewModel(container: SessionContainer, displayRate: Rate? = nil) -> CurrencyPaymentSelectionViewModel {
+        CurrencyPaymentSelectionViewModel(
+            launchCost: launchCost,
+            displayRate: displayRate,
+            session: container.session,
+            ratesController: container.ratesController
+        )
+    }
+
+    @Test("Zero-value balances are hidden from the list")
+    func hidesZeroBalances() throws {
+        let container = try Self.makeContainer(holdings: [
+            .init(mint: .usdf, quarks: 30_000_000),
+            .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: 0),
+        ])
+        let viewModel = Self.makeViewModel(container: container)
+
+        #expect(viewModel.rows.contains { $0.stored.mint == .usdf })
+        #expect(!viewModel.rows.contains { $0.stored.mint == .jeffy })
+    }
+
+    @Test("Row eligibility tracks the launch cost", arguments: [
+        (quarks: UInt64(5_000_000), eligible: false),  // $5 — below $20
+        (quarks: UInt64(30_000_000), eligible: true),  // $30 — covers $20
+    ])
+    func eligibilityTracksCost(quarks: UInt64, eligible: Bool) throws {
+        let container = try Self.makeContainer(holdings: [.init(mint: .usdf, quarks: quarks)])
+        let viewModel = Self.makeViewModel(container: container)
+        let usdf = try #require(viewModel.rows.first { $0.stored.mint == .usdf })
+
+        #expect(viewModel.isEligible(usdf) == eligible)
+    }
+
+    @Test("A fixed display rate overrides the user's balance currency")
+    func fixedDisplayRateOverridesBalanceCurrency() throws {
+        let container = try Self.makeContainer(
+            holdings: [.init(mint: .usdf, quarks: 30_000_000)],
+            currency: .cad,
+            fx: 1.37
+        )
+        let viewModel = Self.makeViewModel(container: container, displayRate: .oneToOne)
+        let usdf = try #require(viewModel.rows.first { $0.stored.mint == .usdf })
+
+        #expect(usdf.exchangedFiat.nativeAmount.currency == .usd)
+        #expect(usdf.exchangedFiat.nativeAmount.value == 30)
+    }
+
+    @Test("Selecting an eligible row raises the Ready To Create dialog")
+    func eligibleSelectionRaisesDialog() throws {
+        let container = try Self.makeContainer(holdings: [.init(mint: .usdf, quarks: 30_000_000)])
+        let viewModel = Self.makeViewModel(container: container)
+        let usdf = try #require(viewModel.rows.first { $0.stored.mint == .usdf })
+
+        var confirmed: StoredBalance?
+        viewModel.select(usdf) { confirmed = $0 }
+
+        #expect(viewModel.dialogItem != nil)
+        #expect(confirmed == nil) // fires only on the dialog's confirm action
+    }
+}

--- a/FlipcashTests/CurrencyLaunchProcessingViewModelTests.swift
+++ b/FlipcashTests/CurrencyLaunchProcessingViewModelTests.swift
@@ -18,7 +18,8 @@ struct CurrencyLaunchProcessingViewModelTests {
             swapId: .generate(),
             launchedMint: .usdf,
             currencyName: currencyName,
-            launchAmount: ExchangedFiat.mockOne
+            launchAmount: ExchangedFiat.mockOne,
+            paymentMint: .usdf
         )
     }
 

--- a/FlipcashTests/TestSupport/MockSession.swift
+++ b/FlipcashTests/TestSupport/MockSession.swift
@@ -12,6 +12,7 @@ import FlipcashCore
 @MainActor
 final class MockSession:
     GiveBalanceReading,
+    LaunchBalanceReading,
     AccountProviding,
     ProfileProviding,
     ProfileManaging,
@@ -171,6 +172,10 @@ final class MockSession:
 
     var usdfReserveBalance: StoredBalance?
 
+    /// Non-USDF balances the launch gate should also weigh. The USDF reserve, if
+    /// set, is included automatically in `balances`.
+    var extraBalances: [StoredBalance] = []
+
     var giveableBalanceExists = false
 
     func hasGiveableBalance(for rate: Rate) -> Bool {
@@ -178,7 +183,11 @@ final class MockSession:
     }
 
     func balance(for mint: PublicKey) -> StoredBalance? {
-        mint == .usdf ? usdfReserveBalance : nil
+        mint == .usdf ? usdfReserveBalance : extraBalances.first { $0.mint == mint }
+    }
+
+    var balances: [StoredBalance] {
+        (usdfReserveBalance.map { [$0] } ?? []) + extraBalances
     }
 }
 


### PR DESCRIPTION
Adds a payment step to the create-currency flow: the launch cost can be paid with USDF or any launchpad currency the user holds.

- Get Started unlocks when any single balance covers the server-driven launch cost, and routes to Add Money otherwise
- New Select Payment Currency step lists balances in USD to match the flow's pricing; under-cost rows are disabled and zero-value balances are hidden
- Ready To Create confirmation before paying; the confirmed row shows an inline loader while the launch submits
- Launchpad payments build the treasury-funded launch transaction the server expects, validating the treasury's spend against the amount the user accepted; the pool's sell fee is absorbed so the user pays exactly the launch cost
- The swap and fee legs are valued at the exact USD components against the pinned reserve proof, and eligibility mirrors the server's acceptance window so a balance displaying \$20.00 can always pay
- Purchase and launch analytics now carry the purchased or launched currency alongside the new Payment Mint property; purchase events previously reported only the payment side

Test plan:
- [x] Create a currency paying with USDF
- [x] Create a currency paying with another currency
- [x] Under-cost rows are greyed out and not tappable; picker shows USD values
- [x] Get Started routes to Add Money when no balance can pay
- [x] Purchase and launch events carry Mint and Payment Mint