### PR TITLE
fix(tips): retry tipcard resolve on cold-channel race

### DIFF
--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -139,18 +139,37 @@ final class TipFlow {
         prepTask = Task {
             defer { prepTask = nil }
             do {
-                async let profile = flipClient.fetchProfile(userID: userID, owner: session.ownerKeyPair)
-                async let destination = flipClient.resolveUserID(userID, owner: session.ownerKeyPair)
-                // The destination is re-resolved (and cached) by the send
-                // itself; here it only proves the user can be paid at all.
-                _ = try await destination
+                // The gRPC channel is often still connecting when a tipcard deep
+                // link fires on a cold foreground (it races `warmUpChannel()`),
+                // so the first resolve fails `.unavailable`; a just-made-tippable
+                // recipient's destination may also not have propagated yet.
+                // Retry both transient conditions before surfacing a hard error —
+                // mirroring the cash-link claim path — so the user isn't told to
+                // "try again" for a tap that a second attempt would have resolved.
+                // A definitive `.denied`/anomaly is not retried.
+                let resolved = try await Task.retry(
+                    maxAttempts: 3,
+                    delay: .milliseconds(500),
+                    shouldRetry: { error in
+                        if let error = error as? ErrorResolve { return error == .notFound || error.isRetryable }
+                        if let error = error as? ErrorFetchProfile { return error.isRetryable }
+                        return false
+                    }
+                ) {
+                    async let profile = flipClient.fetchProfile(userID: userID, owner: session.ownerKeyPair)
+                    async let destination = flipClient.resolveUserID(userID, owner: session.ownerKeyPair)
+                    // The destination is re-resolved (and cached) by the send
+                    // itself; here it only proves the user can be paid at all.
+                    _ = try await destination
+                    return try await profile
+                }
                 let recipient = TipRecipient(
                     userID: userID,
-                    displayName: try await profile.displayName ?? ""
+                    displayName: resolved.displayName ?? ""
                 )
                 guard !Task.isCancelled else { return }
                 present(recipient)
-                await loadAvatar(for: recipient, picture: try await profile.profilePicture)
+                await loadAvatar(for: recipient, picture: resolved.profilePicture)
             } catch {
                 guard !Task.isCancelled else { return }
                 logger.error("Failed to prepare tip recipient", metadata: [


### PR DESCRIPTION
## Problem

Tapping a **tipcard link for the first time** shows **"Tipcard Not Available"**, but tapping it a second time works.

## Root cause

The gRPC channel connects **lazily** — which is exactly why the app fires `warmUpChannel()` on scene `.active` (`AppDelegate.swift:111-112`). A tipcard deep link arriving on that same foreground event **races the warm-up**: `TipFlow.prepare()` fires `resolveUserID`/`fetchProfile` before the channel is connected, grpc-swift fail-fasts the unary call with `RPCError(.unavailable)`, and `prepare()`'s `catch` surfaced *any* error as the hard "Tipcard Not Available" dialog. The second tap succeeds because the channel is now warm.

The classification layer already models this: `.unavailable` → `isTransientNetworkError` → `.transportFailure`, which is `isRetryable == true` (`TransportClassifiableError.swift`). `TipFlow` just never consulted it.

## Why only tips?

The **cash link** deep link goes through the same cold-channel RPC path but is already protected — `Session.receiveCashLink` wraps its resolve in `Task.retry(maxAttempts: 3, delay: 500ms, shouldRetry: { $0 == .notFound || $0.isRetryable })`. `Session.updateProfile` wraps the *same* `fetchProfile` call the same way. `TipFlow.prepare()` was the outlier with no retry.

## Fix

Wrap the tip resolve in the codebase's own `Task.retry` helper with the identical `maxAttempts: 3 / 500ms` shape and a `shouldRetry` mirroring the cash link. It now survives:
- the **cold-channel transport race** (`isRetryable`), and
- a **just-made-tippable recipient** whose destination hasn't propagated yet (`.notFound`, cf. #542).

A definitive `.denied`/anomaly is still surfaced immediately. Cancellation is preserved — `Task.retry` never retries `CancellationError`, and `cancel()` still cancels `prepTask`.

## Testing

- Full `Flipcash` app scheme build succeeds (no errors).
- Reuses the already-tested `Task.retry` primitive (`TaskRetryTests.swift`).
- No TipFlow-level unit test added: `TipFlow` is tightly coupled to concrete `Session`/`FlipClient` with no injection seam, so a deterministic race test would require mocking infrastructure that doesn't exist today.