### PR TITLE
chore: sync core protos + report tip DM send origin

### DIFF
--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -157,7 +157,8 @@ final class TipFlow {
                 }
                 let recipient = TipRecipient(
                     userID: userID,
-                    displayName: resolved.displayName ?? ""
+                    displayName: resolved.displayName ?? "",
+                    origin: .tipcard
                 )
                 guard !Task.isCancelled else { return }
                 present(recipient)

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -223,7 +223,10 @@ final class SendAmountViewModel {
                 destinationPhoneE164: contact.phoneE164
             )
         case .tip(let recipient):
-            return .tipDm(chatID: .tipDm(between: session.userID, and: recipient.userID))
+            return .tipDm(
+                chatID: .tipDm(between: session.userID, and: recipient.userID),
+                origin: recipient.origin
+            )
         }
     }
 

--- a/Flipcash/Core/Screens/Send/SendTarget.swift
+++ b/Flipcash/Core/Screens/Send/SendTarget.swift
@@ -18,6 +18,8 @@ nonisolated enum SendTarget: Hashable, Sendable {
 nonisolated struct TipRecipient: Hashable, Sendable {
     let userID: UserID
     let displayName: String
+    /// The surface this tip is being sent from — reported to the server.
+    let origin: TipOrigin
 }
 
 extension SendTarget {
@@ -34,7 +36,7 @@ extension SendTarget {
                   let userID = counterpart.userID else {
                 return nil
             }
-            self = .tip(TipRecipient(userID: userID, displayName: counterpart.displayName))
+            self = .tip(TipRecipient(userID: userID, displayName: counterpart.displayName, origin: .chat))
         case .contactDm, nil:
             guard let target = ResolvedContact.sendTarget(
                 in: conversation,

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/intent_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/intent_v1_model.pb.swift
@@ -120,14 +120,51 @@ public struct Flipcash_Intent_V1_ChatMetadata: Sendable {
     fileprivate var _destination: Flipcash_Phone_V1_PhoneNumber? = nil
   }
 
-  /// For sending a DM tip payment to someone. The message is empty, since
-  /// it's between two user IDs, which map directly to/from public keys.
+  /// For sending a DM payment to someone using their user ID, which maps
+  /// directly to/from a public key.
   public struct TipDmPayment: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
+    public var location: Flipcash_Intent_V1_ChatMetadata.TipDmPayment.Location = .tipcard
+
     public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    /// Location in the app the payment was sent from
+    public enum Location: SwiftProtobuf.Enum, Swift.CaseIterable {
+      public typealias RawValue = Int
+      case tipcard // = 0
+      case chat // = 1
+      case UNRECOGNIZED(Int)
+
+      public init() {
+        self = .tipcard
+      }
+
+      public init?(rawValue: Int) {
+        switch rawValue {
+        case 0: self = .tipcard
+        case 1: self = .chat
+        default: self = .UNRECOGNIZED(rawValue)
+        }
+      }
+
+      public var rawValue: Int {
+        switch self {
+        case .tipcard: return 0
+        case .chat: return 1
+        case .UNRECOGNIZED(let i): return i
+        }
+      }
+
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Flipcash_Intent_V1_ChatMetadata.TipDmPayment.Location] = [
+        .tipcard,
+        .chat,
+      ]
+
+    }
 
     public init() {}
   }
@@ -300,19 +337,34 @@ extension Flipcash_Intent_V1_ChatMetadata.ContactDmPayment: SwiftProtobuf.Messag
 
 extension Flipcash_Intent_V1_ChatMetadata.TipDmPayment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Flipcash_Intent_V1_ChatMetadata.protoMessageName + ".TipDmPayment"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}location\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    // Load everything into unknown fields
-    while try decoder.nextFieldNumber() != nil {}
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.location) }()
+      default: break
+      }
+    }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.location != .tipcard {
+      try visitor.visitSingularEnumField(value: self.location, fieldNumber: 1)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Flipcash_Intent_V1_ChatMetadata.TipDmPayment, rhs: Flipcash_Intent_V1_ChatMetadata.TipDmPayment) -> Bool {
+    if lhs.location != rhs.location {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
+}
+
+extension Flipcash_Intent_V1_ChatMetadata.TipDmPayment.Location: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0TIPCARD\0\u{1}CHAT\0")
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/messaging_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/messaging_v1_model.pb.swift
@@ -272,13 +272,13 @@ public struct Flipcash_Messaging_V1_CashContent: Sendable {
   /// Clears the value of `amount`. Subsequent reads from it will return its default value.
   public mutating func clearAmount() {self._amount = nil}
 
-  public var action: Flipcash_Messaging_V1_CashContent.Action = .sent
+  public var verb: Flipcash_Messaging_V1_CashContent.Verb = .sent
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  /// Action for how the cash was sent. Clietns should always show SENT as a
+  /// Verb for how the cash was sent. Clietns should always show SENT as a
   /// fallback.
-  public enum Action: SwiftProtobuf.Enum, Swift.CaseIterable {
+  public enum Verb: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case sent // = 0
     case tipped // = 1
@@ -305,7 +305,7 @@ public struct Flipcash_Messaging_V1_CashContent: Sendable {
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    public static let allCases: [Flipcash_Messaging_V1_CashContent.Action] = [
+    public static let allCases: [Flipcash_Messaging_V1_CashContent.Verb] = [
       .sent,
       .tipped,
     ]
@@ -1327,7 +1327,7 @@ extension Flipcash_Messaging_V1_TextContent: SwiftProtobuf.Message, SwiftProtobu
 
 extension Flipcash_Messaging_V1_CashContent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CashContent"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}intent_id\0\u{1}amount\0\u{2}\u{2}action\0\u{c}\u{3}\u{1}")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}intent_id\0\u{1}amount\0\u{2}\u{2}verb\0\u{c}\u{3}\u{1}")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1337,7 +1337,7 @@ extension Flipcash_Messaging_V1_CashContent: SwiftProtobuf.Message, SwiftProtobu
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._intentID) }()
       case 2: try { try decoder.decodeSingularMessageField(value: &self._amount) }()
-      case 4: try { try decoder.decodeSingularEnumField(value: &self.action) }()
+      case 4: try { try decoder.decodeSingularEnumField(value: &self.verb) }()
       default: break
       }
     }
@@ -1354,8 +1354,8 @@ extension Flipcash_Messaging_V1_CashContent: SwiftProtobuf.Message, SwiftProtobu
     try { if let v = self._amount {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     } }()
-    if self.action != .sent {
-      try visitor.visitSingularEnumField(value: self.action, fieldNumber: 4)
+    if self.verb != .sent {
+      try visitor.visitSingularEnumField(value: self.verb, fieldNumber: 4)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1363,13 +1363,13 @@ extension Flipcash_Messaging_V1_CashContent: SwiftProtobuf.Message, SwiftProtobu
   public static func ==(lhs: Flipcash_Messaging_V1_CashContent, rhs: Flipcash_Messaging_V1_CashContent) -> Bool {
     if lhs._intentID != rhs._intentID {return false}
     if lhs._amount != rhs._amount {return false}
-    if lhs.action != rhs.action {return false}
+    if lhs.verb != rhs.verb {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Flipcash_Messaging_V1_CashContent.Action: SwiftProtobuf._ProtoNameProviding {
+extension Flipcash_Messaging_V1_CashContent.Verb: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SENT\0\u{1}TIPPED\0")
 }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/intent/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/intent/v1/model.proto
@@ -38,8 +38,14 @@ message ChatMetadata {
         phone.v1.PhoneNumber destination = 2 [(validate.rules).message.required = true];
     }
 
-    // For sending a DM tip payment to someone. The message is empty, since
-    // it's between two user IDs, which map directly to/from public keys.
+    // For sending a DM payment to someone using their user ID, which maps
+    // directly to/from a public key.
     message TipDmPayment {
+        // Location in the app the payment was sent from
+        enum Location {
+            TIPCARD = 0;
+            CHAT    = 1;
+        }
+        Location location = 1;
     }
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/messaging/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/messaging/v1/model.proto
@@ -126,13 +126,13 @@ message CashContent {
     // Reserved for receiver, which will is required for group chats
     reserved 3;
 
-    // Action for how the cash was sent. Clietns should always show SENT as a
+    // Verb for how the cash was sent. Clietns should always show SENT as a
     // fallback.
-    enum Action {
+    enum Verb {
         SENT   = 0;
         TIPPED = 1;
     }
-    Action action = 4;
+    Verb verb = 4;
 }
 
 // Reply content

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ChatPaymentMetadata.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ChatPaymentMetadata.swift
@@ -16,14 +16,14 @@ import SwiftProtobuf
 public enum ChatPaymentMetadata: Sendable {
 
     case contactDm(chatID: ConversationID, sourcePhoneE164: String, destinationPhoneE164: String)
-    case tipDm(chatID: ConversationID)
+    case tipDm(chatID: ConversationID, origin: TipOrigin)
 
     /// The DM chat this payment posts into.
     public var chatID: ConversationID {
         switch self {
         case .contactDm(let chatID, _, _):
             return chatID
-        case .tipDm(let chatID):
+        case .tipDm(let chatID, _):
             return chatID
         }
     }
@@ -40,10 +40,29 @@ public enum ChatPaymentMetadata: Sendable {
                         $0.source = .with { $0.value = sourcePhoneE164 }
                         $0.destination = .with { $0.value = destinationPhoneE164 }
                     }
-                case .tipDm:
-                    $0.tipDmPayment = .init()
+                case .tipDm(_, let origin):
+                    $0.tipDmPayment = .with { $0.location = origin.proto }
                 }
             }
         }.serializedData()
+    }
+}
+
+/// Where in the app a tip DM payment was sent from. Reported to the server so
+/// it can attribute the tip to the surface it originated on. Mirrors Android's
+/// `TipOrigin`.
+public enum TipOrigin: Sendable {
+
+    /// Sent from a resolved tipcard (scan or deep link).
+    case tipcard
+
+    /// Sent from the Send Cash action inside an existing tip DM thread.
+    case chat
+
+    var proto: Flipcash_Intent_V1_ChatMetadata.TipDmPayment.Location {
+        switch self {
+        case .tipcard: return .tipcard
+        case .chat:    return .chat
+        }
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
@@ -115,8 +115,8 @@ extension ConversationMessage {
                 return nil
             }
             self.content = .cash(amount)
-            // Unrecognized actions fall back to `.sent`, per the proto contract.
-            self.cashAction = cashContent.action == .tipped ? .tipped : .sent
+            // Unrecognized verbs fall back to `.sent`, per the proto contract.
+            self.cashAction = cashContent.verb == .tipped ? .tipped : .sent
         case .deleted:
             self.content = .deleted
             self.cashAction = nil

--- a/FlipcashCore/Tests/FlipcashCoreTests/ChatPaymentMetadataTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ChatPaymentMetadataTests.swift
@@ -27,17 +27,32 @@ struct ChatPaymentMetadataTests {
         #expect(payment.destination.value == "+15551230002")
     }
 
-    @Test("Tip DM payments carry the chat id and the empty tip marker")
-    func tipDmSerialization() throws {
-        let metadata = ChatPaymentMetadata.tipDm(chatID: chatID)
+    @Test("Tip DM payments carry the chat id and the tipcard origin")
+    func tipDmTipcardSerialization() throws {
+        let metadata = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .tipcard)
 
         let decoded = try Flipcash_Intent_V1_AppMetadata(serializedBytes: metadata.serializedAppMetadata())
 
         #expect(decoded.chat.chatID.value == chatID.data)
-        guard case .tipDmPayment = decoded.chat.type else {
+        guard case .tipDmPayment(let payment) = decoded.chat.type else {
             Issue.record("Expected tipDmPayment, got \(String(describing: decoded.chat.type))")
             return
         }
+        #expect(payment.location == .tipcard)
+    }
+
+    @Test("Tip DM payments carry the chat origin when sent from a chat")
+    func tipDmChatSerialization() throws {
+        let metadata = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .chat)
+
+        let decoded = try Flipcash_Intent_V1_AppMetadata(serializedBytes: metadata.serializedAppMetadata())
+
+        #expect(decoded.chat.chatID.value == chatID.data)
+        guard case .tipDmPayment(let payment) = decoded.chat.type else {
+            Issue.record("Expected tipDmPayment, got \(String(describing: decoded.chat.type))")
+            return
+        }
+        #expect(payment.location == .chat)
     }
 
     @Test("Each variant exposes its chat id uniformly")
@@ -47,7 +62,7 @@ struct ChatPaymentMetadataTests {
             sourcePhoneE164: "+15551230001",
             destinationPhoneE164: "+15551230002"
         )
-        let tip = ChatPaymentMetadata.tipDm(chatID: chatID)
+        let tip = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .tipcard)
 
         #expect(contact.chatID == chatID)
         #expect(tip.chatID == chatID)

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
@@ -69,7 +69,7 @@ struct ConversationModelMappingTests {
             $0.messageID = .with { $0.value = 13 }
             $0.content = [.with {
                 $0.cash = .with {
-                    $0.action = .tipped
+                    $0.verb = .tipped
                     $0.amount = .with {
                         $0.currency = "usd"
                         $0.nativeAmount = 2.0

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -503,7 +503,7 @@ struct SendAmountViewModelTests {
     ) -> SendAmountViewModel {
         SendAmountViewModel(
             sessionContainer: container,
-            target: .tip(TipRecipient(userID: recipientID, displayName: "Fred")),
+            target: .tip(TipRecipient(userID: recipientID, displayName: "Fred", origin: .tipcard)),
             mint: .usdf,
             sender: mock,
             resolver: mock
@@ -526,11 +526,12 @@ struct SendAmountViewModelTests {
         #expect(mock.resolveUserIDCalls == [recipientID])
         #expect(mock.resolveContactCalls.isEmpty)
         let chat = try #require(mock.sendCalls.first?.chat)
-        guard case .tipDm(let chatID) = chat else {
+        guard case .tipDm(let chatID, let origin) = chat else {
             Issue.record("Expected tipDm metadata, got \(chat)")
             return
         }
         #expect(chatID == ConversationID.tipDm(between: container.session.userID, and: recipientID))
+        #expect(origin == .tipcard)
     }
 
     @Test("A tip below the server minimum is blocked before submission")


### PR DESCRIPTION
## Summary

Re-vendors the `flipcash2-protobuf-api` **Core** protos, regenerates the Swift bindings, and wires up the one new field that carries product meaning. Payments protos were already up to date. Two commits:

**1. `chore: sync core protos`**
- `messaging.v1.CashContent`: enum `Action` → `Verb`, field `action` → `verb` (wire field 4 unchanged, fully backward-compatible). Updated the two consumers (`ConversationMessage`, `ConversationModelMappingTests`).
- `intent.v1.ChatMetadata.TipDmPayment`: gains a `location` field (`Location { TIPCARD, CHAT }`).

**2. `feat(tips): report the surface a tip DM was sent from`**
- Populates the new `TipDmPayment.location` so the server can attribute a tip to where it originated.
- Threads a Swift `TipOrigin { tipcard, chat }` from each construction site through `TipRecipient` → `SendAmountViewModel` → `ChatPaymentMetadata`, **mirroring Android's `enum class TipOrigin`**.
  - Tipcard scan / deep link (`TipFlow`) → `.tipcard`
  - Send Cash inside a tip-DM thread (`SendTarget`) → `.chat`
- Previously both paths defaulted to `.tipcard`, mislabeling chat-origin tips.

The field is send-only (serialized into `SubmitIntent`, never decoded back), so there is no read-path work.

## Testing
- `./Scripts/build.sh` → **BUILD SUCCEEDED**
- `./Scripts/test.sh FlipcashCoreTests/ChatPaymentMetadataTests FlipcashCoreTests/ConversationModelMappingTests FlipcashTests/SendAmountViewModelTests` → all pass, including new `location`/`origin` assertions for both `.tipcard` and `.chat`.

## Parity note
Android already models this as `TipOrigin { TIPCARD, CHAT }` and threads an `origin` param; this PR matches that naming and semantics on iOS.
