### PR TITLE
fix: polish the buy confirmation and bill creator steps

### DIFF
--- a/Flipcash/Core/Screens/Main/Buy/BuyConfirmationScreen.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyConfirmationScreen.swift
@@ -33,10 +33,10 @@ struct BuyConfirmationScreen: View {
                 BorderedContainer {
                     VStack(spacing: 0) {
                         ConfirmationAmountRow(
-                            title: "You Pay",
-                            currencyName: viewModel.payment.name,
-                            imageURL: viewModel.payment.imageURL,
-                            amount: viewModel.paymentAmount.nativeAmount.formatted()
+                            title: "You Receive",
+                            currencyName: viewModel.targetName,
+                            imageURL: viewModel.targetImageURL,
+                            amount: viewModel.amountToBuy.nativeAmount.formatted()
                         )
                         .padding(.top, 24)
 
@@ -55,10 +55,10 @@ struct BuyConfirmationScreen: View {
                         }
 
                         ConfirmationAmountRow(
-                            title: "You Receive",
-                            currencyName: viewModel.targetName,
-                            imageURL: viewModel.targetImageURL,
-                            amount: viewModel.amountToBuy.nativeAmount.formatted()
+                            title: "You Pay",
+                            currencyName: viewModel.payment.name,
+                            imageURL: viewModel.payment.imageURL,
+                            amount: viewModel.paymentAmount.nativeAmount.formatted()
                         )
                         .padding(.top, viewModel.isUSDF ? 24 : 0)
                         .padding(.bottom, 24)
@@ -96,6 +96,13 @@ struct BuyConfirmationScreen: View {
         .navigationBarBackButtonHidden(viewModel.actionButtonState == .loading)
         .dialog(item: $viewModel.dialogItem)
         .task { await viewModel.loadTargetImage(session: session) }
+        .task {
+            // A sheet presented mid-push is swallowed by the transition — let
+            // the push land before offering Buy Maximum.
+            try? await Task.sleep(for: .seconds(0.35))
+            guard !Task.isCancelled else { return }
+            viewModel.presentInsufficientBalanceIfNeeded(session: session)
+        }
     }
 
     // MARK: - Actions -

--- a/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
@@ -25,6 +25,8 @@ final class BuyConfirmationViewModel {
     /// Icon for the You Receive row, resolved from cached mint metadata.
     private(set) var targetImageURL: URL?
 
+    @ObservationIgnored private var hasCheckedFundsOnAppear = false
+
     var isUSDF: Bool { payment.mint == .usdf }
 
     var canPerformAction: Bool { !pinnedState.isStale }
@@ -58,6 +60,25 @@ final class BuyConfirmationViewModel {
 
     func loadTargetImage(session: Session) async {
         targetImageURL = try? await session.fetchMintMetadata(mint: targetMint).imageURL
+    }
+
+    /// Surfaces the insufficient-balance sheet when the amount pushed onto this
+    /// screen already exceeds the payment balance, at most once per screen.
+    func presentInsufficientBalanceIfNeeded(session: Session) {
+        guard !hasCheckedFundsOnAppear else { return }
+        hasCheckedFundsOnAppear = true
+
+        switch session.hasSufficientFunds(for: paymentAmount) {
+        case .sufficient:
+            break
+        case .insufficient:
+            logger.info("Buy gated on appear: insufficient balance", metadata: [
+                "paymentMint": "\(payment.mint.base58)",
+                "amountQuarks": "\(paymentAmount.onChainAmount.quarks)",
+                "balanceQuarks": "\(session.balance(for: payment.mint)?.quarks ?? 0)",
+            ])
+            showInsufficientBalance(session: session)
+        }
     }
 
     func buyAction(session: Session, router: AppRouter) async {

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -229,7 +229,8 @@ struct CurrencyCreationWizardScreen: View {
             }
             if step == .billCreation {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done", action: advance)
+                    Button("Next", action: advance)
+                        .prominentButtonStyle()
                 }
             }
         }

--- a/FlipcashTests/Buy/BuyConfirmationViewModelTests.swift
+++ b/FlipcashTests/Buy/BuyConfirmationViewModelTests.swift
@@ -142,6 +142,49 @@ struct BuyConfirmationViewModelTests {
         }
     }
 
+    // MARK: - Appear-time gate
+
+    @Test("Landing on the confirmation with an underfunded amount surfaces the sheet without a Buy tap")
+    func appearGate_underfunded_showsSheet() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: Self.jeffyQuarks),
+        ])
+        let rate = container.ratesController.rateForBalanceCurrency()
+        let jeffyBalance = try #require(container.session.balance(for: .jeffy))
+        let displayed = jeffyBalance.computeExchangedValue(with: rate)
+            .nativeAmount.value.rounded(to: CurrencyCode.usd.maximumFractionDigits)
+        let pin = try #require(await container.ratesController.currentPinnedState(for: .usd, mint: .jeffy))
+        let paymentAmount = try Self.makePaymentAmount(entered: displayed, balance: jeffyBalance, pin: pin, container: container)
+
+        let viewModel = Self.makeViewModel(payment: jeffyBalance, paymentAmount: paymentAmount, pin: pin)
+
+        viewModel.presentInsufficientBalanceIfNeeded(session: container.session)
+
+        #expect(viewModel.dialogItem?.title == "Insufficient Balance After Fees")
+
+        // Dismissing must not let the next appear re-present it — the Buy tap
+        // is the only thing that fires the gate again.
+        viewModel.dialogItem = nil
+        viewModel.presentInsufficientBalanceIfNeeded(session: container.session)
+        #expect(viewModel.dialogItem == nil)
+    }
+
+    @Test("Landing on the confirmation with a covered amount surfaces nothing")
+    func appearGate_funded_staysSilent() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .usdf, quarks: 30_000_000),
+        ])
+        let usdfBalance = try #require(container.session.balance(for: .usdf))
+        let pin = try #require(await container.ratesController.currentPinnedState(for: .usd, mint: .usdf))
+        let paymentAmount = try Self.makePaymentAmount(entered: 10, balance: usdfBalance, pin: pin, container: container)
+
+        let viewModel = Self.makeViewModel(payment: usdfBalance, paymentAmount: paymentAmount, pin: pin)
+
+        viewModel.presentInsufficientBalanceIfNeeded(session: container.session)
+
+        #expect(viewModel.dialogItem == nil)
+    }
+
     // MARK: - USDF variant
 
     @Test("USDF payments show no fee and amountToBuy equals the payment")

--- a/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/LiquidGlassCompatibleButtonStyle.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/LiquidGlassCompatibleButtonStyle.swift
@@ -44,6 +44,20 @@ extension View {
             self.buttonStyle(LiquidGlassCompatibleButtonStyle(shape: shape))
         }
     }
+
+    /// Applies Apple's prominent button style — `.glassProminent` on iOS 26+,
+    /// `.borderedProminent` on earlier versions.
+    /// The app tints everything white, which a prominent style takes as its fill —
+    /// opting back out to the system accent has to name the colour, because
+    /// `.tint(nil)` resolves to the white `AccentColor` asset and drops the fill.
+    @ViewBuilder
+    public func prominentButtonStyle() -> some View {
+        if #available(iOS 26, *) {
+            self.buttonStyle(.glassProminent).tint(Color.blue)
+        } else {
+            self.buttonStyle(.borderedProminent).tint(Color.blue)
+        }
+    }
 }
 
 struct LiquidGlassCompatibleButtonStyle: ButtonStyle {


### PR DESCRIPTION
Three small polish fixes.

**Buy**

- The purchase summary now leads with **You Receive** and puts **You Pay** underneath, so the summary opens with what you get. The fee breakdown stays between them.
- If the amount you're about to pay already exceeds your balance, the insufficient-balance sheet now appears when you land on the summary instead of waiting for you to tap Buy. It offers Buy Maximum, same as before. Tapping Buy still re-checks, so dismissing the sheet doesn't get you past the gate.

**Create currency**

- The bill creator's **Done** is now **Next**, and prominent. It was never the last step — two more follow, and the progress bar next to it reads 4/5.

The prominent style is new to the app, so it lives in FlipcashUI next to the existing glass wrapper: `.glassProminent` on iOS 26+, `.borderedProminent` below. Both name their tint explicitly — the app tints everything white, and a prominent style inherits that as its fill, which renders a white label on a white fill on iOS 18. Verified on both an iOS 18.6 and an iOS 26.5 simulator.

**Test plan**

- [x] Buy a currency with another currency — summary reads You Receive, then the fee breakdown, then You Pay
- [x] Buy with USDF — no fee breakdown, both rows still in the new order
- [x] Pick a payment currency you can't fully afford — the sheet appears on landing, before tapping Buy
- [x] Dismiss that sheet and tap Buy — the sheet comes back
- [x] Take Buy Maximum from the sheet — the amounts recompute and Buy goes through
- [x] Create a currency, reach Cash Design — the toolbar button reads Next and is prominent
- [ ] Check the Next button on an iOS 18 device or simulator — legible, not white-on-white