### PR TITLE
feat: move Tips to public beta features

### DIFF
--- a/Flipcash/Core/Controllers/BetaFlags.swift
+++ b/Flipcash/Core/Controllers/BetaFlags.swift
@@ -141,6 +141,23 @@ extension BetaFlags {
                 return "If enabled, the Tips tab is available from the scan screen"
             }
         }
+
+        /// Which Settings surface exposes this flag's toggle.
+        var availability: Availability {
+            switch self {
+            case .vibrateOnScan:  return .developer
+            case .enableCoinbase: return .developer
+            case .enableTips:     return .publicBeta
+            }
+        }
+    }
+
+    /// Where a beta flag's toggle appears in Settings.
+    enum Availability {
+        /// The hidden developer "Beta Flags" screen, unlocked by the 9-tap easter egg.
+        case developer
+        /// The public "Advanced ▸ Beta Features" screen, visible to every user.
+        case publicBeta
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -77,14 +77,20 @@ final class TipFlow {
 
     // MARK: - Entry -
 
-    /// Handles a scanned or deeplinked tipcode. Gates in order: the feature
-    /// flag, own-id scans (ignored), then a tippable profile (held + profile
-    /// creation presented). The card always shows for a tippable recipient; the
-    /// giveable-balance gate is deferred to ``present(_:)``, where it blocks the
-    /// Send a Tip sheet (surfacing the Add Money / Discover dialog) without
-    /// hiding the card.
+    /// Handles a scanned or deeplinked tipcode. Any tipcard interaction opts the
+    /// user into the Tips beta, so the flow proceeds instead of gating on the
+    /// flag. Gates in order: own-id scans (ignored), then a tippable profile
+    /// (held + profile creation presented). The card always shows for a tippable
+    /// recipient; the giveable-balance gate is deferred to ``present(_:)``, where
+    /// it blocks the Send a Tip sheet (surfacing the Add Money / Discover dialog)
+    /// without hiding the card.
     func begin(userID: UserID) {
-        guard session.canUseTips else { return }
+        // Encountering a tipcard opts the user into the Tips beta, revealing the
+        // Tips tab going forward. Only written once — `canUseTips` short-circuits
+        // repeat scans of the same code across camera frames.
+        if !session.canUseTips {
+            BetaFlags.shared.set(.enableTips, enabled: true)
+        }
         guard userID != session.userID else { return }
         guard submission == nil, pendingUserID == nil, prepTask == nil else { return }
         // A dialog is already asking the user something (commonly this flow's

--- a/Flipcash/Core/Screens/Settings/BetaFlagToggleRow.swift
+++ b/Flipcash/Core/Screens/Settings/BetaFlagToggleRow.swift
@@ -1,0 +1,35 @@
+//
+//  BetaFlagToggleRow.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+
+/// A single beta-flag toggle row, shared by the developer "Beta Flags" screen
+/// and the public "Beta Features" screen.
+struct BetaFlagToggleRow: View {
+
+    let option: BetaFlags.Option
+    @Binding var isOn: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle(isOn: $isOn) {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(option.localizedTitle)
+                        .foregroundStyle(.textMain)
+                        .font(.appTextMedium)
+                    Text(option.localizedDescription)
+                        .foregroundStyle(.textSecondary)
+                        .font(.appTextHeading)
+                        .multilineTextAlignment(.leading)
+                }
+                .padding(.trailing, 20)
+            }
+            .tint(.textSuccess)
+        }
+        .padding(20)
+        .vSeparator(color: .rowSeparator, position: .bottom)
+    }
+}

--- a/Flipcash/Core/Screens/Settings/BetaFlagsScreen.swift
+++ b/Flipcash/Core/Screens/Settings/BetaFlagsScreen.swift
@@ -30,24 +30,8 @@ struct BetaFlagsScreen: View {
             LazyTable(spacing: 0) {
                 sectionHeader("Flags")
 
-                ForEach(BetaFlags.Option.allCases) { option in
-                    HStack(spacing: 12) {
-                        Toggle(isOn: betaFlags.bindingFor(option: option)) {
-                            VStack(alignment: .leading, spacing: 5) {
-                                Text(option.localizedTitle)
-                                    .foregroundStyle(.textMain)
-                                    .font(.appTextMedium)
-                                Text(option.localizedDescription)
-                                    .foregroundStyle(.textSecondary)
-                                    .font(.appTextHeading)
-                                    .multilineTextAlignment(.leading)
-                            }
-                            .padding(.trailing, 20)
-                        }
-                        .tint(.textSuccess)
-                    }
-                    .padding(20)
-                    .vSeparator(color: .rowSeparator, position: .bottom)
+                ForEach(BetaFlags.Option.allCases.filter { $0.availability == .developer }) { option in
+                    BetaFlagToggleRow(option: option, isOn: betaFlags.bindingFor(option: option))
                 }
 
                 sectionHeader("Account")

--- a/Flipcash/Core/Screens/Settings/SettingsAdvancedBetaFeaturesScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsAdvancedBetaFeaturesScreen.swift
@@ -10,16 +10,28 @@ import FlipcashUI
 
 struct SettingsAdvancedBetaFeaturesScreen: View {
 
+    @Environment(BetaFlags.self) private var betaFlags
+
+    private let options = BetaFlags.Option.allCases.filter { $0.availability == .publicBeta }
+
     var body: some View {
         Background(color: .backgroundMain) {
-            ContentUnavailableView {
-                Text("No Beta Features")
-                    .font(.appTextLarge)
-                    .foregroundStyle(Color.textMain)
-            } description: {
-                Text("There are no beta features available right now.")
-                    .font(.appTextMedium)
-                    .foregroundStyle(Color.textSecondary)
+            if options.isEmpty {
+                ContentUnavailableView {
+                    Text("No Beta Features")
+                        .font(.appTextLarge)
+                        .foregroundStyle(Color.textMain)
+                } description: {
+                    Text("There are no beta features available right now.")
+                        .font(.appTextMedium)
+                        .foregroundStyle(Color.textSecondary)
+                }
+            } else {
+                LazyTable(spacing: 0) {
+                    ForEach(options) { option in
+                        BetaFlagToggleRow(option: option, isOn: betaFlags.bindingFor(option: option))
+                    }
+                }
             }
         }
         .navigationTitle("Beta Features")
@@ -33,5 +45,6 @@ struct SettingsAdvancedBetaFeaturesScreen: View {
     NavigationStack {
         SettingsAdvancedBetaFeaturesScreen()
     }
+    .environment(BetaFlags.mock)
     .preferredColorScheme(.dark)
 }


### PR DESCRIPTION
## Summary

Moves the **Tips** feature flag out of the hidden developer beta screen and into the public **Settings ▸ Advanced ▸ Beta Features** screen, and auto-enables it when a user encounters a tipcard.

## Changes

- **`BetaFlags.Option` gains an `Availability` category** (`.developer` / `.publicBeta`). `enableTips` is `.publicBeta`; `vibrateOnScan` and `enableCoinbase` remain `.developer`.
- **`SettingsAdvancedBetaFeaturesScreen`** (public, always visible) now renders toggles for `.publicBeta` flags — currently just Tips — keeping the "No Beta Features" empty state as a fallback when none exist.
- **`BetaFlagsScreen`**  now filters to `.developer` flags, so Tips no longer appears there.
- **`BetaFlagToggleRow`** (new) — a shared toggle row used by both screens to avoid duplication.
- **`TipFlow.begin`** replaces the `canUseTips` feature-flag guard with an opt-in: scanning a tipcode or opening a tipcard deeplink now enables `enableTips` (written once; `canUseTips` short-circuits repeat camera frames). Both the scan and deeplink paths share this single chokepoint.

## Notes

- The `isTippable` profile-setup gate (a sender needs their own name + picture before a tip proceeds) is **left unchanged**, pending product requirements.

## Testing

- `./Scripts/build.sh` — **BUILD SUCCEEDED**.