### PR TITLE
chore: remove the enableSend beta flag

### DIFF
--- a/Flipcash/Core/AppIntents/AppIntentContext.swift
+++ b/Flipcash/Core/AppIntents/AppIntentContext.swift
@@ -26,7 +26,7 @@ enum AppIntentContext {
     }
 
     /// Whether the signed-in user can send — gates both the contact query and
-    /// the intent. Mirrors `Session.canSend` (beta flag OR server flag).
+    /// the intent. Mirrors `Session.canSend`.
     static var canSend: Bool {
         loggedInContainer?.session.canSend ?? false
     }

--- a/Flipcash/Core/Controllers/BetaFlags.swift
+++ b/Flipcash/Core/Controllers/BetaFlags.swift
@@ -111,7 +111,6 @@ extension BetaFlags {
 
         case vibrateOnScan
         case enableCoinbase
-        case enableSend
 
         var id: String {
             localizedTitle
@@ -123,8 +122,6 @@ extension BetaFlags {
                 return "Vibrate on scan"
             case .enableCoinbase:
                 return "Enable Coinbase"
-            case .enableSend:
-                return "Send Cash"
             }
         }
 
@@ -134,8 +131,6 @@ extension BetaFlags {
                 return "If enabled, the device will vibrate to indicate that the camera has registered the code on the bill"
             case .enableCoinbase:
                 return "If enabled, Coinbase onramp will be available regardless of region"
-            case .enableSend:
-                return "If enabled, the Send feature is available from the scan screen"
             }
         }
     }

--- a/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingViewModel.swift
@@ -133,16 +133,11 @@ class OnboardingViewModel {
         try await Task.delay(milliseconds: 500) // Delay deferred state change
     }
 
-    /// Whether to collect a phone number during onboarding. The local beta flag
-    /// forces it on; otherwise the server's `enablePhoneNumberSend` decides.
-    /// The flags fetch is time-boxed so a slow connection can't stall onboarding;
+    /// Whether to collect a phone number during onboarding, decided by the
+    /// server's `enablePhoneNumberSend`. The fetch is time-boxed so a slow connection can't stall onboarding;
     /// the step is skipped if the account isn't known yet, the fetch times out, or
     /// it fails — a phone can still be connected later from the Send sheet.
     private func shouldOfferPhoneVerification() async -> Bool {
-        if BetaFlags.shared.hasEnabled(.enableSend) {
-            return true
-        }
-
         guard let userID = initializedAccount?.userID else {
             return false
         }

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -103,7 +103,7 @@ class Session {
     }
 
     var canSend: Bool {
-        BetaFlags.shared.hasEnabled(.enableSend) || userFlags?.enablePhoneNumberSend == true
+        userFlags?.enablePhoneNumberSend == true
     }
 
     var hasPreferredOnrampProvider: Bool {

--- a/FlipcashTests/SessionTests.swift
+++ b/FlipcashTests/SessionTests.swift
@@ -705,10 +705,7 @@ struct SessionOfflineCacheTests {
     }
 }
 
-/// Runs serialized — the beta-flag cases mutate the `BetaFlags.shared`
-/// singleton (UserDefaults-backed), so parallel execution with any other
-/// suite that reads `enableSend` would race on the global flag.
-@Suite("Session.canSend", .serialized)
+@Suite("Session.canSend")
 @MainActor
 struct SessionCanSendTests {
 
@@ -730,28 +727,18 @@ struct SessionCanSendTests {
         )
     }
 
-    private static func withSendBetaFlag<R>(enabled: Bool, _ body: () throws -> R) rethrows -> R {
-        let original = BetaFlags.shared.hasEnabled(.enableSend)
-        BetaFlags.shared.set(.enableSend, enabled: enabled)
-        defer { BetaFlags.shared.set(.enableSend, enabled: original) }
-        return try body()
+    @Test("canSend follows the server flag", arguments: [false, true])
+    func canSend_followsServerFlag(server: Bool) {
+        let session = Session.makeMock(database: .mock)
+        session.userFlags = Self.makeUserFlags(enablePhoneNumberSend: server)
+        #expect(session.canSend == server)
     }
 
-    @Test(
-        "canSend is the beta flag OR the server flag",
-        arguments: [
-            (beta: false, server: false, expected: false),
-            (beta: false, server: true,  expected: true),
-            (beta: true,  server: false, expected: true),
-            (beta: true,  server: true,  expected: true),
-        ]
-    )
-    func canSend(beta: Bool, server: Bool, expected: Bool) {
-        Self.withSendBetaFlag(enabled: beta) {
-            let session = Session.makeMock(database: .mock)
-            session.userFlags = Self.makeUserFlags(enablePhoneNumberSend: server)
-            #expect(session.canSend == expected)
-        }
+    @Test("canSend is false before flags load")
+    func canSend_noFlags_isFalse() {
+        let session = Session.makeMock(database: .mock)
+        #expect(session.userFlags == nil)
+        #expect(session.canSend == false)
     }
 }
 

--- a/FlipcashUITests/Smoke/CreateAccountSmokeTests.swift
+++ b/FlipcashUITests/Smoke/CreateAccountSmokeTests.swift
@@ -8,7 +8,6 @@ import XCTest
 final class CreateAccountSmokeTests: BaseUITestCase {
 
     override var resetPermissions: [XCUIProtectedResource] { [.photos, .contacts] }
-    override var enabledBetaFlags: [String] { ["enableSend"] }
 
     // MARK: - Tests
 

--- a/FlipcashUITests/Smoke/SendSmokeTests.swift
+++ b/FlipcashUITests/Smoke/SendSmokeTests.swift
@@ -9,7 +9,6 @@ final class SendSmokeTests: BaseUITestCase {
 
     override var requiresAuthentication: Bool { true }
     override var resetPermissions: [XCUIProtectedResource] { [.contacts] }
-    override var enabledBetaFlags: [String] { ["enableSend"] }
 
     func testSendFlow_picker_inviteFallback() {
         assertMainScreenReached()

--- a/FlipcashUITests/Support/Screens/RecipientPickerUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/RecipientPickerUIScreen.swift
@@ -18,7 +18,7 @@ struct RecipientPickerUIScreen {
 
     // MARK: - Elements
 
-    /// The Send button on the ScanBottomBar (gated by the `enableSend` flag).
+    /// The Send button on the ScanBottomBar (gated by `Session.canSend`).
     var sendButton: XCUIElement { app.buttons["scan-send-button"] }
 
     /// A recipient row whose accessibility label starts with `name`.


### PR DESCRIPTION
Send Cash is on for everyone and controlled by the server now, so the local beta toggle is gone. The server flag is the only control for both the Send button and the onboarding phone step. Anyone who had the toggle on loses their other beta toggles once.

## Test plan

- [x] Confirm Send still appears for an enabled account.
- [x] Confirm onboarding still asks for a phone number.
- [x] Confirm Send Cash is gone from Beta Features.