### PR TITLE
fix(tests): restore FlipcashTests compilation under Xcode 27 main-actor isolation

### DIFF
--- a/FlipcashTests/Database/Database+MintUpsertTests.swift
+++ b/FlipcashTests/Database/Database+MintUpsertTests.swift
@@ -10,7 +10,10 @@ import Testing
 import FlipcashCore
 @testable import Flipcash
 
+// `@MainActor` because `StoredMintMetadata.metadata` is main-actor-isolated
+// under the module's default isolation and the round-trips read it.
 @Suite("Mint upsert round-trips")
+@MainActor
 struct DatabaseMintUpsertTests {
 
     // MARK: - Helpers

--- a/FlipcashTests/ProfileCreationStateTests.swift
+++ b/FlipcashTests/ProfileCreationStateTests.swift
@@ -17,21 +17,21 @@ struct ProfileCreationStateTests {
     @Test("A timed-out attempt resumes the same blob instead of re-storing")
     func timeoutResumesTheSameBlob() async throws {
         let uploader = StubUploader()
-        await uploader.setFinalizationResult(.failure(ErrorBlob.timedOut))
+        uploader.setFinalizationResult(.failure(ErrorBlob.timedOut))
 
         let state = try await makeState()
 
         await #expect(throws: ErrorBlob.self) {
             try await state.uploadPhoto(with: uploader)
         }
-        #expect(await uploader.storeCount == 1)
+        #expect(uploader.storeCount == 1)
         #expect(state.reservedBlobID != nil)
 
-        await uploader.setFinalizationResult(.success(()))
+        uploader.setFinalizationResult(.success(()))
         try await state.uploadPhoto(with: uploader)
 
-        #expect(await uploader.storeCount == 1)
-        #expect(await uploader.setPictureCount == 1)
+        #expect(uploader.storeCount == 1)
+        #expect(uploader.setPictureCount == 1)
     }
 
     /// Rejection is terminal: the bytes behind a blob are immutable, so the id
@@ -39,7 +39,7 @@ struct ProfileCreationStateTests {
     @Test("A rejection clears the blob so the next attempt re-stores")
     func rejectionForcesAFreshUpload() async throws {
         let uploader = StubUploader()
-        await uploader.setFinalizationResult(.failure(ErrorBlob.rejected(.moderation)))
+        uploader.setFinalizationResult(.failure(ErrorBlob.rejected(.moderation)))
 
         let state = try await makeState()
 
@@ -48,10 +48,10 @@ struct ProfileCreationStateTests {
         }
         #expect(state.reservedBlobID == nil)
 
-        await uploader.setFinalizationResult(.success(()))
+        uploader.setFinalizationResult(.success(()))
         try await state.uploadPhoto(with: uploader)
 
-        #expect(await uploader.storeCount == 2)
+        #expect(uploader.storeCount == 2)
     }
 
     /// A reservation is signed against one byte count, so a different photo can
@@ -59,7 +59,7 @@ struct ProfileCreationStateTests {
     @Test("Choosing a different photo drops the reserved blob")
     func selectingANewPhotoDropsTheReservation() async throws {
         let uploader = StubUploader()
-        await uploader.setFinalizationResult(.failure(ErrorBlob.timedOut))
+        uploader.setFinalizationResult(.failure(ErrorBlob.timedOut))
 
         let state = try await makeState()
 
@@ -82,8 +82,8 @@ struct ProfileCreationStateTests {
 
         try await state.uploadPhoto(with: uploader)
 
-        #expect(await uploader.setPictureCount == 1)
-        #expect(await uploader.refreshCount == 1)
+        #expect(uploader.setPictureCount == 1)
+        #expect(uploader.refreshCount == 1)
         #expect(state.selectedImage == nil)
         #expect(state.isUploading == false)
     }
@@ -96,7 +96,7 @@ struct ProfileCreationStateTests {
         await #expect(throws: ErrorBlob.self) {
             try await state.uploadPhoto(with: uploader)
         }
-        #expect(await uploader.storeCount == 0)
+        #expect(uploader.storeCount == 0)
     }
 
     // MARK: - Helpers -
@@ -132,7 +132,11 @@ struct ProfileCreationStateTests {
 // MARK: - Doubles -
 
 /// Counts each leg of the upload and lets a test choose how finalization ends.
-private actor StubUploader: ProfilePictureUploading {
+/// `@MainActor` (not an `actor`): `ProfilePictureUploading` is main-actor
+/// isolated under the module's default isolation, and an `actor` cannot conform
+/// to a global-actor-isolated protocol. The suite is already `@MainActor`.
+@MainActor
+private final class StubUploader: ProfilePictureUploading {
 
     private(set) var storeCount = 0
     private(set) var setPictureCount = 0

--- a/FlipcashTests/Regressions/Regression_69ea28b0.swift
+++ b/FlipcashTests/Regressions/Regression_69ea28b0.swift
@@ -19,7 +19,11 @@ import Testing
 import FlipcashCore
 @testable import Flipcash
 
+// `@MainActor` because `StoredMintMetadata.init(_:)` and `.metadata` are
+// main-actor-isolated (they bridge to `MintMetadata`); calling them from the
+// nonisolated test context is a hard error under Swift 6 / Xcode 27.
 @Suite("Regression: 69ea28b0 – MintMetadata decoded once per loaded transition", .bug("69ea28b00174c05561fd0000"))
+@MainActor
 struct Regression_69ea28b0 {
 
     @Test("LoadingState.loaded carries both stored row and pre-decoded MintMetadata")

--- a/FlipcashTests/URLSanitizationTests.swift
+++ b/FlipcashTests/URLSanitizationTests.swift
@@ -7,7 +7,10 @@ import Foundation
 import Testing
 @testable import Flipcash
 
+// `@MainActor` because `sanitizedForAnalytics` is main-actor-isolated under the
+// module's default isolation, and the suite reads it from every `#expect`.
 @Suite("URL Sanitization for Analytics")
+@MainActor
 struct URLSanitizationTests {
 
     // MARK: - Fragments are stripped


### PR DESCRIPTION
## Problem
The `FlipcashTests` bundle fails to link on `main` under Xcode 27 / Swift 6. The app module defaults to main-actor isolation, which makes app symbols such as `StoredMintMetadata.metadata` / `StoredMintMetadata.init(_:)` and `URL.sanitizedForAnalytics` main-actor-isolated. Four test suites referenced them from a nonisolated context, so they failed to compile — and a single failing file takes the whole test bundle down at link, blocking the entire suite from running.

Surfaced while verifying the tip-payload change (#523), whose `TipCodeEncodingTests` couldn't execute because of this.

## Fix
Same root cause, minimal per-suite fixes:

- **`Regression_69ea28b0`**, **`URLSanitizationTests`**, **`Database+MintUpsertTests`** — annotate the suite `@MainActor` (matching the convention already used by many suites in this target, e.g. `ChatPreviewMappingTests`, `WithdrawViewModelTests`).
- **`ProfileCreationStateTests`** — its `StubUploader` was an `actor`, which cannot conform to the now-main-actor-isolated `ProfilePictureUploading` protocol. Converted to a `@MainActor final class` and dropped the now-needless `await`s on its synchronous accessors. The suite is already `@MainActor`.

No test logic changed — these are compile-time isolation annotations only.

## Testing
- `xcodebuild build-for-testing` (iPhone 16 Pro sim) links the full `FlipcashTests` target again.
- All four affected suites run green (26 cases): `Regression_69ea28b0`, `ProfileCreationStateTests`, `URLSanitizationTests`, `DatabaseMintUpsertTests`.
