### PR TITLE
chore(release): migrate /release tooling to Android-style CalVer (yyyy.m.#)

### DIFF
--- a/.claude/plans/2026-07-30-calver-versioning-migration.md
+++ b/.claude/plans/2026-07-30-calver-versioning-migration.md
@@ -1,0 +1,65 @@
+# CalVer versioning migration (Android parity) + concurrent-release model
+
+**Date:** 2026-07-30
+**Status:** Phase 1 (tooling) done in this change; Phase 0 (bump) and Phase 2 (cron) pending.
+
+## Problem
+
+1. Run `1.17.0` (in App Review / hotfix window) alongside starting the next feature release, without the two colliding.
+2. Migrate iOS versioning to Android's calendar scheme so the two platforms carry the same version format.
+
+## Findings (as of this date)
+
+### iOS (this repo)
+- Version is **manual** in `Code.xcodeproj/project.pbxproj` — `MARKETING_VERSION` appears 12× on the app-family targets (Flipcash + NotificationService + NotificationContent + UITests × build configs); 8 unrelated `= 1.0;` lines are non-app targets. Bumped via `replace_all`.
+- `CURRENT_PROJECT_VERSION` (build number) = `272`, committed static, **untouched by version bumps**.
+- Tags: `flipcash-X.Y.Z`. Release branches: `release/flipcash-X.Y.Z`, never merged to main.
+- CI: Xcode Cloud ("Deploy Flipcash" workflow) builds on tag push. Fastlane `release` lane only *submits* via `deliver`; it does not build or bump. No `match`, no auto-increment.
+- Release process codified in `.claude/skills/release/SKILL.md`.
+- Current state: `main` = `1.17.0`; `flipcash-1.17.0` tag + `release/flipcash-1.17.0` cut; `chore/bump-version-1.18.0` PR **open, unmerged**.
+
+### Android (`code-android-app`)
+- `buildSrc/src/main/java/Packaging.kt` — `object Flipcash : Packaging(majorVersion=2026, minorVersion=7, patchVersion=6)` → versionName `"$major.$minor.$patch"` = **`2026.7.6`**.
+- **Month is NOT zero-padded** (`minorVersion` is a plain `Int`; rollover uses `date +%m | sed 's/^0//'`).
+- `patchVersion` (`#`) = **release cycle within the month**: reset to `1` on the 1st (cron `prep-dev.yml`), `+1` per production release (`bump-patch.yml` → `update-release-manifest.sh`). Not a build counter.
+- `versionCode` = `git rev-list --count HEAD` (monotonic commit count) — store-side integer, independent of versionName.
+- Tags: `fcash/2026.7.6`. Base branch `code/cash`.
+
+### Parity conclusion
+`2026.7.6` (un-padded) maps **1:1** to Apple's `CFBundleShortVersionString`, which also cannot carry a leading zero (`07`→`7`). Had Android padded, exact parity would be impossible. So `MARKETING_VERSION = 2026.7.6` matches Android exactly.
+
+## Decisions
+
+1. **Format parity, independent cycle counters.** Same `YYYY.M.N` scheme on both; each platform runs its own `N`. Not forcing identical numbers per release — that would imply a coupled release train the teams don't run (cycle counts already diverged; Android is at `.6`).
+2. **Cut over now.** Do **not** ship a `1.18.0`. The next feature release is the first CalVer release. `1.17.x` hotfixes stay semver on `release/flipcash-1.17.0`.
+3. **Build number stays independent** (`CURRENT_PROJECT_VERSION`). Different store, different mechanism; no unification with Android's commit-count `versionCode`.
+
+## Concurrent-release model (unchanged by CalVer)
+
+- **main** = the next dev version's `MARKETING_VERSION`; all feature work lands here.
+- **`release/flipcash-<v>`** = a cut release; hotfixes cherry-pick onto it and re-tag; never merged back.
+- 1.17.x lives entirely on `release/flipcash-1.17.0`; the next CalVer release lives on main → its own release branch. They never collide.
+
+## Plan
+
+### Phase 0 — cut over (unblocks next-release work) — PENDING (user-driven, App-Store-facing)
+- Replace the open `chore/bump-version-1.18.0` PR with `chore/bump-version-<YYYY.M.1>`.
+- `replace_all` the 12 app-family lines `MARKETING_VERSION = 1.17.0;` → `MARKETING_VERSION = <YYYY.M.1>;`.
+- **Month choice:** it's 2026-07-30 — if the next release realistically lands in August, use `2026.8.1`; if a July cut is still imminent, `2026.7.7` (one cycle behind Android's current `.6`). This defines the first App Store CalVer version, so the human picks it.
+- Merge it → main stamps CalVer; close the old 1.18.0 bump PR.
+- The jump `1.17.0 → 2026.M.1` is a valid one-way forward App Store bump.
+
+### Phase 1 — rework `/release` — DONE (this change)
+`.claude/skills/release/SKILL.md`:
+- `argument-hint` `[major|minor|patch]` → `[hotfix]`.
+- Step 2: version derived from calendar + current-month tag scan (`git tag --list "flipcash-$Y.$M.*"`, cycle = max+1 else 1). Transition-safe: a semver tag won't match the CalVer glob, so the first CalVer cut is `.1`.
+- Step 3 gate compares against the computed CalVer string.
+- Step 4/4a/4b + 5/8: `major/minor/patch` → `normal release` vs `hotfix`; hotfix = next cycle off the version's release branch (no 4th component — matches Android).
+- Step 9a: auto-prep bumps main to next **same-month cycle** `N+1`.
+- `Never`: added "don't zero-pad the month"; reworded semver-specific lines.
+
+### Phase 2 — optional automation to match Android — PENDING
+Port Android's `prep-dev.yml`: a GitHub Action on `cron: '0 0 1 * *'` that `replace_all`s `MARKETING_VERSION` in `project.pbxproj` to `<year>.<month>.1` and opens a PR against main. Keeps main's version honest between releases so dogfood/deploy builds are labelled with the right month (Android's `Packaging.kt` rollover equivalent). Without it, `/release` step 9a keeps the same-month cycle current and a manual bump handles month rollover.
+
+## Loose end to verify (orthogonal to CalVer)
+`CURRENT_PROJECT_VERSION` is committed static at `272` and untouched by bumps, yet builds ship — so Xcode Cloud must be overriding `CFBundleVersion` at archive time. Confirm it actually increments per build; if not, TestFlight will reject duplicate build numbers. Independent of this migration.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -2,18 +2,27 @@
 name: release
 description: Use when the user wants to cut a release, ship a version, prepare for release, or invokes /release
 disable-model-invocation: true
-argument-hint: [major|minor|patch]
-allowed-tools: Bash(git log *), Bash(git checkout *), Bash(git tag *), Bash(git push *), Bash(git cherry-pick *), Bash(git add *), Bash(git commit *), Bash(xcodebuild *), Bash(gh *), Bash(fastlane *), Read, Edit, Agent, Grep
+argument-hint: [hotfix]
+allowed-tools: Bash(git log *), Bash(git checkout *), Bash(git tag *), Bash(git push *), Bash(git cherry-pick *), Bash(git add *), Bash(git commit *), Bash(git describe *), Bash(date *), Bash(xcodebuild *), Bash(gh *), Bash(fastlane *), Read, Edit, Agent, Grep
 ---
 
 # Release
 
 Three-phase workflow. The release branch and tag push automatically so TestFlight can build a dogfooding candidate; the tag-built build is submitted to App Review and the public GitHub release drafted only after the user confirms on-device testing.
 
+**Versioning is CalVer — `YYYY.M.N`, matching Android** (`2026.7.6`, not `2026.07.6`):
+- `YYYY.M` = release **year** and **month**, month **un-padded** (Apple normalizes `07`→`7` anyway, and Android strips it — so they match exactly).
+- `N` = the release **cycle within the month**: the first release of a month is `.1`, each subsequent release (feature *or* hotfix) takes the next number. It is **not** a build counter.
+- The number is **derived from the calendar + existing tags**, never chosen by a bump argument. There is no major/minor/patch.
+- Tag prefix stays `flipcash-` (`flipcash-2026.7.6`); Android's is `fcash/…` — prefixes differ, numbers match.
+
+`$ARGUMENTS`: pass `hotfix` to patch an already-shipped version on its release branch; otherwise this is a normal release off `main`.
+
 ## Pre-flight context
 
 - Working tree: !`git status --porcelain`
 - Latest tag: !`git describe --tags --match 'flipcash-*' --abbrev=0 HEAD 2>/dev/null || echo "no tags found"`
+- Today: !`date +%Y-%m-%d`
 
 ## Phase 1: Prepare & Verify
 
@@ -21,43 +30,52 @@ Three-phase workflow. The release branch and tag push automatically so TestFligh
 If the pre-flight working tree output is non-empty → STOP. Commit or stash first.
 
 ### 2. Calculate next version
-Derive the current released version from the pre-flight latest tag (strip the `flipcash-` prefix). Do not infer the version from `MARKETING_VERSION` — it is the version under development, not the version released.
+CalVer is calendar-anchored. Compute the year and month, then scan existing tags for the current month to pick the cycle number — this resets `N` to 1 each month automatically and is transition-safe (a leftover semver tag like `flipcash-1.17.0` simply won't match the current-month glob):
 
-Determine bump type from `$ARGUMENTS` (default: `minor`):
-
-| Argument | Bump | Example |
-|----------|------|---------|
-| `major` | X+1.0.0 | 2.3.1 → 3.0.0 |
-| `minor` (default) | X.Y+1.0 | 2.3.1 → 2.4.0 |
-| `patch` | X.Y.Z+1 | 2.3.1 → 2.3.2 |
-
-Confirm with user: "Bumping {type}: flipcash-{current} → flipcash-{next} — correct?"
-
-### 3. Verify MARKETING_VERSION on main (major / minor only)
-Skip for patch — patch bumps the version on the release branch in step 4b.
-
-The bump must already be merged into `origin/main` before cutting the release. A complete bump flips every app-family line from `{current-version}` to `{next-version}`, so check both counts:
 ```bash
-git fetch origin main
-git show origin/main:Code.xcodeproj/project.pbxproj | grep -c "MARKETING_VERSION = {next-version};"
-git show origin/main:Code.xcodeproj/project.pbxproj | grep -c "MARKETING_VERSION = {current-version};"
+Y=$(date +%Y)
+M=$(date +%m | sed 's/^0//')          # un-padded month, matches Android
+# highest existing cycle for this year+month, else 0
+N=$(git tag --list "flipcash-$Y.$M.*" \
+      | sed "s/^flipcash-$Y\.$M\.//" \
+      | sort -n | tail -1)
+N=$(( ${N:-0} + 1 ))
+NEXT="$Y.$M.$N"
 ```
 
-- **`{next-version}` count is non-zero and `{current-version}` count is `0`**: the bump flipped every line — proceed. (The absolute number doesn't matter; it grows whenever app targets are added.)
-- **Both counts are non-zero**: STOP — the bump PR missed some targets. Have the user re-apply the `replace_all` on `chore/bump-version-{next-version}`, merge, then re-run.
-- **`{next-version}` count is `0`**: STOP. Check whether a `chore/bump-version-{next-version}` PR is already open (the previous /release run should have auto-prepped one in step 9a). If yes, tell the user: *"Merge `chore/bump-version-{next-version}` and re-run /release {bump}."* If no PR exists, tell the user to open one — `MARKETING_VERSION = {current-version};` → `MARKETING_VERSION = {next-version};` with `replace_all` — merge it, then re-run. Do not commit the bump locally to main from inside this skill.
+- **Normal release:** that `NEXT` is the version.
+- **Hotfix (`$ARGUMENTS` = `hotfix`):** same computation (next free cycle this month), but you'll cut it from the release branch of the version being patched, not `main` — see step 4.
+
+Confirm with user: "Cutting flipcash-{NEXT} (CalVer) — correct?" If they expect a different month/cycle (e.g. the release actually lands next month), let them override `NEXT` explicitly.
+
+> **First CalVer release note:** during the semver→CalVer transition the latest tag is still `flipcash-1.17.0`. The current-month glob finds no CalVer tags, so `N`=1 and `NEXT` = `{thisYear}.{thisMonth}.1` — exactly right. `main`'s `MARKETING_VERSION` must already hold that value (set by the Phase-0 bump PR); verify in step 3. The App Store jump `1.17.0 → {YYYY}.{M}.1` is a valid one-way forward bump (year ≫ 1).
+
+### 3. Verify MARKETING_VERSION on main (normal release only)
+Skip for hotfix — the hotfix bumps the version on the release branch in step 4b.
+
+The bump must already be merged into `origin/main` before cutting the release. A complete bump flips every app-family line to `{NEXT}`:
+```bash
+git fetch origin main
+git show origin/main:Code.xcodeproj/project.pbxproj | grep -c "MARKETING_VERSION = {NEXT};"
+# sanity: no stale app-family version should remain (the `= 1.0;` lines are unrelated non-app targets)
+git show origin/main:Code.xcodeproj/project.pbxproj | grep -o "MARKETING_VERSION = [^;]*;" | sort | uniq -c
+```
+
+- **`{NEXT}` count is non-zero and the only app-family value present**: the bump flipped every line — proceed. (The absolute number — 12 today — grows whenever app targets are added; the `MARKETING_VERSION = 1.0;` lines are unrelated non-app targets and stay put.)
+- **A stale app-family value is still present**: STOP — the bump PR missed some targets. Have the user re-apply the `replace_all` on `chore/bump-version-{NEXT}`, merge, then re-run.
+- **`{NEXT}` count is `0`**: STOP. Check whether a `chore/bump-version-{NEXT}` PR is already open (the previous /release run should have auto-prepped one in step 9a, or the Phase-0 migration PR for the first CalVer cut). If yes, tell the user: *"Merge `chore/bump-version-{NEXT}` and re-run /release."* If no PR exists, tell the user to open one — flip the app-family `MARKETING_VERSION` to `{NEXT}` with `replace_all` — merge it, then re-run. Do not commit the bump locally to main from inside this skill.
 
 ### 4. Determine base
-- **major / minor**: base is `origin/main`. Show the pre-flight latest tag to user. If it picks up a legacy tag, ask for the correct base.
-- **patch**: base is the `release/flipcash-X.Y.Z` branch (the release being patched). Checkout that branch before proceeding:
+- **normal release**: base is `origin/main`. Show the pre-flight latest tag to user. If it picks up a legacy/unexpected tag, ask for the correct base.
+- **hotfix**: base is the `release/flipcash-{version-being-patched}` branch. Ask the user which shipped version they're patching, then checkout that branch:
   ```bash
-  git checkout release/flipcash-{current-version}
+  git checkout release/flipcash-{version-being-patched}
   ```
 
-### 4a. Cherry-pick commits (patch only)
+### 4a. Cherry-pick commits (hotfix only)
 Show commits on `main` that aren't on the release branch yet:
 ```bash
-git log release/flipcash-{current-version}..main --oneline --no-merges
+git log release/flipcash-{version-being-patched}..main --oneline --no-merges
 ```
 Ask the user which SHAs to pick (oldest first). Then:
 ```bash
@@ -67,25 +85,25 @@ If a cherry-pick conflicts, STOP and hand off to the user — do not resolve con
 
 Skip this step if the user says there are no commits to pick (rare — usually means the branch already has them applied manually).
 
-### 4b. Bump MARKETING_VERSION (patch only)
-The release branch's `Code.xcodeproj/project.pbxproj` is still pinned at `{current-version}`. The binary produced from this branch needs the patched version or TestFlight/App Store will reject it as a duplicate. Use the Edit tool with `replace_all: true`:
+### 4b. Bump MARKETING_VERSION (hotfix only)
+The release branch's `Code.xcodeproj/project.pbxproj` is still pinned at the version being patched. The binary produced from this branch needs the new cycle number or TestFlight/App Store will reject it as a duplicate. Use the Edit tool with `replace_all: true`:
 
-- **old_string**: `MARKETING_VERSION = {current-version};`
-- **new_string**: `MARKETING_VERSION = {next-version};`
+- **old_string**: `MARKETING_VERSION = {version-being-patched};`
+- **new_string**: `MARKETING_VERSION = {NEXT};`
 
-The Flipcash app and its extension targets share one `MARKETING_VERSION` (extension versions must match the host app), while unrelated targets are pinned at other values — so `replace_all` hits exactly the app-family lines.
+The Flipcash app and its extension targets share one `MARKETING_VERSION` (extension versions must match the host app), while unrelated targets are pinned at other values (`1.0`) — so `replace_all` hits exactly the app-family lines.
 
 Then commit:
 ```bash
 git add Code.xcodeproj/project.pbxproj
-git commit -m "chore: bump version to {next-version}"
+git commit -m "chore: bump version to {NEXT}"
 ```
 
 ### 5. What's shipping
 ```bash
 git log {base-tag}..HEAD --format="- %s" --no-merges
 ```
-For patch releases, `{base-tag}` is `flipcash-{current-version}` (the tag on the branch being patched).
+`{base-tag}` is the latest CalVer tag on the line you're cutting from: for a normal release the previous release tag; for a hotfix, `flipcash-{version-being-patched}`.
 
 Display for sanity check.
 
@@ -112,13 +130,13 @@ Use the Agent tool with `model: "haiku"`. Pass the commit list with this prompt:
 Show to user for approval.
 
 ### 8. Branch
-For **major / minor**: step 3 already verified the bump is on `origin/main`. Pull main locally, then branch:
+For **normal release**: step 3 already verified the bump is on `origin/main`. Pull main locally, then branch:
 ```bash
 git checkout main && git pull --ff-only
-git checkout -b release/flipcash-{next-version}
+git checkout -b release/flipcash-{NEXT}
 ```
 
-For **patch**: already on `release/flipcash-X.Y.Z` from step 4; the version bump commit from step 4b is already on the branch. Skip branch creation.
+For **hotfix**: already on `release/flipcash-{version-being-patched}` from step 4; the version bump commit from step 4b is already on the branch. Skip branch creation.
 
 ### 8a. Write TestFlight "What to Test" notes
 Xcode Cloud attaches `TestFlight/WhatToTest.en-US.txt` (repo root) — read from the **commit it builds** — as the build's "What to Test" for testers, so the notes must be in the tagged commit. Overwrite that file with **two sections**:
@@ -129,42 +147,42 @@ Xcode Cloud attaches `TestFlight/WhatToTest.en-US.txt` (repo root) — read from
 Then commit on the release branch:
 ```bash
 git add TestFlight/WhatToTest.en-US.txt
-git commit -m "chore: TestFlight notes for {next-version}"
+git commit -m "chore: TestFlight notes for {NEXT}"
 ```
-This release-branch commit never merges to main (like the patch bump). First release using this: after the build lands, confirm the notes actually show on the TestFlight build — if Xcode Cloud ignored the file, set them via the ASC API in `fastlane distribute` instead.
+This release-branch commit never merges to main (like the hotfix bump).
 
 ### 8b. Tag
 ```bash
-git tag flipcash-{next-version}
+git tag flipcash-{NEXT}
 ```
 
 ## Phase 2: Push for TestFlight
 
 ### 9. Push branch and tag
 ```bash
-git push -u origin release/flipcash-{version}
-git push origin flipcash-{version}
+git push -u origin release/flipcash-{NEXT}
+git push origin flipcash-{NEXT}
 ```
 The tag push kicks off the TestFlight build.
 
-### 9a. Prep the next-minor bump PR (major / minor only)
-Skip for patch — patches don't change `main`'s `MARKETING_VERSION`.
+### 9a. Prep the next-cycle bump PR (normal release only)
+Skip for hotfix — hotfixes don't change `main`'s `MARKETING_VERSION`.
 
-Compute `{next-minor}` = the next minor after the version being shipped (e.g. shipping `1.10.0` → `1.11.0`; shipping `2.0.0` → `2.1.0`).
+CalVer's "next" is date-dependent, so prep the presumptive **next same-month cycle**: `{next-cycle}` = same `YYYY.M` as the version just shipped, cycle `N+1` (shipping `2026.7.6` → prep `2026.7.7`). If the next release actually lands in a new month, the monthly rollover (the `prep-dev` cron, if adopted — see the migration plan) or a manual bump resets it to `{newYear}.{newMonth}.1`; either way step 3 of the next /release re-verifies before cutting. This mirrors Android's `bump-patch.yml` (increment cycle after a prod release) + monthly cron (reset on the 1st).
 
-Check first — if a `chore/bump-version-{next-minor}` PR or branch already exists, skip silently.
+Check first — if a `chore/bump-version-{next-cycle}` PR or branch already exists, skip silently.
 
 Otherwise, from `main`:
 ```bash
 git checkout main && git pull --ff-only
-git checkout -b chore/bump-version-{next-minor}
+git checkout -b chore/bump-version-{next-cycle}
 ```
-Edit `Code.xcodeproj/project.pbxproj` with `replace_all: true`: `MARKETING_VERSION = {version};` → `MARKETING_VERSION = {next-minor};` (the app and its extensions share the version and flip together — afterwards no `MARKETING_VERSION = {version};` lines should remain).
+Edit `Code.xcodeproj/project.pbxproj` with `replace_all: true`: `MARKETING_VERSION = {NEXT};` → `MARKETING_VERSION = {next-cycle};` (the app and its extensions share the version and flip together — afterwards no app-family `MARKETING_VERSION = {NEXT};` lines should remain).
 ```bash
 git add Code.xcodeproj/project.pbxproj
-git commit -m "chore: bump version to {next-minor}"
-git push -u origin chore/bump-version-{next-minor}
-gh pr create --base main --title "chore: bump version to {next-minor}" --body "<one-line body>"
+git commit -m "chore: bump version to {next-cycle}"
+git push -u origin chore/bump-version-{next-cycle}
+gh pr create --base main --title "chore: bump version to {next-cycle}" --body "<one-line body>"
 ```
 
 The PR sits open for the user to merge whenever — it's a precondition the next /release will need.
@@ -192,25 +210,25 @@ Tell me when you're ready to submit to App Review.
 After user confirms:
 
 ### 10. Submit to App Review
-The gate has cleared the tag-built TestFlight build; submit that same build for `{version}`:
+The gate has cleared the tag-built TestFlight build; submit that same build for `{NEXT}`:
 
 ```bash
-fastlane release version:{version}
+fastlane release version:{NEXT}
 ```
 
-`fastlane release` (in `fastlane/Fastfile`) attaches the latest processed build for `{version}` to the App Store version and submits it with phased release. It reads the ASC creds from `fastlane/.env` — if it reports a missing `ASC_*` / `APP_IDENTIFIER`, have the user restore that file (`Scripts/pull_secrets`) and re-run.
+`fastlane release` (in `fastlane/Fastfile`) attaches the latest processed build for `{NEXT}` to the App Store version and submits it with phased release. It reads the ASC creds from `fastlane/.env` — if it reports a missing `ASC_*` / `APP_IDENTIFIER`, have the user restore that file (`Scripts/pull_secrets`) and re-run.
 
-Use the step-7 changelog as the "What's New" notes — App Store notes are plain text, so drop the `##` section headers and pass the lines: `fastlane release version:{version} notes:"{plain-text changelog}"`. If a build for `{version}` isn't processed yet (deliver can't find it), wait and re-run — don't fall back to a different version.
+Use the step-7 changelog as the "What's New" notes — App Store notes are plain text, so drop the `##` section headers and pass the lines: `fastlane release version:{NEXT} notes:"{plain-text changelog}"`. If a build for `{NEXT}` isn't processed yet (deliver can't find it), wait and re-run — don't fall back to a different version.
 
 **Pass `build:{number}` explicitly** (the tag-built, dogfooded build) — `deliver` otherwise takes the latest build for the version, and a stray deploy build can share the version string. Confirm the number with `fastlane distribute group:'…' dry_run:true` (reports the latest processed build).
 
-**If `deliver` fails at submit** with *"missing … 'whatsNew'"* or a version "not in valid state", the safe fallback is to paste the "What's New" and submit the build from the App Store Connect UI (deliver only *submits* here — the binary is already uploaded, so nothing is lost). The lane sets `whatsNew` via a `set_whats_new` helper before submitting, but that path is unvalidated as of 1.17.0 (which was submitted manually).
+**If `deliver` fails at submit** with *"missing … 'whatsNew'"* or a version "not in valid state", the safe fallback is to paste the "What's New" and submit the build from the App Store Connect UI (deliver only *submits* here — the binary is already uploaded, so nothing is lost). The lane sets `whatsNew` via a `set_whats_new` helper before submitting, but that path was unvalidated as of 1.17.0 (which was submitted manually).
 
 ### 11. GitHub Release (draft)
 Always create the release as a draft. Publish it manually from the GitHub UI once the App Store rollout is live — publishing fires webhooks and "Latest release" badges, so it should reflect what's actually available to users.
 
 ```bash
-gh release create flipcash-{version} --draft --title "Flipcash {version}" --notes "{changelog}"
+gh release create flipcash-{NEXT} --draft --title "Flipcash {NEXT}" --notes "{changelog}"
 ```
 
 Remind the user at the end: *"Submitted to App Review and release drafted. Publish the GitHub release once the App Store rollout is live."*
@@ -221,7 +239,8 @@ Remind the user at the end: *"Submitted to App Review and release drafted. Publi
 - Skip the dogfooding gate
 - Submit to App Review (`fastlane release`) or draft the GitHub release before the user confirms on-device testing
 - Submit a different version than the one that was tagged and dogfooded — if the build isn't processed yet, wait, don't switch versions
-- Tag a patch without bumping `MARKETING_VERSION` on the release branch (step 4b) — TestFlight rejects duplicate build versions
-- Open the bump PR for the *current* release's version inside step 3 — step 3 must find it already on `main`, merged by the user from a prior /release's step-9a PR (or opened manually); auto-prepping the *next* version's bump PR in step 9a is the new normal
+- Zero-pad the month (`2026.07.x`) — Android un-pads and Apple normalizes it away; padding breaks number parity
+- Tag a hotfix without bumping `MARKETING_VERSION` on the release branch (step 4b) — TestFlight rejects duplicate build versions
+- Open the bump PR for the *current* release's version inside step 3 — step 3 must find it already on `main`, merged by the user from a prior /release's step-9a PR (or the Phase-0 migration PR); auto-prepping the *next* cycle's bump PR in step 9a is the norm
 - Cut the release branch or tag from a local-only bump commit — always branch from the `main` whose `origin/main` already has the merged bump
 - Resolve cherry-pick conflicts autonomously — stop and hand off to the user

--- a/.github/workflows/prep-dev.yml
+++ b/.github/workflows/prep-dev.yml
@@ -1,0 +1,83 @@
+name: Roll CalVer to the new month
+
+# On the 1st of each month, roll main's MARKETING_VERSION to <year>.<month>.1
+# (un-padded month, matching Android's Packaging.kt rollover) so dogfood/deploy
+# builds off main are labelled with the right month between releases. Opens a PR
+# rather than pushing to main directly — main is PR-gated.
+#
+# The iOS mirror of Android's .github/workflows/prep-dev.yml. Within a month the
+# cycle number is advanced by /release step 9a; this job only handles the month
+# boundary. Safe to re-run / dispatch mid-month: it no-ops when main is already
+# on the current month (it never downgrades the cycle).
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  roll-version:
+    name: Roll MARKETING_VERSION to the new month
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Compute target version
+        id: calc
+        run: |
+          set -euo pipefail
+          PBX=Code.xcodeproj/project.pbxproj
+          Y=$(date +%Y)
+          M=$(date +%m | sed 's/^0//')          # un-padded month, matches Android
+          NEW="$Y.$M.1"
+
+          # Current app-family version = the sole non-1.0 MARKETING_VERSION value.
+          mapfile -t CURVALS < <(grep -oE 'MARKETING_VERSION = [^;]+;' "$PBX" \
+            | sed -E 's/MARKETING_VERSION = (.+);/\1/' | grep -vx '1.0' | sort -u)
+          if [ "${#CURVALS[@]}" -ne 1 ]; then
+            echo "Expected exactly one app-family MARKETING_VERSION, found: ${CURVALS[*]:-none}" >&2
+            exit 1
+          fi
+          CUR="${CURVALS[0]}"
+          echo "Current: $CUR  Target: $NEW"
+
+          if [[ "$CUR" == "$Y.$M."* ]]; then
+            echo "main is already on $Y.$M — nothing to roll (cycle is managed by /release)."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          sed -i "s/MARKETING_VERSION = ${CUR//./\\.};/MARKETING_VERSION = $NEW;/g" "$PBX"
+          git diff --quiet "$PBX" && { echo "changed=false" >> "$GITHUB_OUTPUT"; exit 0; }
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+
+      - name: Open bump PR
+        if: steps.calc.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW: ${{ steps.calc.outputs.new }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-version-$NEW"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists — skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add Code.xcodeproj/project.pbxproj
+          git commit -m "chore: bump version to $NEW"
+          git push -u origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: bump version to $NEW" \
+            --body "Automated CalVer month roll to \`$NEW\` (un-padded month, Android parity). Merge to set main's dev version for the new month."


### PR DESCRIPTION
Reworks the `/release` skill to compute versions as **CalVer `YYYY.M.N`**, matching Android (`2026.7.7`, un-padded month), plus a monthly-roll workflow. Tooling-only — no app code, no version bump, no App-Store action.

## What changes
- `.claude/skills/release/SKILL.md`
  - `argument-hint`: `[major|minor|patch]` → `[hotfix]`.
  - **`main`'s `MARKETING_VERSION` is the source of truth** for the next release number (like Android's `Packaging.kt`). A normal release cuts whatever `main` holds; step 3 guards it isn't already tagged. Hotfix computes the next free cycle for the patched month via a tag scan. (This replaces tag-derived computation, which couldn't seed the first cut to Android's `.7`.)
  - `major/minor/patch` model → **normal** (off `main`) vs **hotfix** (next cycle off the version's `release/*` branch — no 4th component, matching Android).
  - Step 9a advances `main` to the next same-month cycle after a release.
  - `Never`: added “don’t zero-pad the month”.
- `.github/workflows/prep-dev.yml` — monthly cron (1st of month) rolling `main` to `<year>.<month>.1` via a PR; mirrors Android's `prep-dev.yml`; no-ops mid-month.
- `.claude/plans/2026-07-30-calver-versioning-migration.md` — findings, decisions, plan.

## Parity
iOS seeds to **`2026.7.7`** (Android's current working version) and both roll together — each release + monthly reset keeps them on the same `YYYY.M.N`. Android un-pads the month and Apple normalizes `07`→`7`, so the strings match exactly.

## Companion
**Phase 0** cutover bump `1.17.0 → 2026.7.7` is #538 — merge **this (#536) first, then #538**. `1.17.x` stays semver on `release/flipcash-1.17.0`.