### PR TITLE
fix(reporting): floor user-facing suppressed errors to info

### DIFF
--- a/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
@@ -185,7 +185,8 @@ final class BuyConfirmationViewModel {
             ErrorReporting.captureError(
                 error,
                 reason: "Failed to buy currency from BuyConfirmationScreen",
-                metadata: ["targetMint": targetMint.base58, "paymentMint": payment.mint.base58]
+                metadata: ["targetMint": targetMint.base58, "paymentMint": payment.mint.base58],
+                userFacing: true
             )
             actionButtonState = .normal
             // A submit failure can land after the user popped this screen —

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -344,7 +344,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 if Task.isCancelled { return }
                 logger.error("Currency name availability check failed", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error)
+                ErrorReporting.captureError(error, userFacing: true)
                 presentGenericErrorDialog()
                 return
             }
@@ -378,7 +378,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 if Task.isCancelled { return }
                 logger.error("Currency name moderation failed", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error)
+                ErrorReporting.captureError(error, userFacing: true)
                 presentGenericErrorDialog()
                 return
             }
@@ -406,7 +406,7 @@ struct CurrencyCreationWizardScreen: View {
                 imageData = try await ImageEncoder.encodeForUpload(image, maxBytes: 1_048_576)
             } catch {
                 logger.error("Failed to encode icon within 1 MB budget", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error)
+                ErrorReporting.captureError(error, userFacing: true)
                 errorDialog = .imageProcessingFailed
                 return
             }
@@ -432,7 +432,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 if Task.isCancelled { return }
                 logger.error("Currency icon moderation failed", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error)
+                ErrorReporting.captureError(error, userFacing: true)
                 presentGenericErrorDialog()
                 return
             }
@@ -470,7 +470,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 if Task.isCancelled { return }
                 logger.error("Currency description moderation failed", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error)
+                ErrorReporting.captureError(error, userFacing: true)
                 presentGenericErrorDialog()
                 return
             }
@@ -594,7 +594,7 @@ struct CurrencyCreationWizardScreen: View {
                             "error": "\(error)",
                             "mint": "\(existing.mint.base58)",
                         ])
-                        ErrorReporting.captureError(error)
+                        ErrorReporting.captureError(error, userFacing: true)
                         presentCouldNotCreateCurrencyDialog()
                     }
                     return
@@ -625,7 +625,7 @@ struct CurrencyCreationWizardScreen: View {
                     "error": "\(error)",
                     "mint": "\(launchedMint?.base58 ?? "nil")",
                 ])
-                ErrorReporting.captureError(error)
+                ErrorReporting.captureError(error, userFacing: true)
                 presentCouldNotCreateCurrencyDialog()
                 return
             }

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -344,7 +344,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 if Task.isCancelled { return }
                 logger.error("Currency name availability check failed", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error, userFacing: true)
+                ErrorReporting.captureError(error)
                 presentGenericErrorDialog()
                 return
             }
@@ -378,7 +378,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 if Task.isCancelled { return }
                 logger.error("Currency name moderation failed", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error, userFacing: true)
+                ErrorReporting.captureError(error)
                 presentGenericErrorDialog()
                 return
             }
@@ -406,7 +406,7 @@ struct CurrencyCreationWizardScreen: View {
                 imageData = try await ImageEncoder.encodeForUpload(image, maxBytes: 1_048_576)
             } catch {
                 logger.error("Failed to encode icon within 1 MB budget", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error, userFacing: true)
+                ErrorReporting.captureError(error)
                 errorDialog = .imageProcessingFailed
                 return
             }
@@ -432,7 +432,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 if Task.isCancelled { return }
                 logger.error("Currency icon moderation failed", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error, userFacing: true)
+                ErrorReporting.captureError(error)
                 presentGenericErrorDialog()
                 return
             }
@@ -470,7 +470,7 @@ struct CurrencyCreationWizardScreen: View {
             } catch {
                 if Task.isCancelled { return }
                 logger.error("Currency description moderation failed", metadata: ["error": "\(error)"])
-                ErrorReporting.captureError(error, userFacing: true)
+                ErrorReporting.captureError(error)
                 presentGenericErrorDialog()
                 return
             }

--- a/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellConfirmationViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/CurrencySellConfirmationViewModel.swift
@@ -76,7 +76,8 @@ class CurrencySellConfirmationViewModel {
                         "fee": fee.nativeAmount.formatted(),
                         "amountAfterFees": amountAfterFee.nativeAmount.formatted(),
                         "quarks": "\(amount.onChainAmount.quarks)",
-                    ]
+                    ],
+                    userFacing: true
                 )
                 actionButtonState = .normal
                 showErrorDialog(error: error)

--- a/Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift
+++ b/Flipcash/Core/Screens/Main/Operations/SendCashOperation.swift
@@ -276,12 +276,15 @@ class SendCashOperation {
             "error": "\(error)",
         ])
 
+        // Every `handleFailure` call rethrows, surfacing the give-bill "cash was
+        // returned" dialog — so a suppressed transient here is user-facing.
         ErrorReporting.capturePayment(
             error: error,
             rendezvous: payload.rendezvous.publicKey,
             exchangedFiat: exchangedFiat,
             verifiedState: resolution.state,
-            reason: path.rawValue
+            reason: path.rawValue,
+            userFacing: true
         )
     }
 }

--- a/Flipcash/Core/Screens/Main/TransactionHistoryScreen.swift
+++ b/Flipcash/Core/Screens/Main/TransactionHistoryScreen.swift
@@ -87,7 +87,7 @@ struct TransactionHistoryScreen: View {
             } catch {
                 ErrorReporting.captureError(error, reason: "Failed to cancel cash link", metadata: [
                     "vault": metadata.vault.base58,
-                ])
+                ], userFacing: true)
                 dialogItem = .error(
                     title: "Failed to Cancel Transfer",
                     subtitle: "Something went wrong. Please try again later"

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -247,7 +247,7 @@ final class SendAmountViewModel {
                 continue
             } catch {
                 logger.error("Recipient resolve failed", metadata: ["target": "\(targetLogID)", "error": "\(error)"])
-                ErrorReporting.captureError(error, reason: "Recipient resolve failed")
+                ErrorReporting.captureError(error, reason: "Recipient resolve failed", userFacing: true)
                 return .failed
             }
         }

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawViewModel.swift
@@ -446,7 +446,8 @@ class WithdrawViewModel {
                             "fee": "\(fee.quarks)",
                             "destination": destinationMetadata.destination.token.base58,
                             "requiresInit": "\(destinationMetadata.requiresInitialization)",
-                        ]
+                        ],
+                        userFacing: true
                     )
                     Analytics.withdrawal(exchangedFiat: amountToWithdraw, successful: false, error: error)
                 case .sameMint:

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -898,9 +898,10 @@ class Session {
             ErrorReporting.capturePayment(
                 error: error,
                 rendezvous: rendezvous,
-                exchangedFiat: exchangedFiat
+                exchangedFiat: exchangedFiat,
+                userFacing: true
             )
-            
+
             Analytics.withdrawal(
                 exchangedFiat: exchangedFiat,
                 successful: false,
@@ -978,7 +979,8 @@ class Session {
             ErrorReporting.capturePayment(
                 error: error,
                 rendezvous: rendezvous,
-                exchangedFiat: amount
+                exchangedFiat: amount,
+                userFacing: true
             )
             throw error
         }
@@ -1172,11 +1174,14 @@ class Session {
                     )
 
                 } catch {
-                    ErrorReporting.captureError(error)
                     // Suppress late-arriving errors from stale/orphaned tasks
                     // (e.g. gRPC stream finally giving up minutes later) so they
                     // don't fire dialogs on unrelated bills the user has moved on to.
-                    if self.isShowingBill && self.sendOperation === operation {
+                    let willShowDialog = self.isShowingBill && self.sendOperation === operation
+                    // `userFacing` only when a dialog actually shows — an orphaned-task
+                    // transient stays suppressed (no dialog, no breadcrumb).
+                    ErrorReporting.captureError(error, userFacing: willShowDialog)
+                    if willShowDialog {
                         self.dialogItem = .error(title: "Something Went Wrong", subtitle: "Please try again later")
                     }
                 }
@@ -1616,7 +1621,7 @@ class Session {
                 logger.error("Failed to receive cash link for gift card", metadata: [
                     "public_key": "\(giftCardKeyPair.publicKey)",
                 ])
-                ErrorReporting.captureError(error)
+                ErrorReporting.captureError(error, userFacing: true)
 
                 Analytics.transfer(
                     event: .receiveCashLink,

--- a/Flipcash/Utilities/ErrorReporting.swift
+++ b/Flipcash/Utilities/ErrorReporting.swift
@@ -11,6 +11,28 @@ import FlipcashCore
 
 enum ErrorReporting {
 
+    /// The reporting outcome for a classified error: dropped, or sent at a severity.
+    nonisolated enum Outcome: Equatable {
+        case drop
+        case info
+        case error
+    }
+
+    /// Resolves how a classified error should be reported.
+    ///
+    /// `.suppressed` (transient transport / network weather) is normally dropped, but
+    /// when it reached the user as a hard failure dialog (`userFacing`) it is lifted to
+    /// `.info` — a breadcrumb, never `.error`, so it never pages Slack. Only `.suppressed`
+    /// is ever lifted: user-caused refusals classify `.info`/`.error`, so a user-caused
+    /// failure can never be surfaced by `userFacing`.
+    nonisolated static func outcome(for level: ErrorReportingLevel, userFacing: Bool) -> Outcome {
+        switch level {
+        case .suppressed: userFacing ? .info : .drop
+        case .info:       .info
+        case .error:      .error
+        }
+    }
+
     private static var isEnabled = false
 
     static func initialize() {
@@ -20,8 +42,8 @@ enum ErrorReporting {
         isEnabled = true
     }
 
-    static func capturePayment(error: Swift.Error, rendezvous: PublicKey, exchangedFiat: ExchangedFiat, verifiedState: VerifiedState? = nil, reason: String? = nil, file: String = #file, function: String = #function, line: Int = #line) {
-        capture(error, reason: reason, file: file, function: function, line: line) { userInfo in
+    static func capturePayment(error: Swift.Error, rendezvous: PublicKey, exchangedFiat: ExchangedFiat, verifiedState: VerifiedState? = nil, reason: String? = nil, userFacing: Bool = false, file: String = #file, function: String = #function, line: Int = #line) {
+        capture(error, reason: reason, userFacing: userFacing, file: file, function: function, line: line) { userInfo in
             userInfo["rendezvous"]    = rendezvous.base58
             userInfo["exchangedFiat"] = exchangedFiat.descriptionDictionary
             if let verifiedState {
@@ -39,8 +61,8 @@ enum ErrorReporting {
         }
     }
     
-    static func capturePayment(error: Swift.Error, rendezvous: PublicKey, fiat: FiatAmount, reason: String? = nil, file: String = #file, function: String = #function, line: Int = #line) {
-        capture(error, reason: reason, file: file, function: function, line: line) { userInfo in
+    static func capturePayment(error: Swift.Error, rendezvous: PublicKey, fiat: FiatAmount, reason: String? = nil, userFacing: Bool = false, file: String = #file, function: String = #function, line: Int = #line) {
+        capture(error, reason: reason, userFacing: userFacing, file: file, function: function, line: line) { userInfo in
             userInfo["rendezvous"] = rendezvous.base58
             userInfo["usdc"]       = fiat.formatted()
             userInfo["value"]      = "\(fiat.value)"
@@ -57,22 +79,26 @@ enum ErrorReporting {
     ///     single function contains multiple catch sites that should group separately.
     ///   - metadata: Key-value pairs attached to the Bugsnag event's user info for
     ///     debugging context (e.g. mint, amount, swap ID).
-    static func captureError(_ error: Swift.Error, reason: String? = nil, id: String? = nil, metadata: [String: String] = [:], file: String = #file, function: String = #function, line: Int = #line) {
-        capture(error, reason: reason, id: id, file: file, function: function, line: line) { userInfo in
+    ///   - userFacing: Pass `true` when this error was surfaced to the user as a hard
+    ///     failure dialog. A `.suppressed` (transient transport) error that reached a
+    ///     dialog is then recorded at `.info` instead of dropped — a breadcrumb, never
+    ///     a Slack page. Has no effect on `.info`/`.error` errors.
+    static func captureError(_ error: Swift.Error, reason: String? = nil, id: String? = nil, metadata: [String: String] = [:], userFacing: Bool = false, file: String = #file, function: String = #function, line: Int = #line) {
+        capture(error, reason: reason, id: id, userFacing: userFacing, file: file, function: function, line: line) { userInfo in
             metadata.forEach { key, value in
                 userInfo[key] = value
             }
         }
     }
     
-    private static func capture(_ error: Swift.Error, reason: String? = nil, id: String? = nil, file: String = #file, function: String = #function, line: Int = #line, buildUserInfo: (inout [String: Any]) -> Void) {
+    private static func capture(_ error: Swift.Error, reason: String? = nil, id: String? = nil, userFacing: Bool = false, file: String = #file, function: String = #function, line: Int = #line, buildUserInfo: (inout [String: Any]) -> Void) {
         guard isEnabled else { return }
 
         // A non-ServerError reaching the reporter is unclassified — treat as a real bug.
         let level = (error as? ServerError)?.reportingLevel ?? .error
         let severity: BSGSeverity
-        switch level {
-        case .suppressed:
+        switch outcome(for: level, userFacing: userFacing) {
+        case .drop:
             return
         case .info:
             severity = .info

--- a/FlipcashTests/ErrorReportingOutcomeTests.swift
+++ b/FlipcashTests/ErrorReportingOutcomeTests.swift
@@ -1,0 +1,49 @@
+//
+//  ErrorReportingOutcomeTests.swift
+//  Flipcash
+//
+//  Covers the `userFacing` floor: a transient transport error (`.suppressed`) that
+//  reaches a hard failure dialog is recorded at `.info` — a breadcrumb, never `.error`
+//  (so it never pages Slack), and only ever for `.suppressed` (never user-caused).
+//
+
+import Foundation
+import Testing
+import GRPCCore
+import FlipcashCore
+@testable import Flipcash
+
+@Suite("ErrorReporting.outcome — userFacing floor")
+struct ErrorReportingOutcomeTests {
+
+    @Test("Full level × userFacing matrix", arguments: [
+        // level, userFacing, expected outcome
+        (ErrorReportingLevel.suppressed, false, ErrorReporting.Outcome.drop),
+        (.suppressed, true,  .info),   // the floor: transient dialog → breadcrumb
+        (.info,       false, .info),
+        (.info,       true,  .info),   // unchanged
+        (.error,      false, .error),
+        (.error,      true,  .error),  // real defect still pages, never downgraded
+    ])
+    func outcomeMatrix(level: ErrorReportingLevel, userFacing: Bool, expected: ErrorReporting.Outcome) {
+        #expect(ErrorReporting.outcome(for: level, userFacing: userFacing) == expected)
+    }
+
+    @Test("userFacing never produces .error — cannot page Slack")
+    func userFacingNeverPages() {
+        for level in [ErrorReportingLevel.suppressed, .info] {
+            #expect(ErrorReporting.outcome(for: level, userFacing: true) != .error)
+        }
+    }
+
+    @Test("#545 shape: transient RPCError reaching a dialog becomes an info breadcrumb")
+    func transientTransportFloorsToInfo() {
+        // The cold-channel race throws gRPC .unavailable, which classifies .suppressed.
+        let transient = RPCError(code: .unavailable, message: "channel not connected")
+        #expect(transient.reportingLevel == .suppressed)
+
+        // Without a dialog it is dropped (network weather); with a dialog it is recorded.
+        #expect(ErrorReporting.outcome(for: transient.reportingLevel, userFacing: false) == .drop)
+        #expect(ErrorReporting.outcome(for: transient.reportingLevel, userFacing: true) == .info)
+    }
+}


### PR DESCRIPTION
## Problem
Transient transport errors (gRPC `.unavailable`/`.deadlineExceeded`, transient `URLError`) classify `.suppressed` and are dropped before Bugsnag. When one of them surfaces a hard `DialogItem.error(...)`, the user sees a failure the team never learns about — the same class as #545.

## Change
- Add a `userFacing` flag to `ErrorReporting.captureError`/`capturePayment`. When set, a `.suppressed` error is floored to `.info` — a breadcrumb, **never** `.error`, so it never pages Slack.
- Only `.suppressed` is ever lifted. User-caused refusals classify `.info`/`.error` and never reach that branch, so a user-caused failure can never be surfaced by this flag.
- Extract the pure decision into `ErrorReporting.outcome(for:userFacing:)` (nonisolated, testable).
- Wire `userFacing: true` at the money-path sites that show a hard error dialog: direct send, recipient resolve, give bill, send-as-link, receive cash link, withdraw, buy, sell, currency creation/moderation, cancel transfer.
- The give / create-link paths tie the flag to whether the dialog actually renders, so orphaned-task transients stay silent.

## Tests
`ErrorReportingOutcomeTests` — level × userFacing matrix, the "never `.error`" invariant, and the #545 shape (transient `RPCError(.unavailable)` → dropped normally, `.info` when user-facing).

## Verification
`build_sim` succeeds; new tests pass.