### PR TITLE
refactor(chat): discrete none counterpart for tip DM profile cards

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -403,7 +403,7 @@ struct ConversationScreen: View {
                 avatarID: counterpart?.userID?.uuidString ?? conversationID.description,
                 imageData: tipAvatars.data(for: counterpart?.userID),
                 blurhash: counterpart?.profilePicture?.thumbnailBlurhash,
-                counterpart: .tipcard
+                counterpart: .none
             )
         }
         if let contact = context.resolvedContact(in: directory) {

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatProfileCard.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatProfileCard.swift
@@ -27,9 +27,9 @@ public struct ChatProfileCard: Hashable, Sendable, Codable {
         case contact(phone: String)
         /// Not in the address book: an "Unknown Contact" subtitle and a CTA that adds them.
         case unknown
-        /// A tip DM counterpart, known by profile only: a "via Tip Card"
-        /// subtitle and no contact CTA.
-        case tipcard
+        /// No address-book relationship to surface (e.g. a tip DM counterpart known by
+        /// profile only): just the avatar and name, no subtitle and no contact CTA.
+        case none
     }
 
     public init(name: String, avatarID: String, imageData: Data?, blurhash: String? = nil, counterpart: Counterpart) {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatProfileCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatProfileCardCell.swift
@@ -50,11 +50,12 @@ private struct ProfileCardView: View {
                 .lineLimit(1)
                 .padding(.top, 12)
 
+            ProfileCardSubtitle(counterpart: card.counterpart)
+                .font(.appTextSmall)
+                .padding(.top, 4)
+
             switch card.counterpart {
             case .contact, .unknown:
-                ProfileCardSubtitle(counterpart: card.counterpart)
-                    .font(.appTextSmall)
-                    .padding(.top, 4)
                 ContactActionPill(counterpart: card.counterpart, action: onContactAction)
                     .padding(.top, 16)
             case .none:
@@ -91,7 +92,7 @@ private struct ProfileCardSubtitle: View {
             Text("Unknown Contact")
                 .foregroundStyle(Color.warning)
         case .none:
-            // The hosting card omits the subtitle entirely for this state.
+            // No relationship to surface — renders nothing.
             EmptyView()
         }
     }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatProfileCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatProfileCardCell.swift
@@ -50,15 +50,14 @@ private struct ProfileCardView: View {
                 .lineLimit(1)
                 .padding(.top, 12)
 
-            ProfileCardSubtitle(counterpart: card.counterpart)
-                .font(.appTextSmall)
-                .padding(.top, 4)
-
             switch card.counterpart {
             case .contact, .unknown:
+                ProfileCardSubtitle(counterpart: card.counterpart)
+                    .font(.appTextSmall)
+                    .padding(.top, 4)
                 ContactActionPill(counterpart: card.counterpart, action: onContactAction)
                     .padding(.top, 16)
-            case .tipcard:
+            case .none:
                 EmptyView()
             }
         }
@@ -91,12 +90,9 @@ private struct ProfileCardSubtitle: View {
         case .unknown:
             Text("Unknown Contact")
                 .foregroundStyle(Color.warning)
-        case .tipcard:
-            HStack(spacing: 6) {
-                Image.asset(.kikCode)
-                Text("via Tip Card")
-            }
-            .pill()
+        case .none:
+            // The hosting card omits the subtitle entirely for this state.
+            EmptyView()
         }
     }
 }
@@ -126,7 +122,7 @@ private struct ProfileCardSubtitle: View {
                 name: "Raul",
                 avatarID: "raul",
                 imageData: nil,
-                counterpart: .tipcard
+                counterpart: .none
             ),
             onContactAction: {}
         )

--- a/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactActionPill.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactActionPill.swift
@@ -50,9 +50,8 @@ private struct ContactActionLabel: View {
             } icon: {
                 Image.system(.personBadgePlus)
             }
-        case .tipcard:
-            // Tip counterparts carry no contact action; the hosting card
-            // omits the pill entirely.
+        case .none:
+            // Carries no contact action; the hosting card omits the pill entirely.
             EmptyView()
         }
     }


### PR DESCRIPTION
## What

Tip DM profile cards previously rendered a **"via Tip Card"** pill under the counterpart's name. This replaces the `ChatProfileCard.Counterpart.tipcard` case with a general `.none` state that surfaces no address-book relationship — the card shows just the avatar and name, reading as a quieter, more discrete header for tip chats.

## Details

- `ChatProfileCard.Counterpart`: `.tipcard` → `.none` (documents "no relationship to surface")
- `ChatProfileCardCell`: subtitle + contact pill now render together under `.contact`/`.unknown`; `.none` renders nothing (no leftover subtitle gap)
- `ContactActionPill`: `.none` carries no action
- `ConversationScreen.profileCard`: tip-DM branch now builds `.none`

`.contact` and `.unknown` (including unknown-contact send/DM chats) are byte-for-byte unchanged — they still show the number / "Unknown Contact" subtitle and the View/Add Contact pill.

## Testing

- `./Scripts/build.sh` → **BUILD SUCCEEDED**
- No tests reference `Counterpart.tipcard`.
