### PR TITLE
fix(tips): deliver live events to a switched-to account's conversation stream

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -193,15 +193,18 @@ final class ConversationController {
         guard startTask == nil else { return }
         startTask = Task {
             await hydrateFromDatabase()
-            openStream()
-            observeConnectionState()
+            await openStream()
             await loadFeed()
         }
     }
 
-    private func openStream() {
+    private func openStream() async {
         guard streamTask == nil else { return }
-        let events = streaming.openConversationStream(owner: owner)
+        // Subscribe once for a fresh event + connection-state stream pair (the streamer is an
+        // app-lifetime singleton that vends a new pair per session, so a switched-to account isn't
+        // stranded on the previous session's dead stream). Wire both loops before the feed loads so no
+        // live event is lost mid-load.
+        let (events, states) = await streaming.subscribeConversationStream(owner: owner)
         streamTask = Task { [weak self] in
             for await event in events {
                 guard let self else { return }
@@ -215,16 +218,17 @@ final class ConversationController {
                 }
             }
         }
+        observeConnectionState(states)
     }
 
     /// A reconnect can miss live events while the stream was down; the event log carries a per-chat
     /// cursor, so on reconnect we reconcile the missed window from that cursor via `GetDelta`. The first
     /// `.live` is the initial connection (already loaded by `start()`/the screen); every `.live` after
     /// it is a reconnect. This edge is a belt-and-suspenders trigger — foreground, chat-open, and a
-    /// detected live gap already drive catch-up without waiting for a ping.
-    private func observeConnectionState() {
+    /// detected live gap already drive catch-up without waiting for a ping. Consumes the same
+    /// subscription's connection-state stream opened by `openStream()`.
+    private func observeConnectionState(_ states: AsyncStream<EventStreamConnectionState>) {
         guard connectionStateTask == nil else { return }
-        let states = streaming.conversationConnectionState()
         connectionStateTask = Task { [weak self] in
             for await state in states {
                 guard let self else { return }

--- a/Flipcash/Core/Controllers/FlipClient+Protocols.swift
+++ b/Flipcash/Core/Controllers/FlipClient+Protocols.swift
@@ -89,11 +89,12 @@ protocol ConversationMessaging: AnyObject, Sendable {
 /// The single per-user event stream surface used by `ConversationController`. Wraps the
 /// `event.v1 StreamEvents` lifecycle behind `ConversationStreamEvent`.
 protocol ConversationEventStreaming: AnyObject, Sendable {
-    func openConversationStream(owner: KeyPair) -> AsyncStream<ConversationStreamEvent>
-    /// The event stream's connection state. The event stream carries no cursor, so the controller
-    /// treats the first `.live` as the initial connection and, on each `.live` after (a reconnect),
-    /// reconciles the missed window from the event-log cursor via `GetDelta`.
-    func conversationConnectionState() -> AsyncStream<EventStreamConnectionState>
+    /// Attach this session's consumer to the single per-user event stream, returning fresh decoded-event
+    /// and connection-state streams. Each session gets its own pair, so a switched-to account isn't
+    /// stranded on a dead stream. The event stream carries no cursor, so the controller treats the first
+    /// `.live` as the initial connection and, on each `.live` after (a reconnect), reconciles the missed
+    /// window from the event-log cursor via `GetDelta`.
+    func subscribeConversationStream(owner: KeyPair) async -> (events: AsyncStream<ConversationStreamEvent>, connectionState: AsyncStream<EventStreamConnectionState>)
     func ensureConversationStreamConnected()
     func closeConversationStream()
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
@@ -10,7 +10,7 @@ import Foundation
 extension FlipClient {
 
     /// Page the DM chat feed to exhaustion against a single pinned snapshot.
-    /// The caller must already be consuming `eventStreamer.events` so updates
+    /// The caller must already be consuming its `subscribeConversationStream` events so updates
     /// that land mid-pagination aren't lost.
     public func getDmChatFeed(owner: KeyPair, type: ConversationType) async throws -> [Conversation] {
         var all: [Conversation] = []
@@ -75,16 +75,11 @@ extension FlipClient {
 
     // MARK: - Event stream
 
-    /// Start the single per-user event stream and return its decoded events.
-    public nonisolated func openConversationStream(owner: KeyPair) -> AsyncStream<ConversationStreamEvent> {
-        Task { await eventStreamer.start(owner: owner) }
-        return eventStreamer.events
-    }
-
-    /// The event stream's connection state over time, so the caller can refetch
-    /// the window a dropped-and-reconnected stream missed.
-    public nonisolated func conversationConnectionState() -> AsyncStream<EventStreamConnectionState> {
-        eventStreamer.connectionState
+    /// Attach this session's consumer to the single per-user event stream, returning fresh decoded-event
+    /// and connection-state streams and opening the stream for `owner`. Each session gets its own pair —
+    /// see `EventStreamer.subscribe` for why reusing one across sessions strands a switched-to account.
+    public nonisolated func subscribeConversationStream(owner: KeyPair) async -> (events: AsyncStream<ConversationStreamEvent>, connectionState: AsyncStream<EventStreamConnectionState>) {
+        await eventStreamer.subscribe(owner: owner)
     }
 
     public nonisolated func ensureConversationStreamConnected() {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/EventStreamer.swift
@@ -23,8 +23,8 @@ public enum EventStreamConnectionState: Sendable {
 }
 
 /// Owns the single per-user bidirectional event stream (`event.v1 StreamEvents`)
-/// and decodes conversation updates into `ConversationStreamEvent`s consumed via `events`. The
-/// server enforces one stream per user, so exactly one instance must exist per
+/// and decodes conversation updates into `ConversationStreamEvent`s consumed via the pair returned by
+/// `subscribe(owner:)`. The server enforces one stream per user, so exactly one instance must exist per
 /// session; opening a second silently evicts the first. The owner must call
 /// `stop()` on logout so a stale stream doesn't evict the next session's.
 public actor EventStreamer {
@@ -34,16 +34,20 @@ public actor EventStreamer {
         Flipcash_Event_V1_StreamEventsResponse
     >
 
-    /// Decoded conversation updates. Consume with `for await event in streamer.events`.
-    public nonisolated let events: AsyncStream<ConversationStreamEvent>
-    private let continuation: AsyncStream<ConversationStreamEvent>.Continuation
+    /// Decoded conversation updates for the current subscriber. Recreated on every `subscribe(owner:)`
+    /// (not vended once) because an `AsyncStream` is finished for good once its first consumer ends: the
+    /// streamer is an app-lifetime singleton, so a prior session's `ConversationController` consumed the
+    /// old stream and cancelling it on account switch/logout killed it — a new session handed that dead
+    /// stream would never see another event. Consume via the pair returned by `subscribe(owner:)`.
+    private var events: AsyncStream<ConversationStreamEvent>
+    private var continuation: AsyncStream<ConversationStreamEvent>.Continuation
 
-    /// The stream's connection state over time. The event stream itself carries no cursor, so a
-    /// consumer treats the first `.live` as the initial connection and, on each `.live` after that
-    /// (a reconnect), reconciles the missed window from its own durable cursor (chat catch-up runs
-    /// `GetDelta`). Consume with `for await state in streamer.connectionState`.
-    public nonisolated let connectionState: AsyncStream<EventStreamConnectionState>
-    private let connectionStateContinuation: AsyncStream<EventStreamConnectionState>.Continuation
+    /// The stream's connection state over time, recreated per subscriber alongside `events`. The event
+    /// stream itself carries no cursor, so a consumer treats the first `.live` as the initial connection
+    /// and, on each `.live` after that (a reconnect), reconciles the missed window from its own durable
+    /// cursor (chat catch-up runs `GetDelta`).
+    private var connectionState: AsyncStream<EventStreamConnectionState>
+    private var connectionStateContinuation: AsyncStream<EventStreamConnectionState>.Continuation
 
     private let service: EventStreamingService
     private var owner: KeyPair?
@@ -83,8 +87,25 @@ public actor EventStreamer {
 
     // MARK: - Public API
 
-    /// Open the event stream for the signed-in owner. Idempotent.
-    public func start(owner: KeyPair) {
+    /// Attach a session's consumer: hand back FRESH event + connection-state streams and (idempotently)
+    /// open the underlying gRPC stream for `owner`. Vending a fresh pair per subscription is what lets a
+    /// newly switched-to/registered account receive live events (e.g. an incoming tip's chat) without an
+    /// app relaunch — see the note on `events` for why the old streams can't be reused.
+    public func subscribe(owner: KeyPair) -> (events: AsyncStream<ConversationStreamEvent>, connectionState: AsyncStream<EventStreamConnectionState>) {
+        continuation.finish()
+        connectionStateContinuation.finish()
+        (events, continuation) = AsyncStream<ConversationStreamEvent>.makeStream()
+        (connectionState, connectionStateContinuation) = AsyncStream<EventStreamConnectionState>.makeStream()
+        // The fresh consumer hasn't been told the connection is live; clear the dedupe latch so the open
+        // below (or an already-live stream's next ping) re-reports `.live` to the new stream.
+        isConnectionLive = false
+        start(owner: owner)
+        return (events, connectionState)
+    }
+
+    /// Open the event stream for the signed-in owner. Idempotent. Reached only via `subscribe(owner:)`
+    /// so a consumer always gets a fresh stream paired with the open.
+    private func start(owner: KeyPair) {
         guard !isStreaming else { return }
         self.owner = owner
         isStreaming = true

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -99,20 +99,20 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     var deltaAfterSequences: [UInt64] { lock.withLock { _deltaAfterSequences } }
     var didEnsure: Bool { lock.withLock { _didEnsure } }
     var didClose: Bool { lock.withLock { _didClose } }
-    /// Whether `openConversationStream` has been called — events emitted
+    /// Whether `subscribeConversationStream` has been called — events emitted
     /// before that are dropped, so tests wait on this before `emit(_:)`.
     var streamOpened: Bool { lock.withLock { _streamContinuation != nil } }
-    /// Whether `conversationConnectionState` has been subscribed — states emitted
+    /// Whether `subscribeConversationStream` has vended a connection-state stream — states emitted
     /// before that are dropped, so tests wait on this before `emitConnectionState(_:)`.
     var connectionStateStreamOpened: Bool { lock.withLock { _connectionStateContinuation != nil } }
 
-    /// Push a live event onto the stream returned by `openConversationStream`.
+    /// Push a live event onto the stream returned by `subscribeConversationStream`.
     func emit(_ event: ConversationStreamEvent) {
         lock.withLock { _streamContinuation }?.yield(event)
     }
 
     /// Push a connection-state transition onto the stream returned by
-    /// `conversationConnectionState`, as the streamer does on a ping or teardown.
+    /// `subscribeConversationStream`, as the streamer does on a ping or teardown.
     func emitConnectionState(_ state: EventStreamConnectionState) {
         lock.withLock { _connectionStateContinuation }?.yield(state)
     }
@@ -180,16 +180,14 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
 
     // MARK: - ConversationEventStreaming
 
-    func openConversationStream(owner: KeyPair) -> AsyncStream<ConversationStreamEvent> {
-        let (stream, continuation) = AsyncStream<ConversationStreamEvent>.makeStream()
-        lock.withLock { _streamContinuation = continuation }
-        return stream
-    }
-
-    func conversationConnectionState() -> AsyncStream<EventStreamConnectionState> {
-        let (stream, continuation) = AsyncStream<EventStreamConnectionState>.makeStream()
-        lock.withLock { _connectionStateContinuation = continuation }
-        return stream
+    func subscribeConversationStream(owner: KeyPair) async -> (events: AsyncStream<ConversationStreamEvent>, connectionState: AsyncStream<EventStreamConnectionState>) {
+        let (events, eventContinuation) = AsyncStream<ConversationStreamEvent>.makeStream()
+        let (state, stateContinuation) = AsyncStream<EventStreamConnectionState>.makeStream()
+        lock.withLock {
+            _streamContinuation = eventContinuation
+            _connectionStateContinuation = stateContinuation
+        }
+        return (events, state)
     }
 
     func ensureConversationStreamConnected() { lock.withLock { _didEnsure = true } }


### PR DESCRIPTION
## Problem
A tip received by a **newly switched-to / registered account** doesn't appear in the Tips list live — the chat only shows up after killing and relaunching the app.

## Root cause
`EventStreamer` is an app-lifetime singleton (via the shared `FlipClient`), but its `events` and `connectionState` `AsyncStream`s are created **once** in `init` and consumed by the **per-session** `ConversationController`. An `AsyncStream` is finished for good once its first consumer ends — so when an account switch/logout calls `ConversationController.stop()` and cancels the outgoing session's stream loops, those shared streams die. The next account's `ConversationController` subscribes to the now-dead streams and receives **no** live events. The incoming tip never reaches `hydrateIfUnknown`, so its chat never inserts into the store until an app relaunch rebuilds everything.

Confirmed from a device log (the new account's `conversation-controller` was silent — no hydrate, and no reconnect catch-up at the gen-3 reconnect while `event-streamer` kept running) and reproduced in isolation: a second `for await` on a reused `AsyncStream` after the first consumer is cancelled receives zero events.

## Fix
Vend a **fresh** event + connection-state stream pair per session via `EventStreamer.subscribe(owner:)`, wired through `FlipClient`, the `ConversationEventStreaming` protocol, and `ConversationController` (one async subscribe drives both loops). Each session gets its own streams, so a switched-to account is never stranded on a dead one.

## Testing
- `FlipcashCore` builds for iOS; full app builds.
- All 40 `ConversationControllerTests` pass, including `hydratesUnknownConversation()` (the tip-insert path), `appliesStreamedEvent()`, `reconnectCatchesUpVisibleTranscript()`, and `reconnectRefreshesFeed()`.
