### PR TITLE
feat(tips): show the rendered tip code in the share sheet preview

### DIFF
--- a/Flipcash/Core/Screens/Main/Tips/TipCodePreviewRenderer.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipCodePreviewRenderer.swift
@@ -1,0 +1,95 @@
+//
+//  TipCodePreviewRenderer.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashCore
+
+/// A pair of rendered images for the tip code share sheet header: a wide hero
+/// and a square icon.
+struct TipCodePreview {
+    let hero: UIImage
+    let icon: UIImage
+}
+
+/// Renders a tip code into share sheet preview images ahead of the share tap.
+///
+/// Everything downstream — the cache, the item source, the call site — depends
+/// only on this protocol, so a future CMP-backed renderer can drop in without
+/// touching them.
+protocol TipCodePreviewRenderer {
+    /// Returns the hero and icon preview for `payload`, or `nil` if rendering fails.
+    @MainActor func render(_ payload: TipCode.Payload) async -> TipCodePreview?
+}
+
+/// Renders the preview with `ImageRenderer` over `TipCodeShareCard`.
+struct SwiftUITipCodePreviewRenderer: TipCodePreviewRenderer {
+
+    @MainActor
+    func render(_ payload: TipCode.Payload) async -> TipCodePreview? {
+        let codeData = payload.codeData()
+
+        guard
+            let hero = image(.hero, codeData: codeData),
+            let icon = image(.icon, codeData: codeData)
+        else {
+            return nil
+        }
+
+        return TipCodePreview(hero: hero, icon: icon)
+    }
+
+    @MainActor
+    private func image(_ layout: TipCodeShareCard.Layout, codeData: Data) -> UIImage? {
+        let renderer = ImageRenderer(content: TipCodeShareCard(layout: layout, codeData: codeData))
+        renderer.scale = UIScreen.main.scale
+        renderer.isOpaque = true
+        return renderer.uiImage
+    }
+}
+
+/// Caches rendered tip code previews so the share sheet never renders on the tap.
+///
+/// Keyed by the tip code's user identifier. `warm(_:)` kicks off rendering
+/// eagerly when the card is displayed; `preview(for:)` is a non-blocking read at
+/// share time that returns `nil` until the render completes.
+@MainActor
+final class TipCodePreviewCache {
+
+    private let renderer: TipCodePreviewRenderer
+    private var previews: [UserID: TipCodePreview] = [:]
+    private var tasks: [UserID: Task<Void, Never>] = [:]
+
+    init(renderer: TipCodePreviewRenderer = SwiftUITipCodePreviewRenderer()) {
+        self.renderer = renderer
+    }
+
+    /// Renders and stores the preview for `payload` unless one already exists or
+    /// is already in flight.
+    func warm(_ payload: TipCode.Payload) {
+        let userID = payload.userID
+        guard previews[userID] == nil, tasks[userID] == nil else { return }
+
+        tasks[userID] = Task { [weak self] in
+            guard let self else { return }
+            let preview = await renderer.render(payload)
+            tasks[userID] = nil
+            guard !Task.isCancelled, let preview else { return }
+            previews[userID] = preview
+        }
+    }
+
+    /// The cached preview for `userID`, or `nil` if it is not ready yet.
+    func preview(for userID: UserID) -> TipCodePreview? {
+        previews[userID]
+    }
+
+    /// Drops any cached or in-flight preview for `userID` so the next display
+    /// re-renders — call on regenerate, redeem, or expiry.
+    func invalidate(_ userID: UserID) {
+        tasks[userID]?.cancel()
+        tasks[userID] = nil
+        previews[userID] = nil
+    }
+}

--- a/Flipcash/Core/Screens/Main/Tips/TipCodeShareCard.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipCodeShareCard.swift
@@ -1,0 +1,49 @@
+//
+//  TipCodeShareCard.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+
+/// A fixed-frame, environment-free rendering of a tip code for the share sheet
+/// preview: the scannable code centered on an opaque black background.
+///
+/// Deliberately deterministic — an explicit size and a hardcoded color scheme —
+/// so `ImageRenderer` produces the same image regardless of the trait
+/// environment it is invoked from.
+struct TipCodeShareCard: View {
+
+    /// The two preview surfaces iOS shows in the share sheet header.
+    enum Layout {
+        /// The wide hero image behind the large link preview (~1200×630).
+        case hero
+        /// The square image used for the compact icon; recomposed rather than
+        /// cropped from the hero so the code stays centered.
+        case icon
+
+        var size: CGSize {
+            switch self {
+            case .hero: CGSize(width: 1200, height: 630)
+            case .icon: CGSize(width: 1080, height: 1080)
+            }
+        }
+    }
+
+    let layout: Layout
+    let codeData: Data
+
+    var body: some View {
+        let canvas = layout.size
+        let codeSide = min(canvas.width, canvas.height) * 0.6
+
+        ZStack {
+            Color.black
+            CodeView(data: codeData)
+                .foregroundStyle(Color.white)
+                .frame(width: codeSide, height: codeSide)
+        }
+        .frame(width: canvas.width, height: canvas.height)
+        .environment(\.colorScheme, .dark)
+    }
+}

--- a/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
@@ -17,6 +17,10 @@ struct TipcardScreen: View {
     @State private var avatar: UIImage?
     @State private var exportImage: Image?
 
+    /// Renders the share sheet preview image ahead of the share tap so it never
+    /// lands on the tap; keyed by user, warmed when the card is displayed.
+    @State private var previewCache = TipCodePreviewCache()
+
     /// The card's on-screen width; the export renders the same view at @3x.
     private static let cardWidth: CGFloat = 300
 
@@ -37,7 +41,9 @@ struct TipcardScreen: View {
                 Spacer()
 
                 HStack(spacing: 40) {
-                    ShareLink(item: url) {
+                    Button {
+                        shareTipCard()
+                    } label: {
                         TipcardAction(icon: .Icons.share, title: "Share")
                     }
                     .accessibilityIdentifier("tipcard-share-button")
@@ -69,6 +75,7 @@ struct TipcardScreen: View {
         .navigationTitle("My Tip Card")
         .toolbarTitleDisplayMode(.inline)
         .task(id: profilePicture?.thumbnailBlobID) {
+            previewCache.warm(TipCode.Payload(userID: sessionContainer.session.userID))
             await loadAvatar()
             renderExportImage()
         }
@@ -143,6 +150,27 @@ struct TipcardScreen: View {
         }
 
         exportImage = Image(uiImage: rendered)
+    }
+
+    // MARK: - Sharing -
+
+    /// The label iOS shows beside the preview; the sharer's name, not the URL.
+    private var shareTitle: String {
+        if let name = profile?.displayName, !name.isEmpty {
+            "Tip \(name)"
+        } else {
+            "My Tip Card"
+        }
+    }
+
+    private func shareTipCard() {
+        let item = TipCodeShareItem(
+            url: url,
+            title: shareTitle,
+            preview: previewCache.preview(for: sessionContainer.session.userID)
+        )
+
+        ShareSheet.present(activityItem: item) { _ in }
     }
 }
 

--- a/Flipcash/Share/TipCodeShareItem.swift
+++ b/Flipcash/Share/TipCodeShareItem.swift
@@ -1,0 +1,52 @@
+//
+//  TipCodeShareItem.swift
+//  Flipcash
+//
+
+import UIKit
+import LinkPresentation
+
+/// Shares a tip code link with a header built from the rendered tip code image.
+///
+/// Supplying `LPLinkMetadata` makes iOS skip its own network fetch for the
+/// preview. Recipients always receive the URL — never the image — so the link
+/// resolves its own Open Graph preview in the destination app.
+final class TipCodeShareItem: NSObject, UIActivityItemSource {
+
+    private let url: URL
+    private let title: String
+    private let preview: TipCodePreview?
+
+    init(url: URL, title: String, preview: TipCodePreview?) {
+        self.url = url
+        self.title = title
+        self.preview = preview
+        super.init()
+    }
+
+    // MARK: - UIActivityItemSource -
+
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        url
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        url
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
+        title
+    }
+
+    func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
+        guard let preview else { return nil }
+
+        let metadata = LPLinkMetadata()
+        metadata.originalURL = url
+        metadata.url = url
+        metadata.title = title
+        metadata.imageProvider = NSItemProvider(object: preview.hero)
+        metadata.iconProvider = NSItemProvider(object: preview.icon)
+        return metadata
+    }
+}


### PR DESCRIPTION
## What

Sharing a tip code link showed a **generic link preview** in the iOS share sheet. This builds the share sheet header from the **rendered tip code image** so it appears immediately with no network fetch.

Scope is the share sheet **header UI only** — the receiving app (iMessage, WhatsApp, Slack) still resolves its own preview from the URL's OG tags; that path is untouched.

## How

- **`TipCodeShareCard`** — a fixed-frame, environment-free view rendering the scannable code centered on an opaque black background, with a hardcoded color scheme so `ImageRenderer` output is deterministic regardless of the trait environment.
- **`TipCodePreviewRenderer`** protocol + **`SwiftUITipCodePreviewRenderer`** — renders a ~1200×630 hero and a 1:1 icon (each recomposed, not cropped) via `ImageRenderer` at `UIScreen.main.scale`, opaque. Behind a protocol so a future CMP-backed renderer can drop in without touching the cache, item source, or call site.
- **`TipCodePreviewCache`** — renders eagerly when the card is displayed, keyed by user id, so the render never lands on the share tap. Returns `nil` (never blocks the share sheet) if not ready; exposes `invalidate(_:)` for future regenerate/redeem/expiry triggers.
- **`TipCodeShareItem`** (`UIActivityItemSource`) — supplies `LPLinkMetadata` (`originalURL`, `url`, `title`, `imageProvider` = hero, `iconProvider` = icon) so iOS skips its own network fetch. Placeholder and per-activity item are always the **URL** — recipients get a link, never a photo.
- Wires the **Tip Card screen's Share button** through the item source and warms the cache in the display `.task`. Preserves existing behavior; the full-card **export** scaffold (`exportImage` / `renderExportImage`) is left intact for the forthcoming export feature.

## Cache location & invalidation

The cache is screen-local `@State` on `TipcardScreen` (the only tip-code share surface). It's keyed by `UserID` and warmed in the screen's display `.task`. The image is deterministic from the user's tip code, so no content invalidation is needed today; `TipCodePreviewCache.invalidate(_:)` is provided for regenerate/redeem/expiry when those lifecycle events land.

## Testing

- Builds and runs on the iPhone 17 simulator.
- Verified the share sheet header shows the rendered code image, and the URL arrives intact (not the image) in the target apps.

## Notes

- No `commonMain` changes, no new dependencies, and nothing in the rendered image beyond what's visible in the tip code UI.
- The renderer protocol takes `TipCode.Payload` (the concrete tip code) rather than the illustrative `TipCode` from the spec, since the real `TipCode` enum is a namespace with no render payload.