### PR TITLE
fix(tips): prewarm the verified rate during tip presentation

### DIFF
--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -185,6 +185,14 @@ final class TipFlow {
             target: .tip(recipient)
         )
 
+        // A tip deep link can beat the app's foreground stream refresh, so kick the
+        // rate stream to reconnect now and warm the verified proof while the card
+        // animates in and the user reads the sheet. This overlaps the rate wait with
+        // on-screen time so the swipe submits instantly instead of racing a cold
+        // cache; the submit-time poll in `prepareSubmission` remains the backstop.
+        ratesController.ensureStreamConnected()
+        Task { [weak self] in await self?.submission?.prewarmVerifiedRate() }
+
         session.billState = BillState(bill: .tipcard(
             codeData: TipCode.Payload(userID: recipient.userID).codeData(),
             name: recipient.displayName,

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -38,6 +38,12 @@ final class SendAmountViewModel {
     /// transient send failure) skips the round-trip.
     private var resolvedRecipient: PublicKey?
 
+    /// A verified rate proof warmed while the send UI is on screen (see
+    /// `prewarmVerifiedRate()`) so `submit` doesn't race a cold cache at the
+    /// moment the user commits. Consumed by `prepareSubmission`; invalidated on
+    /// token change and re-checked for staleness before use.
+    private var prewarmedState: VerifiedState?
+
     /// Amount validity only — never gated on the recipient. A red subtitle in
     /// `EnterAmountView` (driven by `!canSend`) therefore means over-limit, not
     /// "recipient unresolved"; resolution happens on the Send tap instead.
@@ -293,10 +299,16 @@ final class SendAmountViewModel {
         let pinnedState: VerifiedState?
         switch target {
         case .tip:
-            pinnedState = await ratesController.awaitPinnedState(
-                for: ratesController.balanceCurrency,
-                mint: mint
-            )
+            // Prefer a proof warmed while the sheet was on screen; fall back to a
+            // fresh poll if the prewarm never finished or has since gone stale.
+            if let prewarmedState, !prewarmedState.isStale {
+                pinnedState = prewarmedState
+            } else {
+                pinnedState = await ratesController.awaitPinnedState(
+                    for: ratesController.balanceCurrency,
+                    mint: mint
+                )
+            }
         case .contact:
             pinnedState = await ratesController.currentPinnedState(
                 for: ratesController.balanceCurrency,
@@ -325,10 +337,26 @@ final class SendAmountViewModel {
         return (amount, pin)
     }
 
+    /// Warms the verified rate proof while the send UI is on screen so `submit`
+    /// doesn't race a cold cache at the moment the user commits — the wait overlaps
+    /// the time the user spends reading the sheet instead of stalling the swipe.
+    /// Safe to call fire-and-forget: `prepareSubmission` falls back to a fresh poll
+    /// if this hasn't finished or the cached proof has since gone stale.
+    func prewarmVerifiedRate() async {
+        guard let mint = selectedBalance?.stored.mint else { return }
+        prewarmedState = await ratesController.awaitPinnedState(
+            for: ratesController.balanceCurrency,
+            mint: mint
+        )
+    }
+
     func selectCurrencyAction(exchangedBalance: ExchangedBalance) {
         selectedBalance = exchangedBalance
         ratesController.selectToken(exchangedBalance.stored.mint)
         enteredAmount = ""
+        // The warmed proof was for the previous token (and a launchpad mint also
+        // needs its own reserve proof) — drop it so submission re-warms/polls.
+        prewarmedState = nil
     }
 
     // MARK: - Navigation -

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/VerifiedProtoService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/VerifiedProtoService.swift
@@ -57,6 +57,11 @@ public actor VerifiedProtoService {
                 guard let currency = try? CurrencyCode(currencyCode: row.currency),
                       exchangeRates[currency] == nil else { continue }
                 if let proto = try? Ocp_Currency_V1_VerifiedCoreMintFiatExchangeRate(serializedBytes: row.rateProto) {
+                    // Skip protos already past the client freshness window. Loading a
+                    // stale one only gets it rejected by `isStale` at read time, but it
+                    // also masks an empty cache as "populated" and leaves consumers that
+                    // don't re-check staleness (`awaitVerifiedState`) exposed to it.
+                    guard !VerifiedState(rateProto: proto).isStale else { continue }
                     exchangeRates[currency] = proto
                 }
             }

--- a/FlipcashTests/VerifiedProtoServiceTests.swift
+++ b/FlipcashTests/VerifiedProtoServiceTests.swift
@@ -146,8 +146,8 @@ struct VerifiedProtoServiceTests {
     func init_warmLoadsRates() async throws {
         let store = InMemoryVerifiedProtoStore()
 
-        // Pre-seed the store with a serialized rate proto.
-        let rateProto = Ocp_Currency_V1_VerifiedCoreMintFiatExchangeRate.makeTest(currencyCode: "usd", rate: 1.0)
+        // Pre-seed the store with a serialized, in-window rate proto.
+        let rateProto = Ocp_Currency_V1_VerifiedCoreMintFiatExchangeRate.freshRate(currencyCode: "usd", rate: 1.0)
         let data = try rateProto.serializedData()
         try store.writeRates([StoredRateRow(currency: "usd", rateProto: data)])
 
@@ -157,6 +157,24 @@ struct VerifiedProtoServiceTests {
         try await Task.sleep(for: .milliseconds(150))
 
         #expect(await service.hasVerifiedRate(for: .usd))
+    }
+
+    @Test("init warm-load skips rate protos already past the freshness window")
+    func init_warmLoadSkipsStaleRates() async throws {
+        let store = InMemoryVerifiedProtoStore()
+
+        // Pre-seed the store with a proto older than the 13-minute client window.
+        let staleProto = Ocp_Currency_V1_VerifiedCoreMintFiatExchangeRate.staleRate(currencyCode: "usd", rate: 1.0)
+        try store.writeRates([StoredRateRow(currency: "usd", rateProto: try staleProto.serializedData())])
+
+        let service = VerifiedProtoService(store: store)
+
+        // Allow warm-load task a turn.
+        try await Task.sleep(for: .milliseconds(150))
+
+        // A stale proof must not populate the cache: a submission would only reject it,
+        // and `awaitVerifiedState` consumers don't re-check staleness before use.
+        #expect(await service.hasVerifiedRate(for: .usd) == false)
     }
 
     @Test("init warm-loads reserves from the store into the in-memory cache")


### PR DESCRIPTION
Follow-up to #549. That PR made tip submission await a fresh verified rate, which fixes the cold-start race — but only *at swipe time*. On a 13-min-backgrounded wake, the warm-loaded proof is stale and the submit-time poll can stall ~5s and still fail (worse UX than an instant failure). This moves the work earlier so the wait overlaps the time the user spends reading the sheet.

## Root cause recap
The "Rate Unavailable" dialog fires from `SendAmountViewModel.prepareSubmission` when the **verified** rate cache (`VerifiedProtoService.exchangeRates`) is empty/stale. That cache loads async (warm-load Task + live stream), while the **display** cache (`cachedRates`) loads synchronously — so the sheet renders correct amounts and *then* submit fails. It's a timing race, not a structural absence (the rate is delivered and persisted).

## Change
- **Prewarm on present** — `TipFlow.present` calls `ratesController.ensureStreamConnected()` and starts `SendAmountViewModel.prewarmVerifiedRate()` while the tipcard animates in. The verified proof is usually warm by the time the user swipes.
- **Prefer the prewarmed proof** — `SendAmountViewModel` caches it and `prepareSubmission` uses it (re-checking `isStale`), falling back to the #549 submit-time poll if it never finished or has gone stale. Invalidated on token change.
- **Discard stale protos at warm-load** — `VerifiedProtoService.warmLoadFromStore` skips protos past the 13-min window, so a stale warm-loaded proof no longer masquerades as "populated" and no longer reaches `awaitVerifiedState` consumers (receive-cash-link, currency-launch), which don't re-check staleness.

The #549 submit-time await stays as the backstop.

## Tests
- `VerifiedProtoServiceTests.init_warmLoadSkipsStaleRates` (new) + existing warm-load test switched to a fresh proto.
- Full `VerifiedProtoServiceTests` + `RatesControllerTests` pass (37 tests).

## Not covered
The prewarm consumption path in `SendAmountViewModel` isn't unit-tested (needs a full `SessionContainer`); it's backstopped by the #549 await and the rate logic itself is covered by `RatesControllerTests`.

## Verification
`build_sim` succeeds; the two suites above pass.