### PR TITLE
feat: add profile setters and blob upload infrastructure

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Blob/BlobUploader.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Blob/BlobUploader.swift
@@ -1,0 +1,153 @@
+//
+//  BlobUploader.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+private let logger = Logger(label: "flipcash.blob-uploader")
+
+/// The blob RPCs an upload depends on.
+protocol BlobReserving: Sendable {
+    func initiateExternalUpload(mimeType: String, sizeBytes: Int, owner: KeyPair) async throws -> ReservedUpload
+    func completeExternalUpload(blobID: BlobID, owner: KeyPair) async throws -> BlobState
+    func blobState(blobID: BlobID, owner: KeyPair) async throws -> BlobState
+}
+
+/// Stores bytes in blob storage and waits for the server to finalize them.
+///
+/// Stateless — every call carries its own bytes, so instances are shareable.
+final class BlobUploader: Sendable {
+
+    private let reserving: BlobReserving
+    private let transport: BlobUploading
+    private let pollInterval: Duration
+    private let timeout: Duration
+
+    init(
+        reserving: BlobReserving,
+        transport: BlobUploading,
+        pollInterval: Duration = .seconds(2),
+        timeout: Duration = .seconds(60)
+    ) {
+        self.reserving    = reserving
+        self.transport    = transport
+        self.pollInterval = pollInterval
+        self.timeout      = timeout
+    }
+
+    /// Uploads `data` and returns its blob once the server has finalized it.
+    func upload(_ data: Data, mimeType: String, owner: KeyPair) async throws -> BlobID {
+        let reserved = try await reserving.initiateExternalUpload(
+            mimeType: mimeType,
+            sizeBytes: data.count,
+            owner: owner
+        )
+
+        logger.info("Reserved blob upload", metadata: [
+            "blobId": "\(reserved.blobID)",
+            "mimeType": "\(mimeType)",
+            "sizeBytes": "\(data.count)",
+        ])
+
+        try await store(data, mimeType: mimeType, to: reserved.target)
+
+        switch try await reserving.completeExternalUpload(blobID: reserved.blobID, owner: owner) {
+        case .ready:
+            return reserved.blobID
+        case .rejected(let reason):
+            throw ErrorBlob.rejected(reason)
+        case .pending, .processing:
+            try await awaitFinalization(blobID: reserved.blobID, owner: owner)
+            return reserved.blobID
+        }
+    }
+
+    /// Polls until the blob is finalized.
+    ///
+    /// Separate from `upload(_:mimeType:owner:)` so a timed-out attempt can be
+    /// resumed: the bytes are already stored, and a rejection is terminal.
+    func awaitFinalization(blobID: BlobID, owner: KeyPair) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+
+        while true {
+            try Task.checkCancellation()
+
+            switch try await reserving.blobState(blobID: blobID, owner: owner) {
+            case .ready:
+                return
+            case .rejected(let reason):
+                logger.info("Blob rejected", metadata: [
+                    "blobId": "\(blobID)",
+                    "reason": "\(reason)",
+                ])
+                throw ErrorBlob.rejected(reason)
+            case .pending, .processing:
+                break
+            }
+
+            guard ContinuousClock.now < deadline else {
+                logger.info("Blob finalization timed out", metadata: ["blobId": "\(blobID)"])
+                throw ErrorBlob.timedOut
+            }
+
+            try await Task.sleep(for: pollInterval)
+        }
+    }
+
+    // MARK: - Upload -
+
+    private func store(_ data: Data, mimeType: String, to target: UploadTarget) async throws {
+        let boundary = "Boundary-\(UUID().uuidString)"
+
+        let (status, responseBody) = try await transport.post(
+            url: target.url,
+            contentType: "multipart/form-data; boundary=\(boundary)",
+            headers: target.headers,
+            body: Self.multipartBody(
+                fields: target.formFields,
+                file: data,
+                mimeType: mimeType,
+                boundary: boundary
+            )
+        )
+
+        guard (200..<300).contains(status) else {
+            // Storage reports signature and policy failures only in the body.
+            logger.error("Storage refused the upload", metadata: [
+                "status": "\(status)",
+                "response": "\(String(decoding: responseBody.prefix(1024), as: UTF8.self))",
+            ])
+            throw ErrorBlob.uploadFailed(status)
+        }
+    }
+
+    /// Builds the `multipart/form-data` body: the signed policy fields in a
+    /// stable order, then the file.
+    ///
+    /// Storage ignores every field after the file part, so it must come last.
+    static func multipartBody(fields: [String: String], file: Data, mimeType: String, boundary: String) -> Data {
+        var body = Data()
+
+        for (name, value) in fields.sorted(by: { $0.key < $1.key }) {
+            body.append("--\(boundary)\r\n")
+            body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+            body.append("\(value)\r\n")
+        }
+
+        body.append("--\(boundary)\r\n")
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"blob\"\r\n")
+        body.append("Content-Type: \(mimeType)\r\n\r\n")
+        body.append(file)
+        body.append("\r\n")
+        body.append("--\(boundary)--\r\n")
+
+        return body
+    }
+}
+
+private extension Data {
+    mutating func append(_ string: String) {
+        append(Data(string.utf8))
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Blob/BlobUploading.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Blob/BlobUploading.swift
@@ -1,0 +1,50 @@
+//
+//  BlobUploading.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+/// Issues the direct-to-storage upload request.
+///
+/// The body is an explicit parameter rather than part of a `URLRequest` so
+/// callers — and tests — can observe the bytes that go on the wire.
+public protocol BlobUploading: Sendable {
+    func post(
+        url: URL,
+        contentType: String,
+        headers: [String: String],
+        body: Data
+    ) async throws -> (status: Int, body: Data)
+}
+
+/// The production `BlobUploading`, over a shared `URLSession`.
+public struct URLSessionBlobUploader: BlobUploading {
+
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func post(
+        url: URL,
+        contentType: String,
+        headers: [String: String],
+        body: Data
+    ) async throws -> (status: Int, body: Data) {
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+
+        for (field, value) in headers {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+
+        let (data, response) = try await session.upload(for: request, from: body)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+
+        return (status, data)
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Blob.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Blob.swift
@@ -1,0 +1,22 @@
+//
+//  FlipClient+Blob.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+extension FlipClient {
+
+    /// Uploads `data` to blob storage and returns its blob once the server has
+    /// finalized it.
+    public func uploadBlob(_ data: Data, mimeType: String, owner: KeyPair) async throws -> BlobID {
+        try await blobUploader.upload(data, mimeType: mimeType, owner: owner)
+    }
+
+    /// Waits for an already-uploaded blob to finish finalizing.
+    ///
+    /// Resumes an attempt whose polling timed out, without re-uploading.
+    public func awaitBlobFinalization(blobID: BlobID, owner: KeyPair) async throws {
+        try await blobUploader.awaitFinalization(blobID: blobID, owner: owner)
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Profile.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Profile.swift
@@ -14,4 +14,16 @@ extension FlipClient {
             profileService.fetchProfile(userID: userID, owner: owner) { c.resume(with: $0) }
         }
     }
+
+    /// Sets the caller's display name, which the server moderates before it
+    /// persists.
+    public func setDisplayName(_ displayName: String, owner: KeyPair) async throws {
+        try await profileService.setDisplayName(displayName, owner: owner)
+    }
+
+    /// Attaches an already-finalized blob as the caller's profile picture and
+    /// returns the rendition set the server derived from it.
+    public func setProfilePicture(blobID: BlobID, owner: KeyPair) async throws -> ProfilePicture {
+        try await profileService.setProfilePicture(blobID: blobID, owner: owner)
+    }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient.swift
@@ -29,6 +29,8 @@ public class FlipClient: ObservableObject {
     internal let phoneService: PhoneService
     internal let emailService: EmailService
     internal let profileService: ProfileService
+    internal let blobService: BlobService
+    internal let blobUploader: BlobUploader
     internal let settingsService: SettingsService
     internal let moderationService: ModerationService
     internal let contactListService: ContactListService
@@ -67,6 +69,14 @@ public class FlipClient: ObservableObject {
         self.phoneService       = PhoneService(client: client)
         self.emailService       = EmailService(client: client)
         self.profileService     = ProfileService(client: client)
+
+        let blobService         = BlobService(client: client)
+        self.blobService        = blobService
+        self.blobUploader       = BlobUploader(
+            reserving: blobService,
+            transport: URLSessionBlobUploader()
+        )
+
         self.settingsService    = SettingsService(client: client)
         self.moderationService  = ModerationService(client: client)
         self.contactListService = ContactListService(client: client)

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/BlobService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/BlobService.swift
@@ -1,0 +1,146 @@
+//
+//  BlobService.swift
+//  FlipcashCore
+//
+
+import Foundation
+import FlipcashAPI
+import GRPCCore
+
+private let logger = Logger(label: "flipcash.blob-service")
+
+final class BlobService: Sendable {
+
+    private let service: Flipcash_Blob_V1_BlobStorage.Client<AppTransport>
+
+    init(client: GRPCClient<AppTransport>) {
+        self.service = Flipcash_Blob_V1_BlobStorage.Client(wrapping: client)
+    }
+}
+
+// MARK: - BlobReserving -
+
+extension BlobService: BlobReserving {
+
+    func initiateExternalUpload(mimeType: String, sizeBytes: Int, owner: KeyPair) async throws -> ReservedUpload {
+        var request = Flipcash_Blob_V1_InitiateExternalUploadRequest()
+        request.mimeType  = mimeType
+        request.sizeBytes = UInt64(sizeBytes)
+        request.auth      = owner.authFor(message: request)
+
+        do {
+            let response = try await service.initiateExternalUpload(request, options: .unaryDefault)
+
+            switch response.result {
+            case .ok:
+                guard let target = UploadTarget(response.uploadTarget) else {
+                    throw ErrorBlob.unknown
+                }
+
+                return ReservedUpload(
+                    blobID: BlobID(data: response.blobID.value),
+                    target: target
+                )
+
+            case .denied:
+                throw ErrorBlob.uploadDenied
+            case .unsupportedType:
+                throw ErrorBlob.unsupportedType
+            case .tooLarge:
+                throw ErrorBlob.tooLarge
+            case .quotaExceeded:
+                throw ErrorBlob.quotaExceeded
+            case .UNRECOGNIZED:
+                throw ErrorBlob.unknown
+            }
+        } catch let error as ErrorBlob {
+            throw error
+        } catch {
+            throw ErrorBlob.network(error)
+        }
+    }
+
+    func completeExternalUpload(blobID: BlobID, owner: KeyPair) async throws -> BlobState {
+        var request = Flipcash_Blob_V1_CompleteExternalUploadRequest()
+        request.blobID = .with { $0.value = blobID.data }
+        request.auth   = owner.authFor(message: request)
+
+        do {
+            let response = try await service.completeExternalUpload(request, options: .unaryDefault)
+
+            switch response.result {
+            case .ok:
+                return BlobState(status: response.status, rejection: response.rejectionMetadata)
+            case .notFound:
+                throw ErrorBlob.notFound
+            case .notUploaded:
+                throw ErrorBlob.notUploaded
+            case .UNRECOGNIZED:
+                throw ErrorBlob.unknown
+            }
+        } catch let error as ErrorBlob {
+            throw error
+        } catch {
+            throw ErrorBlob.network(error)
+        }
+    }
+
+    func blobState(blobID: BlobID, owner: KeyPair) async throws -> BlobState {
+        var request = Flipcash_Blob_V1_GetBlobsRequest()
+        request.blobIds = .with { $0.blobIds = [.with { $0.value = blobID.data }] }
+        request.auth    = owner.authFor(message: request)
+
+        do {
+            let response = try await service.getBlobs(request, options: .unaryDefault)
+
+            switch response.result {
+            case .ok:
+                // Unauthorized or unknown ids are omitted rather than reported.
+                guard let blob = response.blobs.blobs.first else {
+                    throw ErrorBlob.notFound
+                }
+
+                return BlobState(status: blob.status, rejection: blob.rejection)
+
+            case .denied:
+                throw ErrorBlob.uploadDenied
+            case .UNRECOGNIZED:
+                throw ErrorBlob.unknown
+            }
+        } catch let error as ErrorBlob {
+            throw error
+        } catch {
+            throw ErrorBlob.network(error)
+        }
+    }
+}
+
+// MARK: - Errors -
+
+public enum ErrorBlob: Error, Sendable {
+    case uploadDenied
+    case unsupportedType
+    case tooLarge
+    case quotaExceeded
+    case notFound
+    case notUploaded
+    case rejected(BlobRejectionReason)
+    case uploadFailed(Int)
+    case timedOut
+    case unknown
+    case network(Error)
+}
+
+extension ErrorBlob: ServerError {
+    public var reportingLevel: ErrorReportingLevel {
+        switch self {
+        case .uploadDenied, .unsupportedType, .tooLarge, .quotaExceeded,
+             .notFound, .notUploaded, .rejected, .uploadFailed, .timedOut:
+            .info
+        case .unknown:
+            .error
+        case .network(let error):
+            (error as? ServerError)?.reportingLevel ?? .error
+        }
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
@@ -57,6 +57,74 @@ final class ProfileService: Sendable {
             }
         }
     }
+
+    // MARK: - Setters -
+    // Async-native, unlike `fetchProfile` above: a continuation over a detached
+    // Task never propagates cancellation into the RPC.
+
+    func setDisplayName(_ displayName: String, owner: KeyPair) async throws {
+        var request = Flipcash_Profile_V1_SetDisplayNameRequest()
+        request.displayName = displayName
+        request.auth        = owner.authFor(message: request)
+
+        do {
+            let response = try await service.setDisplayName(request, options: .unaryDefault)
+
+            switch response.result {
+            case .ok:
+                logger.info("Display name set")
+            case .invalidDisplayName:
+                throw ErrorProfile.invalidDisplayName
+            case .denied:
+                throw ErrorProfile.denied
+            case .failedModerated:
+                throw ErrorProfile.moderated(response.flaggedCategory)
+            case .UNRECOGNIZED:
+                throw ErrorProfile.unknown
+            }
+        } catch let error as ErrorProfile {
+            throw error
+        } catch {
+            throw ErrorProfile.network(error)
+        }
+    }
+
+    func setProfilePicture(blobID: BlobID, owner: KeyPair) async throws -> ProfilePicture {
+        var request = Flipcash_Profile_V1_SetProfilePictureRequest()
+        request.blobID = .with { $0.value = blobID.data }
+        request.auth   = owner.authFor(message: request)
+
+        do {
+            let response = try await service.setProfilePicture(request, options: .unaryDefault)
+
+            switch response.result {
+            case .ok:
+                guard let picture = ProfilePicture(response.profilePicture) else {
+                    throw ErrorProfile.unknown
+                }
+
+                logger.info("Profile picture set", metadata: ["blobId": "\(blobID)"])
+                return picture
+
+            case .denied:
+                throw ErrorProfile.denied
+            case .blobNotFound:
+                throw ErrorProfile.blobNotFound
+            case .blobNotReady:
+                throw ErrorProfile.blobNotReady
+            case .blobRejected:
+                throw ErrorProfile.blobRejected
+            case .invalidBlob:
+                throw ErrorProfile.invalidBlob
+            case .UNRECOGNIZED:
+                throw ErrorProfile.unknown
+            }
+        } catch let error as ErrorProfile {
+            throw error
+        } catch {
+            throw ErrorProfile.network(error)
+        }
+    }
 }
 
 // MARK: - Errors -
@@ -77,6 +145,32 @@ extension ErrorFetchProfile: ServerError, TransportClassifiableError {
         case .cancelled: .info
         case .notFound: .info
         case .unknown, .rejected: .error
+        }
+    }
+}
+
+public enum ErrorProfile: Error, Sendable {
+    case denied
+    case invalidDisplayName
+    case moderated(Flipcash_Moderation_V1_FlaggedCategory)
+    case blobNotFound
+    case blobNotReady
+    case blobRejected
+    case invalidBlob
+    case unknown
+    case network(Error)
+}
+
+extension ErrorProfile: ServerError {
+    public var reportingLevel: ErrorReportingLevel {
+        switch self {
+        case .denied, .invalidDisplayName, .moderated,
+             .blobNotFound, .blobNotReady, .blobRejected, .invalidBlob:
+            .info
+        case .unknown:
+            .error
+        case .network(let error):
+            (error as? ServerError)?.reportingLevel ?? .error
         }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Blob.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Blob.swift
@@ -1,0 +1,100 @@
+//
+//  Blob.swift
+//  FlipcashCore
+//
+
+import Foundation
+import FlipcashAPI
+
+/// Where a blob is in its lifecycle.
+public enum BlobState: Sendable, Equatable {
+    case pending
+    case processing
+    case ready
+    case rejected(BlobRejectionReason)
+}
+
+/// Why finalization refused a blob after its bytes were stored.
+///
+/// Terminal: the bytes behind a blob are immutable, so a rejected blob never
+/// becomes ready and a retry must reserve a fresh upload.
+public enum BlobRejectionReason: Sendable, Equatable {
+    case moderation
+    case unsupportedType
+    case mismatchedType
+    case tooLarge
+    case corrupt
+    case privacyMetadata
+    case unknown
+}
+
+/// A reserved upload: the blob it will become, and the request that stores its
+/// bytes.
+public struct ReservedUpload: Sendable, Equatable {
+    public let blobID: BlobID
+    public let target: UploadTarget
+}
+
+/// The HTTP request that uploads a blob's bytes directly to storage.
+///
+/// A bearer credential — anyone holding it can write to the reserved key until
+/// it expires, so it is never persisted or shared.
+public struct UploadTarget: Sendable, Equatable {
+    public let url: URL
+    public let headers: [String: String]
+    public let formFields: [String: String]
+
+    public init(url: URL, headers: [String: String], formFields: [String: String]) {
+        self.url        = url
+        self.headers    = headers
+        self.formFields = formFields
+    }
+}
+
+// MARK: - Proto -
+
+extension BlobState {
+    init(status: Flipcash_Blob_V1_BlobStatus, rejection: Flipcash_Blob_V1_RejectionMetadata) {
+        switch status {
+        case .pending:
+            self = .pending
+        case .processing:
+            self = .processing
+        case .ready:
+            self = .ready
+        case .rejected:
+            self = .rejected(BlobRejectionReason(rejection.reason))
+        case .unknown, .UNRECOGNIZED:
+            self = .processing
+        }
+    }
+}
+
+extension BlobRejectionReason {
+    init(_ proto: Flipcash_Blob_V1_RejectionReason) {
+        switch proto {
+        case .moderation:       self = .moderation
+        case .unsupportedType:  self = .unsupportedType
+        case .mismatchedType:   self = .mismatchedType
+        case .tooLarge:         self = .tooLarge
+        case .corrupt:          self = .corrupt
+        case .privacyMetadata:  self = .privacyMetadata
+        case .internal:         self = .unknown
+        case .unknown, .UNRECOGNIZED: self = .unknown
+        }
+    }
+}
+
+extension UploadTarget {
+    init?(_ proto: Flipcash_Blob_V1_UploadTarget) {
+        guard let url = URL(string: proto.url) else {
+            return nil
+        }
+
+        self.init(
+            url: url,
+            headers: proto.headers,
+            formFields: proto.formFields
+        )
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Models/Profile.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Profile.swift
@@ -19,9 +19,16 @@ public struct Profile: Codable, Equatable, Sendable {
     public let displayName: String?
     public let phone: Phone?
     public let email: String?
-    
+    public let profilePicture: ProfilePicture?
+
     public var isPhoneVerified: Bool {
         phone != nil
+    }
+
+    /// Returns whether this profile can receive tips — both a name and a
+    /// picture are required.
+    public var isTippable: Bool {
+        displayName?.isEmpty == false && profilePicture != nil
     }
 
     /// Returns whether this profile gained a phone number not present in `previous`.
@@ -29,7 +36,7 @@ public struct Profile: Codable, Equatable, Sendable {
         phone != nil && phone?.e164 != previous?.phone?.e164
     }
 
-    public init(displayName: String?, phone: String?, email: String?) throws {
+    public init(displayName: String?, phone: String?, email: String?, profilePicture: ProfilePicture? = nil) throws {
 
         // Only parse phone if it's not empty
         var parsedPhone: Phone?
@@ -48,14 +55,16 @@ public struct Profile: Codable, Equatable, Sendable {
         self.init(
             displayName: displayName,
             phone: parsedPhone,
-            email: normalizedEmail
+            email: normalizedEmail,
+            profilePicture: profilePicture
         )
     }
-    
-    public init(displayName: String?, phone: Phone?, email: String?) {
+
+    public init(displayName: String?, phone: Phone?, email: String?, profilePicture: ProfilePicture? = nil) {
         self.displayName = displayName
         self.phone = phone
         self.email = email
+        self.profilePicture = profilePicture
     }
 }
 
@@ -72,7 +81,8 @@ extension Profile {
         try self.init(
             displayName: proto.displayName,
             phone: proto.phoneNumber.value,
-            email: proto.emailAddress.value
+            email: proto.emailAddress.value,
+            profilePicture: proto.hasProfilePicture ? ProfilePicture(proto.profilePicture) : nil
         )
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/ProfilePicture.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/ProfilePicture.swift
@@ -1,0 +1,75 @@
+//
+//  ProfilePicture.swift
+//  FlipcashCore
+//
+
+import Foundation
+import FlipcashAPI
+
+/// A handle to the blob backing a profile picture.
+///
+/// Sixteen opaque bytes, minted by `InitiateExternalUpload`.
+public typealias BlobID = ID
+
+/// A user's profile picture: the durable blob handle plus the renditions the
+/// server derived from it.
+public struct ProfilePicture: Codable, Equatable, Sendable {
+
+    /// The original rendition's blob. Stable across fetches — use it as the
+    /// image cache key, never the URL.
+    public let blobID: BlobID
+
+    /// Signed URL for the avatar-sized rendition, expiring at `expiresAt`.
+    public let thumbnailURL: URL?
+
+    /// Signed URL for the full-size rendition, expiring at `expiresAt`.
+    public let displayURL: URL?
+
+    /// When the signed URLs stop resolving.
+    public let expiresAt: Date?
+
+    public init(blobID: BlobID, thumbnailURL: URL?, displayURL: URL?, expiresAt: Date?) {
+        self.blobID       = blobID
+        self.thumbnailURL = thumbnailURL
+        self.displayURL   = displayURL
+        self.expiresAt    = expiresAt
+    }
+}
+
+// MARK: - Proto -
+
+extension ProfilePicture {
+
+    /// Returns the picture described by `proto`, or `nil` when it carries no
+    /// original rendition.
+    init?(_ proto: Flipcash_Blob_V1_Media) {
+        let renditions = proto.renditions
+
+        guard let original = renditions.first(where: { $0.role == .original }) else {
+            return nil
+        }
+
+        let thumbnail = renditions.first { $0.role == .thumbnail } ?? original
+        let display   = renditions.first { $0.role == .display }   ?? original
+
+        self.init(
+            blobID: BlobID(data: original.blobID.value),
+            thumbnailURL: thumbnail.downloadURL,
+            displayURL: display.downloadURL,
+            expiresAt: thumbnail.downloadExpiry
+        )
+    }
+}
+
+private extension Flipcash_Blob_V1_Rendition {
+
+    var downloadURL: URL? {
+        guard hasBlob, blob.hasDownloadURL else { return nil }
+        return URL(string: blob.downloadURL.url)
+    }
+
+    var downloadExpiry: Date? {
+        guard hasBlob, blob.hasDownloadURL, blob.downloadURL.hasExpiresAt else { return nil }
+        return blob.downloadURL.expiresAt.date
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Validation/DisplayNameValidator.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Validation/DisplayNameValidator.swift
@@ -1,0 +1,35 @@
+//
+//  DisplayNameValidator.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+/// Validates a profile display name: 1–64 Unicode scalars of any script.
+///
+/// Returns the name trimmed of leading and trailing whitespace.
+public struct DisplayNameValidator: Validator {
+
+    /// PGV `max_len` from `FlipcashAPI/Core/proto/profile/v1/profile_service.proto`
+    /// counts Unicode scalars, not grapheme clusters — one ZWJ emoji spends seven.
+    public static let maxScalars = 64
+
+    public init() {}
+
+    public func validate(_ input: String) -> String? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmed.isEmpty, trimmed.unicodeScalars.count <= Self.maxScalars else {
+            return nil
+        }
+
+        return trimmed
+    }
+
+    /// Returns how many more Unicode scalars the name accepts, negative once it
+    /// has already exceeded the limit.
+    public func remaining(in input: String) -> Int {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        return Self.maxScalars - trimmed.unicodeScalars.count
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/BlobUploaderTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/BlobUploaderTests.swift
@@ -1,0 +1,318 @@
+//
+//  BlobUploaderTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("Blob upload")
+struct BlobUploaderTests {
+
+    // MARK: - Multipart body -
+
+    @Test("Signed policy fields come first, the file last")
+    func multipartOrdersFileLast() async throws {
+        let transport = RecordingTransport()
+        let uploader = makeUploader(transport: transport, states: [.ready])
+
+        _ = try await uploader.upload(Self.fileBytes, mimeType: "image/jpeg", owner: try Self.owner())
+
+        let parsed = try await Self.parse(transport)
+        #expect(parsed.names.last == "file")
+        #expect(Array(parsed.names.dropLast()) == ["Content-Type", "key", "policy", "x-amz-signature"])
+    }
+
+    @Test("Signed policy fields reach storage verbatim")
+    func multipartPreservesSignedFields() async throws {
+        let transport = RecordingTransport()
+        let uploader = makeUploader(transport: transport, states: [.ready])
+
+        _ = try await uploader.upload(Self.fileBytes, mimeType: "image/jpeg", owner: try Self.owner())
+
+        let parsed = try await Self.parse(transport)
+        for (name, value) in Self.formFields {
+            #expect(parsed.values[name] == value)
+        }
+    }
+
+    @Test("The boundary declared in Content-Type is the one delimiting the body")
+    func multipartBoundaryMatchesContentType() async throws {
+        let transport = RecordingTransport()
+        let uploader = makeUploader(transport: transport, states: [.ready])
+
+        _ = try await uploader.upload(Self.fileBytes, mimeType: "image/jpeg", owner: try Self.owner())
+
+        let contentType = try #require(await transport.contentType)
+        let boundary = try #require(contentType.components(separatedBy: "boundary=").last)
+        let body = String(decoding: try #require(await transport.body), as: UTF8.self)
+
+        #expect(contentType.hasPrefix("multipart/form-data; "))
+        #expect(body.hasPrefix("--\(boundary)\r\n"))
+        #expect(body.hasSuffix("--\(boundary)--\r\n"))
+    }
+
+    /// Storage signs `content-length-range` as `[size, size]`, so the file part
+    /// must carry exactly the byte count declared to `InitiateExternalUpload`.
+    @Test("The file part carries exactly the declared byte count")
+    func filePartMatchesDeclaredSize() async throws {
+        let transport = RecordingTransport()
+        let reserving = StubReserving(states: [.ready])
+        let uploader = BlobUploader(reserving: reserving, transport: transport)
+
+        _ = try await uploader.upload(Self.fileBytes, mimeType: "image/jpeg", owner: try Self.owner())
+
+        let declared = try #require(await reserving.declaredSizeBytes)
+        #expect(declared == Self.fileBytes.count)
+        #expect(try await Self.parse(transport).fileByteCount == declared)
+    }
+
+    @Test("Parts are CRLF-delimited, not bare newlines")
+    func multipartUsesCRLF() async throws {
+        let transport = RecordingTransport()
+        let uploader = makeUploader(transport: transport, states: [.ready])
+
+        _ = try await uploader.upload(Self.fileBytes, mimeType: "image/jpeg", owner: try Self.owner())
+
+        let body = String(decoding: try #require(await transport.body), as: UTF8.self)
+        #expect(body.contains("Content-Disposition: form-data; name=\"key\"\r\n\r\n"))
+        #expect(!body.contains("form-data; name=\"key\"\n\n"))
+    }
+
+    // MARK: - Upload failure -
+
+    @Test("A non-2xx from storage surfaces its status")
+    func storageFailureCarriesStatus() async throws {
+        let transport = RecordingTransport()
+        await transport.setResponse(status: 403, body: Data("<Error>SignatureDoesNotMatch</Error>".utf8))
+        let uploader = makeUploader(transport: transport, states: [.ready])
+
+        await #expect(throws: ErrorBlob.self) {
+            _ = try await uploader.upload(Self.fileBytes, mimeType: "image/jpeg", owner: try Self.owner())
+        }
+    }
+
+    // MARK: - Finalization -
+
+    @Test("Polls until the blob is ready")
+    func pollsUntilReady() async throws {
+        let reserving = StubReserving(states: [.processing, .processing, .ready])
+        let uploader = BlobUploader(
+            reserving: reserving,
+            transport: RecordingTransport(),
+            pollInterval: .milliseconds(1),
+            timeout: .seconds(5)
+        )
+
+        _ = try await uploader.upload(Self.fileBytes, mimeType: "image/jpeg", owner: try Self.owner())
+
+        #expect(await reserving.pollCount == 3)
+    }
+
+    @Test("A rejection stops polling and reports why")
+    func rejectionIsTerminal() async throws {
+        let reserving = StubReserving(states: [.processing, .rejected(.moderation)])
+        let uploader = BlobUploader(
+            reserving: reserving,
+            transport: RecordingTransport(),
+            pollInterval: .milliseconds(1),
+            timeout: .seconds(5)
+        )
+
+        await #expect(throws: ErrorBlob.self) {
+            _ = try await uploader.upload(Self.fileBytes, mimeType: "image/jpeg", owner: try Self.owner())
+        }
+        #expect(await reserving.pollCount == 2)
+    }
+
+    @Test("Polling gives up at the deadline")
+    func pollingHonoursTheDeadline() async throws {
+        let reserving = StubReserving(states: [])
+        let uploader = BlobUploader(
+            reserving: reserving,
+            transport: RecordingTransport(),
+            pollInterval: .milliseconds(1),
+            timeout: .milliseconds(20)
+        )
+
+        await #expect(throws: ErrorBlob.self) {
+            _ = try await uploader.upload(Self.fileBytes, mimeType: "image/jpeg", owner: try Self.owner())
+        }
+    }
+
+    /// A timed-out attempt already stored its bytes, so resuming must poll the
+    /// same blob rather than reserve a second upload.
+    @Test("Resuming finalization does not re-upload")
+    func resumingDoesNotReupload() async throws {
+        let transport = RecordingTransport()
+        let reserving = StubReserving(states: [.ready])
+        let uploader = BlobUploader(
+            reserving: reserving,
+            transport: transport,
+            pollInterval: .milliseconds(1),
+            timeout: .seconds(5)
+        )
+
+        try await uploader.awaitFinalization(blobID: StubReserving.blobID, owner: try Self.owner())
+
+        #expect(await transport.body == nil)
+        #expect(await reserving.reserveCount == 0)
+    }
+
+    // MARK: - Fixtures -
+
+    private static let fileBytes = Data(repeating: 0xAB, count: 4096)
+
+    private static let formFields = [
+        "key": "uploads/abc123",
+        "Content-Type": "image/jpeg",
+        "policy": "eyJleHBpcmF0aW9uIjoi",
+        "x-amz-signature": "deadbeef",
+    ]
+
+    private static func owner() throws -> KeyPair {
+        try #require(KeyPair.generate())
+    }
+
+    private func makeUploader(transport: RecordingTransport, states: [BlobState]) -> BlobUploader {
+        BlobUploader(
+            reserving: StubReserving(states: states),
+            transport: transport,
+            pollInterval: .milliseconds(1),
+            timeout: .seconds(5)
+        )
+    }
+
+    private struct ParsedBody {
+        let names: [String]
+        let values: [String: String]
+        let fileByteCount: Int
+    }
+
+    private static func parse(_ transport: RecordingTransport) async throws -> ParsedBody {
+        let contentType = try #require(await transport.contentType)
+        let boundary = try #require(contentType.components(separatedBy: "boundary=").last)
+        var body = try #require(await transport.body)
+
+        let closing = Data("--\(boundary)--\r\n".utf8)
+        let closingRange = try #require(body.range(of: closing))
+        #expect(closingRange.upperBound == body.endIndex)
+        body = Data(body[body.startIndex..<closingRange.lowerBound])
+
+        var names: [String] = []
+        var values: [String: String] = [:]
+        var fileByteCount = 0
+
+        for segment in Self.segments(of: body, delimitedBy: "--\(boundary)\r\n") {
+            guard let terminator = segment.range(of: Data("\r\n\r\n".utf8)) else { continue }
+
+            let headers = String(decoding: segment[segment.startIndex..<terminator.lowerBound], as: UTF8.self)
+            guard let name = headers.components(separatedBy: "name=\"").dropFirst().first?
+                .components(separatedBy: "\"").first else { continue }
+            names.append(name)
+
+            // Each part is terminated by a CRLF before the next delimiter.
+            let payload = Data(segment[terminator.upperBound...].dropLast(2))
+
+            if name == "file" {
+                fileByteCount = payload.count
+            } else {
+                values[name] = String(decoding: payload, as: UTF8.self)
+            }
+        }
+
+        return ParsedBody(names: names, values: values, fileByteCount: fileByteCount)
+    }
+
+    private static func segments(of body: Data, delimitedBy delimiter: String) -> [Data] {
+        let marker = Data(delimiter.utf8)
+        var segments: [Data] = []
+        var cursor = body.startIndex
+
+        while let range = body.range(of: marker, in: cursor..<body.endIndex) {
+            if range.lowerBound > cursor {
+                segments.append(Data(body[cursor..<range.lowerBound]))
+            }
+            cursor = range.upperBound
+        }
+
+        if cursor < body.endIndex {
+            segments.append(Data(body[cursor..<body.endIndex]))
+        }
+
+        return segments
+    }
+}
+
+// MARK: - Doubles -
+
+/// Records the upload request and returns a canned response. Per-instance state,
+/// so suites using it stay parallel-safe.
+private actor RecordingTransport: BlobUploading {
+
+    private(set) var url: URL?
+    private(set) var contentType: String?
+    private(set) var headers: [String: String] = [:]
+    private(set) var body: Data?
+
+    private var status = 204
+    private var responseBody = Data()
+
+    func setResponse(status: Int, body: Data) {
+        self.status = status
+        self.responseBody = body
+    }
+
+    func post(url: URL, contentType: String, headers: [String: String], body: Data) async throws -> (status: Int, body: Data) {
+        self.url         = url
+        self.contentType = contentType
+        self.headers     = headers
+        self.body        = body
+
+        return (status, responseBody)
+    }
+}
+
+private actor StubReserving: BlobReserving {
+
+    static let blobID = BlobID(uuid: UUID(uuidString: "3f2504e0-4f89-11d3-9a0c-0305e82c3301")!)
+
+    private var states: [BlobState]
+    private(set) var pollCount = 0
+    private(set) var reserveCount = 0
+    private(set) var declaredSizeBytes: Int?
+
+    init(states: [BlobState]) {
+        self.states = states
+    }
+
+    func initiateExternalUpload(mimeType: String, sizeBytes: Int, owner: KeyPair) async throws -> ReservedUpload {
+        reserveCount += 1
+        declaredSizeBytes = sizeBytes
+
+        return ReservedUpload(
+            blobID: Self.blobID,
+            target: UploadTarget(
+                url: URL(string: "https://storage.example.com/bucket")!,
+                headers: [:],
+                formFields: [
+                    "key": "uploads/abc123",
+                    "Content-Type": "image/jpeg",
+                    "policy": "eyJleHBpcmF0aW9uIjoi",
+                    "x-amz-signature": "deadbeef",
+                ]
+            )
+        )
+    }
+
+    /// Always `PROCESSING`, so every test exercises the polling path.
+    func completeExternalUpload(blobID: BlobID, owner: KeyPair) async throws -> BlobState {
+        .processing
+    }
+
+    func blobState(blobID: BlobID, owner: KeyPair) async throws -> BlobState {
+        pollCount += 1
+        return states.isEmpty ? .processing : states.removeFirst()
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/DisplayNameValidatorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/DisplayNameValidatorTests.swift
@@ -1,0 +1,91 @@
+//
+//  DisplayNameValidatorTests.swift
+//  FlipcashCoreTests
+//
+
+import Testing
+import FlipcashCore
+
+@Suite("Display name validation")
+struct DisplayNameValidatorTests {
+
+    private let validator = DisplayNameValidator()
+
+    @Test("Accepts names within the scalar limit",
+          arguments: [
+              "A",
+              "Ted Livingston",
+              "Ra\u{00FA}l Riera",
+              "\u{5C71}\u{7530}\u{592A}\u{90CE}",
+              "\u{1F389}",
+              String(repeating: "A", count: 64),
+          ])
+    func acceptsValidNames(_ input: String) {
+        #expect(validator.validate(input) == input)
+    }
+
+    @Test("Rejects empty, whitespace-only, and over-limit names",
+          arguments: [
+              "",
+              "   ",
+              "\n\t",
+              String(repeating: "A", count: 65),
+          ])
+    func rejectsInvalidNames(_ input: String) {
+        #expect(validator.validate(input) == nil)
+    }
+
+    @Test("Trims surrounding whitespace rather than rejecting it",
+          arguments: [
+              (input: "  Ted Livingston  ", expected: "Ted Livingston"),
+              (input: "\nTed\n",            expected: "Ted"),
+              (input: "Ted Livingston",     expected: "Ted Livingston"),
+          ] as [(input: String, expected: String)])
+    func trimsWhitespace(input: String, expected: String) {
+        #expect(validator.validate(input) == expected)
+    }
+
+    /// A grapheme-based limit would accept names the server rejects: one ZWJ
+    /// family emoji is a single grapheme but five scalars.
+    @Test("Counts Unicode scalars, not grapheme clusters")
+    func countsScalarsNotGraphemes() {
+        let family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}"
+        #expect(family.count == 1)
+        #expect(family.unicodeScalars.count == 5)
+
+        let thirteen = String(repeating: family, count: 13)
+        #expect(thirteen.count <= DisplayNameValidator.maxScalars)
+        #expect(thirteen.unicodeScalars.count == 65)
+        #expect(validator.validate(thirteen) == nil)
+
+        let twelve = String(repeating: family, count: 12)
+        #expect(twelve.unicodeScalars.count == 60)
+        #expect(validator.validate(twelve) == twelve)
+    }
+
+    @Test("A combining mark spends its own scalar")
+    func combiningMarksCount() {
+        let decomposed = "e\u{0301}"
+        #expect(decomposed.count == 1)
+        #expect(decomposed.unicodeScalars.count == 2)
+
+        #expect(validator.validate(String(repeating: decomposed, count: 32)) != nil)
+        #expect(validator.validate(String(repeating: decomposed, count: 33)) == nil)
+    }
+
+    @Test("Remaining agrees with validity at the boundary")
+    func remainingAgreesWithValidity() {
+        let atLimit = String(repeating: "A", count: 64)
+        #expect(validator.remaining(in: atLimit) == 0)
+        #expect(validator.validate(atLimit) != nil)
+
+        let overLimit = String(repeating: "A", count: 65)
+        #expect(validator.remaining(in: overLimit) == -1)
+        #expect(validator.validate(overLimit) == nil)
+    }
+
+    @Test("Remaining counts the trimmed name, which is what gets submitted")
+    func remainingIgnoresSurroundingWhitespace() {
+        #expect(validator.remaining(in: "  Ted  ") == DisplayNameValidator.maxScalars - 3)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/ProfileTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ProfileTests.swift
@@ -5,6 +5,7 @@
 //  Created by Raul Riera on 2026-04-07.
 //
 
+import Foundation
 import Testing
 import FlipcashCore
 
@@ -40,6 +41,47 @@ struct ProfileTests {
         #expect(x.hasNewlyLinkedPhone(since: x)    == false) // same number (relaunch)
         #expect(x.hasNewlyLinkedPhone(since: y)    == true)  // number changed
         #expect(none.hasNewlyLinkedPhone(since: x) == false) // number removed
+    }
+
+    /// Profiles persist as a JSON blob in a single-row table, so adding
+    /// `profilePicture` is only safe if rows written before it still decode.
+    /// This is the whole reason the change ships without a `SQLiteVersion` bump.
+    @Test("A row persisted before profile pictures still decodes")
+    func decodesProfilePersistedBeforeProfilePictures() throws {
+        let legacy = Data(#"{"displayName":"Ted Livingston","email":"ted@example.com"}"#.utf8)
+
+        let profile = try JSONDecoder().decode(Profile.self, from: legacy)
+
+        #expect(profile.displayName == "Ted Livingston")
+        #expect(profile.email == "ted@example.com")
+        #expect(profile.phone == nil)
+        #expect(profile.profilePicture == nil)
+        #expect(profile.isTippable == false)
+    }
+
+    @Test("A profile needs both a name and a picture to receive tips",
+          arguments: [
+              (name: "Ted", hasPicture: true,  expected: true),
+              (name: "Ted", hasPicture: false, expected: false),
+              (name: nil,   hasPicture: true,  expected: false),
+              (name: "",    hasPicture: true,  expected: false),
+          ] as [(name: String?, hasPicture: Bool, expected: Bool)])
+    func isTippableRequiresNameAndPicture(name: String?, hasPicture: Bool, expected: Bool) {
+        let picture = ProfilePicture(
+            blobID: .mock,
+            thumbnailURL: URL(string: "https://cdn.example.com/thumb"),
+            displayURL: URL(string: "https://cdn.example.com/display"),
+            expiresAt: nil
+        )
+
+        let profile = Profile(
+            displayName: name,
+            phone: Optional<Phone>.none,
+            email: nil,
+            profilePicture: hasPicture ? picture : nil
+        )
+
+        #expect(profile.isTippable == expected)
     }
 }
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
@@ -7,6 +7,7 @@ import Foundation
 import Testing
 import GRPCCore
 import GRPCInProcessTransport
+import FlipcashAPI
 @testable import FlipcashCore
 
 @Suite("Transport classification — classifiable errors route transient gRPC failures to a non-reportable case")
@@ -100,6 +101,28 @@ struct TransportClassificationTests {
         #expect(ErrorLaunchCurrency.network(RPCError(code: .deadlineExceeded, message: "")).reportingLevel == .suppressed)
         #expect(ErrorLaunchCurrency.network(RPCError(code: .internalError, message: "")).reportingLevel == .error)
         #expect(ErrorLaunchCurrency.unknown.reportingLevel == .error)
+    }
+
+    @Test("ErrorProfile.network is reportable only for non-transient errors")
+    func errorProfileNetwork() {
+        #expect(ErrorProfile.network(RPCError(code: .deadlineExceeded, message: "")).reportingLevel == .suppressed)
+        #expect(ErrorProfile.network(RPCError(code: .internalError, message: "")).reportingLevel == .error)
+        #expect(ErrorProfile.unknown.reportingLevel == .error)
+        // Server verdicts on user input are expected outcomes, not defects.
+        #expect(ErrorProfile.moderated(.nsfw).reportingLevel == .info)
+        #expect(ErrorProfile.invalidDisplayName.reportingLevel == .info)
+        #expect(ErrorProfile.blobRejected.reportingLevel == .info)
+    }
+
+    @Test("ErrorBlob.network is reportable only for non-transient errors")
+    func errorBlobNetwork() {
+        #expect(ErrorBlob.network(RPCError(code: .deadlineExceeded, message: "")).reportingLevel == .suppressed)
+        #expect(ErrorBlob.network(RPCError(code: .internalError, message: "")).reportingLevel == .error)
+        #expect(ErrorBlob.unknown.reportingLevel == .error)
+        // Storage refusals and a poll that ran out of budget are both expected.
+        #expect(ErrorBlob.rejected(.moderation).reportingLevel == .info)
+        #expect(ErrorBlob.uploadFailed(403).reportingLevel == .info)
+        #expect(ErrorBlob.timedOut.reportingLevel == .info)
     }
 
     @Test("ErrorSwap classifies grpcStatus by transience; grpcError always reports")


### PR DESCRIPTION
Groundwork for the Tips feature. Wraps the profile display-name and picture setters, and builds the direct-to-storage upload pipeline they depend on. No UI — nothing in the app calls this yet.

The blob contract diverges from its own proto comments in two ways that matter:

- `CompleteExternalUpload` is described as advisory, but server-side it is the only thing that starts finalization. Skip it and the blob stays pending forever.
- The proto defines a completion event, but the server never emits one. Finalization is discovered by polling.

Uploads are an S3 multipart POST whose signed policy pins the byte count exactly, so the image is encoded once and never re-encoded afterwards.

Moderation stays on the server. The name setter classifies text before it persists, and images are classified inside the blob pipeline — both through the same backend a client-side pre-check would call, so pre-checking would be double cost for the same verdict. Neither setter accepts an attestation, which is where this deliberately differs from currency creation.

Rejection is terminal, but a timeout is not, so a timed-out attempt resumes polling the same blob instead of re-uploading.

No database version bump: the profile is stored as a JSON blob and the new field is optional, so existing rows still decode. There is a test pinning exactly that.

## Test plan

- [x] `FlipcashCoreTests` pass
- [x] `FlipcashTests` pass