### PR TITLE
chore: sync protos and scope the DM feed by chat type

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -416,7 +416,7 @@ final class ConversationController {
         isLoadingFeed = true
         defer { isLoadingFeed = false }
         do {
-            let conversations = try await fetching.getDmChatFeed(owner: owner)
+            let conversations = try await fetching.getDmChatFeed(owner: owner, type: .contactDm)
             store.setFeed(conversations)
             persist(operation: "replace-feed") { try database.replaceConversationFeed(store.conversations) }
         } catch {

--- a/Flipcash/Core/Controllers/FlipClient+Protocols.swift
+++ b/Flipcash/Core/Controllers/FlipClient+Protocols.swift
@@ -61,7 +61,7 @@ protocol ContactSyncing: AnyObject, Sendable {
 /// DM conversation read surface used by `ConversationController` — the feed plus a
 /// single conversation by id. Maps 1:1 to the `flipcash.chat.v1.Chat` RPCs.
 protocol ConversationFetching: AnyObject, Sendable {
-    func getDmChatFeed(owner: KeyPair) async throws -> [Conversation]
+    func getDmChatFeed(owner: KeyPair, type: ConversationType) async throws -> [Conversation]
     func getChat(owner: KeyPair, conversationID: ConversationID) async throws -> Conversation
 }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/chat_v1_chat_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/chat_v1_chat_service.pb.swift
@@ -134,6 +134,11 @@ public struct Flipcash_Chat_V1_GetDmChatFeedRequest: Sendable {
   /// Clears the value of `queryOptions`. Subsequent reads from it will return its default value.
   public mutating func clearQueryOptions() {self._queryOptions = nil}
 
+  /// The type of DM chat to filter for
+  ///
+  /// For backwards compatiblity, UNKNOWN maps to CONTACT_DM for legacy clients
+  public var dmChatType: Flipcash_Chat_V1_ChatType = .unknown
+
   public var auth: Flipcash_Common_V1_Auth {
     get {_auth ?? Flipcash_Common_V1_Auth()}
     set {_auth = newValue}
@@ -314,7 +319,7 @@ extension Flipcash_Chat_V1_GetChatResponse.Result: SwiftProtobuf._ProtoNameProvi
 
 extension Flipcash_Chat_V1_GetDmChatFeedRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetDmChatFeedRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}query_options\0\u{2}\u{9}auth\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}query_options\0\u{3}dm_chat_type\0\u{2}\u{8}auth\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -323,6 +328,7 @@ extension Flipcash_Chat_V1_GetDmChatFeedRequest: SwiftProtobuf.Message, SwiftPro
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._queryOptions) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.dmChatType) }()
       case 10: try { try decoder.decodeSingularMessageField(value: &self._auth) }()
       default: break
       }
@@ -337,6 +343,9 @@ extension Flipcash_Chat_V1_GetDmChatFeedRequest: SwiftProtobuf.Message, SwiftPro
     try { if let v = self._queryOptions {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     } }()
+    if self.dmChatType != .unknown {
+      try visitor.visitSingularEnumField(value: self.dmChatType, fieldNumber: 2)
+    }
     try { if let v = self._auth {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
     } }()
@@ -345,6 +354,7 @@ extension Flipcash_Chat_V1_GetDmChatFeedRequest: SwiftProtobuf.Message, SwiftPro
 
   public static func ==(lhs: Flipcash_Chat_V1_GetDmChatFeedRequest, rhs: Flipcash_Chat_V1_GetDmChatFeedRequest) -> Bool {
     if lhs._queryOptions != rhs._queryOptions {return false}
+    if lhs.dmChatType != rhs.dmChatType {return false}
     if lhs._auth != rhs._auth {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/chat_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/chat_v1_model.pb.swift
@@ -20,6 +20,44 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
+public enum Flipcash_Chat_V1_ChatType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  public typealias RawValue = Int
+  case unknown // = 0
+  case contactDm // = 1
+  case tipDm // = 2
+  case UNRECOGNIZED(Int)
+
+  public init() {
+    self = .unknown
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .unknown
+    case 1: self = .contactDm
+    case 2: self = .tipDm
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .unknown: return 0
+    case .contactDm: return 1
+    case .tipDm: return 2
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static let allCases: [Flipcash_Chat_V1_ChatType] = [
+    .unknown,
+    .contactDm,
+    .tipDm,
+  ]
+
+}
+
 public struct Flipcash_Chat_V1_Metadata: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -35,7 +73,7 @@ public struct Flipcash_Chat_V1_Metadata: @unchecked Sendable {
   public mutating func clearChatID() {_uniqueStorage()._chatID = nil}
 
   /// The type of chat
-  public var type: Flipcash_Chat_V1_Metadata.ChatType {
+  public var type: Flipcash_Chat_V1_ChatType {
     get {_storage._type}
     set {_uniqueStorage()._type = newValue}
   }
@@ -81,40 +119,6 @@ public struct Flipcash_Chat_V1_Metadata: @unchecked Sendable {
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public enum ChatType: SwiftProtobuf.Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case unknown // = 0
-    case dm // = 1
-    case UNRECOGNIZED(Int)
-
-    public init() {
-      self = .unknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .dm
-      default: self = .UNRECOGNIZED(rawValue)
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .dm: return 1
-      case .UNRECOGNIZED(let i): return i
-      }
-    }
-
-    // The compiler won't synthesize support with the UNRECOGNIZED case.
-    public static let allCases: [Flipcash_Chat_V1_Metadata.ChatType] = [
-      .unknown,
-      .dm,
-    ]
-
-  }
 
   public init() {}
 
@@ -242,13 +246,17 @@ public struct Flipcash_Chat_V1_MetadataUpdate: Sendable {
 
 fileprivate let _protobuf_package = "flipcash.chat.v1"
 
+extension Flipcash_Chat_V1_ChatType: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}CONTACT_DM\0\u{1}TIP_DM\0")
+}
+
 extension Flipcash_Chat_V1_Metadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Metadata"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}chat_id\0\u{1}type\0\u{1}members\0\u{3}last_message\0\u{3}last_activity\0\u{3}latest_event_sequence\0")
 
   fileprivate class _StorageClass {
     var _chatID: Flipcash_Common_V1_ChatId? = nil
-    var _type: Flipcash_Chat_V1_Metadata.ChatType = .unknown
+    var _type: Flipcash_Chat_V1_ChatType = .unknown
     var _members: [Flipcash_Chat_V1_Member] = []
     var _lastMessage: Flipcash_Messaging_V1_Message? = nil
     var _lastActivity: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
@@ -345,10 +353,6 @@ extension Flipcash_Chat_V1_Metadata: SwiftProtobuf.Message, SwiftProtobuf._Messa
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
-}
-
-extension Flipcash_Chat_V1_Metadata.ChatType: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}DM\0")
 }
 
 extension Flipcash_Chat_V1_Member: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/intent_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/intent_v1_model.pb.swift
@@ -70,10 +70,19 @@ public struct Flipcash_Intent_V1_ChatMetadata: Sendable {
     set {type = .contactDmPayment(newValue)}
   }
 
+  public var tipDmPayment: Flipcash_Intent_V1_ChatMetadata.TipDmPayment {
+    get {
+      if case .tipDmPayment(let v)? = type {return v}
+      return Flipcash_Intent_V1_ChatMetadata.TipDmPayment()
+    }
+    set {type = .tipDmPayment(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_Type: Equatable, Sendable {
     case contactDmPayment(Flipcash_Intent_V1_ChatMetadata.ContactDmPayment)
+    case tipDmPayment(Flipcash_Intent_V1_ChatMetadata.TipDmPayment)
 
   }
 
@@ -109,6 +118,18 @@ public struct Flipcash_Intent_V1_ChatMetadata: Sendable {
 
     fileprivate var _source: Flipcash_Phone_V1_PhoneNumber? = nil
     fileprivate var _destination: Flipcash_Phone_V1_PhoneNumber? = nil
+  }
+
+  /// For sending a DM tip payment to someone. The message is empty, since
+  /// it's between two user IDs, which map directly to/from public keys.
+  public struct TipDmPayment: Sendable {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
   }
 
   public init() {}
@@ -168,7 +189,7 @@ extension Flipcash_Intent_V1_AppMetadata: SwiftProtobuf.Message, SwiftProtobuf._
 
 extension Flipcash_Intent_V1_ChatMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ChatMetadata"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}chat_id\0\u{3}contact_dm_payment\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}chat_id\0\u{3}contact_dm_payment\0\u{3}tip_dm_payment\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -190,6 +211,19 @@ extension Flipcash_Intent_V1_ChatMetadata: SwiftProtobuf.Message, SwiftProtobuf.
           self.type = .contactDmPayment(v)
         }
       }()
+      case 3: try {
+        var v: Flipcash_Intent_V1_ChatMetadata.TipDmPayment?
+        var hadOneofValue = false
+        if let current = self.type {
+          hadOneofValue = true
+          if case .tipDmPayment(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.type = .tipDmPayment(v)
+        }
+      }()
       default: break
       }
     }
@@ -203,9 +237,17 @@ extension Flipcash_Intent_V1_ChatMetadata: SwiftProtobuf.Message, SwiftProtobuf.
     try { if let v = self._chatID {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     } }()
-    try { if case .contactDmPayment(let v)? = self.type {
+    switch self.type {
+    case .contactDmPayment?: try {
+      guard case .contactDmPayment(let v)? = self.type else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    } }()
+    }()
+    case .tipDmPayment?: try {
+      guard case .tipDmPayment(let v)? = self.type else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }()
+    case nil: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -251,6 +293,25 @@ extension Flipcash_Intent_V1_ChatMetadata.ContactDmPayment: SwiftProtobuf.Messag
   public static func ==(lhs: Flipcash_Intent_V1_ChatMetadata.ContactDmPayment, rhs: Flipcash_Intent_V1_ChatMetadata.ContactDmPayment) -> Bool {
     if lhs._source != rhs._source {return false}
     if lhs._destination != rhs._destination {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Intent_V1_ChatMetadata.TipDmPayment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Flipcash_Intent_V1_ChatMetadata.protoMessageName + ".TipDmPayment"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Intent_V1_ChatMetadata.TipDmPayment, rhs: Flipcash_Intent_V1_ChatMetadata.TipDmPayment) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.pb.swift
@@ -144,6 +144,11 @@ public struct Flipcash_Profile_V1_SetDisplayNameResponse: Sendable {
 
   public var result: Flipcash_Profile_V1_SetDisplayNameResponse.Result = .ok
 
+  /// The best-fit category that tripped moderation, mirroring the Moderation
+  /// service's vocabulary. Set only when result == FAILED_MODERATED; NONE
+  /// otherwise.
+  public var flaggedCategory: Flipcash_Moderation_V1_FlaggedCategory = .none
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum Result: SwiftProtobuf.Enum, Swift.CaseIterable {
@@ -151,6 +156,7 @@ public struct Flipcash_Profile_V1_SetDisplayNameResponse: Sendable {
     case ok // = 0
     case invalidDisplayName // = 1
     case denied // = 2
+    case failedModerated // = 3
     case UNRECOGNIZED(Int)
 
     public init() {
@@ -162,6 +168,7 @@ public struct Flipcash_Profile_V1_SetDisplayNameResponse: Sendable {
       case 0: self = .ok
       case 1: self = .invalidDisplayName
       case 2: self = .denied
+      case 3: self = .failedModerated
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
@@ -171,6 +178,7 @@ public struct Flipcash_Profile_V1_SetDisplayNameResponse: Sendable {
       case .ok: return 0
       case .invalidDisplayName: return 1
       case .denied: return 2
+      case .failedModerated: return 3
       case .UNRECOGNIZED(let i): return i
       }
     }
@@ -180,6 +188,7 @@ public struct Flipcash_Profile_V1_SetDisplayNameResponse: Sendable {
       .ok,
       .invalidDisplayName,
       .denied,
+      .failedModerated,
     ]
 
   }
@@ -647,7 +656,7 @@ extension Flipcash_Profile_V1_SetDisplayNameRequest: SwiftProtobuf.Message, Swif
 
 extension Flipcash_Profile_V1_SetDisplayNameResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SetDisplayNameResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}result\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}result\0\u{3}flagged_category\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -656,6 +665,7 @@ extension Flipcash_Profile_V1_SetDisplayNameResponse: SwiftProtobuf.Message, Swi
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularEnumField(value: &self.result) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.flaggedCategory) }()
       default: break
       }
     }
@@ -665,18 +675,22 @@ extension Flipcash_Profile_V1_SetDisplayNameResponse: SwiftProtobuf.Message, Swi
     if self.result != .ok {
       try visitor.visitSingularEnumField(value: self.result, fieldNumber: 1)
     }
+    if self.flaggedCategory != .none {
+      try visitor.visitSingularEnumField(value: self.flaggedCategory, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Flipcash_Profile_V1_SetDisplayNameResponse, rhs: Flipcash_Profile_V1_SetDisplayNameResponse) -> Bool {
     if lhs.result != rhs.result {return false}
+    if lhs.flaggedCategory != rhs.flaggedCategory {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
 extension Flipcash_Profile_V1_SetDisplayNameResponse.Result: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}INVALID_DISPLAY_NAME\0\u{1}DENIED\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}INVALID_DISPLAY_NAME\0\u{1}DENIED\0\u{1}FAILED_MODERATED\0")
 }
 
 extension Flipcash_Profile_V1_SetProfilePictureRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/chat/v1/chat_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/chat/v1/chat_service.proto
@@ -67,6 +67,13 @@ message GetDmChatFeedRequest {
     // snapshot. The token is opaque and server-generated; do not construct it.
     common.v1.QueryOptions query_options = 1;
 
+    // The type of DM chat to filter for
+    //
+    // For backwards compatiblity, UNKNOWN maps to CONTACT_DM for legacy clients
+    ChatType dm_chat_type = 2 [(validate.rules).enum = {
+        in: [0, 1, 2] // UNKNOWN, CONTACT_DM, TIP_DM
+    }];
+
     common.v1.Auth auth = 10 [(validate.rules).message.required = true];
 }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/chat/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/chat/v1/model.proto
@@ -12,6 +12,12 @@ import "messaging/v1/model.proto";
 import "validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
+enum ChatType {
+    UNKNOWN    = 0;
+    CONTACT_DM = 1;
+    TIP_DM     = 2;
+}
+
 message Metadata {
     common.v1.ChatId chat_id = 1 [(validate.rules).message.required = true];
 
@@ -19,10 +25,6 @@ message Metadata {
     ChatType type = 2 [(validate.rules).enum = {
         not_in: [0] // UNKNOWN
     }];
-    enum ChatType {
-        UNKNOWN = 0;
-        DM      = 1;
-    }
 
     // Members of this chat
     repeated Member members = 3;

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/intent/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/intent/v1/model.proto
@@ -26,6 +26,7 @@ message ChatMetadata {
         option (validate.required) = true;
 
         ContactDmPayment contact_dm_payment = 2;
+        TipDmPayment     tip_dm_payment     = 3;
     }
 
     // For sending a payment to a contact in a DM
@@ -35,5 +36,10 @@ message ChatMetadata {
 
         // Destination phone number that is being paid. This is validated to be linked to the receiver.
         phone.v1.PhoneNumber destination = 2 [(validate.rules).message.required = true];
+    }
+
+    // For sending a DM tip payment to someone. The message is empty, since
+    // it's between two user IDs, which map directly to/from public keys.
+    message TipDmPayment {
     }
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/profile_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/profile_service.proto
@@ -8,6 +8,7 @@ option objc_class_prefix = "FPBProfileV1";
 
 import "blob/v1/model.proto";
 import "common/v1/common.proto";
+import "moderation/v1/model.proto";
 import "profile/v1/model.proto";
 import "validate/validate.proto";
 
@@ -69,7 +70,13 @@ message SetDisplayNameResponse {
 		OK                   = 0;
 		INVALID_DISPLAY_NAME = 1;
 		DENIED               = 2;
+		FAILED_MODERATED     = 3;
 	}
+
+	// The best-fit category that tripped moderation, mirroring the Moderation
+    // service's vocabulary. Set only when result == FAILED_MODERATED; NONE
+	// otherwise.
+    moderation.v1.FlaggedCategory flagged_category = 2;
 }
 
 message SetProfilePictureRequest {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
@@ -12,13 +12,13 @@ extension FlipClient {
     /// Page the DM chat feed to exhaustion against a single pinned snapshot.
     /// The caller must already be consuming `eventStreamer.events` so updates
     /// that land mid-pagination aren't lost.
-    public func getDmChatFeed(owner: KeyPair) async throws -> [Conversation] {
+    public func getDmChatFeed(owner: KeyPair, type: ConversationType) async throws -> [Conversation] {
         var all: [Conversation] = []
         var pagingToken: Data?
 
         while true {
             let page = try await withCheckedThrowingContinuation { c in
-                chatService.getDmChatFeed(owner: owner, pagingToken: pagingToken) { c.resume(with: $0) }
+                chatService.getDmChatFeed(owner: owner, type: type, pagingToken: pagingToken) { c.resume(with: $0) }
             }
             all.append(contentsOf: page.conversations)
             if !page.hasMore { break }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatService.swift
@@ -25,7 +25,7 @@ final class ChatService: Sendable {
         let hasMore: Bool
     }
 
-    func getDmChatFeed(owner: KeyPair, pageSize: Int = 50, pagingToken: Data?, completion: @Sendable @escaping (Result<DmFeedPage, ErrorGetDmChatFeed>) -> Void) {
+    func getDmChatFeed(owner: KeyPair, type: ConversationType, pageSize: Int = 50, pagingToken: Data?, completion: @Sendable @escaping (Result<DmFeedPage, ErrorGetDmChatFeed>) -> Void) {
         let request = Flipcash_Chat_V1_GetDmChatFeedRequest.with {
             $0.queryOptions = .with {
                 $0.pageSize = Int32(pageSize)
@@ -33,6 +33,7 @@ final class ChatService: Sendable {
                     $0.pagingToken = .with { $0.value = pagingToken }
                 }
             }
+            $0.dmChatType = type.proto
             $0.auth = owner.authFor(message: $0)
         }
 

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Conversation.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Conversation.swift
@@ -26,6 +26,21 @@ public struct Conversation: Identifiable, Hashable, Sendable {
     }
 }
 
+/// The kind of direct-message conversation, used to scope the DM feed.
+public enum ConversationType: Sendable {
+    case contactDm
+    case tipDm
+}
+
+extension ConversationType {
+    var proto: Flipcash_Chat_V1_ChatType {
+        switch self {
+        case .contactDm: .contactDm
+        case .tipDm:     .tipDm
+        }
+    }
+}
+
 extension Conversation {
     public init(_ proto: Flipcash_Chat_V1_Metadata) {
         self.id = ConversationID(proto.chatID)

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
@@ -92,7 +92,7 @@ struct ConversationModelMappingTests {
         let conversationBytes = Data(repeating: 0xAB, count: 32)
         let proto = Flipcash_Chat_V1_Metadata.with {
             $0.chatID = .with { $0.value = conversationBytes }
-            $0.type = .dm
+            $0.type = .contactDm
             $0.lastActivity = .init(date: Date(timeIntervalSince1970: 1_700_000_500))
             $0.lastMessage = .with {
                 $0.messageID = .with { $0.value = 9 }

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -119,7 +119,7 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
 
     // MARK: - ConversationFetching
 
-    func getDmChatFeed(owner: KeyPair) async throws -> [Conversation] { feed }
+    func getDmChatFeed(owner: KeyPair, type: ConversationType) async throws -> [Conversation] { feed }
 
     func getChat(owner: KeyPair, conversationID: ConversationID) async throws -> Conversation {
         guard let conversation = feed.first(where: { $0.id == conversationID }) else {


### PR DESCRIPTION
Regenerates the Core protos from upstream.

The one breaking change: `ChatType` moved out of `Metadata` to the top level, and `DM` was renamed `CONTACT_DM` to make room for a new `TIP_DM`. Only a single test referenced the old case.

The DM feed request gained a `dm_chat_type` field. Leaving it unset would work today — the server maps `UNKNOWN` to `CONTACT_DM` for legacy clients — but since the tip feed and contact feed are going to be separate screens, the type is now a parameter that each caller has to name. The existing conversation feed passes `.contactDm`, which is what it was already getting implicitly.

Also picked up, both additive and unused for now: a `TipDmPayment` intent variant, and a `FAILED_MODERATED` result with a flagged category on `SetDisplayName`.

## Test plan

- [x] Conversation feed still loads and shows contact DMs
- [x] Sending a DM payment still works end to end