### PR TITLE
fix(tips): hydrate conversation metadata on chat open

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -224,6 +224,11 @@ struct ConversationScreen: View {
         // created yet error-reports. Fires when the chat materializes.
         .task(id: chatExists ? conversationID : nil) {
             guard chatExists, let conversationID else { return }
+            // Ensure the conversation metadata is in the store before the title, tip styling, and Send
+            // Cash target rely on it. The post-tip open (and any push/link that lands here before the
+            // feed or stream has the freshly-created chat) would otherwise render the unresolved
+            // counterpart — a "Flipcash User" title and no Send Cash button. No-ops when already loaded.
+            _ = await conversationController.hydratedConversation(withID: conversationID)
             // The newest page IS the fresh state and seats the event-log cursor to head, so opening a
             // chat needs no separate catch-up. Missed-while-open windows are reconciled by the
             // foreground / reconnect / live-gap triggers instead.


### PR DESCRIPTION
## Problem
After the Send-tab removal (#546), tip chats opened via the post-tip-send flow render the **unknown-contact** state: the profile card / title shows **"Flipcash User"** and there is **no Send Cash button** in the chat.

## Root cause
`TipFlow.finish()` derives the new tip chat's id and navigates to `.tipConversationWithKeyboard(chatID)` **without seeding the conversation into `ConversationController`'s store**, and `ConversationScreen` only loads *messages* on open — it never hydrates the conversation **metadata**. So when the chat opens before the feed/stream has it, `conversation(withID:)` is nil and the counterpart doesn't resolve:

- `title` → `"Flipcash User"`
- `tipCounterpart` → nil → no tip styling
- `sendTarget` → nil → no Send Cash button (`SendTarget` needs a counterpart `userID`)
- `counterpartSeed` (profile card) finds no member → `"Flipcash User"`

The SQLite snapshot confirmed this is a hydration-timing gap, not a mapping bug — persisted tip DMs carry proper members.

## Fix
Hydrate the conversation metadata on chat open via the existing, already-tested `hydratedConversation(withID:)` (`getChat` → store), before the title / tip styling / Send Cash target read it. This resolves **every** entry point (post-tip nav, push, link), not just the deep-link path that already hydrated. No-ops when the feed already holds the conversation.

## Testing
- Full app builds.
- Reuses `hydratedConversation(withID:)`, already covered by the passing `hydratesUnknownConversation()` test.
