### PR TITLE
fix(tips): await a fresh rate on cold-deeplink tip submission

### DIFF
--- a/Flipcash/Core/Controllers/RatesController.swift
+++ b/Flipcash/Core/Controllers/RatesController.swift
@@ -257,6 +257,32 @@ class RatesController {
         return nil
     }
 
+    /// Wait for a *fresh* (non-stale) pinned verified state, polling the cache.
+    ///
+    /// Unlike ``awaitVerifiedState(for:mint:maxAttempts:interval:)`` this re-applies
+    /// the staleness check on every poll, so a stale warm-loaded proof is rejected and
+    /// we keep waiting for the live stream to deliver a fresh one. Use this on a path
+    /// that races cold-start warm-up (e.g. a tip deep link) where the cache may be
+    /// momentarily empty or holding a stale proof. Returns nil on timeout.
+    func awaitPinnedState(
+        for currency: CurrencyCode,
+        mint: PublicKey,
+        maxAttempts: Int = 25,
+        interval: Duration = .milliseconds(200)
+    ) async -> VerifiedState? {
+        for i in 0..<maxAttempts {
+            if Task.isCancelled { return nil }
+            if i > 0 {
+                try? await Task.sleep(for: interval)
+            }
+            if let state = await verifiedProtoService.getVerifiedState(for: currency, mint: mint), !state.isStale {
+                return state
+            }
+        }
+        logger.error("awaitPinnedState timed out", metadata: ["currency": "\(currency.rawValue)", "mint": "\(mint.base58)"])
+        return nil
+    }
+
     // MARK: - Rates -
 
     /// Cache of rates from streaming. Tracked by `@Observable` so views update automatically.
@@ -363,6 +389,13 @@ extension RatesController {
     enum Error: Swift.Error {
         case exchangeRateUnavailable
     }
+}
+
+extension RatesController.Error: ServerError {
+    /// Expected, self-healing cold-start condition — the rate cache is momentarily
+    /// empty or holding a stale proof while the live stream warms up. Worth an `.info`
+    /// breadcrumb when it surfaces to the user, but never a Slack page.
+    var reportingLevel: ErrorReportingLevel { .info }
 }
 
 // MARK: - LocalDefaults -

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -159,6 +159,18 @@ final class SendAmountViewModel {
             }
 
             guard let (amountToSend, pinnedState) = await prepareSubmission(entered: entered) else {
+                // A nil here is a silent local cache miss (no RPC, no thrown error), so
+                // it would otherwise be invisible to reporting. Record a breadcrumb at
+                // `.info` — the classified level of `exchangeRateUnavailable` — so a
+                // spike in cold-start rate races is visible without paging Slack.
+                ErrorReporting.captureError(
+                    RatesController.Error.exchangeRateUnavailable,
+                    reason: "No fresh rate at send submission",
+                    metadata: [
+                        "target": targetLogID,
+                        "mint": selectedBalance.stored.mint.base58,
+                    ]
+                )
                 session.dialogItem = .error(
                     title: "Rate Unavailable",
                     subtitle: "Couldn't get a fresh rate. Please try again."
@@ -273,10 +285,25 @@ final class SendAmountViewModel {
         guard let selectedBalance else { return nil }
         let mint = selectedBalance.stored.mint
 
-        guard let pin = await ratesController.currentPinnedState(
-            for: ratesController.balanceCurrency,
-            mint: mint
-        ) else { return nil }
+        // A tip deep link opens on a cold foreground, racing the rate stream/warm-load
+        // (a sibling of the #545 recipient-resolve race). For tips, poll for a fresh
+        // pinned state rather than failing the first time the cache is momentarily empty
+        // or holding a stale warm-loaded proof. In-app contact sends run warm, so they
+        // keep the single-shot read.
+        let pinnedState: VerifiedState?
+        switch target {
+        case .tip:
+            pinnedState = await ratesController.awaitPinnedState(
+                for: ratesController.balanceCurrency,
+                mint: mint
+            )
+        case .contact:
+            pinnedState = await ratesController.currentPinnedState(
+                for: ratesController.balanceCurrency,
+                mint: mint
+            )
+        }
+        guard let pin = pinnedState else { return nil }
 
         let nativeEntered = FiatAmount(value: entered, currency: pin.rate.currency)
 

--- a/FlipcashTests/RatesControllerErrorReportingTests.swift
+++ b/FlipcashTests/RatesControllerErrorReportingTests.swift
@@ -1,0 +1,22 @@
+//
+//  RatesControllerErrorReportingTests.swift
+//  Flipcash
+//
+//  The tip-deeplink "Rate Unavailable" breadcrumb records `exchangeRateUnavailable`.
+//  It must classify `.info` — a self-healing cold-start rate race is worth visibility
+//  but must never page Slack. Guards against a drift to `.error`.
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@Suite("RatesController.Error reporting level")
+struct RatesControllerErrorReportingTests {
+
+    @Test("exchangeRateUnavailable reports at .info (breadcrumb, never a Slack page)")
+    func exchangeRateUnavailableIsInfo() {
+        #expect(RatesController.Error.exchangeRateUnavailable.reportingLevel == .info)
+    }
+}


### PR DESCRIPTION
## Problem
A tip deep link opens on a cold foreground, racing the gRPC channel warm-up and the rate stream/warm-load — a sibling of #545. `SendAmountViewModel.submit` read the verified-rate cache once via `currentPinnedState`; if the cache was momentarily empty or holding a stale (>13 min) warm-loaded proof, it failed instantly with a hard "Rate Unavailable" dialog. That path is a silent nil-guard (no RPC, no thrown error), so it produced **zero telemetry** — invisible to Bugsnag and analytics.

## Change
- Add `RatesController.awaitPinnedState(for:mint:)` — polls the cache (~5s) and, unlike the existing `awaitVerifiedState`, re-applies the staleness check each poll so it never returns a stale proof.
- For **tips only**, `prepareSubmission` polls `awaitPinnedState`, letting a momentarily-empty/stale cache fill from the live stream before failing. In-app contact sends run warm and keep the single-shot read.
- Classify `RatesController.Error` as a `.info` `ServerError` and record it on the nil path, so a spike in cold-start rate races is visible in Bugsnag without paging Slack.

## Scope
Tip path only. Give/Buy/Withdraw share the same single-shot pattern but are intentionally left for a separate review.

## Tests
`RatesControllerErrorReportingTests` — asserts `exchangeRateUnavailable` classifies `.info`.

## Verification
`build_sim` succeeds standalone.