### PR TITLE
fix(tips): make name-only profiles tippable

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Models/Profile.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Profile.swift
@@ -25,10 +25,12 @@ public struct Profile: Codable, Equatable, Sendable {
         phone != nil
     }
 
-    /// Returns whether this profile can receive tips — both a name and a
-    /// picture are required.
+    /// Returns whether this profile can receive tips — only a display name is
+    /// required. A profile picture is not part of onboarding, so requiring one
+    /// left every name-only profile non-tippable and bounced Tips back to the
+    /// intro screen on reopen.
     public var isTippable: Bool {
-        displayName?.isEmpty == false && profilePicture != nil
+        displayName?.isEmpty == false
     }
 
     /// Returns whether this profile gained a phone number not present in `previous`.

--- a/FlipcashCore/Tests/FlipcashCoreTests/ProfileTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ProfileTests.swift
@@ -74,7 +74,8 @@ struct ProfileTests {
         #expect(profile.email == "ted@example.com")
         #expect(profile.phone == nil)
         #expect(profile.profilePicture == nil)
-        #expect(profile.isTippable == false)
+        // A name-only profile is tippable — a picture is not required.
+        #expect(profile.isTippable == true)
     }
 
     /// A fixture, not a round-trip: a round-trip passes even if the key names
@@ -108,14 +109,15 @@ struct ProfileTests {
         #expect(profile.isTippable)
     }
 
-    @Test("A profile needs both a name and a picture to receive tips",
+    @Test("A profile needs only a non-empty name to receive tips — a picture is not required",
           arguments: [
               (name: "Ted", hasPicture: true,  expected: true),
-              (name: "Ted", hasPicture: false, expected: false),
+              (name: "Ted", hasPicture: false, expected: true),
               (name: nil,   hasPicture: true,  expected: false),
-              (name: "",    hasPicture: true,  expected: false),
+              (name: nil,   hasPicture: false, expected: false),
+              (name: "",    hasPicture: false, expected: false),
           ] as [(name: String?, hasPicture: Bool, expected: Bool)])
-    func isTippableRequiresNameAndPicture(name: String?, hasPicture: Bool, expected: Bool) {
+    func isTippableRequiresName(name: String?, hasPicture: Bool, expected: Bool) {
         let picture = ProfilePicture(blobID: .mock, thumbnailBlobID: .mock)
 
         let profile = Profile(


### PR DESCRIPTION
## Problem

On a new account, after creating a tip card and viewing it, reopening Tips bounced back to the "Start Receiving Tips" onboarding screen.

## Root cause

`Profile.isTippable` required **both** a display name and a profile picture:

```swift
displayName?.isEmpty == false && profilePicture != nil
```

But onboarding only collects a **name** — there is no photo step, and the tipcard intentionally omits the photo. So every freshly created (name-only) profile was non-tippable, and `TipsScreen` gates on `session.profile?.isTippable`, falling back to `TipsIntroScreen`. The same stale gate also meant a tip held for profile creation never resumed (`ScanScreen`/`TipFlow` wait for the profile to "become tippable", which never happened).

## Fix

Require only a non-empty display name:

```swift
public var isTippable: Bool {
    displayName?.isEmpty == false
}
```

The `profilePicture` field is untouched — it's just no longer required for tippability. Updated `ProfileTests` to the corrected contract; the `name:"Ted", hasPicture:false → tippable` case fails on the old code and passes on the fix.

## Release

Hotfix for **1.17.0** — no version bump (the `flipcash-1.17.0` tag is being deleted and re-cut off this branch after merge).

Note: `main` (CalVer) carries the same bug and needs the identical fix forward-ported.

## Test plan

- `./Scripts/test.sh FlipcashCoreTests/ProfileTests`
