### PR TITLE
fix: rate error when paying with a low-value currency

### DIFF
--- a/Flipcash/UI/ExchangedBalance+EnteredFiat.swift
+++ b/Flipcash/UI/ExchangedBalance+EnteredFiat.swift
@@ -10,10 +10,11 @@ extension ExchangedBalance {
 
     /// Prices a user-entered fiat `amount` against this balance for amount-entry
     /// screens. USDF maps straight through; a bonded mint resolves via the bonding
-    /// curve. When the curve cannot price the request (entered value exceeds the
-    /// curve's TVL), returns a synthetic over-balance value whose `onChainAmount`
-    /// is a sentinel (`quarks + 1`) so `Session.hasSufficientFunds` reports
-    /// `.insufficient` with a real shortfall — this value is never transported.
+    /// curve. When the entered value exceeds the curve's TVL (the compute clamps
+    /// to the full supply), returns a synthetic over-balance value whose
+    /// `onChainAmount` is a sentinel (`quarks + 1`) so the entered amount stays
+    /// on screen and `Session.hasSufficientFunds` reports `.insufficient` with a
+    /// real shortfall — this value is never transported.
     /// Returns nil for a non-positive amount or a bonded mint with no supply.
     func enteredFiat(for amount: Decimal, rate: Rate) -> ExchangedFiat? {
         guard amount > 0 else { return nil }
@@ -32,7 +33,7 @@ extension ExchangedBalance {
             rate: rate,
             mint: mint,
             supplyQuarks: supplyQuarks
-        ) {
+        ), priced.onChainAmount.quarks < supplyQuarks {
             return priced
         }
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/ExchangedFiat.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/ExchangedFiat.swift
@@ -125,7 +125,9 @@ public struct ExchangedFiat: Equatable, Hashable, Codable, Sendable {
         )
     }
 
-    /// Build an `ExchangedFiat` from a user-entered fiat amount.
+    /// Build an `ExchangedFiat` from a user-entered fiat amount. A bonded
+    /// request worth more than the curve's TVL clamps to the maximum
+    /// extractable quote (the full supply) rather than failing.
     ///
     /// - Parameters:
     ///   - amount: User-entered fiat amount (in `rate.currency`).
@@ -175,7 +177,18 @@ public struct ExchangedFiat: Equatable, Hashable, Codable, Sendable {
             fiat: BigDecimal(cappedNative.value),
             fiatRate: BigDecimal(rate.fx),
             supplyQuarks: Int(supplyQuarks),
-        ) else { return nil }
+        ) else {
+            // The curve refuses a request worth more than its TVL. Clamp to
+            // the maximum extractable quote — the entire supply (or the token
+            // balance cap) — so an over-ask surfaces as insufficient balance
+            // downstream instead of failing outright.
+            guard cappedUSD.isPositive, supplyQuarks > 0 else { return nil }
+            return compute(
+                onChainAmount: TokenAmount(quarks: min(supplyQuarks, tokenBalanceQuarks ?? supplyQuarks), mint: mint),
+                rate: rate,
+                supplyQuarks: supplyQuarks,
+            )
+        }
 
         let tokenQuarks = valuation.tokens.asDecimal().scaleUpInt(mint.mintDecimals)
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/ExchangedFiatTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ExchangedFiatTests.swift
@@ -259,7 +259,7 @@ struct ExchangedFiatTests {
             let currentTVL = curve.tokensToValue(currentSupply: 0, tokens: Int(supplyTokens))?.asDecimal()
 
             for fiat in fiatToTest {
-                let shouldSucceed = currentTVL.map { fiat <= $0 } ?? false
+                let withinTVL = currentTVL.map { fiat <= $0 } ?? false
                 let exchanged = ExchangedFiat.compute(
                     fromEntered: FiatAmount(value: fiat, currency: .usd),
                     rate: .oneToOne,
@@ -267,12 +267,16 @@ struct ExchangedFiatTests {
                     supplyQuarks: supplyQuarks
                 )
 
-                if shouldSucceed {
-                    #expect(exchanged != nil, "Expected exchange to succeed for \(fiat) at supply \(supplyTokens)")
-                }
+                #expect(exchanged != nil, "Expected exchange to succeed for \(fiat) at supply \(supplyTokens)")
 
-                guard let exchanged else {
-                    continue // Skip if amount exceeds what's available
+                guard let exchanged else { continue }
+
+                guard withinTVL else {
+                    // Beyond the TVL the quote clamps to the full supply; it
+                    // can't join the constant-usdfValue checks below.
+                    #expect(exchanged.onChainAmount.quarks == supplyQuarks,
+                           "Over-TVL entry should clamp to the full supply at \(supplyTokens) tokens")
+                    continue
                 }
 
                 results.append((
@@ -487,6 +491,47 @@ struct ExchangedFiatComputeFromEnteredTests {
 
         #expect(result != nil)
         #expect(result?.onChainAmount.quarks == balanceQuarks)
+    }
+
+    @Test("Entered value beyond the curve TVL clamps to the full supply")
+    func overTVLClampsToFullSupply() throws {
+        // A 1000-token curve holds ≈ $10 of value; $50 cannot be extracted.
+        let curve = DiscreteBondingCurve()
+        let tvl = try #require(curve.tokensToValue(currentSupply: 0, tokens: 1000)?.asDecimal())
+        #expect(tvl < 50, "Test premise: the curve's TVL must be below the entered value")
+
+        let result = try #require(ExchangedFiat.compute(
+            fromEntered: FiatAmount.usd(50),
+            rate: .oneToOne,
+            mint: testMint,
+            supplyQuarks: testSupplyQuarks
+        ))
+
+        #expect(result.onChainAmount.quarks == testSupplyQuarks)
+        // The quote's value is the TVL, matching compute(onChainAmount:) for
+        // the full supply — server-consistent, not the unpriceable $50.
+        let fullSupply = ExchangedFiat.compute(
+            onChainAmount: TokenAmount(quarks: testSupplyQuarks, mint: testMint),
+            rate: .oneToOne,
+            supplyQuarks: testSupplyQuarks
+        )
+        #expect(result.nativeAmount.value == fullSupply.nativeAmount.value)
+        #expect(result.nativeAmount.value < 50)
+    }
+
+    @Test("Over-TVL clamp still respects the token balance cap")
+    func overTVLRespectsTokenBalanceCap() throws {
+        let balanceQuarks: UInt64 = 999 * Self.quarksPerToken // holder of 999 of 1000 tokens
+
+        let result = try #require(ExchangedFiat.compute(
+            fromEntered: FiatAmount.usd(50),
+            rate: .oneToOne,
+            mint: testMint,
+            supplyQuarks: testSupplyQuarks,
+            tokenBalanceQuarks: balanceQuarks
+        ))
+
+        #expect(result.onChainAmount.quarks == balanceQuarks)
     }
 }
 

--- a/FlipcashTests/Buy/BuyPaymentCurrencyViewModelTests.swift
+++ b/FlipcashTests/Buy/BuyPaymentCurrencyViewModelTests.swift
@@ -14,11 +14,14 @@ struct BuyPaymentCurrencyViewModelTests {
 
     private static let jeffySupply: UInt64 = 50_000 * 10_000_000_000
     private static let jeffyQuarks: UInt64 = 2_000 * 10_000_000_000 // ≈ $20 of curve value
+    /// A freshly launched currency: the creator holds the entire ≈ $10 curve.
+    private static let soleHolderSupply: UInt64 = 9_996_054_730_448
 
     private static func makeContainer(
         holdings: [SessionContainer.Holding],
         currency: CurrencyCode = .usd,
-        fx: Double = 1.0
+        fx: Double = 1.0,
+        jeffySupply: UInt64 = jeffySupply
     ) async throws -> SessionContainer {
         let container = try SessionContainer.makeTest(holdings: holdings)
 
@@ -198,6 +201,53 @@ struct BuyPaymentCurrencyViewModelTests {
         // that overshoot is what drives the insufficient-after-fees sheet.
         #expect(amount.onChainAmount.quarks > jeffyBalance.quarks)
         #expect(amount.mint == .jeffy)
+    }
+
+    /// Regression (2026-07-20 log): paying with a freshly created currency the
+    /// user wholly owns. The entered value exceeds the curve's entire TVL, so
+    /// the uncapped compute used to fail and select() dead-ended in a
+    /// "Rate Unavailable" dialog the user could never escape.
+    @Test("Token payment beyond the curve TVL clamps instead of failing")
+    func tokenCompute_overTVL_returnsClampedQuote() async throws {
+        let container = try await Self.makeContainer(
+            holdings: [
+                .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.soleHolderSupply), quarks: Self.soleHolderSupply),
+            ],
+            currency: .cad,
+            fx: 1.37,
+            jeffySupply: Self.soleHolderSupply
+        )
+        let viewModel = Self.makeViewModel(entered: 50, currency: .cad, container: container)
+        let jeffyBalance = try #require(container.session.balance(for: .jeffy))
+        let pin = try #require(await container.ratesController.currentPinnedState(for: .cad, mint: .jeffy))
+
+        let amount = try #require(viewModel.computePaymentAmount(for: jeffyBalance, pin: pin))
+
+        // The maximum extractable quote: the whole curve, i.e. the whole balance.
+        #expect(amount.onChainAmount.quarks == jeffyBalance.quarks)
+        #expect(amount.mint == .jeffy)
+    }
+
+    @Test("Selecting a source worth less than the entered value still reaches the confirmation")
+    func select_overTVL_pushesConfirmation() async throws {
+        let container = try await Self.makeContainer(
+            holdings: [
+                .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.soleHolderSupply), quarks: Self.soleHolderSupply),
+            ],
+            currency: .cad,
+            fx: 1.37,
+            jeffySupply: Self.soleHolderSupply
+        )
+        let viewModel = Self.makeViewModel(entered: 50, currency: .cad, container: container)
+        let router = AppRouter()
+        router.present(.balance)
+        router.presentNested(.buy(.usdcAuthority))
+
+        let jeffyRow = try #require(viewModel.rows.first { $0.stored.mint == .jeffy })
+        await viewModel.select(jeffyRow, router: router)
+
+        #expect(router[.buy].count == 1)
+        #expect(viewModel.dialogItem == nil)
     }
 
     @Test("A pin without reserve supply fails the token compute")

--- a/FlipcashTests/ExchangedBalanceEnteredFiatTests.swift
+++ b/FlipcashTests/ExchangedBalanceEnteredFiatTests.swift
@@ -51,4 +51,19 @@ struct ExchangedBalanceEnteredFiatTests {
         let fiat = try #require(balance.enteredFiat(for: 1_000_000_000_000_000, rate: .oneToOne))
         #expect(fiat.onChainAmount.quarks == balance.stored.quarks + 1)
     }
+
+    @Test("Sole holder entering beyond the TVL still gets the sentinel")
+    func bonded_soleHolderBeyondTVL_returnsSentinel() throws {
+        // The creator owns the entire ≈ $10 curve; a $50 entry must stay an
+        // over-balance sentinel so the funds gate reports a real shortfall.
+        let supplyQuarks: UInt64 = 9_996_054_730_448
+        let balance = ExchangedBalance.makeTest(
+            mint: .jeffy,
+            quarks: supplyQuarks,
+            supplyQuarks: supplyQuarks
+        )
+        let fiat = try #require(balance.enteredFiat(for: 50, rate: .oneToOne))
+        #expect(fiat.onChainAmount.quarks == balance.stored.quarks + 1)
+        #expect(fiat.nativeAmount.value == 50)
+    }
 }


### PR DESCRIPTION
Paying for a currency with another currency the user barely holds — most commonly one they just created — always failed with "Rate Unavailable", even though rates were fine. The entered amount exceeded the total value of the payment currency's bonding curve, the curve math refused to quote it, and the buy flow misread that refusal as a rate problem. Retrying could never help.

- The quote computation now clamps an over-ask to the maximum the curve can provide, so the flow reaches the confirmation where the existing insufficient-balance sheet offers Buy Maximum Amount, as designed
- The clamp still respects the token balance cap, and zero or missing supply still fails as before
- Give and Send previews keep their existing behavior: the entered amount stays on screen and the shortfall is reported against the real balance
- Regression tests reproduce the trap end to end: a sole-holder currency worth ~$10, $50 entered, selection must reach the confirmation instead of the dialog

Test plan:
- [x] Create a currency, then buy another currency paying with it, entering more than it's worth — confirmation offers Buy Maximum Amount instead of "Rate Unavailable"
- [x] Buy Maximum from that sheet completes the swap
- [x] Give/Send with an amount above a currency's value still shows the insufficient sheet with the entered amount
- [x] FlipcashTests + FlipcashCoreTests pass