### PR TITLE
feat: sync core protos and adopt new fields (tip card, group chats, activity substitutions, profile cache)

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -644,6 +644,10 @@ final class ConversationController {
     /// Tip DMs skip the contact lookup — their derived ids can never match a
     /// contact's, so the directory scan is a guaranteed miss.
     func displayName(for conversation: Conversation) -> String {
+        // Group chats are named by their server-set title, not a counterpart.
+        if let title = conversation.title, !title.isEmpty {
+            return title
+        }
         if conversation.type != .tipDm, let contactName = contactName(for: conversation.id) {
             return contactName
         }

--- a/Flipcash/Core/Controllers/Database/Database+Conversations.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Conversations.swift
@@ -81,7 +81,8 @@ nonisolated extension Database {
                 lastMessage: try latestMessage(conversationId: id),
                 lastActivity: Date(timeIntervalSinceReferenceDate: row[c.lastActivity]),
                 type: ConversationType(rawValue: row[c.type]) ?? .contactDm,
-                isHidden: row[c.isHidden]
+                isHidden: row[c.isHidden],
+                title: row[c.title]
             )
         }
     }
@@ -287,6 +288,7 @@ nonisolated extension Database {
                 c.lastActivity <- conversation.lastActivity.timeIntervalSinceReferenceDate,
                 c.type         <- conversation.type.rawValue,
                 c.isHidden     <- conversation.isHidden,
+                c.title        <- conversation.title,
                 onConflictOf: c.id
             )
         )

--- a/Flipcash/Core/Controllers/Database/Database+UserProfiles.swift
+++ b/Flipcash/Core/Controllers/Database/Database+UserProfiles.swift
@@ -1,0 +1,46 @@
+//
+//  Database+UserProfiles.swift
+//  Flipcash
+//
+
+import Foundation
+import FlipcashCore
+import SQLite
+
+/// Keyed cache of other users' `Profile`s. The signed-in user's own profile
+/// lives in the singleton `profile` table (`Database+Profile.swift`); this table
+/// holds counterpart/tip-recipient/blocked-user profiles keyed by user id.
+nonisolated extension Database {
+
+    // MARK: - Get -
+
+    /// The cached profile for `userID`, or `nil` when it hasn't been fetched yet.
+    func getUserProfile(userID: UserID) throws -> Profile? {
+        let t = UserProfileTable()
+        guard let row = try reader.pluck(t.table.filter(t.userID == userID)) else {
+            return nil
+        }
+        return try JSONDecoder().decode(Profile.self, from: row[t.data])
+    }
+
+    // MARK: - Insert -
+
+    /// Cache `profile` under `userID`, replacing any existing row.
+    func upsertUserProfile(_ profile: Profile, userID: UserID) throws {
+        let t = UserProfileTable()
+        let data = try JSONEncoder().encode(profile)
+        try writer.run(t.table.upsert(
+            t.userID <- userID,
+            t.data   <- data,
+            onConflictOf: t.userID
+        ))
+    }
+
+    // MARK: - Delete -
+
+    /// Remove the cached profile for `userID`.
+    func deleteUserProfile(userID: UserID) throws {
+        let t = UserProfileTable()
+        try writer.run(t.table.filter(t.userID == userID).delete())
+    }
+}

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -111,6 +111,18 @@ nonisolated struct ProfileTable: Sendable {
     let data  = Expression <Data> ("data")
 }
 
+/// Cache of *other* users' profiles, keyed by user id. Populated cache-through
+/// as profiles are fetched for display (chat counterparts, tip recipients,
+/// blocked users). The signed-in user's own profile stays in the singleton
+/// `profile` table. Stored as a JSON blob — reads are only ever by-key.
+nonisolated struct UserProfileTable: Sendable {
+    static let name = "user_profile"
+
+    let table  = Table(Self.name)
+    let userID = Expression <UUID> ("userID")   // PK
+    let data   = Expression <Data> ("data")     // JSON-encoded Profile
+}
+
 nonisolated struct UserFlagsTable: Sendable {
     static let name = "userFlags"
 
@@ -187,6 +199,8 @@ nonisolated struct ConversationTable: Sendable {
     // Server-set: the counterpart is on the owner's blocklist. Retained so an
     // unblock restores the conversation; filtered from the displayed feed.
     let isHidden      = Expression <Bool>    ("isHidden")
+    // Server-set title, group chats only. Nil for DMs.
+    let title         = Expression <String?> ("title")
 }
 
 nonisolated struct ConversationMemberTable: Sendable {
@@ -353,6 +367,15 @@ nonisolated extension Database {
             })
         }
 
+        let userProfileTable = UserProfileTable()
+
+        try writer.transaction {
+            try writer.run(userProfileTable.table.create(ifNotExists: true, withoutRowid: true) { t in
+                t.column(userProfileTable.userID, primaryKey: true)
+                t.column(userProfileTable.data)
+            })
+        }
+
         let userFlagsTable = UserFlagsTable()
 
         try writer.transaction {
@@ -406,6 +429,7 @@ nonisolated extension Database {
                 t.column(conversationTable.catchupCursor)
                 t.column(conversationTable.type, defaultValue: ConversationType.contactDm.rawValue)
                 t.column(conversationTable.isHidden, defaultValue: false)
+                t.column(conversationTable.title)
             })
         }
 

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -184,7 +184,7 @@ struct DeepLinkAction {
         switch conversation?.type {
         case .tipDm:
             container.appRouter.navigate(to: .tipConversation(conversationID))
-        case .contactDm, nil:
+        case .contactDm, .group, nil:
             logger.info("Ignoring non-tip chat deeplink", metadata: [
                 "conversationID": "\(conversationID)",
             ])

--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -155,6 +155,7 @@ final class TipFlow {
                     _ = try await destination
                     return try await profile
                 }
+                session.cacheUserProfile(resolved, for: userID)
                 let recipient = TipRecipient(
                     userID: userID,
                     displayName: resolved.displayName ?? "",

--- a/Flipcash/Core/Screens/Profile/UserProfileScreen.swift
+++ b/Flipcash/Core/Screens/Profile/UserProfileScreen.swift
@@ -131,9 +131,19 @@ final class UserProfileViewModel {
         self.blurhash = seed.blurhash
     }
 
-    /// Fetches the profile for a fresh name, join date, and avatar.
+    /// Fetches the profile for a fresh name, join date, and avatar. Seeds from
+    /// the shared profile cache first for instant display, then caches the
+    /// freshly fetched profile.
     func loadProfile() async {
+        if let cached = session.cachedUserProfile(for: userID) {
+            apply(cached)
+        }
         guard let profile = try? await flipClient.fetchProfile(userID: userID, owner: owner) else { return }
+        session.cacheUserProfile(profile, for: userID)
+        apply(profile)
+    }
+
+    private func apply(_ profile: Profile) {
         if let name = profile.displayName, !name.isEmpty { displayName = name }
         if blurhash == nil { blurhash = profile.profilePicture?.thumbnailBlurhash }
         if let joined = profile.joinedAt {

--- a/Flipcash/Core/Screens/Send/SendTarget.swift
+++ b/Flipcash/Core/Screens/Send/SendTarget.swift
@@ -46,6 +46,9 @@ extension SendTarget {
                 return nil
             }
             self = .contact(target)
+        case .group:
+            // A group chat has no single counterpart to pay through this path.
+            return nil
         }
     }
 }

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -301,6 +301,20 @@ class Session {
         }
     }
 
+    // MARK: - User Profile Cache -
+
+    /// The cached profile for another user, or `nil` when it hasn't been fetched
+    /// yet. The signed-in user's own profile is `self.profile`.
+    func cachedUserProfile(for userID: UserID) -> Profile? {
+        try? database.getUserProfile(userID: userID)
+    }
+
+    /// Cache another user's fetched profile for later reuse (best-effort, mirrors
+    /// the own-profile persistence in `updateProfile()`).
+    func cacheUserProfile(_ profile: Profile, for userID: UserID) {
+        try? database.upsertUserProfile(profile, userID: userID)
+    }
+
     func unlinkProfile() async throws {
         if let profile {
             if let email = profile.email {

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 		<string>com.flipcash.app.openChat</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Flipcash/Utilities/Events.swift
+++ b/Flipcash/Utilities/Events.swift
@@ -241,6 +241,7 @@ private extension Optional where Wrapped == ConversationType {
         switch self {
         case .contactDm: "Contact"
         case .tipDm:     "Tip"
+        case .group:     "Group"
         case .none:      "Unknown"
         }
     }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/activity_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/activity_v1_model.pb.swift
@@ -263,6 +263,9 @@ public struct Flipcash_Activity_V1_Notification: Sendable {
     set {additionalMetadata = .soldCrypto(newValue)}
   }
 
+  /// Ordered substitutions to apply to localized_text
+  public var textSubstitutions: [Flipcash_Common_V1_Substitution] = []
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Additional metadata for this notification specific to the notification
@@ -291,18 +294,27 @@ public struct Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata: Senda
 
   public var destinationIdentifier: Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata.OneOf_DestinationIdentifier? = nil
 
-  public var phone: Flipcash_Phone_V1_PhoneNumber {
+  public var phone: Flipcash_Common_V1_PhoneNumber {
     get {
       if case .phone(let v)? = destinationIdentifier {return v}
-      return Flipcash_Phone_V1_PhoneNumber()
+      return Flipcash_Common_V1_PhoneNumber()
     }
     set {destinationIdentifier = .phone(newValue)}
+  }
+
+  public var userID: Flipcash_Common_V1_UserId {
+    get {
+      if case .userID(let v)? = destinationIdentifier {return v}
+      return Flipcash_Common_V1_UserId()
+    }
+    set {destinationIdentifier = .userID(newValue)}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_DestinationIdentifier: Equatable, Sendable {
-    case phone(Flipcash_Phone_V1_PhoneNumber)
+    case phone(Flipcash_Common_V1_PhoneNumber)
+    case userID(Flipcash_Common_V1_UserId)
 
   }
 
@@ -316,18 +328,27 @@ public struct Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata: Sendable 
 
   public var sourceIdentifier: Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata.OneOf_SourceIdentifier? = nil
 
-  public var phone: Flipcash_Phone_V1_PhoneNumber {
+  public var phone: Flipcash_Common_V1_PhoneNumber {
     get {
       if case .phone(let v)? = sourceIdentifier {return v}
-      return Flipcash_Phone_V1_PhoneNumber()
+      return Flipcash_Common_V1_PhoneNumber()
     }
     set {sourceIdentifier = .phone(newValue)}
+  }
+
+  public var userID: Flipcash_Common_V1_UserId {
+    get {
+      if case .userID(let v)? = sourceIdentifier {return v}
+      return Flipcash_Common_V1_UserId()
+    }
+    set {sourceIdentifier = .userID(newValue)}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_SourceIdentifier: Equatable, Sendable {
-    case phone(Flipcash_Phone_V1_PhoneNumber)
+    case phone(Flipcash_Common_V1_PhoneNumber)
+    case userID(Flipcash_Common_V1_UserId)
 
   }
 
@@ -453,7 +474,7 @@ extension Flipcash_Activity_V1_NotificationId: SwiftProtobuf.Message, SwiftProto
 
 extension Flipcash_Activity_V1_Notification: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Notification"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}localized_text\0\u{3}payment_amount\0\u{1}ts\0\u{1}state\0\u{4}\u{2}directly_sent_crypto\0\u{3}received_crypto\0\u{3}withdrew_crypto\0\u{3}indirectly_sent_crypto\0\u{3}deposited_crypto\0\u{3}bought_crypto\0\u{3}sold_crypto\0\u{c}\u{6}\u{1}")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}localized_text\0\u{3}payment_amount\0\u{1}ts\0\u{1}state\0\u{4}\u{2}directly_sent_crypto\0\u{3}received_crypto\0\u{3}withdrew_crypto\0\u{3}indirectly_sent_crypto\0\u{3}deposited_crypto\0\u{3}bought_crypto\0\u{3}sold_crypto\0\u{4}W\u{1}text_substitutions\0\u{c}\u{6}\u{1}")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -557,6 +578,7 @@ extension Flipcash_Activity_V1_Notification: SwiftProtobuf.Message, SwiftProtobu
           self.additionalMetadata = .soldCrypto(v)
         }
       }()
+      case 100: try { try decoder.decodeRepeatedMessageField(value: &self.textSubstitutions) }()
       default: break
       }
     }
@@ -613,6 +635,9 @@ extension Flipcash_Activity_V1_Notification: SwiftProtobuf.Message, SwiftProtobu
     }()
     case nil: break
     }
+    if !self.textSubstitutions.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.textSubstitutions, fieldNumber: 100)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -623,6 +648,7 @@ extension Flipcash_Activity_V1_Notification: SwiftProtobuf.Message, SwiftProtobu
     if lhs._ts != rhs._ts {return false}
     if lhs.state != rhs.state {return false}
     if lhs.additionalMetadata != rhs.additionalMetadata {return false}
+    if lhs.textSubstitutions != rhs.textSubstitutions {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -630,7 +656,7 @@ extension Flipcash_Activity_V1_Notification: SwiftProtobuf.Message, SwiftProtobu
 
 extension Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DirectlySentCryptoNotificationMetadata"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phone\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phone\0\u{3}user_id\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -639,7 +665,7 @@ extension Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata: SwiftProt
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        var v: Flipcash_Phone_V1_PhoneNumber?
+        var v: Flipcash_Common_V1_PhoneNumber?
         var hadOneofValue = false
         if let current = self.destinationIdentifier {
           hadOneofValue = true
@@ -649,6 +675,19 @@ extension Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata: SwiftProt
         if let v = v {
           if hadOneofValue {try decoder.handleConflictingOneOf()}
           self.destinationIdentifier = .phone(v)
+        }
+      }()
+      case 2: try {
+        var v: Flipcash_Common_V1_UserId?
+        var hadOneofValue = false
+        if let current = self.destinationIdentifier {
+          hadOneofValue = true
+          if case .userID(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.destinationIdentifier = .userID(v)
         }
       }()
       default: break
@@ -661,9 +700,17 @@ extension Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata: SwiftProt
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
     // https://github.com/apple/swift-protobuf/issues/1182
-    try { if case .phone(let v)? = self.destinationIdentifier {
+    switch self.destinationIdentifier {
+    case .phone?: try {
+      guard case .phone(let v)? = self.destinationIdentifier else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    } }()
+    }()
+    case .userID?: try {
+      guard case .userID(let v)? = self.destinationIdentifier else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case nil: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -676,7 +723,7 @@ extension Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata: SwiftProt
 
 extension Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReceivedCryptoNotificationMetadata"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phone\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phone\0\u{3}user_id\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -685,7 +732,7 @@ extension Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata: SwiftProtobuf
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        var v: Flipcash_Phone_V1_PhoneNumber?
+        var v: Flipcash_Common_V1_PhoneNumber?
         var hadOneofValue = false
         if let current = self.sourceIdentifier {
           hadOneofValue = true
@@ -695,6 +742,19 @@ extension Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata: SwiftProtobuf
         if let v = v {
           if hadOneofValue {try decoder.handleConflictingOneOf()}
           self.sourceIdentifier = .phone(v)
+        }
+      }()
+      case 2: try {
+        var v: Flipcash_Common_V1_UserId?
+        var hadOneofValue = false
+        if let current = self.sourceIdentifier {
+          hadOneofValue = true
+          if case .userID(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.sourceIdentifier = .userID(v)
         }
       }()
       default: break
@@ -707,9 +767,17 @@ extension Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata: SwiftProtobuf
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
     // https://github.com/apple/swift-protobuf/issues/1182
-    try { if case .phone(let v)? = self.sourceIdentifier {
+    switch self.sourceIdentifier {
+    case .phone?: try {
+      guard case .phone(let v)? = self.sourceIdentifier else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    } }()
+    }()
+    case .userID?: try {
+      guard case .userID(let v)? = self.sourceIdentifier else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case nil: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/chat_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/chat_v1_model.pb.swift
@@ -25,6 +25,7 @@ public enum Flipcash_Chat_V1_ChatType: SwiftProtobuf.Enum, Swift.CaseIterable {
   case unknown // = 0
   case contactDm // = 1
   case tipDm // = 2
+  case group // = 3
   case UNRECOGNIZED(Int)
 
   public init() {
@@ -36,6 +37,7 @@ public enum Flipcash_Chat_V1_ChatType: SwiftProtobuf.Enum, Swift.CaseIterable {
     case 0: self = .unknown
     case 1: self = .contactDm
     case 2: self = .tipDm
+    case 3: self = .group
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
@@ -45,6 +47,7 @@ public enum Flipcash_Chat_V1_ChatType: SwiftProtobuf.Enum, Swift.CaseIterable {
     case .unknown: return 0
     case .contactDm: return 1
     case .tipDm: return 2
+    case .group: return 3
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -54,6 +57,7 @@ public enum Flipcash_Chat_V1_ChatType: SwiftProtobuf.Enum, Swift.CaseIterable {
     .unknown,
     .contactDm,
     .tipDm,
+    .group,
   ]
 
 }
@@ -79,6 +83,8 @@ public struct Flipcash_Chat_V1_Metadata: @unchecked Sendable {
   }
 
   /// Members of this chat
+  ///
+  /// For large group chats, this is a subset of all members.
   public var members: [Flipcash_Chat_V1_Member] {
     get {return _storage._members}
     set {_uniqueStorage()._members = newValue}
@@ -124,6 +130,12 @@ public struct Flipcash_Chat_V1_Metadata: @unchecked Sendable {
   public var isHidden: Bool {
     get {return _storage._isHidden}
     set {_uniqueStorage()._isHidden = newValue}
+  }
+
+  /// Title for this chat. Only supported for group chats
+  public var title: String {
+    get {return _storage._title}
+    set {_uniqueStorage()._title = newValue}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -255,12 +267,12 @@ public struct Flipcash_Chat_V1_MetadataUpdate: Sendable {
 fileprivate let _protobuf_package = "flipcash.chat.v1"
 
 extension Flipcash_Chat_V1_ChatType: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}CONTACT_DM\0\u{1}TIP_DM\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}CONTACT_DM\0\u{1}TIP_DM\0\u{1}GROUP\0")
 }
 
 extension Flipcash_Chat_V1_Metadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Metadata"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}chat_id\0\u{1}type\0\u{1}members\0\u{3}last_message\0\u{3}last_activity\0\u{3}latest_event_sequence\0\u{3}is_hidden\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}chat_id\0\u{1}type\0\u{1}members\0\u{3}last_message\0\u{3}last_activity\0\u{3}latest_event_sequence\0\u{3}is_hidden\0\u{1}title\0")
 
   fileprivate class _StorageClass {
     var _chatID: Flipcash_Common_V1_ChatId? = nil
@@ -270,6 +282,7 @@ extension Flipcash_Chat_V1_Metadata: SwiftProtobuf.Message, SwiftProtobuf._Messa
     var _lastActivity: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
     var _latestEventSequence: UInt64 = 0
     var _isHidden: Bool = false
+    var _title: String = String()
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -287,6 +300,7 @@ extension Flipcash_Chat_V1_Metadata: SwiftProtobuf.Message, SwiftProtobuf._Messa
       _lastActivity = source._lastActivity
       _latestEventSequence = source._latestEventSequence
       _isHidden = source._isHidden
+      _title = source._title
     }
   }
 
@@ -312,6 +326,7 @@ extension Flipcash_Chat_V1_Metadata: SwiftProtobuf.Message, SwiftProtobuf._Messa
         case 5: try { try decoder.decodeSingularMessageField(value: &_storage._lastActivity) }()
         case 6: try { try decoder.decodeSingularUInt64Field(value: &_storage._latestEventSequence) }()
         case 7: try { try decoder.decodeSingularBoolField(value: &_storage._isHidden) }()
+        case 8: try { try decoder.decodeSingularStringField(value: &_storage._title) }()
         default: break
         }
       }
@@ -345,6 +360,9 @@ extension Flipcash_Chat_V1_Metadata: SwiftProtobuf.Message, SwiftProtobuf._Messa
       if _storage._isHidden != false {
         try visitor.visitSingularBoolField(value: _storage._isHidden, fieldNumber: 7)
       }
+      if !_storage._title.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._title, fieldNumber: 8)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -361,6 +379,7 @@ extension Flipcash_Chat_V1_Metadata: SwiftProtobuf.Message, SwiftProtobuf._Messa
         if _storage._lastActivity != rhs_storage._lastActivity {return false}
         if _storage._latestEventSequence != rhs_storage._latestEventSequence {return false}
         if _storage._isHidden != rhs_storage._isHidden {return false}
+        if _storage._title != rhs_storage._title {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/common_v1_common.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/common_v1_common.pb.swift
@@ -178,6 +178,9 @@ public struct Flipcash_Common_V1_ChatId: Sendable {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  /// value has the following structure:
+  ///  - 32 byte hash for DMs
+  ///  - 16 byte UUID for group chats
   public var value: Data = Data()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -201,6 +204,33 @@ public struct Flipcash_Common_V1_IntentId: Sendable {
 /// identify a device. Value should remain private and not be shared across
 /// installs.
 public struct Flipcash_Common_V1_AppInstallId: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var value: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// PhoneNumber is an E.164 phone number
+public struct Flipcash_Common_V1_PhoneNumber: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Regex provided by Twilio here: https://www.twilio.com/docs/glossary/what-e164#regex-matching-for-e164
+  public var value: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// EmailAddress is an email address
+public struct Flipcash_Common_V1_EmailAddress: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -444,6 +474,62 @@ public struct Flipcash_Common_V1_Region: Sendable {
   public var value: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Color represents an RGB colour
+public struct Flipcash_Common_V1_Color: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Hex colour value (e.g. "#19191A")
+  public var hex: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Substitution is a text subsitution
+public struct Flipcash_Common_V1_Substitution: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Fallback string for forwards compatibility
+  public var fallback: String = String()
+
+  public var kind: Flipcash_Common_V1_Substitution.OneOf_Kind? = nil
+
+  /// Phone number -> contact name or formatted phone number
+  public var phoneNumberToContactName: Flipcash_Common_V1_PhoneNumber {
+    get {
+      if case .phoneNumberToContactName(let v)? = kind {return v}
+      return Flipcash_Common_V1_PhoneNumber()
+    }
+    set {kind = .phoneNumberToContactName(newValue)}
+  }
+
+  /// User ID -> display name
+  public var userIDToDisplayName: Flipcash_Common_V1_UserId {
+    get {
+      if case .userIDToDisplayName(let v)? = kind {return v}
+      return Flipcash_Common_V1_UserId()
+    }
+    set {kind = .userIDToDisplayName(newValue)}
+  }
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public enum OneOf_Kind: Equatable, Sendable {
+    /// Phone number -> contact name or formatted phone number
+    case phoneNumberToContactName(Flipcash_Common_V1_PhoneNumber)
+    /// User ID -> display name
+    case userIDToDisplayName(Flipcash_Common_V1_UserId)
+
+  }
 
   public init() {}
 }
@@ -745,6 +831,66 @@ extension Flipcash_Common_V1_AppInstallId: SwiftProtobuf.Message, SwiftProtobuf.
   }
 
   public static func ==(lhs: Flipcash_Common_V1_AppInstallId, rhs: Flipcash_Common_V1_AppInstallId) -> Bool {
+    if lhs.value != rhs.value {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Common_V1_PhoneNumber: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".PhoneNumber"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}value\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.value) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.value.isEmpty {
+      try visitor.visitSingularStringField(value: self.value, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Common_V1_PhoneNumber, rhs: Flipcash_Common_V1_PhoneNumber) -> Bool {
+    if lhs.value != rhs.value {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Common_V1_EmailAddress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".EmailAddress"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}value\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.value) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.value.isEmpty {
+      try visitor.visitSingularStringField(value: self.value, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Common_V1_EmailAddress, rhs: Flipcash_Common_V1_EmailAddress) -> Bool {
     if lhs.value != rhs.value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -1087,6 +1233,108 @@ extension Flipcash_Common_V1_Region: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
   public static func ==(lhs: Flipcash_Common_V1_Region, rhs: Flipcash_Common_V1_Region) -> Bool {
     if lhs.value != rhs.value {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Common_V1_Color: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Color"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}hex\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.hex) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.hex.isEmpty {
+      try visitor.visitSingularStringField(value: self.hex, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Common_V1_Color, rhs: Flipcash_Common_V1_Color) -> Bool {
+    if lhs.hex != rhs.hex {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Common_V1_Substitution: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Substitution"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}fallback\0\u{3}phone_number_to_contact_name\0\u{3}user_id_to_display_name\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.fallback) }()
+      case 2: try {
+        var v: Flipcash_Common_V1_PhoneNumber?
+        var hadOneofValue = false
+        if let current = self.kind {
+          hadOneofValue = true
+          if case .phoneNumberToContactName(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.kind = .phoneNumberToContactName(v)
+        }
+      }()
+      case 3: try {
+        var v: Flipcash_Common_V1_UserId?
+        var hadOneofValue = false
+        if let current = self.kind {
+          hadOneofValue = true
+          if case .userIDToDisplayName(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.kind = .userIDToDisplayName(v)
+        }
+      }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if !self.fallback.isEmpty {
+      try visitor.visitSingularStringField(value: self.fallback, fieldNumber: 1)
+    }
+    switch self.kind {
+    case .phoneNumberToContactName?: try {
+      guard case .phoneNumberToContactName(let v)? = self.kind else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case .userIDToDisplayName?: try {
+      guard case .userIDToDisplayName(let v)? = self.kind else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }()
+    case nil: break
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Common_V1_Substitution, rhs: Flipcash_Common_V1_Substitution) -> Bool {
+    if lhs.fallback != rhs.fallback {return false}
+    if lhs.kind != rhs.kind {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/contact_v1_contact_list_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/contact_v1_contact_list_service.pb.swift
@@ -129,9 +129,9 @@ public struct Flipcash_Contact_V1_DeltaUploadRequest: Sendable {
   /// Clears the value of `auth`. Subsequent reads from it will return its default value.
   public mutating func clearAuth() {self._auth = nil}
 
-  public var adds: [Flipcash_Phone_V1_PhoneNumber] = []
+  public var adds: [Flipcash_Common_V1_PhoneNumber] = []
 
-  public var removes: [Flipcash_Phone_V1_PhoneNumber] = []
+  public var removes: [Flipcash_Common_V1_PhoneNumber] = []
 
   /// The checksum the client expected the server to have *before* applying
   /// this delta. Server applies only if stored == old_checksum.
@@ -244,7 +244,7 @@ public struct Flipcash_Contact_V1_FullUploadRequest: Sendable {
 
   /// The complete current contact set. Server replaces stored state with
   /// this list in one transaction.
-  public var phones: [Flipcash_Phone_V1_PhoneNumber] = []
+  public var phones: [Flipcash_Common_V1_PhoneNumber] = []
 
   /// XOR-of-SHA256 over the client's current set of normalized E.164 phones.
   /// Sent on the last streamed request to indicate the end of the upload.

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/contact_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/contact_v1_model.pb.swift
@@ -25,8 +25,8 @@ public struct Flipcash_Contact_V1_FlipcashContact: Sendable {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var phone: Flipcash_Phone_V1_PhoneNumber {
-    get {return _phone ?? Flipcash_Phone_V1_PhoneNumber()}
+  public var phone: Flipcash_Common_V1_PhoneNumber {
+    get {return _phone ?? Flipcash_Common_V1_PhoneNumber()}
     set {_phone = newValue}
   }
   /// Returns true if `phone` has been explicitly set.
@@ -59,7 +59,7 @@ public struct Flipcash_Contact_V1_FlipcashContact: Sendable {
 
   public init() {}
 
-  fileprivate var _phone: Flipcash_Phone_V1_PhoneNumber? = nil
+  fileprivate var _phone: Flipcash_Common_V1_PhoneNumber? = nil
   fileprivate var _dmChatID: Flipcash_Common_V1_ChatId? = nil
   fileprivate var _joinTs: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/email_v1_email_verification_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/email_v1_email_verification_service.pb.swift
@@ -26,8 +26,8 @@ public struct Flipcash_Email_V1_SendVerificationCodeRequest: Sendable {
   // methods supported on all messages.
 
   /// The email address to send a verification code to
-  public var emailAddress: Flipcash_Email_V1_EmailAddress {
-    get {return _emailAddress ?? Flipcash_Email_V1_EmailAddress()}
+  public var emailAddress: Flipcash_Common_V1_EmailAddress {
+    get {return _emailAddress ?? Flipcash_Common_V1_EmailAddress()}
     set {_emailAddress = newValue}
   }
   /// Returns true if `emailAddress` has been explicitly set.
@@ -51,7 +51,7 @@ public struct Flipcash_Email_V1_SendVerificationCodeRequest: Sendable {
 
   public init() {}
 
-  fileprivate var _emailAddress: Flipcash_Email_V1_EmailAddress? = nil
+  fileprivate var _emailAddress: Flipcash_Common_V1_EmailAddress? = nil
   fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
 }
 
@@ -121,8 +121,8 @@ public struct Flipcash_Email_V1_CheckVerificationCodeRequest: Sendable {
   // methods supported on all messages.
 
   /// The email address being verified
-  public var emailAddress: Flipcash_Email_V1_EmailAddress {
-    get {return _emailAddress ?? Flipcash_Email_V1_EmailAddress()}
+  public var emailAddress: Flipcash_Common_V1_EmailAddress {
+    get {return _emailAddress ?? Flipcash_Common_V1_EmailAddress()}
     set {_emailAddress = newValue}
   }
   /// Returns true if `emailAddress` has been explicitly set.
@@ -153,7 +153,7 @@ public struct Flipcash_Email_V1_CheckVerificationCodeRequest: Sendable {
 
   public init() {}
 
-  fileprivate var _emailAddress: Flipcash_Email_V1_EmailAddress? = nil
+  fileprivate var _emailAddress: Flipcash_Common_V1_EmailAddress? = nil
   fileprivate var _code: Flipcash_Email_V1_VerificationCode? = nil
   fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
 }
@@ -234,8 +234,8 @@ public struct Flipcash_Email_V1_UnlinkRequest: Sendable {
   // methods supported on all messages.
 
   /// The email address to unlink
-  public var emailAddress: Flipcash_Email_V1_EmailAddress {
-    get {return _emailAddress ?? Flipcash_Email_V1_EmailAddress()}
+  public var emailAddress: Flipcash_Common_V1_EmailAddress {
+    get {return _emailAddress ?? Flipcash_Common_V1_EmailAddress()}
     set {_emailAddress = newValue}
   }
   /// Returns true if `emailAddress` has been explicitly set.
@@ -256,7 +256,7 @@ public struct Flipcash_Email_V1_UnlinkRequest: Sendable {
 
   public init() {}
 
-  fileprivate var _emailAddress: Flipcash_Email_V1_EmailAddress? = nil
+  fileprivate var _emailAddress: Flipcash_Common_V1_EmailAddress? = nil
   fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
 }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/email_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/email_v1_model.pb.swift
@@ -20,19 +20,6 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-/// EmailAddress is an email address
-public struct Flipcash_Email_V1_EmailAddress: Sendable {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  public var value: String = String()
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
 /// VerificationCode is a 4-10 digit numerical code for verification
 public struct Flipcash_Email_V1_VerificationCode: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
@@ -49,36 +36,6 @@ public struct Flipcash_Email_V1_VerificationCode: Sendable {
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "flipcash.email.v1"
-
-extension Flipcash_Email_V1_EmailAddress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".EmailAddress"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}value\0")
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.value) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.value.isEmpty {
-      try visitor.visitSingularStringField(value: self.value, fieldNumber: 1)
-    }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Flipcash_Email_V1_EmailAddress, rhs: Flipcash_Email_V1_EmailAddress) -> Bool {
-    if lhs.value != rhs.value {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
 
 extension Flipcash_Email_V1_VerificationCode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".VerificationCode"

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/intent_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/intent_v1_model.pb.swift
@@ -93,8 +93,8 @@ public struct Flipcash_Intent_V1_ChatMetadata: Sendable {
     // methods supported on all messages.
 
     /// Source phone number that is paying. This is validated to be linked to the sender.
-    public var source: Flipcash_Phone_V1_PhoneNumber {
-      get {return _source ?? Flipcash_Phone_V1_PhoneNumber()}
+    public var source: Flipcash_Common_V1_PhoneNumber {
+      get {return _source ?? Flipcash_Common_V1_PhoneNumber()}
       set {_source = newValue}
     }
     /// Returns true if `source` has been explicitly set.
@@ -103,8 +103,8 @@ public struct Flipcash_Intent_V1_ChatMetadata: Sendable {
     public mutating func clearSource() {self._source = nil}
 
     /// Destination phone number that is being paid. This is validated to be linked to the receiver.
-    public var destination: Flipcash_Phone_V1_PhoneNumber {
-      get {return _destination ?? Flipcash_Phone_V1_PhoneNumber()}
+    public var destination: Flipcash_Common_V1_PhoneNumber {
+      get {return _destination ?? Flipcash_Common_V1_PhoneNumber()}
       set {_destination = newValue}
     }
     /// Returns true if `destination` has been explicitly set.
@@ -116,8 +116,8 @@ public struct Flipcash_Intent_V1_ChatMetadata: Sendable {
 
     public init() {}
 
-    fileprivate var _source: Flipcash_Phone_V1_PhoneNumber? = nil
-    fileprivate var _destination: Flipcash_Phone_V1_PhoneNumber? = nil
+    fileprivate var _source: Flipcash_Common_V1_PhoneNumber? = nil
+    fileprivate var _destination: Flipcash_Common_V1_PhoneNumber? = nil
   }
 
   /// For sending a DM payment to someone using their user ID, which maps

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/phone_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/phone_v1_model.pb.swift
@@ -20,20 +20,6 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-/// PhoneNumber is an E.164 phone number
-public struct Flipcash_Phone_V1_PhoneNumber: Sendable {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  /// Regex provided by Twilio here: https://www.twilio.com/docs/glossary/what-e164#regex-matching-for-e164
-  public var value: String = String()
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
 /// VerificationCode is a 4-10 digit numerical code for verification
 public struct Flipcash_Phone_V1_VerificationCode: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
@@ -50,36 +36,6 @@ public struct Flipcash_Phone_V1_VerificationCode: Sendable {
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "flipcash.phone.v1"
-
-extension Flipcash_Phone_V1_PhoneNumber: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".PhoneNumber"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}value\0")
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.value) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.value.isEmpty {
-      try visitor.visitSingularStringField(value: self.value, fieldNumber: 1)
-    }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Flipcash_Phone_V1_PhoneNumber, rhs: Flipcash_Phone_V1_PhoneNumber) -> Bool {
-    if lhs.value != rhs.value {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
 
 extension Flipcash_Phone_V1_VerificationCode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".VerificationCode"

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/phone_v1_phone_verification_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/phone_v1_phone_verification_service.pb.swift
@@ -26,8 +26,8 @@ public struct Flipcash_Phone_V1_SendVerificationCodeRequest: Sendable {
   // methods supported on all messages.
 
   /// The phone number to send a verification code over SMS to
-  public var phoneNumber: Flipcash_Phone_V1_PhoneNumber {
-    get {return _phoneNumber ?? Flipcash_Phone_V1_PhoneNumber()}
+  public var phoneNumber: Flipcash_Common_V1_PhoneNumber {
+    get {return _phoneNumber ?? Flipcash_Common_V1_PhoneNumber()}
     set {_phoneNumber = newValue}
   }
   /// Returns true if `phoneNumber` has been explicitly set.
@@ -51,7 +51,7 @@ public struct Flipcash_Phone_V1_SendVerificationCodeRequest: Sendable {
 
   public init() {}
 
-  fileprivate var _phoneNumber: Flipcash_Phone_V1_PhoneNumber? = nil
+  fileprivate var _phoneNumber: Flipcash_Common_V1_PhoneNumber? = nil
   fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
 }
 
@@ -128,8 +128,8 @@ public struct Flipcash_Phone_V1_CheckVerificationCodeRequest: Sendable {
   // methods supported on all messages.
 
   /// The phone number being verified
-  public var phoneNumber: Flipcash_Phone_V1_PhoneNumber {
-    get {return _phoneNumber ?? Flipcash_Phone_V1_PhoneNumber()}
+  public var phoneNumber: Flipcash_Common_V1_PhoneNumber {
+    get {return _phoneNumber ?? Flipcash_Common_V1_PhoneNumber()}
     set {_phoneNumber = newValue}
   }
   /// Returns true if `phoneNumber` has been explicitly set.
@@ -160,7 +160,7 @@ public struct Flipcash_Phone_V1_CheckVerificationCodeRequest: Sendable {
 
   public init() {}
 
-  fileprivate var _phoneNumber: Flipcash_Phone_V1_PhoneNumber? = nil
+  fileprivate var _phoneNumber: Flipcash_Common_V1_PhoneNumber? = nil
   fileprivate var _code: Flipcash_Phone_V1_VerificationCode? = nil
   fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
 }
@@ -241,8 +241,8 @@ public struct Flipcash_Phone_V1_UnlinkRequest: Sendable {
   // methods supported on all messages.
 
   /// The phone number to unlink
-  public var phoneNumber: Flipcash_Phone_V1_PhoneNumber {
-    get {return _phoneNumber ?? Flipcash_Phone_V1_PhoneNumber()}
+  public var phoneNumber: Flipcash_Common_V1_PhoneNumber {
+    get {return _phoneNumber ?? Flipcash_Common_V1_PhoneNumber()}
     set {_phoneNumber = newValue}
   }
   /// Returns true if `phoneNumber` has been explicitly set.
@@ -263,7 +263,7 @@ public struct Flipcash_Phone_V1_UnlinkRequest: Sendable {
 
   public init() {}
 
-  fileprivate var _phoneNumber: Flipcash_Phone_V1_PhoneNumber? = nil
+  fileprivate var _phoneNumber: Flipcash_Common_V1_PhoneNumber? = nil
   fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
 }
 
@@ -319,8 +319,8 @@ public struct Flipcash_Phone_V1_LinkForPaymentRequest: Sendable {
   // methods supported on all messages.
 
   /// The phone number to link for payment
-  public var phoneNumber: Flipcash_Phone_V1_PhoneNumber {
-    get {return _phoneNumber ?? Flipcash_Phone_V1_PhoneNumber()}
+  public var phoneNumber: Flipcash_Common_V1_PhoneNumber {
+    get {return _phoneNumber ?? Flipcash_Common_V1_PhoneNumber()}
     set {_phoneNumber = newValue}
   }
   /// Returns true if `phoneNumber` has been explicitly set.
@@ -341,7 +341,7 @@ public struct Flipcash_Phone_V1_LinkForPaymentRequest: Sendable {
 
   public init() {}
 
-  fileprivate var _phoneNumber: Flipcash_Phone_V1_PhoneNumber? = nil
+  fileprivate var _phoneNumber: Flipcash_Common_V1_PhoneNumber? = nil
   fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
 }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_model.pb.swift
@@ -33,8 +33,8 @@ public struct Flipcash_Profile_V1_UserProfile: Sendable {
 
   /// Phone number linked to this user. This is private and will only be returned
   /// when the requesting user asks for their own profile
-  public var phoneNumber: Flipcash_Phone_V1_PhoneNumber {
-    get {return _phoneNumber ?? Flipcash_Phone_V1_PhoneNumber()}
+  public var phoneNumber: Flipcash_Common_V1_PhoneNumber {
+    get {return _phoneNumber ?? Flipcash_Common_V1_PhoneNumber()}
     set {_phoneNumber = newValue}
   }
   /// Returns true if `phoneNumber` has been explicitly set.
@@ -44,8 +44,8 @@ public struct Flipcash_Profile_V1_UserProfile: Sendable {
 
   /// Email address linked to this user. This is private and will only be returned
   /// when the requesting user asks for their own profile
-  public var emailAddress: Flipcash_Email_V1_EmailAddress {
-    get {return _emailAddress ?? Flipcash_Email_V1_EmailAddress()}
+  public var emailAddress: Flipcash_Common_V1_EmailAddress {
+    get {return _emailAddress ?? Flipcash_Common_V1_EmailAddress()}
     set {_emailAddress = newValue}
   }
   /// Returns true if `emailAddress` has been explicitly set.
@@ -81,14 +81,27 @@ public struct Flipcash_Profile_V1_UserProfile: Sendable {
   /// Clears the value of `joinTs`. Subsequent reads from it will return its default value.
   public mutating func clearJoinTs() {self._joinTs = nil}
 
+  /// How the user has customized their Tip Card. Public, so it is returned for
+  /// any user, not just the caller. Always set — the server resolves defaults
+  /// for anything the user hasn't customized. Update it with UpdateTipCard.
+  public var tipCardCustomization: Flipcash_Profile_V1_TipCardCustomization {
+    get {return _tipCardCustomization ?? Flipcash_Profile_V1_TipCardCustomization()}
+    set {_tipCardCustomization = newValue}
+  }
+  /// Returns true if `tipCardCustomization` has been explicitly set.
+  public var hasTipCardCustomization: Bool {return self._tipCardCustomization != nil}
+  /// Clears the value of `tipCardCustomization`. Subsequent reads from it will return its default value.
+  public mutating func clearTipCardCustomization() {self._tipCardCustomization = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _phoneNumber: Flipcash_Phone_V1_PhoneNumber? = nil
-  fileprivate var _emailAddress: Flipcash_Email_V1_EmailAddress? = nil
+  fileprivate var _phoneNumber: Flipcash_Common_V1_PhoneNumber? = nil
+  fileprivate var _emailAddress: Flipcash_Common_V1_EmailAddress? = nil
   fileprivate var _profilePicture: Flipcash_Blob_V1_Media? = nil
   fileprivate var _joinTs: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
+  fileprivate var _tipCardCustomization: Flipcash_Profile_V1_TipCardCustomization? = nil
 }
 
 public struct Flipcash_Profile_V1_SocialProfile: Sendable {
@@ -189,13 +202,37 @@ public struct Flipcash_Profile_V1_XProfile: Sendable {
   public init() {}
 }
 
+/// Customization for a Tip Card
+public struct Flipcash_Profile_V1_TipCardCustomization: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The colour of the Tip Card. Always set — the server falls back to the
+  /// default colour when the user hasn't picked one.
+  public var color: Flipcash_Common_V1_Color {
+    get {return _color ?? Flipcash_Common_V1_Color()}
+    set {_color = newValue}
+  }
+  /// Returns true if `color` has been explicitly set.
+  public var hasColor: Bool {return self._color != nil}
+  /// Clears the value of `color`. Subsequent reads from it will return its default value.
+  public mutating func clearColor() {self._color = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _color: Flipcash_Common_V1_Color? = nil
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "flipcash.profile.v1"
 
 extension Flipcash_Profile_V1_UserProfile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UserProfile"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}display_name\0\u{3}social_profiles\0\u{3}phone_number\0\u{3}email_address\0\u{3}profile_picture\0\u{3}join_ts\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}display_name\0\u{3}social_profiles\0\u{3}phone_number\0\u{3}email_address\0\u{3}profile_picture\0\u{3}join_ts\0\u{3}tip_card_customization\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -209,6 +246,7 @@ extension Flipcash_Profile_V1_UserProfile: SwiftProtobuf.Message, SwiftProtobuf.
       case 4: try { try decoder.decodeSingularMessageField(value: &self._emailAddress) }()
       case 5: try { try decoder.decodeSingularMessageField(value: &self._profilePicture) }()
       case 6: try { try decoder.decodeSingularMessageField(value: &self._joinTs) }()
+      case 7: try { try decoder.decodeSingularMessageField(value: &self._tipCardCustomization) }()
       default: break
       }
     }
@@ -237,6 +275,9 @@ extension Flipcash_Profile_V1_UserProfile: SwiftProtobuf.Message, SwiftProtobuf.
     try { if let v = self._joinTs {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
     } }()
+    try { if let v = self._tipCardCustomization {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -247,6 +288,7 @@ extension Flipcash_Profile_V1_UserProfile: SwiftProtobuf.Message, SwiftProtobuf.
     if lhs._emailAddress != rhs._emailAddress {return false}
     if lhs._profilePicture != rhs._profilePicture {return false}
     if lhs._joinTs != rhs._joinTs {return false}
+    if lhs._tipCardCustomization != rhs._tipCardCustomization {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -360,4 +402,38 @@ extension Flipcash_Profile_V1_XProfile: SwiftProtobuf.Message, SwiftProtobuf._Me
 
 extension Flipcash_Profile_V1_XProfile.VerifiedType: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0NONE\0\u{1}BLUE\0\u{1}BUSINESS\0\u{1}GOVERNMENT\0")
+}
+
+extension Flipcash_Profile_V1_TipCardCustomization: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".TipCardCustomization"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}color\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._color) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._color {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Profile_V1_TipCardCustomization, rhs: Flipcash_Profile_V1_TipCardCustomization) -> Bool {
+    if lhs._color != rhs._color {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.grpc.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.grpc.swift
@@ -56,6 +56,18 @@ public enum Flipcash_Profile_V1_Profile {
                 method: "SetProfilePicture"
             )
         }
+        /// Namespace for "UpdateTipCard" metadata.
+        public enum UpdateTipCard {
+            /// Request type for "UpdateTipCard".
+            public typealias Input = Flipcash_Profile_V1_UpdateTipCardRequest
+            /// Response type for "UpdateTipCard".
+            public typealias Output = Flipcash_Profile_V1_UpdateTipCardResponse
+            /// Descriptor for "UpdateTipCard".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "flipcash.profile.v1.Profile"),
+                method: "UpdateTipCard"
+            )
+        }
         /// Namespace for "LinkSocialAccount" metadata.
         public enum LinkSocialAccount {
             /// Request type for "LinkSocialAccount".
@@ -85,6 +97,7 @@ public enum Flipcash_Profile_V1_Profile {
             GetProfile.descriptor,
             SetDisplayName.descriptor,
             SetProfilePicture.descriptor,
+            UpdateTipCard.descriptor,
             LinkSocialAccount.descriptor,
             UnlinkSocialAccount.descriptor
         ]
@@ -171,6 +184,30 @@ extension Flipcash_Profile_V1_Profile {
             deserializer: some GRPCCore.MessageDeserializer<Flipcash_Profile_V1_SetProfilePictureResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetProfilePictureResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "UpdateTipCard" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > UpdateTipCard updates the caller's Tip Card customization. Every field is
+        /// > optional; only the ones set in the request are changed.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Flipcash_Profile_V1_UpdateTipCardRequest` message.
+        ///   - serializer: A serializer for `Flipcash_Profile_V1_UpdateTipCardRequest` messages.
+        ///   - deserializer: A deserializer for `Flipcash_Profile_V1_UpdateTipCardResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func updateTipCard<Result>(
+            request: GRPCCore.ClientRequest<Flipcash_Profile_V1_UpdateTipCardRequest>,
+            serializer: some GRPCCore.MessageSerializer<Flipcash_Profile_V1_UpdateTipCardRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Flipcash_Profile_V1_UpdateTipCardResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_UpdateTipCardResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
 
         /// Call the "LinkSocialAccount" method.
@@ -336,6 +373,41 @@ extension Flipcash_Profile_V1_Profile {
             )
         }
 
+        /// Call the "UpdateTipCard" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > UpdateTipCard updates the caller's Tip Card customization. Every field is
+        /// > optional; only the ones set in the request are changed.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Flipcash_Profile_V1_UpdateTipCardRequest` message.
+        ///   - serializer: A serializer for `Flipcash_Profile_V1_UpdateTipCardRequest` messages.
+        ///   - deserializer: A deserializer for `Flipcash_Profile_V1_UpdateTipCardResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func updateTipCard<Result>(
+            request: GRPCCore.ClientRequest<Flipcash_Profile_V1_UpdateTipCardRequest>,
+            serializer: some GRPCCore.MessageSerializer<Flipcash_Profile_V1_UpdateTipCardRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Flipcash_Profile_V1_UpdateTipCardResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_UpdateTipCardResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Flipcash_Profile_V1_Profile.Method.UpdateTipCard.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
         /// Call the "LinkSocialAccount" method.
         ///
         /// > Source IDL Documentation:
@@ -494,6 +566,36 @@ extension Flipcash_Profile_V1_Profile.ClientProtocol {
         )
     }
 
+    /// Call the "UpdateTipCard" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > UpdateTipCard updates the caller's Tip Card customization. Every field is
+    /// > optional; only the ones set in the request are changed.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Flipcash_Profile_V1_UpdateTipCardRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func updateTipCard<Result>(
+        request: GRPCCore.ClientRequest<Flipcash_Profile_V1_UpdateTipCardRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_UpdateTipCardResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.updateTipCard(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Flipcash_Profile_V1_UpdateTipCardRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Flipcash_Profile_V1_UpdateTipCardResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
     /// Call the "LinkSocialAccount" method.
     ///
     /// > Source IDL Documentation:
@@ -647,6 +749,40 @@ extension Flipcash_Profile_V1_Profile.ClientProtocol {
             metadata: metadata
         )
         return try await self.setProfilePicture(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "UpdateTipCard" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > UpdateTipCard updates the caller's Tip Card customization. Every field is
+    /// > optional; only the ones set in the request are changed.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func updateTipCard<Result>(
+        _ message: Flipcash_Profile_V1_UpdateTipCardRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_UpdateTipCardResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Flipcash_Profile_V1_UpdateTipCardRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.updateTipCard(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.pb.swift
@@ -313,6 +313,88 @@ public struct Flipcash_Profile_V1_SetProfilePictureResponse: Sendable {
   fileprivate var _profilePicture: Flipcash_Blob_V1_Media? = nil
 }
 
+public struct Flipcash_Profile_V1_UpdateTipCardRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The new colour of the Tip Card. Left unchanged when unset.
+  public var color: Flipcash_Common_V1_Color {
+    get {return _color ?? Flipcash_Common_V1_Color()}
+    set {_color = newValue}
+  }
+  /// Returns true if `color` has been explicitly set.
+  public var hasColor: Bool {return self._color != nil}
+  /// Clears the value of `color`. Subsequent reads from it will return its default value.
+  public mutating func clearColor() {self._color = nil}
+
+  public var auth: Flipcash_Common_V1_Auth {
+    get {return _auth ?? Flipcash_Common_V1_Auth()}
+    set {_auth = newValue}
+  }
+  /// Returns true if `auth` has been explicitly set.
+  public var hasAuth: Bool {return self._auth != nil}
+  /// Clears the value of `auth`. Subsequent reads from it will return its default value.
+  public mutating func clearAuth() {self._auth = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _color: Flipcash_Common_V1_Color? = nil
+  fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
+}
+
+public struct Flipcash_Profile_V1_UpdateTipCardResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var result: Flipcash_Profile_V1_UpdateTipCardResponse.Result = .ok
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public enum Result: SwiftProtobuf.Enum, Swift.CaseIterable {
+    public typealias RawValue = Int
+    case ok // = 0
+    case denied // = 1
+    case invalidColor // = 2
+    case UNRECOGNIZED(Int)
+
+    public init() {
+      self = .ok
+    }
+
+    public init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .ok
+      case 1: self = .denied
+      case 2: self = .invalidColor
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    public var rawValue: Int {
+      switch self {
+      case .ok: return 0
+      case .denied: return 1
+      case .invalidColor: return 2
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Flipcash_Profile_V1_UpdateTipCardResponse.Result] = [
+      .ok,
+      .denied,
+      .invalidColor,
+    ]
+
+  }
+
+  public init() {}
+}
+
 public struct Flipcash_Profile_V1_LinkSocialAccountRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -773,6 +855,79 @@ extension Flipcash_Profile_V1_SetProfilePictureResponse: SwiftProtobuf.Message, 
 
 extension Flipcash_Profile_V1_SetProfilePictureResponse.Result: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}DENIED\0\u{1}BLOB_NOT_FOUND\0\u{1}BLOB_NOT_READY\0\u{1}BLOB_REJECTED\0\u{1}INVALID_BLOB\0")
+}
+
+extension Flipcash_Profile_V1_UpdateTipCardRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".UpdateTipCardRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}color\0\u{2}\u{9}auth\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._color) }()
+      case 10: try { try decoder.decodeSingularMessageField(value: &self._auth) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._color {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    try { if let v = self._auth {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Profile_V1_UpdateTipCardRequest, rhs: Flipcash_Profile_V1_UpdateTipCardRequest) -> Bool {
+    if lhs._color != rhs._color {return false}
+    if lhs._auth != rhs._auth {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Profile_V1_UpdateTipCardResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".UpdateTipCardResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}result\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.result) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.result != .ok {
+      try visitor.visitSingularEnumField(value: self.result, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Profile_V1_UpdateTipCardResponse, rhs: Flipcash_Profile_V1_UpdateTipCardResponse) -> Bool {
+    if lhs.result != rhs.result {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Profile_V1_UpdateTipCardResponse.Result: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}DENIED\0\u{1}INVALID_COLOR\0")
 }
 
 extension Flipcash_Profile_V1_LinkSocialAccountRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/push_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/push_v1_model.pb.swift
@@ -79,10 +79,10 @@ public struct Flipcash_Push_V1_Payload: Sendable {
   public mutating func clearNavigation() {self._navigation = nil}
 
   /// Ordered substitutions to apply to push title
-  public var titleSubstitutions: [Flipcash_Push_V1_Substitution] = []
+  public var titleSubstitutions: [Flipcash_Common_V1_Substitution] = []
 
   /// Ordered substitutions to apply to push body
-  public var bodySubstitutions: [Flipcash_Push_V1_Substitution] = []
+  public var bodySubstitutions: [Flipcash_Common_V1_Substitution] = []
 
   /// Push notification category
   public var category: Flipcash_Push_V1_Payload.Category = .default
@@ -185,10 +185,10 @@ public struct Flipcash_Push_V1_Navigation: Sendable {
   }
 
   /// Chat for a contact with the provided phone number
-  public var chatContactPhoneNumber: Flipcash_Phone_V1_PhoneNumber {
+  public var chatContactPhoneNumber: Flipcash_Common_V1_PhoneNumber {
     get {
       if case .chatContactPhoneNumber(let v)? = type {return v}
-      return Flipcash_Phone_V1_PhoneNumber()
+      return Flipcash_Common_V1_PhoneNumber()
     }
     set {type = .chatContactPhoneNumber(newValue)}
   }
@@ -201,37 +201,7 @@ public struct Flipcash_Push_V1_Navigation: Sendable {
     /// Chat for the provided ID
     case chatID(Flipcash_Common_V1_ChatId)
     /// Chat for a contact with the provided phone number
-    case chatContactPhoneNumber(Flipcash_Phone_V1_PhoneNumber)
-
-  }
-
-  public init() {}
-}
-
-public struct Flipcash_Push_V1_Substitution: Sendable {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  /// Fallback string for forwards compatibility
-  public var fallback: String = String()
-
-  public var kind: Flipcash_Push_V1_Substitution.OneOf_Kind? = nil
-
-  /// Phone number -> contact name or formatted phone number
-  public var contact: Flipcash_Phone_V1_PhoneNumber {
-    get {
-      if case .contact(let v)? = kind {return v}
-      return Flipcash_Phone_V1_PhoneNumber()
-    }
-    set {kind = .contact(newValue)}
-  }
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public enum OneOf_Kind: Equatable, Sendable {
-    /// Phone number -> contact name or formatted phone number
-    case contact(Flipcash_Phone_V1_PhoneNumber)
+    case chatContactPhoneNumber(Flipcash_Common_V1_PhoneNumber)
 
   }
 
@@ -375,7 +345,7 @@ extension Flipcash_Push_V1_Navigation: SwiftProtobuf.Message, SwiftProtobuf._Mes
         }
       }()
       case 3: try {
-        var v: Flipcash_Phone_V1_PhoneNumber?
+        var v: Flipcash_Common_V1_PhoneNumber?
         var hadOneofValue = false
         if let current = self.type {
           hadOneofValue = true
@@ -417,57 +387,6 @@ extension Flipcash_Push_V1_Navigation: SwiftProtobuf.Message, SwiftProtobuf._Mes
 
   public static func ==(lhs: Flipcash_Push_V1_Navigation, rhs: Flipcash_Push_V1_Navigation) -> Bool {
     if lhs.type != rhs.type {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-extension Flipcash_Push_V1_Substitution: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Substitution"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}fallback\0\u{1}contact\0")
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.fallback) }()
-      case 2: try {
-        var v: Flipcash_Phone_V1_PhoneNumber?
-        var hadOneofValue = false
-        if let current = self.kind {
-          hadOneofValue = true
-          if case .contact(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.kind = .contact(v)
-        }
-      }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    if !self.fallback.isEmpty {
-      try visitor.visitSingularStringField(value: self.fallback, fieldNumber: 1)
-    }
-    try { if case .contact(let v)? = self.kind {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    } }()
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Flipcash_Push_V1_Substitution, rhs: Flipcash_Push_V1_Substitution) -> Bool {
-    if lhs.fallback != rhs.fallback {return false}
-    if lhs.kind != rhs.kind {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/resolver_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/resolver_v1_model.pb.swift
@@ -29,10 +29,10 @@ public struct Flipcash_Resolver_V1_Identifier: Sendable {
 
   public var kind: Flipcash_Resolver_V1_Identifier.OneOf_Kind? = nil
 
-  public var phone: Flipcash_Phone_V1_PhoneNumber {
+  public var phone: Flipcash_Common_V1_PhoneNumber {
     get {
       if case .phone(let v)? = kind {return v}
-      return Flipcash_Phone_V1_PhoneNumber()
+      return Flipcash_Common_V1_PhoneNumber()
     }
     set {kind = .phone(newValue)}
   }
@@ -48,7 +48,7 @@ public struct Flipcash_Resolver_V1_Identifier: Sendable {
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_Kind: Equatable, Sendable {
-    case phone(Flipcash_Phone_V1_PhoneNumber)
+    case phone(Flipcash_Common_V1_PhoneNumber)
     case userID(Flipcash_Common_V1_UserId)
 
   }
@@ -98,7 +98,7 @@ extension Flipcash_Resolver_V1_Identifier: SwiftProtobuf.Message, SwiftProtobuf.
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        var v: Flipcash_Phone_V1_PhoneNumber?
+        var v: Flipcash_Common_V1_PhoneNumber?
         var hadOneofValue = false
         if let current = self.kind {
           hadOneofValue = true

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/activity/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/activity/v1/model.proto
@@ -7,7 +7,6 @@ option java_package = "com.codeinc.flipcash.gen.activity.v1";
 option objc_class_prefix = "FCPBActivityV1";
 
 import "common/v1/common.proto";
-import "phone/v1/model.proto";
 import "google/protobuf/timestamp.proto";
 import "validate/validate.proto";
 
@@ -51,17 +50,22 @@ message Notification {
     }
 
     reserved 6; // Deprecated WelcomeBonusNotificationMetadata
+
+    // Ordered substitutions to apply to localized_text
+    repeated common.v1.Substitution text_substitutions = 100;
 }
 
 message DirectlySentCryptoNotificationMetadata {
     oneof destination_identifier {
-        phone.v1.PhoneNumber phone = 1;
+        common.v1.PhoneNumber phone   = 1;
+        common.v1.UserId      user_id = 2;
     }
 }
 
 message ReceivedCryptoNotificationMetadata {
     oneof source_identifier {
-        phone.v1.PhoneNumber phone = 1;
+        common.v1.PhoneNumber phone   = 1;
+        common.v1.UserId      user_id = 2;
     }
 }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/chat/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/chat/v1/model.proto
@@ -16,6 +16,7 @@ enum ChatType {
     UNKNOWN    = 0;
     CONTACT_DM = 1;
     TIP_DM     = 2;
+    GROUP      = 3;
 }
 
 message Metadata {
@@ -27,6 +28,8 @@ message Metadata {
     }];
 
     // Members of this chat
+    //
+    // For large group chats, this is a subset of all members.
     repeated Member members = 3;
 
     // The last message in this chat
@@ -50,6 +53,12 @@ message Metadata {
     // Per-viewer and server-computed (e.g. the chat's peer is on the caller's
     // blocklist). Clients should exclude hidden chats from the primary DM list.
     bool is_hidden = 7;
+
+    // Title for this chat. Only supported for group chats
+    string title = 8 [(validate.rules).string = {
+        min_len: 0
+        max_len: 64
+    }];
 }
 
 message Member {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/common/v1/common.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/common/v1/common.proto
@@ -6,6 +6,9 @@ option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/g
 option java_package = "com.codeinc.flipcash.gen.common.v1";
 option objc_class_prefix = "FPBCommonV1";
 
+// Note: common/v1 is imported by every other domain, so it must remain a leaf
+// package. Importing another flipcash domain here creates a Go import cycle,
+// since that domain's service protos import common/v1 in turn.
 import "validate/validate.proto";
 
 message PublicKey {
@@ -59,8 +62,11 @@ message UserId {
 }
 
 message ChatId {
+    // value has the following structure:
+    //  - 32 byte hash for DMs
+    //  - 16 byte UUID for group chats
     bytes value = 1 [(validate.rules).bytes = {
-        min_len: 32
+        min_len: 16
         max_len: 32
     }];
 }
@@ -80,6 +86,17 @@ message AppInstallId {
         min_len: 1
         max_len: 256 // todo: What's a reasonable size
     }];
+}
+
+// PhoneNumber is an E.164 phone number
+message PhoneNumber {
+    // Regex provided by Twilio here: https://www.twilio.com/docs/glossary/what-e164#regex-matching-for-e164
+    string value = 1 [(validate.rules).string.pattern = "^\\+[1-9]\\d{1,14}$"];
+}
+
+// EmailAddress is an email address
+message EmailAddress {
+    string value = 1 [(validate.rules).string.pattern = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"];
 }
 
 enum Platform {
@@ -181,4 +198,31 @@ message Region {
     string value = 1 [(validate.rules).string = {
         pattern: "^[a-z]{3,4}$"
     }];
+}
+
+// Color represents an RGB colour
+message Color {
+    // Hex colour value (e.g. "#19191A")
+    string hex = 1 [(validate.rules).string = {
+        pattern: "^#[0-9a-fA-F]{6}$"
+    }];
+}
+
+// Substitution is a text subsitution
+message Substitution {
+    // Fallback string for forwards compatibility
+    string fallback = 1 [(validate.rules).string = {
+        min_len: 1
+        max_len: 4096 // Arbitrary
+    }];
+
+    oneof kind {
+        option (validate.required) = true;
+
+        // Phone number -> contact name or formatted phone number
+        common.v1.PhoneNumber phone_number_to_contact_name = 2;
+
+        // User ID -> display name
+        common.v1.UserId      user_id_to_display_name      = 3;
+    }
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/contact/v1/contact_list_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/contact/v1/contact_list_service.proto
@@ -4,7 +4,6 @@ package flipcash.contact.v1;
 
 import "contact/v1/model.proto";
 import "common/v1/common.proto";
-import "phone/v1/model.proto";
 import "validate/validate.proto";
 
 option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/go/contact/v1;contactpb";
@@ -64,9 +63,9 @@ message CheckSyncResponse {
 message DeltaUploadRequest {
     common.v1.Auth auth = 1 [(validate.rules).message.required = true];
 
-    repeated phone.v1.PhoneNumber adds = 2 [(validate.rules).repeated.max_items = 1000];
+    repeated common.v1.PhoneNumber adds = 2 [(validate.rules).repeated.max_items = 1000];
 
-    repeated phone.v1.PhoneNumber removes = 3 [(validate.rules).repeated.max_items = 1000];
+    repeated common.v1.PhoneNumber removes = 3 [(validate.rules).repeated.max_items = 1000];
 
     // The checksum the client expected the server to have *before* applying
     // this delta. Server applies only if stored == old_checksum.
@@ -97,7 +96,7 @@ message FullUploadRequest {
 
     // The complete current contact set. Server replaces stored state with
     // this list in one transaction.
-    repeated phone.v1.PhoneNumber phones = 2 [(validate.rules).repeated.max_items = 1000];
+    repeated common.v1.PhoneNumber phones = 2 [(validate.rules).repeated.max_items = 1000];
 
     // XOR-of-SHA256 over the client's current set of normalized E.164 phones.
     // Sent on the last streamed request to indicate the end of the upload.

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/contact/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/contact/v1/model.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package flipcash.contact.v1;
 
 import "common/v1/common.proto";
-import "phone/v1/model.proto";
 import "google/protobuf/timestamp.proto";
 import "validate/validate.proto";
 
@@ -12,7 +11,7 @@ option java_package = "com.codeinc.flipcash.gen.contact.v1";
 option objc_class_prefix = "FPBContactV1";
 
 message FlipcashContact {
-    phone.v1.PhoneNumber phone = 1 [(validate.rules).message.required = true];
+    common.v1.PhoneNumber phone = 1 [(validate.rules).message.required = true];
 
     // The DM chat ID for the Flipcash contact. If the chat doesn't exist, it needs
     // to be initiated with a cash send to initialize it

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/email/v1/email_verification_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/email/v1/email_verification_service.proto
@@ -26,7 +26,7 @@ service EmailVerification {
 
 message SendVerificationCodeRequest {
     // The email address to send a verification code to
-    EmailAddress email_address = 1 [(validate.rules).message.required = true];
+    common.v1.EmailAddress email_address = 1 [(validate.rules).message.required = true];
 
     common.v1.Auth auth = 2 [(validate.rules).message.required = true];
 
@@ -51,7 +51,7 @@ message SendVerificationCodeResponse {
 
 message CheckVerificationCodeRequest {
     // The email address being verified
-    EmailAddress email_address = 1 [(validate.rules).message.required = true];
+    common.v1.EmailAddress email_address = 1 [(validate.rules).message.required = true];
 
     // The verification code received via email
     VerificationCode code = 2 [(validate.rules).message.required = true];
@@ -81,7 +81,7 @@ message CheckVerificationCodeResponse {
 
 message UnlinkRequest {
     // The email address to unlink
-    EmailAddress email_address = 1 [(validate.rules).message.required = true];
+    common.v1.EmailAddress email_address = 1 [(validate.rules).message.required = true];
 
     common.v1.Auth auth = 2 [(validate.rules).message.required = true];
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/email/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/email/v1/model.proto
@@ -8,11 +8,6 @@ option objc_class_prefix = "FPBEmailV1";
 
 import "validate/validate.proto";
 
-// EmailAddress is an email address
-message EmailAddress {
-    string value = 1 [(validate.rules).string.pattern = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"];
-}
-
 // VerificationCode is a 4-10 digit numerical code for verification
 message VerificationCode {
     string value = 2 [(validate.rules).string = {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/intent/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/intent/v1/model.proto
@@ -7,7 +7,6 @@ option java_package = "com.codeinc.flipcash.gen.intent.v1";
 option objc_class_prefix = "FPBIntentV1";
 
 import "common/v1/common.proto";
-import "phone/v1/model.proto";
 import "validate/validate.proto";
 
 message AppMetadata {
@@ -32,10 +31,10 @@ message ChatMetadata {
     // For sending a payment to a contact in a DM
     message ContactDmPayment {
         // Source phone number that is paying. This is validated to be linked to the sender.
-        phone.v1.PhoneNumber source = 1 [(validate.rules).message.required = true];
+        common.v1.PhoneNumber source = 1 [(validate.rules).message.required = true];
 
         // Destination phone number that is being paid. This is validated to be linked to the receiver.
-        phone.v1.PhoneNumber destination = 2 [(validate.rules).message.required = true];
+        common.v1.PhoneNumber destination = 2 [(validate.rules).message.required = true];
     }
 
     // For sending a DM payment to someone using their user ID, which maps

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/phone/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/phone/v1/model.proto
@@ -8,12 +8,6 @@ option objc_class_prefix = "FPBPhoneV1";
 
 import "validate/validate.proto";
 
-// PhoneNumber is an E.164 phone number
-message PhoneNumber {
-    // Regex provided by Twilio here: https://www.twilio.com/docs/glossary/what-e164#regex-matching-for-e164
-    string value = 1 [(validate.rules).string.pattern = "^\\+[1-9]\\d{1,14}$"];
-}
-
 // VerificationCode is a 4-10 digit numerical code for verification
 message VerificationCode {
     string value = 2 [(validate.rules).string = {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/phone/v1/phone_verification_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/phone/v1/phone_verification_service.proto
@@ -29,7 +29,7 @@ service PhoneVerification {
 
 message SendVerificationCodeRequest {
     // The phone number to send a verification code over SMS to
-    PhoneNumber phone_number = 1 [(validate.rules).message.required = true];
+    common.v1.PhoneNumber phone_number = 1 [(validate.rules).message.required = true];
 
     // The app platform that's making this request
     common.v1.Platform platform = 2 [(validate.rules).enum = {in: [1,2]}];
@@ -55,7 +55,7 @@ message SendVerificationCodeResponse {
 
 message CheckVerificationCodeRequest {
     // The phone number being verified
-    PhoneNumber phone_number = 1 [(validate.rules).message.required = true];
+    common.v1.PhoneNumber phone_number = 1 [(validate.rules).message.required = true];
 
     // The verification code received via SMS
     VerificationCode code = 2 [(validate.rules).message.required = true];
@@ -85,7 +85,7 @@ message CheckVerificationCodeResponse {
 
 message UnlinkRequest {
     // The phone number to unlink
-    PhoneNumber phone_number = 1 [(validate.rules).message.required = true];
+    common.v1.PhoneNumber phone_number = 1 [(validate.rules).message.required = true];
 
     common.v1.Auth auth = 2 [(validate.rules).message.required = true];
 }
@@ -101,7 +101,7 @@ message UnlinkResponse {
 
 message LinkForPaymentRequest {
     // The phone number to link for payment
-    PhoneNumber phone_number = 1 [(validate.rules).message.required = true];
+    common.v1.PhoneNumber phone_number = 1 [(validate.rules).message.required = true];
 
     common.v1.Auth auth = 2 [(validate.rules).message.required = true];
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/model.proto
@@ -7,8 +7,7 @@ option java_package = "com.codeinc.flipcash.gen.profile.v1";
 option objc_class_prefix = "FPBProfileV1";
 
 import "blob/v1/model.proto";
-import "email/v1/model.proto";
-import "phone/v1/model.proto";
+import "common/v1/common.proto";
 import "google/protobuf/timestamp.proto";
 import "validate/validate.proto";
 
@@ -28,11 +27,11 @@ message UserProfile {
 
     // Phone number linked to this user. This is private and will only be returned
     // when the requesting user asks for their own profile
-    phone.v1.PhoneNumber phone_number = 3;
+    common.v1.PhoneNumber phone_number = 3;
 
     // Email address linked to this user. This is private and will only be returned
     // when the requesting user asks for their own profile
-    email.v1.EmailAddress email_address = 4;
+    common.v1.EmailAddress email_address = 4;
 
     // The user's profile picture, as the set of renditions it is stored as —
     // typically a DISPLAY for the profile view and a THUMBNAIL for avatars in
@@ -47,6 +46,11 @@ message UserProfile {
 
     // Timestamp the user joined Flipcash
     google.protobuf.Timestamp join_ts = 6 [(validate.rules).timestamp.required = true];
+
+    // How the user has customized their Tip Card. Public, so it is returned for
+    // any user, not just the caller. Always set — the server resolves defaults
+    // for anything the user hasn't customized. Update it with UpdateTipCard.
+    TipCardCustomization tip_card_customization = 7 [(validate.rules).message.required = true];
 }
 
 message SocialProfile {
@@ -97,4 +101,11 @@ message XProfile {
 
     // The number of followers the user has on X
     uint32 follower_count = 7;    
+}
+
+// Customization for a Tip Card
+message TipCardCustomization {
+    // The colour of the Tip Card. Always set — the server falls back to the
+    // default colour when the user hasn't picked one.
+    common.v1.Color color = 1 [(validate.rules).message.required = true];
 }

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/profile_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/profile_service.proto
@@ -26,6 +26,10 @@ service Profile {
 	// DISPLAY and THUMBNAIL renditions itself and returns the full set.
 	rpc SetProfilePicture(SetProfilePictureRequest) returns (SetProfilePictureResponse);
 
+	// UpdateTipCard updates the caller's Tip Card customization. Every field is
+	// optional; only the ones set in the request are changed.
+	rpc UpdateTipCard(UpdateTipCardRequest) returns (UpdateTipCardResponse);
+
 	// LinkSocialAccount links a social account to a user
 	rpc LinkSocialAccount(LinkSocialAccountRequest) returns (LinkSocialAccountResponse);
 
@@ -102,6 +106,22 @@ message SetProfilePictureResponse {
 	// The caller's new profile picture, including the renditions the server
 	// derived. Set only when result == OK.
 	blob.v1.Media profile_picture = 2;
+}
+
+message UpdateTipCardRequest {
+	// The new colour of the Tip Card. Left unchanged when unset.
+	common.v1.Color color = 1;
+
+	common.v1.Auth auth = 10 [(validate.rules).message.required = true];
+}
+
+message UpdateTipCardResponse {
+	Result result = 1;
+	enum Result {
+		OK            = 0;
+		DENIED        = 1;
+		INVALID_COLOR = 2;
+	}
 }
 
 message LinkSocialAccountRequest {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/push/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/push/v1/model.proto
@@ -8,7 +8,6 @@ option objc_class_prefix = "FPBPushV1";
 
 import "chat/v1/model.proto";
 import "common/v1/common.proto";
-import "phone/v1/model.proto";
 import "validate/validate.proto";
 
 enum TokenType {
@@ -25,10 +24,10 @@ message Payload {
     Navigation navigation = 1;
 
     // Ordered substitutions to apply to push title
-    repeated Substitution title_substitutions = 2;
+    repeated common.v1.Substitution title_substitutions = 2;
 
     // Ordered substitutions to apply to push body
-    repeated Substitution body_substitutions = 3;
+    repeated common.v1.Substitution body_substitutions = 3;
 
     // Push notification category
     Category category = 4;
@@ -62,25 +61,9 @@ message Navigation {
         common.v1.ChatId chat_id = 2;
 
         // Chat for a contact with the provided phone number
-        phone.v1.PhoneNumber chat_contact_phone_number = 3;
+        common.v1.PhoneNumber chat_contact_phone_number = 3;
     }
 }
-
-message Substitution {
-    // Fallback string for forwards compatibility
-    string fallback = 1 [(validate.rules).string = {
-        min_len: 1
-        max_len: 4096 // Arbitrary
-    }];
-
-    oneof kind {
-        option (validate.required) = true;
-
-        // Phone number -> contact name or formatted phone number
-        phone.v1.PhoneNumber contact = 2;
-    }
-}
-
 // Additional metadata provided for chat pushes
 message ChatMetadata {
     // The user ID that sent a chat message

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/resolver/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/resolver/v1/model.proto
@@ -7,7 +7,6 @@ option java_package = "com.codeinc.flipcash.gen.resolver.v1";
 option objc_class_prefix = "FPBResolverV1";
 
 import "common/v1/common.proto";
-import "phone/v1/model.proto";
 import "validate/validate.proto";
 
 // Identifier wraps a real-world identifier that can be resolved to a
@@ -16,8 +15,8 @@ message Identifier {
     oneof kind {
         option (validate.required) = true;
 
-        phone.v1.PhoneNumber phone   = 1;
-        common.v1.UserId     user_id = 2;
+        common.v1.PhoneNumber phone   = 1;
+        common.v1.UserId      user_id = 2;
     }
 }
 

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Profile.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Profile.swift
@@ -25,4 +25,10 @@ extension FlipClient {
     public func setProfilePicture(blobID: BlobID, owner: KeyPair) async throws {
         try await profileService.setProfilePicture(blobID: blobID, owner: owner)
     }
+
+    /// Updates the caller's Tip Card customization. The server validates the
+    /// colour and falls back to the default for anything left unset.
+    public func updateTipCard(_ customization: TipCardCustomization, owner: KeyPair) async throws {
+        try await profileService.updateTipCard(color: customization.colorProto, owner: owner)
+    }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ContactListService.swift
@@ -72,10 +72,10 @@ final class ContactListService: Sendable {
 
         let request = Flipcash_Contact_V1_DeltaUploadRequest.with {
             $0.adds = adds.map { e164 in
-                Flipcash_Phone_V1_PhoneNumber.with { $0.value = e164 }
+                Flipcash_Common_V1_PhoneNumber.with { $0.value = e164 }
             }
             $0.removes = removes.map { e164 in
-                Flipcash_Phone_V1_PhoneNumber.with { $0.value = e164 }
+                Flipcash_Common_V1_PhoneNumber.with { $0.value = e164 }
             }
             $0.oldChecksum = .with { $0.value = oldChecksum }
             $0.newChecksum = .with { $0.value = newChecksum }
@@ -137,7 +137,7 @@ final class ContactListService: Sendable {
                         for chunk in allChunks {
                             let request = Flipcash_Contact_V1_FullUploadRequest.with {
                                 $0.phones = chunk.map { e164 in
-                                    Flipcash_Phone_V1_PhoneNumber.with { $0.value = e164 }
+                                    Flipcash_Common_V1_PhoneNumber.with { $0.value = e164 }
                                 }
                                 $0.expectedChecksum = .with { $0.value = checksum }
                                 $0.auth = owner.authFor(message: $0)

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
@@ -120,6 +120,30 @@ final class ProfileService: Sendable {
             throw ErrorProfile.network(error)
         }
     }
+
+    func updateTipCard(color: Flipcash_Common_V1_Color, owner: KeyPair) async throws {
+        logger.info("Updating tip card")
+
+        var request = Flipcash_Profile_V1_UpdateTipCardRequest()
+        request.color = color
+        request.auth  = owner.authFor(message: request)
+
+        do {
+            let response = try await service.updateTipCard(request, options: .unaryDefault)
+            let error = ErrorUpdateTipCard(rawValue: response.result.rawValue) ?? .unknown
+            guard error == .ok else {
+                logger.error("Failed to update tip card", metadata: ["error": "\(error)"])
+                throw error
+            }
+            logger.info("Tip card updated")
+        } catch let error as ErrorUpdateTipCard {
+            throw error
+        } catch let error as RPCError {
+            throw ErrorUpdateTipCard.from(transportError: error)
+        } catch {
+            throw ErrorUpdateTipCard.unknown
+        }
+    }
 }
 
 // MARK: - Errors -
@@ -139,6 +163,28 @@ extension ErrorFetchProfile: ServerError, TransportClassifiableError {
         case .ok, .transportFailure: .suppressed
         case .cancelled: .info
         case .notFound: .info
+        case .unknown, .rejected: .error
+        }
+    }
+}
+
+public enum ErrorUpdateTipCard: Int, Error {
+    case ok
+    case denied
+    /// The requested colour failed server-side validation (bad hex).
+    case invalidColor
+    case unknown = -1
+    case transportFailure = -2
+    case cancelled = -3
+    case rejected = -4
+}
+
+extension ErrorUpdateTipCard: ServerError, TransportClassifiableError {
+    public var reportingLevel: ErrorReportingLevel {
+        switch self {
+        case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
+        case .denied, .invalidColor: .info
         case .unknown, .rejected: .error
         }
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
@@ -17,6 +17,12 @@ public struct Activity: Identifiable, Sendable, Equatable, Hashable {
     public let date: Date
     public let metadata: Metadata?
 
+    /// The ordered placeholder substitutions the server sent for `title`. `title`
+    /// is already rendered with each substitution's `fallback`; a contact-aware
+    /// layer can re-render richer names (a contact name for a phone, a display
+    /// name for a user) from these.
+    public let textSubstitutions: [TextSubstitution]
+
     public var cancellableCashLinkMetadata: CashLinkMetadata? {
         switch state {
         case .pending:
@@ -31,7 +37,7 @@ public struct Activity: Identifiable, Sendable, Equatable, Hashable {
         return nil
     }
 
-    public init(id: PublicKey, state: State, kind: Kind, title: String, exchangedFiat: ExchangedFiat, date: Date, metadata: Metadata?) {
+    public init(id: PublicKey, state: State, kind: Kind, title: String, exchangedFiat: ExchangedFiat, date: Date, metadata: Metadata?, textSubstitutions: [TextSubstitution] = []) {
         self.id = id
         self.state = state
         self.kind = kind
@@ -39,6 +45,7 @@ public struct Activity: Identifiable, Sendable, Equatable, Hashable {
         self.exchangedFiat = exchangedFiat
         self.date = date
         self.metadata = metadata
+        self.textSubstitutions = textSubstitutions
     }
 }
 
@@ -87,18 +94,69 @@ extension Activity {
     }
 }
 
+// MARK: - TextSubstitution -
+
+extension Activity {
+    /// A placeholder substitution for `title`. The server sends `title` with
+    /// positional `{0}`, `{1}`, … markers and one substitution per marker; each
+    /// carries a `fallback` used when the client can't resolve a richer value.
+    public enum TextSubstitution: Sendable, Equatable, Hashable {
+        /// Resolve a phone number to a local contact name; `fallback` is the
+        /// server-formatted number.
+        case phoneNumber(e164: String, fallback: String)
+        /// Resolve a user ID to a display name; `fallback` is a server default.
+        case userID(UserID, fallback: String)
+        /// A substitution kind this client doesn't recognize — use `fallback`.
+        case unrecognized(fallback: String)
+
+        /// The rendering used when no richer resolution is available.
+        public var fallback: String {
+            switch self {
+            case .phoneNumber(_, let fallback): fallback
+            case .userID(_, let fallback):      fallback
+            case .unrecognized(let fallback):   fallback
+            }
+        }
+    }
+}
+
+extension Activity.TextSubstitution {
+    init(_ proto: Flipcash_Common_V1_Substitution) {
+        switch proto.kind {
+        case .phoneNumberToContactName(let phone):
+            self = .phoneNumber(e164: phone.value, fallback: proto.fallback)
+        case .userIDToDisplayName(let userID):
+            if let id = try? UserID(data: userID.value) {
+                self = .userID(id, fallback: proto.fallback)
+            } else {
+                self = .unrecognized(fallback: proto.fallback)
+            }
+        case .none:
+            self = .unrecognized(fallback: proto.fallback)
+        }
+    }
+}
+
 // MARK: - Proto -
 
 extension Activity {
     init(_ proto: Flipcash_Activity_V1_Notification) throws {
+        let substitutions = proto.textSubstitutions.map(TextSubstitution.init)
         self.init(
             id: try PublicKey(proto.id.value),
             state: .init(rawValue: proto.state.rawValue) ?? .unknown,
             kind: .init(proto.additionalMetadata),
-            title: proto.localizedText,
+            // Render placeholders with each substitution's fallback so the title
+            // never shows raw `{0}` markers. `textSubstitutions` is retained for
+            // richer, contact-aware re-rendering.
+            title: SubstitutionApplier.apply(
+                template: proto.localizedText,
+                resolutions: substitutions.map(\.fallback)
+            ),
             exchangedFiat: try ExchangedFiat(proto.paymentAmount),
             date: proto.ts.date,
-            metadata: .init(proto.additionalMetadata)
+            metadata: .init(proto.additionalMetadata),
+            textSubstitutions: substitutions
         )
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Conversation.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Conversation.swift
@@ -20,22 +20,27 @@ public struct Conversation: Identifiable, Hashable, Sendable {
     public let type: ConversationType
     /// Whether the server has hidden this conversation from the feed because the counterpart is on the owner's blocklist.
     public var isHidden: Bool
+    /// The server-set title. Only populated for group chats; `nil` for DMs,
+    /// where the counterpart's name is used instead.
+    public var title: String?
 
-    public init(id: ConversationID, members: [ConversationMember], lastMessage: ConversationMessage?, lastActivity: Date, type: ConversationType = .contactDm, isHidden: Bool = false) {
+    public init(id: ConversationID, members: [ConversationMember], lastMessage: ConversationMessage?, lastActivity: Date, type: ConversationType = .contactDm, isHidden: Bool = false, title: String? = nil) {
         self.id = id
         self.members = members
         self.lastMessage = lastMessage
         self.lastActivity = lastActivity
         self.type = type
         self.isHidden = isHidden
+        self.title = title
     }
 }
 
-/// The kind of direct-message conversation, used to scope the DM feed. Raw
-/// values match the proto's `ChatType` and are what the local cache stores.
+/// The kind of conversation, used to scope the feed. Raw values match the
+/// proto's `ChatType` and are what the local cache stores.
 public enum ConversationType: Int, Sendable {
     case contactDm = 1
     case tipDm = 2
+    case group = 3
 }
 
 extension ConversationType {
@@ -43,6 +48,7 @@ extension ConversationType {
         switch self {
         case .contactDm: .contactDm
         case .tipDm:     .tipDm
+        case .group:     .group
         }
     }
 
@@ -52,6 +58,8 @@ extension ConversationType {
         switch proto {
         case .tipDm:
             self = .tipDm
+        case .group:
+            self = .group
         case .contactDm, .unknown, .UNRECOGNIZED:
             self = .contactDm
         }
@@ -66,6 +74,9 @@ extension Conversation {
         self.lastActivity = proto.hasLastActivity ? proto.lastActivity.date : .distantPast
         self.type = ConversationType(proto.type)
         self.isHidden = proto.isHidden
+        // Proto represents an unset title as an empty string; normalize to nil so
+        // DMs (which never carry a title) and untitled groups behave the same.
+        self.title = proto.title.isEmpty ? nil : proto.title
     }
 
     /// The member that isn't the signed-in user, used to title the conversation.

--- a/FlipcashCore/Sources/FlipcashCore/Models/Profile.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Profile.swift
@@ -16,7 +16,7 @@ public struct Profile: Codable, Equatable, Sendable {
         email: nil,
         joinedAt: nil
     )
-    
+
     public let displayName: String?
     public let phone: Phone?
     public let email: String?
@@ -24,6 +24,11 @@ public struct Profile: Codable, Equatable, Sendable {
 
     /// The date the user joined Flipcash, or `nil` when the server did not supply one.
     public let joinedAt: Date?
+
+    /// How the user has customized their Tip Card. `nil` when the server did not
+    /// supply one (older responses); otherwise always populated — the server
+    /// resolves defaults for anything the user hasn't customized.
+    public let tipCardCustomization: TipCardCustomization?
 
     public var isPhoneVerified: Bool {
         phone != nil
@@ -42,7 +47,7 @@ public struct Profile: Codable, Equatable, Sendable {
         phone != nil && phone?.e164 != previous?.phone?.e164
     }
 
-    public init(displayName: String?, phone: String?, email: String?, profilePicture: ProfilePicture? = nil, joinedAt: Date? = nil) throws {
+    public init(displayName: String?, phone: String?, email: String?, profilePicture: ProfilePicture? = nil, joinedAt: Date? = nil, tipCardCustomization: TipCardCustomization? = nil) throws {
 
         // Only parse phone if it's not empty
         var parsedPhone: Phone?
@@ -63,16 +68,30 @@ public struct Profile: Codable, Equatable, Sendable {
             phone: parsedPhone,
             email: normalizedEmail,
             profilePicture: profilePicture,
-            joinedAt: joinedAt
+            joinedAt: joinedAt,
+            tipCardCustomization: tipCardCustomization
         )
     }
 
-    public init(displayName: String?, phone: Phone?, email: String?, profilePicture: ProfilePicture? = nil, joinedAt: Date? = nil) {
+    public init(displayName: String?, phone: Phone?, email: String?, profilePicture: ProfilePicture? = nil, joinedAt: Date? = nil, tipCardCustomization: TipCardCustomization? = nil) {
         self.displayName = displayName
         self.phone = phone
         self.email = email
         self.profilePicture = profilePicture
         self.joinedAt = joinedAt
+        self.tipCardCustomization = tipCardCustomization
+    }
+}
+
+/// How a user has customized their Tip Card. Public — returned for any user,
+/// not just the caller.
+public struct TipCardCustomization: Codable, Equatable, Sendable {
+
+    /// The Tip Card colour as an RGB hex string (e.g. "#19191A").
+    public let colorHex: String
+
+    public init(colorHex: String) {
+        self.colorHex = colorHex
     }
 }
 
@@ -91,7 +110,19 @@ extension Profile {
             phone: proto.phoneNumber.value,
             email: proto.emailAddress.value,
             profilePicture: proto.hasProfilePicture ? ProfilePicture(proto.profilePicture) : nil,
-            joinedAt: proto.hasJoinTs ? proto.joinTs.date : nil
+            joinedAt: proto.hasJoinTs ? proto.joinTs.date : nil,
+            tipCardCustomization: proto.hasTipCardCustomization ? TipCardCustomization(proto.tipCardCustomization) : nil
         )
+    }
+}
+
+extension TipCardCustomization {
+    init(_ proto: Flipcash_Profile_V1_TipCardCustomization) {
+        self.init(colorHex: proto.color.hex)
+    }
+
+    /// The customization's colour as the `common.v1.Color` the profile service expects.
+    var colorProto: Flipcash_Common_V1_Color {
+        .with { $0.hex = colorHex }
     }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
@@ -139,6 +139,46 @@ struct ActivityProtoMappingTests {
         #expect(activity.metadata == nil)
     }
 
+    // MARK: Text substitutions
+
+    @Test("Title renders positional placeholders using each substitution's fallback")
+    func titleAppliesSubstitutionFallbacks() throws {
+        var proto = baseNotification()
+        proto.localizedText = "You received cash from {0}"
+        proto.textSubstitutions = [
+            .with {
+                $0.fallback = "+15551234567"
+                $0.phoneNumberToContactName = .with { $0.value = "+15551234567" }
+            },
+        ]
+
+        let activity = try Activity(proto)
+        #expect(activity.title == "You received cash from +15551234567")
+    }
+
+    @Test("Substitutions map phone and user-id kinds")
+    func substitutionKindsMap() throws {
+        let userUUID = UUID()
+        var proto = baseNotification()
+        proto.localizedText = "{0} and {1}"
+        proto.textSubstitutions = [
+            .with {
+                $0.fallback = "+15551234567"
+                $0.phoneNumberToContactName = .with { $0.value = "+15551234567" }
+            },
+            .with {
+                $0.fallback = "Alice"
+                $0.userIDToDisplayName = .with { $0.value = userUUID.data }
+            },
+        ]
+
+        let activity = try Activity(proto)
+        #expect(activity.textSubstitutions == [
+            .phoneNumber(e164: "+15551234567", fallback: "+15551234567"),
+            .userID(userUUID, fallback: "Alice"),
+        ])
+    }
+
     // MARK: Invalid payment amount
 
     // proto3 always materialises `paymentAmount` as a default

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
@@ -150,6 +150,36 @@ struct ConversationModelMappingTests {
         #expect(Conversation(proto).type == .contactDm)
     }
 
+    @Test("Metadata maps the group chat type and title")
+    func dmMetadataMapsGroupTypeAndTitle() {
+        let proto = Flipcash_Chat_V1_Metadata.with {
+            $0.chatID = .with { $0.value = Data(repeating: 0xAB, count: 16) }
+            $0.type = .group
+            $0.title = "Team Flipcash"
+        }
+
+        let conversation = Conversation(proto)
+        #expect(conversation.type == .group)
+        #expect(conversation.title == "Team Flipcash")
+    }
+
+    @Test("An empty title normalizes to nil (DMs never carry one)")
+    func dmMetadataEmptyTitleNormalizesToNil() {
+        let proto = Flipcash_Chat_V1_Metadata.with {
+            $0.chatID = .with { $0.value = Data(repeating: 0xAB, count: 32) }
+            $0.type = .contactDm
+        }
+
+        #expect(Conversation(proto).title == nil)
+    }
+
+    @Test("ConversationType round-trips through its proto value")
+    func conversationTypeRoundTripsThroughProto() {
+        for type in [ConversationType.contactDm, .tipDm, .group] {
+            #expect(ConversationType(type.proto) == type)
+        }
+    }
+
     @Test("Member maps the profile picture's rendition blob ids")
     func memberMapsProfilePicture() {
         let originalBlob = Data(repeating: 0x0A, count: 16)

--- a/FlipcashCore/Tests/FlipcashCoreTests/ProfileTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ProfileTests.swift
@@ -129,6 +129,35 @@ struct ProfileTests {
 
         #expect(profile.isTippable == expected)
     }
+
+    @Test("Tip card customization round-trips")
+    func tipCardCustomizationRoundTrips() throws {
+        let profile = Profile(
+            displayName: "Ted",
+            phone: Optional<Phone>.none,
+            email: nil,
+            tipCardCustomization: TipCardCustomization(colorHex: "#19191A")
+        )
+
+        let restored = try JSONDecoder().decode(
+            Profile.self,
+            from: try JSONEncoder().encode(profile)
+        )
+
+        #expect(restored.tipCardCustomization?.colorHex == "#19191A")
+    }
+
+    /// The signed-in user's profile persists as a JSON blob; `tipCardCustomization`
+    /// is optional so rows written before it still decode (to a nil customization).
+    @Test("A row persisted before tip card customization still decodes")
+    func decodesProfilePersistedBeforeTipCard() throws {
+        let legacy = Data(#"{"displayName":"Ted Livingston","email":"ted@example.com"}"#.utf8)
+
+        let profile = try JSONDecoder().decode(Profile.self, from: legacy)
+
+        #expect(profile.displayName == "Ted Livingston")
+        #expect(profile.tipCardCustomization == nil)
+    }
 }
 
 private func makeProfile(email: String? = nil, phone: String? = nil) throws -> Profile {

--- a/FlipcashCore/Tests/FlipcashCoreTests/Push/NotificationPayloadTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/Push/NotificationPayloadTests.swift
@@ -25,7 +25,7 @@ struct NotificationPayloadTests {
         let substitution = try #require(payload.titleSubstitutions.first)
         #expect(payload.titleSubstitutions.count == 1)
         #expect(substitution.fallback == "+15551234567")
-        #expect(substitution.contact.value == "+15551234567")
+        #expect(substitution.phoneNumberToContactName.value == "+15551234567")
     }
 
     @Test("Decodes a payload nested under the aps dictionary")

--- a/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
@@ -55,6 +55,7 @@ struct TransportClassificationTests {
     @Test func errorCheckEmailCode() { assertClassifies(ErrorCheckEmailCode.self) }
     @Test func errorUnlinkEmail() { assertClassifies(ErrorUnlinkEmail.self) }
     @Test func errorFetchProfile() { assertClassifies(ErrorFetchProfile.self) }
+    @Test func errorUpdateTipCard() { assertClassifies(ErrorUpdateTipCard.self) }
     @Test func errorBlocklist() { assertClassifies(ErrorBlocklist.self) }
     @Test func errorRateHistory() { assertClassifies(ErrorRateHistory.self) }
     @Test func errorGetSwap() { assertClassifies(ErrorGetSwap.self) }

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -103,22 +103,27 @@ final class NotificationService: UNNotificationServiceExtension {
             return
         }
 
-        // Only the `.contact` substitution kind ships today, resolved to a local
-        // name, or to the number itself (national format) when no contact
-        // matches — the sender is never anonymous. The server's per-substitution
-        // `fallback` is reserved for future kinds this client doesn't yet recognize.
-        let titleContacts = payload.titleSubstitutions.map { resolve($0.contact) }
+        // Phone-number substitutions resolve to a local contact name, or to the
+        // number itself (national format) when no contact matches — the sender is
+        // never anonymous. User-ID substitutions (and any kind this client doesn't
+        // yet recognize) resolve to the server's per-substitution `fallback`, since
+        // the extension can't map a user ID to a display name offline. Only the
+        // phone kind yields a resolved contact for the communication styling below.
+        let titleContacts: [ResolvedContact?] = payload.titleSubstitutions.map { substitution in
+            guard case .phoneNumberToContactName(let phone) = substitution.kind else { return nil }
+            return resolve(phone)
+        }
 
         bestAttemptContent.title = SubstitutionApplier.apply(
             template: bestAttemptContent.title,
             resolutions: zip(titleContacts, payload.titleSubstitutions).map { contact, substitution in
-                displayText(contact: contact, phone: substitution.contact)
+                displayText(contact: contact, for: substitution)
             }
         )
         bestAttemptContent.body = SubstitutionApplier.apply(
             template: bestAttemptContent.body,
             resolutions: payload.bodySubstitutions.map { substitution in
-                displayText(contact: resolve(substitution.contact), phone: substitution.contact)
+                displayText(for: substitution)
             }
         )
         bestAttemptContent.threadIdentifier = payload.groupKey
@@ -181,16 +186,30 @@ final class NotificationService: UNNotificationServiceExtension {
         delivery.deliver()
     }
 
-    /// The substitution display: the matched contact's name, else the number
-    /// itself in national format (e.g. "(747) 217-6923"), falling back to the
-    /// raw E.164.
-    private func displayText(contact: ResolvedContact?, phone: Flipcash_Phone_V1_PhoneNumber) -> String {
-        contact?.name ?? Phone(phone.value)?.national ?? phone.value
+    /// The display for a substitution given an already-resolved contact (the
+    /// title path resolves contacts up front to also pick the communication
+    /// sender). Phone-number kinds show the contact's name, else the number in
+    /// national format (e.g. "(747) 217-6923"), else the raw E.164. Any other
+    /// kind falls back to the substitution's server-provided `fallback`.
+    private func displayText(contact: ResolvedContact?, for substitution: Flipcash_Common_V1_Substitution) -> String {
+        guard case .phoneNumberToContactName(let phone) = substitution.kind else {
+            return substitution.fallback
+        }
+        return contact?.name ?? Phone(phone.value)?.national ?? phone.value
+    }
+
+    /// The display for a substitution, resolving the contact on demand (body
+    /// path). Delegates to the pre-resolved variant once the contact is known.
+    private func displayText(for substitution: Flipcash_Common_V1_Substitution) -> String {
+        guard case .phoneNumberToContactName(let phone) = substitution.kind else {
+            return substitution.fallback
+        }
+        return displayText(contact: resolve(phone), for: substitution)
     }
 
     /// Returns the contact matching `phone`, or `nil` if no contact matches, the
     /// contact has no usable name, or Contacts permission is unavailable.
-    private func resolve(_ phone: Flipcash_Phone_V1_PhoneNumber) -> ResolvedContact? {
+    private func resolve(_ phone: Flipcash_Common_V1_PhoneNumber) -> ResolvedContact? {
         let predicate = CNContact.predicateForContacts(
             matching: CNPhoneNumber(stringValue: phone.value)
         )


### PR DESCRIPTION
## What

Syncs the flipcash2 **core** protos and adopts the new surface across the app. Payments (ocp) protos regenerated identically — no change.

The dominant proto change is a **consolidation of shared value types into `common/v1`**: `PhoneNumber`, `EmailAddress`, and `Substitution` move out of `phone/v1`/`email/v1`/`push/v1`, and `Substitution.contact` becomes a `kind` oneof (`phoneNumberToContactName` + a new `userIdToDisplayName`). On top of that, several new fields/RPCs are adopted.

## Commits (reviewable in order)

1. **`chore: sync core protos`** — regenerated `Generated/` + re-vendored `proto/`.
2. **`fix: adopt relocated common types and Substitution oneof`** — build-restoring reference updates (`ContactListService`, `NotificationService`, one test). User-id / unrecognized substitution kinds render the server `fallback` (the notification extension can't resolve a user id offline).
3. **`feat: scaffold UpdateTipCard RPC and tip card customization`** — `ProfileService.updateTipCard` + `ErrorUpdateTipCard`, `FlipClient` wrapper, and `Profile.tipCardCustomization` (previously dropped on decode).
4. **`feat: support group chats (type and title)`** — real `ConversationType.group` (was a `.contactDm` stopgap), `Conversation.title`, `displayName` prefers it, and the newly-exhaustive switches handled (`SendTarget`, `DeepLinkController`, `Events` → `"Group"`, matching Android).
5. **`feat: plumb activity text substitutions`** — `Activity.textSubstitutions`; the title now renders `{0}` placeholders via each substitution's `fallback` so raw markers never surface.
6. **`feat: cache user profiles in their own table`** — a keyed `user_profile` table (matching Android's move), `Database+UserProfiles`, a `Session` cache API, cache-through at `UserProfileScreen`/`TipFlow`, and `SQLiteVersion` 29 → 30.

## Notes

- **One PR, not several:** the pieces share the regenerated generated files, `Schema.swift`, and `Conversation.swift`, so they can't cleanly split into independent parallel PRs. Commits are scoped for sequential review.
- **Profile cache shape:** stored as a JSON blob keyed by userID (iOS's existing profile-table convention) rather than Android's decomposed columns — reads are only ever by-key.
- **Left as follow-up:** wiring the blocklist profile fetch into the shared cache (it already persists its own name+avatar row, so caching the full profile there is redundant).
- **Build note:** `./Scripts/build.sh` currently fails at SPM dependency resolution (auto-updates into a swift-nio-extras / swift-http-types traits conflict). Built/tested with `-onlyUsePackageVersionsFromResolvedFile -disableAutomaticPackageResolution` to honor the pinned `Package.resolved`. Pre-existing and unrelated to this change.

## Test plan

- `xcodebuild build` (app) — **BUILD SUCCEEDED**.
- Affected suites pass, incl. 7 new tests: `ProfileTests`, `ConversationModelMappingTests`, `ActivityProtoMappingTests`, `TransportClassificationTests`, `NotificationPayloadTests`.
