### PR TITLE
fix: make the Next button label white

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -229,8 +229,11 @@ struct CurrencyCreationWizardScreen: View {
             }
             if step == .billCreation {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("Next", action: advance)
-                        .prominentButtonStyle()
+                    Button(action: advance) {
+                        Text("Next")
+                            .foregroundStyle(.white)
+                    }
+                    .prominentButtonStyle()
                 }
             }
         }

--- a/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/LiquidGlassCompatibleButtonStyle.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/LiquidGlassCompatibleButtonStyle.swift
@@ -50,6 +50,9 @@ extension View {
     /// The app tints everything white, which a prominent style takes as its fill —
     /// opting back out to the system accent has to name the colour, because
     /// `.tint(nil)` resolves to the white `AccentColor` asset and drops the fill.
+    /// The label colour cannot be set here — a prominent style applies its own
+    /// foreground inside the style, so it overrides anything set on the button.
+    /// Colour the label's content instead.
     @ViewBuilder
     public func prominentButtonStyle() -> some View {
         if #available(iOS 26, *) {


### PR DESCRIPTION
The Next button in the currency creation wizard uses a prominent glass style tinted blue, but its label rendered black.

A prominent button style applies its own foreground colour inside the style, so a colour set on the button loses to it. The colour now sits on the label's content, where it wins. Added a note on the shared helper so the dead end isn't retried there.

## Test plan
- [x] Create a currency and advance to the bill creation step
- [x] The Next button reads white on blue