### PR TITLE
fix(chat): tap-to-dismiss keyboard and scope cash bubble taps

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -99,6 +99,13 @@ public final class ChatCashCardCell: ChatColumnCell {
     @available(*, unavailable)
     public required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
+    /// Scopes the row's touch target to the fixed-width card. The cell spans the full transcript
+    /// width, so without this the selection machinery opens currency info from a tap in the dead
+    /// space beside the card — the same reason the retry gesture on text rows hugs the bubble.
+    public override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        card.convert(card.bounds, to: self).contains(point)
+    }
+
     private func configureCircle(_ imageView: UIImageView, diameter: CGFloat) {
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -104,6 +104,13 @@ public final class ChatViewController: UICollectionViewController {
         collectionView.backgroundColor = UIColor(Color.backgroundMain)
         collectionView.alwaysBounceVertical = true
         collectionView.keyboardDismissMode = .interactive
+        // A tap anywhere in the transcript lowers the keyboard, iMessage-style. It rides alongside
+        // the cells' own recognizers (it doesn't cancel touches and recognizes simultaneously), so a
+        // tap on a cash card still opens its currency info — the dismissal just happens too.
+        let dismissKeyboardTap = UITapGestureRecognizer(target: self, action: #selector(lowerKeyboard))
+        dismissKeyboardTap.cancelsTouchesInView = false
+        dismissKeyboardTap.delegate = self
+        collectionView.addGestureRecognizer(dismissKeyboardTap)
         // The adjusted content inset (safe area + the bar inset the owner sets) is how the keyboard
         // and bar reserve space; ChatLayout reads it for positioning, so let UIKit manage it.
         collectionView.contentInsetAdjustmentBehavior = .always
@@ -284,6 +291,14 @@ public final class ChatViewController: UICollectionViewController {
         (cell as? ChatTypingIndicatorCell)?.stopAnimating()
     }
 
+    // MARK: - Keyboard
+
+    /// Lowers the keyboard from a transcript tap. Ends editing at the window so it reaches the
+    /// composer, which lives in a sibling hosted bar outside this controller's view tree.
+    @objc private func lowerKeyboard() {
+        collectionView.window?.endEditing(true)
+    }
+
     // MARK: - Scrolling
 
     /// Open at the newest message once there is content and real bounds. Runs once — ChatLayout
@@ -406,6 +421,14 @@ public final class ChatViewController: UICollectionViewController {
 /// The controller is the layout delegate so cells inherit ChatLayout's defaults — auto self-sizing
 /// and full-width alignment. No row needs a custom size, so nothing is overridden.
 extension ChatViewController: ChatLayoutDelegate {}
+
+extension ChatViewController: UIGestureRecognizerDelegate {
+    /// Lets the tap-to-dismiss recognizer fire alongside the collection view's own scroll and
+    /// selection recognizers, so lowering the keyboard never pre-empts a cell tap.
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        true
+    }
+}
 
 // MARK: - Context menu
 


### PR DESCRIPTION
## Summary

Two chat-screen interaction fixes:

1. **Tap anywhere in the transcript dismisses the keyboard** (iMessage-style). Previously only the interactive swipe-down lowered it. A tap recognizer on the transcript collection view ends editing at the *window* so it reaches the composer, which lives in a sibling hosted bar outside the transcript's view tree. It sets `cancelsTouchesInView = false` and recognizes simultaneously with the collection view's own scroll/selection recognizers, so a tap on a cell still performs its action — the dismissal just rides alongside. Stays in sync with the composer's SwiftUI `@FocusState` via the same `.onChange` path the existing swipe-to-dismiss already uses.

2. **Only the cash bubble navigates, not the dead space beside it.** Cash rows span the full transcript width but the card is a fixed 232pt bubble hugging one edge, so the selection machinery was opening currency info from taps in the empty space next to it. `point(inside:with:)` now scopes the cell's hit area to the card's frame — mirroring how the text-row retry gesture is already scoped to the bubble-width column.

The two fixes compose: tapping beside a cash card now dismisses the keyboard without navigating; tapping the card itself both navigates and lowers the keyboard.
