### PR TITLE
chore(tips): remove profile photo from tip card setup for now

### DIFF
--- a/Flipcash/Core/Screens/Main/Profile/ProfileNameScreen.swift
+++ b/Flipcash/Core/Screens/Main/Profile/ProfileNameScreen.swift
@@ -95,7 +95,9 @@ struct ProfileNameScreen: View {
                 // RPCs — by now the user may have swapped to another sheet, whose
                 // stack has no profile-creation state to mount against.
                 guard !Task.isCancelled, router.presentedSheet?.stack == .tips else { return }
-                router.push(.profilePhoto)
+                // The photo-capture step is skipped for now — the card omits the
+                // profile photo, so setup goes straight from the name to the card.
+                router.push(.tipcard)
 
             } catch ErrorProfile.moderated(let category) {
                 logger.info("Display name moderation denied", metadata: ["category": "\(category)"])

--- a/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
@@ -26,6 +26,11 @@ struct TipcardView: View {
     /// contrast against different surfaces (share sheet vs. live camera).
     var tintOpacity: Double = 0.72
 
+    /// The profile photo is intentionally omitted from the card for now, so the
+    /// avatar is gated off by default. Kept as a flag (rather than deleted) so
+    /// re-enabling it is a one-line change once the product decision reverts.
+    var includePhoto: Bool = false
+
     var body: some View {
         VStack(spacing: 0) {
             CodeView(data: codeData)
@@ -35,12 +40,14 @@ struct TipcardView: View {
             HStack(spacing: 8) {
                 Text("Tip")
 
-                avatarImage
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: avatarDimension, height: avatarDimension)
-                    .foregroundStyle(Color.textSecondary)
-                    .clipShape(Circle())
+                if includePhoto {
+                    avatarImage
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: avatarDimension, height: avatarDimension)
+                        .foregroundStyle(Color.textSecondary)
+                        .clipShape(Circle())
+                }
 
                 Text(name)
                     .lineLimit(1)

--- a/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
@@ -47,7 +47,7 @@ private struct TipsIntroScreen: View {
                     .multilineTextAlignment(.center)
                     .padding(.top, 32)
 
-                Text("Add your name and a picture to receive tips")
+                Text("Add your name to receive tips")
                     .font(.appTextSmall)
                     .foregroundStyle(Color.textSecondary)
                     .multilineTextAlignment(.center)


### PR DESCRIPTION
Ports Android [#1160](https://github.com/code-payments/code-android-app/pull/1160) to iOS.

## What & why
Remove the profile photo from tip card setup for now.

- **Setup flow** — after entering the name, setup now goes straight to the tip card, skipping the photo-capture step (`ProfileNameScreen` pushes `.tipcard` instead of `.profilePhoto`). `ProfilePhotoScreen` and the `.profilePhoto` route are left in place for easy re-enable.
- **Rendered card** — the avatar is gated behind a new `includePhoto` flag on `TipcardView`, defaulting to `false`. Both surfaces that build the card (My Tip Card screen and the scanned recipient card in `BillCanvas`) use the default, so no tip card renders a photo. This mirrors Android, where the card's `includePhoto` param defaults false and no caller enables it.
- **Copy** — the Tips intro subtitle drops "and a picture" ("Add your name to receive tips").

The avatar rendering and load paths are kept behind the flag, so restoring the photo later is a one-line change.

## Testing
- `Flipcash` app scheme compiles clean (iPhone 16 Pro sim).
