### PR TITLE
fix(release): make `fastlane release` lane actually submit

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -188,6 +188,10 @@ fastlane release version:{version}
 
 Use the step-7 changelog as the "What's New" notes — App Store notes are plain text, so drop the `##` section headers and pass the lines: `fastlane release version:{version} notes:"{plain-text changelog}"`. If a build for `{version}` isn't processed yet (deliver can't find it), wait and re-run — don't fall back to a different version.
 
+**Pass `build:{number}` explicitly** (the tag-built, dogfooded build) — `deliver` otherwise takes the latest build for the version, and a stray deploy build can share the version string. Confirm the number with `fastlane distribute group:'…' dry_run:true` (reports the latest processed build).
+
+**If `deliver` fails at submit** with *"missing … 'whatsNew'"* or a version "not in valid state", the safe fallback is to paste the "What's New" and submit the build from the App Store Connect UI (deliver only *submits* here — the binary is already uploaded, so nothing is lost). The lane sets `whatsNew` via a `set_whats_new` helper before submitting, but that path is unvalidated as of 1.17.0 (which was submitted manually).
+
 ### 11. GitHub Release (draft)
 Always create the release as a draft. Publish it manually from the GitHub UI once the App Store rollout is live — publishing fires webhooks and "Latest release" badges, so it should reflect what's actually available to users.
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,10 +53,31 @@ platform :ios do
       is_key_content_base64: true
     )
 
+    # Set the version and select the build, but do NOT submit yet. Under
+    # skip_metadata deliver never sets "What's New", and review submission
+    # rejects a version whose whatsNew is empty — so notes must be set between
+    # selecting the build and submitting.
     deliver(
       api_key: api_key,
+      app_identifier: ENV["APP_IDENTIFIER"],
       app_version: version,
       build_number: build_number,
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      skip_metadata: true,
+      force: true,
+      submit_for_review: false,
+      precheck_include_in_app_purchases: false
+    )
+
+    # deliver skipped whatsNew (skip_metadata); set it on the editable version's
+    # en-US localization directly, then submit.
+    set_whats_new(version, release_notes)
+
+    deliver(
+      api_key: api_key,
+      app_identifier: ENV["APP_IDENTIFIER"],
+      app_version: version,
       skip_binary_upload: true,
       skip_screenshots: true,
       skip_metadata: true,
@@ -64,9 +85,6 @@ platform :ios do
       submit_for_review: true,
       automatic_release: true,
       phased_release: true,
-      release_notes: {
-        "en-US" => release_notes
-      },
       submission_information: {
         add_id_info_uses_idfa: false
       },
@@ -261,6 +279,29 @@ platform :ios do
       key: ENV["ASC_KEY_CONTENT"],
       is_key_content_base64: true
     )
+  end
+
+  # Set the "What's New" (release notes) on the editable App Store version's
+  # en-US localization. deliver skips this under skip_metadata, but review
+  # submission requires a non-empty whatsNew.
+  #
+  # NOTE: unvalidated against a live submit — 1.17.0 was submitted via the App
+  # Store Connect UI because the old single-deliver lane failed here. Confirm on
+  # the next release; if it errors, set What's New + submit in App Store Connect.
+  def set_whats_new(version, notes)
+    Spaceship::ConnectAPI.token = asc_token
+    app = Spaceship::ConnectAPI::App.find(ENV["APP_IDENTIFIER"])
+    UI.user_error!("App '#{ENV['APP_IDENTIFIER']}' not found in App Store Connect") unless app
+
+    edit_version = app.get_edit_app_store_version(platform: "IOS")
+    UI.user_error!("No editable App Store version to set 'What's New' on") unless edit_version
+
+    localizations = edit_version.get_app_store_version_localizations
+    loc = localizations.find { |l| l.locale == "en-US" } || localizations.first
+    UI.user_error!("No App Store version localization to set 'What's New' on") unless loc
+
+    loc.update(attributes: { whatsNew: notes })
+    UI.success("Set 'What's New' for #{version}")
   end
 
   def current_branch


### PR DESCRIPTION
## Why
The `release` lane has never worked end to end — cutting 1.17.0 hit two failures in a row, and the build was ultimately submitted for review **manually via the App Store Connect UI**.

## Bugs fixed
1. **Missing `app_identifier`** — `deliver` couldn't infer the bundle ID and crashed in non-interactive mode (`Could not infer your App's Bundle Identifier`). Now passes `app_identifier: ENV["APP_IDENTIFIER"]`, consistent with every other lane.
2. **`skip_metadata: true` drops the release notes** — so the App Store version had no `whatsNew`, and the submit call failed (`missing a required attribute 'whatsNew'` / version "not in valid state"). The `release_notes:` hash the lane passed to `deliver` isn't applied when metadata is skipped.

## Fix for #2
Split the single `deliver` into **select-build (no submit) → set `whatsNew` → submit**. A new `set_whats_new` helper sets the notes on the editable version's en-US localization via Spaceship (reusing the lane's existing `asc_token`), keeping `skip_metadata: true` so **no other App Store metadata (description, keywords, screenshots) is touched** — deliberately avoiding the "just remove skip_metadata" fix, which would sync the whole metadata dir and could wipe live listing fields.

## ⚠️ Validation gap
The `whatsNew` path is **unvalidated against a live submit** — 1.17.0 was submitted by hand, so this code has not actually run a successful review submission. It's commented as such, and the `/release` skill (step 10) now documents the manual ASC-UI fallback + passing `build:{number}` explicitly. **Validate on the 1.18.0 release**; if `set_whats_new` errors (Spaceship method names can drift across versions), fall back to the UI and we refine from the real error.