### PR TITLE
chore: quiet Swift 6 concurrency and inference warnings

### DIFF
--- a/FlipcashCore/Tests/FlipcashCoreTests/SHA512Tests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/SHA512Tests.swift
@@ -29,7 +29,7 @@ struct SHA512Tests {
             "47d0d13c5d85f2b0ff8318d2877eec2f" +
             "63b931bd47417a81a538327af927da3e"
         ),
-    ])
+    ] as [(String, String)])
     func fips180_2_vectors(input: String, expectedHex: String) {
         #expect(hexString(SHA512.digest(input)) == expectedHex)
     }

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraSession.swift
@@ -236,7 +236,10 @@ public final class CameraSession<T>: AnyCameraSession, @unchecked Sendable where
     /// extractor work runs off-main; the result is hopped to the main queue
     /// before publishing to subscribers.
     private nonisolated func receiveSampleBuffer(output: AVCaptureOutput, sampleBuffer: CMSampleBuffer, connection: AVCaptureConnection) {
-        let extracted = extractor.extract(output: output, sampleBuffer: sampleBuffer, connection: connection)
+        // SAFETY: `T.Output` has no Sendable constraint, but the extracted value
+        // is produced here on `videoDelegate.queue` and consumed exactly once on
+        // the main queue — there is no shared reference, so the hop is sound.
+        nonisolated(unsafe) let extracted = extractor.extract(output: output, sampleBuffer: sampleBuffer, connection: connection)
         let extraction = self.extraction
         DispatchQueue.main.async {
             extraction.send(extracted)

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -512,13 +512,15 @@ extension ChatMessage {
             "👍", "See you then.",
         ]
         let senders: [Sender] = (0..<count).map { $0 % 3 == 0 ? .other : .me }
-        return (0..<count).map { i in
-            ChatMessage(
+        return (0..<count).map { (i: Int) -> ChatMessage in
+            let isContinuation = i > 0 && senders[i - 1] == senders[i]
+            let isContinued = i < count - 1 && senders[i + 1] == senders[i]
+            return ChatMessage(
                 id: "msg-\(i)",
                 text: texts[i % texts.count],
                 sender: senders[i],
-                isContinuationFromPrevious: i > 0 && senders[i - 1] == senders[i],
-                isContinuedByNext: i < count - 1 && senders[i + 1] == senders[i]
+                isContinuationFromPrevious: isContinuation,
+                isContinuedByNext: isContinued
             )
         }
     }

--- a/FlipcashUI/Sources/FlipcashUI/Views/Bill/BillView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Bill/BillView.swift
@@ -293,7 +293,7 @@ struct LineView: View {
 
 // MARK: - BillClipShape -
 
-private struct BillClipShape: Shape {
+private nonisolated struct BillClipShape: Shape {
     
     let codeWidth: CGFloat
     let codePadding: CGFloat

--- a/FlipcashUI/Sources/FlipcashUI/Views/Bill/CodeView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Bill/CodeView.swift
@@ -46,7 +46,7 @@ public struct CodeView: View {
 
 // MARK: - Code Shape -
 
-struct CodeShape: Shape {
+nonisolated struct CodeShape: Shape {
     
     var data: Data
     

--- a/FlipcashUI/Sources/FlipcashUI/Views/RectEdgeShape.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/RectEdgeShape.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-public struct RectEdgeShape: Shape, InsettableShape {
+nonisolated public struct RectEdgeShape: Shape, InsettableShape {
 
     public var edge: UIRectEdge
     public var insets: CGFloat


### PR DESCRIPTION
Small, independent cleanups to quiet Swift 6 concurrency and inference diagnostics. No behavior change.

### Changes
- Mark the Sendable value-type Shapes (`BillClipShape`, `CodeShape`, `RectEdgeShape`) `nonisolated` so they satisfy `Shape`'s nonisolated requirements.
- Annotate the camera extraction hop `nonisolated(unsafe)` — the value is produced on the delegate queue and consumed once on main, with no shared reference.
- Give the chat preview-data closure and SHA512 test vectors explicit types to avoid slow/ambiguous inference.

Branched directly off `main`; independent of the tips/BlurHash work.
