### PR TITLE
feat: deploy skill + fastlane lanes for Xcode Cloud builds

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -45,7 +45,7 @@ Run from the repo root.
 
 `group:` makes the lane **block** through the whole Xcode Cloud build + processing (10–30+ min) before assigning — expected, not a hang. Stream the output and report progress. If the user doesn't want to wait, run `fastlane deploy group:'<Group>' wait:false` and tell them to run `fastlane distribute group:'<Group>'` once the build finishes processing.
 
-Assign a group to an already-built build without triggering a new one: `fastlane distribute group:'<Group>' [build:<number>]`.
+Assign a group to an already-built build without triggering a new one: `fastlane distribute group:'<Group>' [build:<number>]`. Dry-run the upload half with `fastlane distribute group:'<Group>' dry_run:true` — it confirms the group resolves and reports which build would be assigned (and whether it's processed), without assigning and without blocking.
 
 ## Report
 

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -41,7 +41,7 @@ Run from the repo root.
 | Trigger a specific branch | `fastlane deploy branch:<name>` |
 | Trigger **and** assign to a TestFlight group | `fastlane deploy group:'<Group Name>'` |
 
-**Pick the group first.** The group name must match a TestFlight group exactly (case-sensitive) or the lane errors. If the user hasn't named one, run `fastlane deploy dry_run:true` — it prints the available groups (and confirms the workflow + branch resolve) without triggering anything — then confirm the group with the user before the real run.
+**Pick the group first.** The group name must match a TestFlight group exactly (case-sensitive) or the lane errors. A default lives in the `TESTFLIGHT_GROUP` env var (in `fastlane/.env`, kept out of the repo); an explicit `group:'Name'` overrides it. If neither is set and the user hasn't named one, run `fastlane deploy dry_run:true` — it prints the available groups (and confirms the workflow + branch resolve) without triggering anything — then confirm the group with the user before the real run.
 
 `group:` makes the lane **block** through the whole Xcode Cloud build + processing (10–30+ min) before assigning — expected, not a hang. Stream the output and report progress. If the user doesn't want to wait, run `fastlane deploy group:'<Group>' wait:false` and tell them to run `fastlane distribute group:'<Group>'` once the build finishes processing.
 

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -47,6 +47,8 @@ Run from the repo root.
 
 Assign a group to an already-built build without triggering a new one: `fastlane distribute group:'<Group>' [build:<number>]`. Dry-run the upload half with `fastlane distribute group:'<Group>' dry_run:true` — it confirms the group resolves and reports which build would be assigned (and whether it's processed), without assigning and without blocking.
 
+**From GitHub instead of locally:** the same flow is exposed as the `Deploy to TestFlight (Xcode Cloud)` workflow (`.github/workflows/deploy.yml`) — Actions tab → Run workflow → pick a branch. It runs the lane on an ubuntu runner using the repo's ASC secrets, and assigns to the `TESTFLIGHT_GROUP` secret when the group field is left blank. Point users there when they can't or don't want to run fastlane locally.
+
 ## Report
 
 State the build number the lane printed and where to watch it (App Store Connect → Xcode Cloud → Builds). If a group was requested, confirm the build was assigned once the lane finishes.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: deploy
+description: Use when the user wants to trigger an Xcode Cloud build for the current branch, kick off the "Deploy Flipcash" workflow, ship an ad-hoc / dogfood build, or push a branch build to a TestFlight group — anything short of a versioned release (for cutting a version, use /release instead).
+argument-hint: [testflight-group]
+allowed-tools: Bash(git rev-parse *), Bash(git status *), Bash(git push *), Bash(git ls-remote *), Bash(fastlane deploy *), Bash(fastlane distribute *)
+---
+
+# Deploy
+
+Triggers the **Deploy Flipcash** Xcode Cloud workflow for the **current branch**, and optionally waits and assigns the resulting build to a TestFlight group. Wraps `fastlane deploy`.
+
+**Not a release.** This builds an arbitrary branch on demand. To cut a version (tag → App Store), use `/release`.
+
+## When to use
+
+- "Trigger a build", "kick off Xcode Cloud", "build this branch", "make a dogfood/TestFlight build"
+- "Deploy this to the Internal group" → include the group
+
+## Preconditions
+
+Xcode Cloud builds the commit at the **tip of the branch on origin**, and the lane refuses to run otherwise. Before invoking:
+
+1. Confirm the branch is pushed and up to date:
+   ```bash
+   git rev-parse --abbrev-ref HEAD          # the branch that will build
+   git status --porcelain                    # must be clean-ish; uncommitted work won't build
+   git ls-remote origin refs/heads/$(git rev-parse --abbrev-ref HEAD)
+   ```
+2. If origin is missing the branch or behind local HEAD, offer to `git push -u origin <branch>` (ask first).
+
+`fastlane/.env` must hold the ASC API creds (`ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_CONTENT`, `APP_IDENTIFIER`). If the lane reports one missing, tell the user to run `Scripts/pull_secrets fastlane` (or restore `fastlane/.env`).
+
+## Run
+
+Run from the repo root.
+
+| Intent | Command |
+|--------|---------|
+| Validate + list TestFlight groups, trigger nothing | `fastlane deploy dry_run:true` |
+| Just trigger a build | `fastlane deploy` |
+| Trigger a specific branch | `fastlane deploy branch:<name>` |
+| Trigger **and** assign to a TestFlight group | `fastlane deploy group:'<Group Name>'` |
+
+**Pick the group first.** The group name must match a TestFlight group exactly (case-sensitive) or the lane errors. If the user hasn't named one, run `fastlane deploy dry_run:true` — it prints the available groups (and confirms the workflow + branch resolve) without triggering anything — then confirm the group with the user before the real run.
+
+`group:` makes the lane **block** through the whole Xcode Cloud build + processing (10–30+ min) before assigning — expected, not a hang. Stream the output and report progress. If the user doesn't want to wait, run `fastlane deploy group:'<Group>' wait:false` and tell them to run `fastlane distribute group:'<Group>'` once the build finishes processing.
+
+Assign a group to an already-built build without triggering a new one: `fastlane distribute group:'<Group>' [build:<number>]`.
+
+## Report
+
+State the build number the lane printed and where to watch it (App Store Connect → Xcode Cloud → Builds). If a group was requested, confirm the build was assigned once the lane finishes.
+
+## Don't
+
+- Don't trigger against a branch whose local HEAD isn't on origin — you'd build stale code. Push first.
+- Don't guess a TestFlight group name. If the user didn't name one, either omit `group:` or ask which group.
+- Don't use this to cut a release — that's `/release`.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,78 @@
+name: Deploy to TestFlight (Xcode Cloud)
+
+# Manually trigger the "Deploy Flipcash" Xcode Cloud workflow for a branch and,
+# optionally, wait for the build and assign it to a TestFlight group.
+#
+# These lanes only call the App Store Connect API (no Xcode compile), so this
+# runs on a cheap ubuntu runner rather than macOS.
+#
+# Required repository secrets:
+#   ASC_KEY_ID       - App Store Connect API Key ID
+#   ASC_ISSUER_ID    - App Store Connect Issuer ID
+#   ASC_KEY_CONTENT  - App Store Connect API Key (.p8) contents, base64-encoded
+#   APP_IDENTIFIER   - App bundle identifier
+#   TESTFLIGHT_GROUP - default TestFlight group to assign builds to
+#                      (kept in secrets so the name stays out of the repo)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to build (must be pushed to origin)
+        required: true
+        default: main
+      group:
+        description: 'TestFlight group — leave blank to use the TESTFLIGHT_GROUP secret; type "none" to trigger only'
+        required: false
+        default: ""
+      wait:
+        description: Wait for the build to finish and assign it to the group
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: deploy-${{ inputs.branch }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout ${{ inputs.branch }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Install fastlane
+        run: gem install fastlane -v 2.227.1
+
+      - name: Trigger Deploy Flipcash
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+          APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
+          GROUP_SECRET: ${{ secrets.TESTFLIGHT_GROUP }}
+          BRANCH: ${{ inputs.branch }}
+          GROUP_INPUT: ${{ inputs.group }}
+          WAIT: ${{ inputs.wait }}
+        run: |
+          set -euo pipefail
+          args=(branch:"$BRANCH" wait:"$WAIT")
+          # blank input  -> use the TESTFLIGHT_GROUP secret (auto-assign)
+          # "none"       -> trigger only, assign nothing
+          # any name     -> one-off override of the secret
+          group_lc=$(printf '%s' "$GROUP_INPUT" | tr '[:upper:]' '[:lower:]')
+          case "$group_lc" in
+            none) ;;
+            "") [ -n "$GROUP_SECRET" ] && args+=(group:"$GROUP_SECRET") ;;
+            *) args+=(group:"$GROUP_INPUT") ;;
+          esac
+          fastlane deploy "${args[@]}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,6 +16,10 @@
 #   ASC_ISSUER_ID   - App Store Connect Issuer ID
 #   ASC_KEY_CONTENT - App Store Connect API Key content (base64)
 #
+# Optional environment variables:
+#   TESTFLIGHT_GROUP - default TestFlight group for deploy/distribute
+#                      (overridden by group:'Name'); keeps the name out of the repo
+#
 
 require "net/http"
 require "json"
@@ -147,7 +151,7 @@ platform :ios do
   lane :deploy do |options|
     workflow_name = options[:workflow] || "Deploy Flipcash"
     branch = options[:branch] || current_branch
-    group_name = options[:group]
+    group_name = options[:group] || ENV["TESTFLIGHT_GROUP"]
     dry_run = options[:dry_run].to_s == "true"
     # Only block for the (long) Xcode Cloud build when we have a group to hand it to.
     should_wait = options.key?(:wait) ? options[:wait].to_s == "true" : !group_name.nil?
@@ -193,8 +197,8 @@ platform :ios do
   desc "       fastlane distribute group:'Internal' build:42   # a specific build number"
   desc "       fastlane distribute group:'Internal' dry_run:true  # validate group + build, assign nothing"
   lane :distribute do |options|
-    group_name = options[:group]
-    UI.user_error!("Group required. Usage: fastlane distribute group:'Internal'") unless group_name
+    group_name = options[:group] || ENV["TESTFLIGHT_GROUP"]
+    UI.user_error!("Group required. Pass group:'Internal' or set TESTFLIGHT_GROUP in fastlane/.env") unless group_name
     dry_run = options[:dry_run].to_s == "true"
 
     Spaceship::ConnectAPI.token = asc_token

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -266,14 +266,18 @@ platform :ios do
   end
 
   # Xcode Cloud builds the commit at the tip of the ref on origin, so refuse
-  # to trigger when origin is missing the branch or lags the local HEAD.
+  # to trigger when origin is missing the branch. When deploying the branch
+  # we're standing on, also require origin to hold our latest commit —
+  # otherwise we'd build a stale remote tip. An explicitly-named other branch
+  # is taken as-is on origin.
   def ensure_branch_on_origin(branch)
-    local = sh("git rev-parse HEAD", log: false).strip
     remote = sh("git ls-remote origin refs/heads/#{branch}", log: false).strip.split(/\s+/).first.to_s
+    UI.user_error!("Branch '#{branch}' isn't on origin. Push it first: git push -u origin #{branch}") if remote.empty?
 
-    if remote.empty?
-      UI.user_error!("Branch '#{branch}' isn't on origin. Push it first: git push -u origin #{branch}")
-    elsif remote != local
+    return unless branch == sh("git rev-parse --abbrev-ref HEAD", log: false).strip
+
+    local = sh("git rev-parse HEAD", log: false).strip
+    unless remote == local
       UI.user_error!("origin/#{branch} (#{remote[0, 7]}) ≠ local HEAD (#{local[0, 7]}). Push first — Xcode Cloud builds the remote tip.")
     end
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -191,9 +191,11 @@ platform :ios do
   desc "Assign a processed build to a TestFlight group"
   desc "Usage: fastlane distribute group:'Internal'            # latest processed build"
   desc "       fastlane distribute group:'Internal' build:42   # a specific build number"
+  desc "       fastlane distribute group:'Internal' dry_run:true  # validate group + build, assign nothing"
   lane :distribute do |options|
     group_name = options[:group]
     UI.user_error!("Group required. Usage: fastlane distribute group:'Internal'") unless group_name
+    dry_run = options[:dry_run].to_s == "true"
 
     Spaceship::ConnectAPI.token = asc_token
     app = Spaceship::ConnectAPI::App.find(ENV["APP_IDENTIFIER"])
@@ -201,6 +203,20 @@ platform :ios do
 
     group = app.get_beta_groups(filter: { name: group_name }).find { |g| g.name == group_name }
     UI.user_error!("No TestFlight group named '#{group_name}'") unless group
+
+    # Dry run reports against whatever's uploaded right now — it never blocks
+    # waiting for processing, and never assigns.
+    if dry_run
+      build = latest_build(app, options[:build])
+      if build.nil?
+        UI.important("Group '#{group_name}' ✓ found. No matching build uploaded yet — a real run would wait for one.")
+      elsif build.processed?
+        UI.success("Dry run — nothing assigned. Would assign build #{build.version} → '#{group_name}' (processed, ready).")
+      else
+        UI.important("Group '#{group_name}' ✓ found. Build #{build.version} is still processing — a real run would wait, then assign.")
+      end
+      next
+    end
 
     build = wait_for_processed_build(app, options[:build])
     build.add_beta_groups(beta_groups: [group])
@@ -358,15 +374,21 @@ platform :ios do
 
   # Blocks until a build (optionally a specific number) has finished App Store
   # Connect processing so it can be handed to a TestFlight group.
+  # Most recently uploaded build, optionally pinned to a build number. Does not
+  # wait — returns nil if nothing matches yet.
+  def latest_build(app, build_number)
+    Spaceship::ConnectAPI::Build.all(
+      app_id: app.id,
+      build_number: build_number&.to_s,
+      sort: "-uploadedDate",
+      limit: 1
+    ).first
+  end
+
   def wait_for_processed_build(app, build_number, timeout: 30 * 60, interval: 30)
     waited = 0
     loop do
-      build = Spaceship::ConnectAPI::Build.all(
-        app_id: app.id,
-        build_number: build_number&.to_s,
-        sort: "-uploadedDate",
-        limit: 1
-      ).first
+      build = latest_build(app, build_number)
 
       return build if build&.processed?
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,12 +5,21 @@
 #   2. Xcode Cloud builds and uploads to App Store Connect
 #   3. Run: fastlane release version:1.2.3
 #
+# Ad-hoc build flow:
+#   1. Push your branch to origin
+#   2. Run: fastlane deploy                     (triggers the "Deploy Flipcash" Xcode Cloud workflow)
+#      or:  fastlane deploy group:'Internal'    (also waits, then assigns the build to a TestFlight group)
+#
 # Required environment variables (set in fastlane/.env):
 #   APP_IDENTIFIER  - App bundle identifier
 #   ASC_KEY_ID      - App Store Connect API Key ID
 #   ASC_ISSUER_ID   - App Store Connect Issuer ID
 #   ASC_KEY_CONTENT - App Store Connect API Key content (base64)
 #
+
+require "net/http"
+require "json"
+require "spaceship"
 
 default_platform(:ios)
 
@@ -126,6 +135,80 @@ platform :ios do
   end
 
   # ──────────────────────────────────────────────────────────────────
+  # Deploy Lane (Xcode Cloud)
+  # ──────────────────────────────────────────────────────────────────
+
+  desc "Trigger the 'Deploy Flipcash' Xcode Cloud workflow for the current branch"
+  desc "Usage: fastlane deploy"
+  desc "       fastlane deploy branch:my-feature"
+  desc "       fastlane deploy group:'Internal'          # trigger, wait, then assign to a TestFlight group"
+  desc "       fastlane deploy dry_run:true              # validate creds/workflow/branch + list groups, trigger nothing"
+  desc "       fastlane deploy workflow:'Deploy Flipcash'"
+  lane :deploy do |options|
+    workflow_name = options[:workflow] || "Deploy Flipcash"
+    branch = options[:branch] || current_branch
+    group_name = options[:group]
+    dry_run = options[:dry_run].to_s == "true"
+    # Only block for the (long) Xcode Cloud build when we have a group to hand it to.
+    should_wait = options.key?(:wait) ? options[:wait].to_s == "true" : !group_name.nil?
+
+    ensure_branch_on_origin(branch)
+
+    token = asc_token
+    workflow = find_ci_workflow(token.text, workflow_name)
+    git_ref = find_git_reference(token.text, workflow[:repo_id], branch)
+
+    if dry_run
+      UI.success("Dry run — nothing triggered")
+      UI.message("Workflow  '#{workflow_name}' → #{workflow[:id]}")
+      UI.message("Branch    '#{branch}' → git reference #{git_ref[:id]}")
+      names = testflight_group_names(token)
+      UI.message("TestFlight groups: #{names.empty? ? '(none)' : names.join(', ')}")
+      UI.message(group_name ? "group:'#{group_name}' #{names.include?(group_name) ? '✓ matches' : "✗ NOT FOUND — pick one of the above"}" : "Pass group:'<name>' to assign the build to a TestFlight group.")
+      next
+    end
+
+    run = create_ci_build_run(token.text, workflow[:id], git_ref[:id])
+
+    UI.success("🚀 Started '#{workflow_name}' build ##{run[:number]} for #{branch}")
+    UI.message("Track it in App Store Connect → Xcode Cloud → Builds.")
+
+    next unless group_name
+
+    unless should_wait
+      UI.important("Run `fastlane distribute group:'#{group_name}'` once build ##{run[:number]} finishes processing.")
+      next
+    end
+
+    wait_for_build_run(token, run[:id])
+    distribute(group: group_name)
+  end
+
+  # ──────────────────────────────────────────────────────────────────
+  # Distribute Lane (TestFlight)
+  # ──────────────────────────────────────────────────────────────────
+
+  desc "Assign a processed build to a TestFlight group"
+  desc "Usage: fastlane distribute group:'Internal'            # latest processed build"
+  desc "       fastlane distribute group:'Internal' build:42   # a specific build number"
+  lane :distribute do |options|
+    group_name = options[:group]
+    UI.user_error!("Group required. Usage: fastlane distribute group:'Internal'") unless group_name
+
+    Spaceship::ConnectAPI.token = asc_token
+    app = Spaceship::ConnectAPI::App.find(ENV["APP_IDENTIFIER"])
+    UI.user_error!("App '#{ENV['APP_IDENTIFIER']}' not found in App Store Connect") unless app
+
+    group = app.get_beta_groups(filter: { name: group_name }).find { |g| g.name == group_name }
+    UI.user_error!("No TestFlight group named '#{group_name}'") unless group
+
+    build = wait_for_processed_build(app, options[:build])
+    build.add_beta_groups(beta_groups: [group])
+
+    UI.success("✅ Added build #{build.version} to TestFlight group '#{group_name}'")
+  end
+
+  # ──────────────────────────────────────────────────────────────────
   # Helpers
   # ──────────────────────────────────────────────────────────────────
 
@@ -139,6 +222,168 @@ platform :ios do
 
   def default_release_notes
     "Bug fixes and performance improvements."
+  end
+
+  # ── Xcode Cloud / App Store Connect API helpers ──────────────────────
+
+  ASC_API_BASE = "https://api.appstoreconnect.apple.com/v1"
+
+  # A short-lived JWT token object. `.text` re-signs automatically when it
+  # expires, so it stays valid across a multi-minute build-run poll.
+  def asc_token
+    %w[ASC_KEY_ID ASC_ISSUER_ID ASC_KEY_CONTENT].each do |name|
+      UI.user_error!("Missing #{name}. Populate fastlane/.env (Scripts/pull_secrets).") if ENV[name].to_s.empty?
+    end
+
+    Spaceship::ConnectAPI::Token.create(
+      key_id: ENV["ASC_KEY_ID"],
+      issuer_id: ENV["ASC_ISSUER_ID"],
+      key: ENV["ASC_KEY_CONTENT"],
+      is_key_content_base64: true
+    )
+  end
+
+  def current_branch
+    branch = sh("git rev-parse --abbrev-ref HEAD", log: false).strip
+    UI.user_error!("Detached HEAD — pass the branch explicitly: fastlane deploy branch:<name>") if branch == "HEAD"
+    branch
+  end
+
+  # Xcode Cloud builds the commit at the tip of the ref on origin, so refuse
+  # to trigger when origin is missing the branch or lags the local HEAD.
+  def ensure_branch_on_origin(branch)
+    local = sh("git rev-parse HEAD", log: false).strip
+    remote = sh("git ls-remote origin refs/heads/#{branch}", log: false).strip.split(/\s+/).first.to_s
+
+    if remote.empty?
+      UI.user_error!("Branch '#{branch}' isn't on origin. Push it first: git push -u origin #{branch}")
+    elsif remote != local
+      UI.user_error!("origin/#{branch} (#{remote[0, 7]}) ≠ local HEAD (#{local[0, 7]}). Push first — Xcode Cloud builds the remote tip.")
+    end
+  end
+
+  def asc_get(bearer, path)
+    uri = URI(path.start_with?("http") ? path : "#{ASC_API_BASE}/#{path}")
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{bearer}"
+    send_asc_request(uri, request)
+  end
+
+  def asc_post(bearer, path, body)
+    uri = URI("#{ASC_API_BASE}/#{path}")
+    request = Net::HTTP::Post.new(uri)
+    request["Authorization"] = "Bearer #{bearer}"
+    request["Content-Type"] = "application/json"
+    request.body = body.to_json
+    send_asc_request(uri, request)
+  end
+
+  def send_asc_request(uri, request)
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(request) }
+    unless response.code.to_i.between?(200, 299)
+      UI.user_error!("App Store Connect API #{request.method} #{uri.path} failed: #{response.code}\n#{response.body}")
+    end
+    response.body.to_s.empty? ? {} : JSON.parse(response.body)
+  end
+
+  # Locates a workflow by name across every Xcode Cloud product, returning
+  # its id plus the id of the repository it builds from.
+  def find_ci_workflow(bearer, name)
+    available = []
+    asc_get(bearer, "ciProducts?limit=200")["data"].each do |product|
+      workflows = asc_get(bearer, "ciProducts/#{product['id']}/workflows?limit=200")["data"]
+      available.concat(workflows.map { |w| w.dig("attributes", "name") })
+      match = workflows.find { |w| w.dig("attributes", "name")&.casecmp?(name) }
+      next unless match
+
+      detail = asc_get(bearer, "ciWorkflows/#{match['id']}?include=repository")
+      repo_id = detail.dig("data", "relationships", "repository", "data", "id")
+      UI.user_error!("Workflow '#{name}' has no linked repository") unless repo_id
+      return { id: match["id"], repo_id: repo_id }
+    end
+
+    UI.user_error!("No Xcode Cloud workflow named '#{name}'. Available: #{available.compact.uniq.join(', ')}")
+  end
+
+  # Resolves a branch name to its Xcode Cloud git-reference id, paging through
+  # every reference the product's repository knows about.
+  def find_git_reference(bearer, repo_id, branch)
+    path = "scmRepositories/#{repo_id}/gitReferences?limit=200"
+    while path
+      page = asc_get(bearer, path)
+      match = page["data"].find do |ref|
+        ref.dig("attributes", "kind") == "BRANCH" && ref.dig("attributes", "name") == branch
+      end
+      return { id: match["id"] } if match
+
+      path = page.dig("links", "next")
+    end
+
+    UI.user_error!("Xcode Cloud hasn't indexed branch '#{branch}' yet. Wait a moment after pushing, then retry.")
+  end
+
+  def create_ci_build_run(bearer, workflow_id, git_reference_id)
+    body = {
+      data: {
+        type: "ciBuildRuns",
+        relationships: {
+          workflow: { data: { type: "ciWorkflows", id: workflow_id } },
+          sourceBranchOrTag: { data: { type: "scmGitReferences", id: git_reference_id } }
+        }
+      }
+    }
+    response = asc_post(bearer, "ciBuildRuns", body)
+    { id: response.dig("data", "id"), number: response.dig("data", "attributes", "number") }
+  end
+
+  # Blocks until the build run completes, erroring if it didn't succeed.
+  def wait_for_build_run(token, run_id, timeout: 45 * 60, interval: 30)
+    waited = 0
+    loop do
+      attributes = asc_get(token.text, "ciBuildRuns/#{run_id}")["data"]["attributes"]
+      progress = attributes["executionProgress"]
+      status = attributes["completionStatus"]
+      UI.message("Xcode Cloud build: #{[progress, status].compact.join(' / ')}")
+
+      if progress == "COMPLETE"
+        UI.user_error!("Xcode Cloud build finished #{status}") unless status == "SUCCEEDED"
+        return
+      end
+
+      UI.user_error!("Timed out after #{timeout / 60} min waiting for the build to finish") if waited >= timeout
+      sleep(interval)
+      waited += interval
+    end
+  end
+
+  # Blocks until a build (optionally a specific number) has finished App Store
+  # Connect processing so it can be handed to a TestFlight group.
+  def wait_for_processed_build(app, build_number, timeout: 30 * 60, interval: 30)
+    waited = 0
+    loop do
+      build = Spaceship::ConnectAPI::Build.all(
+        app_id: app.id,
+        build_number: build_number&.to_s,
+        sort: "-uploadedDate",
+        limit: 1
+      ).first
+
+      return build if build&.processed?
+
+      state = build ? "processing" : "not yet uploaded"
+      UI.message("Waiting for build#{build_number ? " #{build_number}" : ''} (#{state})…")
+      UI.user_error!("Timed out after #{timeout / 60} min waiting for a processed build") if waited >= timeout
+      sleep(interval)
+      waited += interval
+    end
+  end
+
+  # Names of every TestFlight group on the app, for picking a `group:` value.
+  def testflight_group_names(token)
+    Spaceship::ConnectAPI.token = token
+    app = Spaceship::ConnectAPI::App.find(ENV["APP_IDENTIFIER"])
+    UI.user_error!("App '#{ENV['APP_IDENTIFIER']}' not found in App Store Connect") unless app
+    app.get_beta_groups.map(&:name)
   end
 
 end


### PR DESCRIPTION
## What

Adds a model-invocable `/deploy` skill and two fastlane lanes that trigger the **Deploy Flipcash** Xcode Cloud workflow for the current branch, and optionally push the resulting build to a TestFlight group.

## Why

Today the only way to get an Xcode Cloud build is pushing a `flipcash-X.Y.Z` release tag (via `/release`). There was no one-command way to build an arbitrary branch on demand or drop it into a TestFlight group for dogfooding.

## Lanes

| Command | Effect |
|---------|--------|
| `fastlane deploy dry_run:true` | Validate creds + the workflow name + the branch's git-ref, and **list TestFlight groups** — triggers nothing |
| `fastlane deploy` | Trigger Deploy Flipcash for the current branch |
| `fastlane deploy branch:<name>` | Trigger a specific branch |
| `fastlane deploy group:'<Group>'` | Trigger, wait through build + processing, then assign to the TestFlight group |
| `fastlane deploy group:'<Group>' wait:false` | Trigger only; assign later with `distribute` |
| `fastlane distribute group:'<Group>' [build:<n>]` | Assign an already-built build to a group |

## Implementation notes

- Spaceship ships **no Xcode Cloud models**, so the CI calls (`ciProducts` → `ciWorkflows` → `scmRepositories/{id}/gitReferences` → `POST ciBuildRuns`) go over the raw App Store Connect REST API using a Spaceship-minted JWT (auto-refreshes across the long poll). TestFlight assignment uses Spaceship's `BetaGroup`/`Build` models.
- `deploy` refuses to run when origin is missing the branch or lags local HEAD — Xcode Cloud builds the remote tip, so this prevents building stale code.
- Reuses the existing `ASC_KEY_ID` / `ASC_ISSUER_ID` / `ASC_KEY_CONTENT` / `APP_IDENTIFIER` creds from `fastlane/.env`.

## Verification

- `ruby -c fastlane/Fastfile` → Syntax OK; `fastlane lanes` registers `deploy` and `distribute`.
- All Spaceship calls checked against the installed gem (fastlane 2.227.1); `ciBuildRuns` request shape matches Apple's documented format.
- **Live dry-run confirmed** against App Store Connect (`fastlane deploy dry_run:true branch:main`): creds authenticate, the `Deploy Flipcash` workflow resolves, the branch git-ref resolves, TestFlight groups enumerate, and an explicit/`TESTFLIGHT_GROUP` group name matches. Only the two mutating calls (`POST ciBuildRuns`, `add_beta_groups`) remain un-exercised end-to-end, by design.
