### PR TITLE
feat(wallet): recent activity preview

### DIFF
--- a/Flipcash/Core/Controllers/Database/Database+Activities.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Activities.swift
@@ -80,6 +80,8 @@ nonisolated extension Database {
             a.currency,
             a.mint,
             a.date,
+            a.counterpartyUserID,
+            a.counterpartyPhone,
 
             c.vault,
             c.canCancel
@@ -94,42 +96,76 @@ nonisolated extension Database {
         LIMIT 1024;
         """, bindings: Blob(bytes: mint.bytes))
         
-        let a = ActivityTable()
-        
-        let activities = try statement.map { row in
-            let kind = Activity.Kind(rawValue: row[a.kind])!
-            let mint = row[a.mint]
-            let currency = row[a.currency]
-            let onChain = TokenAmount(quarks: row[a.quarks], mint: mint)
-            let nativeAmount = FiatAmount(
-                value: Decimal(row[a.nativeAmount]),
-                currency: currency,
-            )
-            // Synthesize the FX rate from the stored amounts. For USDF this is
-            // the correct native-per-USD FX; for bonded mints it is a per-token
-            // rate (the proto doesn't carry an exchange rate on this surface,
-            // and storing one is out of scope for this fix).
-            let fx: Decimal = onChain.decimalValue > 0
-                ? nativeAmount.value / onChain.decimalValue
-                : 1
-            return Activity.init(
-                id: row[a.id],
-                state: .init(rawValue: row[a.state]) ?? .unknown,
-                kind: kind,
-                title: row[a.title],
-                exchangedFiat: ExchangedFiat(
-                    onChainAmount: onChain,
-                    nativeAmount: nativeAmount,
-                    currencyRate: Rate(fx: fx, currency: currency),
-                ),
-                date: row[a.date],
-                metadata: metadata(for: kind, row: row)
-            )
-        }
-        
-        return activities
+        return try statement.map(makeActivity)
     }
-    
+
+    /// The unified, cross-mint recent activity for the wallet preview: the newest
+    /// `limit` activities regardless of token. `getActivities(mint:)` is the
+    /// per-token slice; this is the "everything" feed.
+    func getRecentActivities(limit: Int) throws -> [Activity] {
+        let statement = try reader.prepareRowIterator("""
+        SELECT
+            a.id,
+            a.kind,
+            a.state,
+            a.title,
+            a.quarks,
+            a.nativeAmount,
+            a.currency,
+            a.mint,
+            a.date,
+            a.counterpartyUserID,
+            a.counterpartyPhone,
+
+            c.vault,
+            c.canCancel
+
+        FROM activity a
+
+        LEFT JOIN cashLinkMetadata c ON c.id = a.id
+
+        ORDER BY a.date DESC
+        LIMIT ?;
+        """, bindings: limit)
+
+        return try statement.map(makeActivity)
+    }
+
+    /// Maps a joined activity row into an ``Activity``. Shared by the per-mint
+    /// and cross-mint queries, which select the same columns.
+    private func makeActivity(_ row: RowIterator.Element) -> Activity {
+        let a = ActivityTable()
+        let kind = Activity.Kind(rawValue: row[a.kind])!
+        let mint = row[a.mint]
+        let currency = row[a.currency]
+        let onChain = TokenAmount(quarks: row[a.quarks], mint: mint)
+        let nativeAmount = FiatAmount(
+            value: Decimal(row[a.nativeAmount]),
+            currency: currency,
+        )
+        // Synthesize the FX rate from the stored amounts. For USDF this is
+        // the correct native-per-USD FX; for bonded mints it is a per-token
+        // rate (the proto doesn't carry an exchange rate on this surface,
+        // and storing one is out of scope for this fix).
+        let fx: Decimal = onChain.decimalValue > 0
+            ? nativeAmount.value / onChain.decimalValue
+            : 1
+        return Activity(
+            id: row[a.id],
+            state: .init(rawValue: row[a.state]) ?? .unknown,
+            kind: kind,
+            title: row[a.title],
+            exchangedFiat: ExchangedFiat(
+                onChainAmount: onChain,
+                nativeAmount: nativeAmount,
+                currencyRate: Rate(fx: fx, currency: currency),
+            ),
+            date: row[a.date],
+            metadata: metadata(for: kind, row: row),
+            counterparty: Activity.Counterparty(userID: row[a.counterpartyUserID], phone: row[a.counterpartyPhone])
+        )
+    }
+
     private func metadata(for kind: Activity.Kind, row: RowIterator.Element) -> Activity.Metadata? {
         switch kind {
         case .gave, .received, .withdrew, .deposited, .paid, .distributed, .bought, .sold, .unknown:
@@ -166,7 +202,9 @@ nonisolated extension Database {
                 table.currency     <- activity.exchangedFiat.nativeAmount.currency,
                 table.mint         <- activity.exchangedFiat.mint,
                 table.date         <- activity.date,
-                
+                table.counterpartyUserID <- activity.counterparty?.userID,
+                table.counterpartyPhone  <- activity.counterparty?.phone,
+
                 onConflictOf: table.id,
             )
         )

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -67,6 +67,10 @@ nonisolated struct ActivityTable: Sendable {
     let currency     = Expression <CurrencyCode> ("currency")
     let mint         = Expression <PublicKey>    ("mint")
     let date         = Expression <Date>         ("date")
+    // The peer on a send/receive, for feed-row avatar + name enrichment. Both
+    // nil for non-peer activity (deposits, buys, withdrawals).
+    let counterpartyUserID = Expression <UUID?>   ("counterpartyUserID")
+    let counterpartyPhone  = Expression <String?> ("counterpartyPhone")
 }
 
 nonisolated struct CashLinkMetadataTable: Sendable {
@@ -309,6 +313,8 @@ nonisolated extension Database {
                 t.column(activityTable.currency)
                 t.column(activityTable.mint)
                 t.column(activityTable.date)
+                t.column(activityTable.counterpartyUserID)
+                t.column(activityTable.counterpartyPhone)
             })
         }
         

--- a/Flipcash/Core/Screens/Main/Home/WalletActivityRow.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletActivityRow.swift
@@ -1,0 +1,145 @@
+//
+//  WalletActivityRow.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+import FlipcashCore
+
+/// A single row in the v2 Wallet's "Recent" activity preview (Figma 8966:1910,
+/// ported from Android's `ActivityFeedRow`): a 40pt avatar, the title + relative
+/// time, and a signed amount. The avatar is the counterparty's profile photo for
+/// peer activity (tips/sends), the token image for token activity (deposits,
+/// buys), or a monogram fallback. A sent tip reads "Tipped <name>" once the
+/// counterparty resolves.
+struct WalletActivityRow: View {
+
+    let activity: Activity
+    var onTap: () -> Void = {}
+
+    @Environment(SessionContainer.self) private var sessionContainer
+    private var session: Session { sessionContainer.session }
+
+    /// The counterparty's resolved display name (cached profile / contact).
+    @State private var counterpartyName: String?
+    /// The counterparty's resolved avatar bytes + blurhash.
+    @State private var avatarData: Data?
+    @State private var avatarBlurhash: String?
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                avatar
+                    .frame(width: 40, height: 40)
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(displayTitle)
+                        .font(.appTextMedium)
+                        .foregroundStyle(Color.textMain)
+                        .lineLimit(1)
+                    Text(activity.date.formattedRelatively(useTimeForToday: true))
+                        .font(.appTextSmall)
+                        .foregroundStyle(Color.textSecondary)
+                }
+
+                Spacer(minLength: 8)
+
+                Text(signedAmount)
+                    .font(.appTextMedium)
+                    .foregroundStyle(Color.textMain)
+                    .lineLimit(1)
+            }
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .task(id: activity.id) { await resolveCounterparty() }
+    }
+
+    // MARK: - Title
+
+    /// Peer tips render with the resolved counterparty name — "Tipped <name>"
+    /// for a sent tip, "Tip from <name>" for a received one — once it resolves;
+    /// every other row uses the server-rendered title.
+    private var displayTitle: String {
+        if let name = counterpartyName, !name.isEmpty {
+            switch activity.kind {
+            case .gave:     return "Tipped \(name)"
+            case .received: return "Tip from \(name)"
+            default:        break
+            }
+        }
+        return activity.title
+    }
+
+    // MARK: - Avatar
+
+    @ViewBuilder private var avatar: some View {
+        switch activity.counterparty {
+        case .user(let userID):
+            ContactAvatarView(
+                id: userID.uuidString,
+                displayName: counterpartyName ?? "",
+                imageData: avatarData,
+                blurhash: avatarBlurhash,
+                size: 40
+            )
+        case .phone(let e164):
+            ContactAvatarView(
+                id: e164,
+                displayName: counterpartyName ?? "",
+                imageData: avatarData,
+                size: 40
+            )
+        case .none:
+            tokenOrGenericAvatar()
+        }
+    }
+
+    @ViewBuilder private func tokenOrGenericAvatar() -> some View {
+        if let token = session.balance(for: activity.exchangedFiat.mint), let url = token.imageURL {
+            RemoteImage(url: url)
+        } else {
+            ContactAvatarView(id: activity.id.base58, displayName: "", size: 40)
+        }
+    }
+
+    // MARK: - Amount
+
+    private var signedAmount: String {
+        let formatted = activity.exchangedFiat.nativeAmount.formatted()
+        switch activity.kind {
+        case .received, .deposited, .bought, .distributed, .sold:
+            return "+\(formatted)"
+        case .gave, .withdrew, .cashLink, .paid:
+            return "-\(formatted)"
+        case .unknown:
+            return formatted
+        }
+    }
+
+    // MARK: - Resolution
+
+    /// Resolves the counterparty's name and avatar: a cached profile (+ fetched
+    /// thumbnail) for a user, or an address-book contact for a phone number.
+    /// Uncached counterparties fall back to the server title + a monogram.
+    private func resolveCounterparty() async {
+        switch activity.counterparty {
+        case .user(let userID):
+            let profile = session.cachedUserProfile(for: userID)
+            counterpartyName = profile?.displayName
+            avatarBlurhash = profile?.profilePicture?.thumbnailBlurhash
+            guard let picture = profile?.profilePicture else { return }
+            await sessionContainer.tipAvatars.load(userID: userID, picture: picture)
+            avatarData = sessionContainer.tipAvatars.data(for: userID)
+        case .phone(let e164):
+            let contact = sessionContainer.contactSyncController.resolvedContacts.onFlipcash.first { $0.phoneE164 == e164 }
+            counterpartyName = contact?.displayName
+            avatarData = contact?.imageData
+        case .none:
+            break
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -46,7 +46,13 @@ private struct WalletScreenContent: View {
     @State private var appreciation: (amount: FiatAmount, isPositive: Bool)
     @State private var hasAddedMoney: Bool
     @State private var hasTipped: Bool
+    /// The unified recent-activity preview (newest first).
+    @State private var recentActivities: [Activity]
     @State private var scrolledPast: CGFloat = 0
+
+    /// Rows of recent activity previewed on the wallet (the rest lives on the
+    /// per-token transaction history).
+    private static let recentPreviewCount = 3
     /// The height of everything above the card stack (header + funnel) — the
     /// scroll distance before the stack reaches the top. Collapse starts past it.
     @State private var headerHeight: CGFloat = 150
@@ -65,6 +71,7 @@ private struct WalletScreenContent: View {
         _appreciation = State(initialValue: seed.appreciation)
         _hasAddedMoney = State(initialValue: seed.hasAddedMoney)
         _hasTipped = State(initialValue: seed.hasTipped)
+        _recentActivities = State(initialValue: sessionContainer.session.recentActivities(limit: Self.recentPreviewCount))
     }
 
     private var rate: Rate { ratesController.rateForBalanceCurrency() }
@@ -89,13 +96,18 @@ private struct WalletScreenContent: View {
             .onAppear { historyController.sync() }
             .onChange(of: session.balances) { _, _ in refresh() }
             .onChange(of: rate) { _, _ in refresh() }
+            // Activities land in the DB independently of a balance change (e.g.
+            // a synced history page), so reload the preview on any DB change.
+            .onReceive(NotificationCenter.default.publisher(for: .databaseDidChange)) { _ in
+                recentActivities = session.recentActivities(limit: Self.recentPreviewCount)
+            }
         }
     }
 
     // MARK: - Content
 
     private var walletContent: some View {
-        ScrollView {
+        ScrollView(.vertical, showsIndicators: false) {
             VStack(spacing: 0) {
                 // Header + funnel scroll off before the stack collapses, so their
                 // combined height (scroll-independent, measured once at layout) is
@@ -132,6 +144,10 @@ private struct WalletScreenContent: View {
                 if hasAddedMoney {
                     addMoneyButton
                         .padding(.top, 24)
+                }
+
+                if !recentActivities.isEmpty {
+                    recentActivitySection
                 }
 
                 // Bottom inset so the last card clears the floating tab bar.
@@ -172,6 +188,23 @@ private struct WalletScreenContent: View {
             .frame(maxWidth: .infinity)
         }
         .buttonStyle(.plain)
+    }
+
+    private var recentActivitySection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Recent")
+                .font(.appTextLarge)
+                .foregroundStyle(Color.textMain)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 24)
+                .padding(.bottom, 4)
+
+            ForEach(recentActivities) { activity in
+                WalletActivityRow(activity: activity) {
+                    router.push(.transactionHistory(activity.exchangedFiat.mint))
+                }
+            }
+        }
     }
 
     private func handleOnboardingTap(_ item: OnboardingItem) {

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -152,6 +152,12 @@ class Session {
         updateableBalances.value.first { $0.mint == mint }
     }
 
+    /// The newest `limit` activities across all tokens — the unified feed shown
+    /// as the wallet's "Recent Activity" preview.
+    func recentActivities(limit: Int) -> [Activity] {
+        (try? database.getRecentActivities(limit: limit)) ?? []
+    }
+
     /// Whether the caller has ever added money (a completed deposit or buy) —
     /// the wallet onboarding "add money" milestone. Derived from durable history,
     /// so it stays true after the balance is spent.

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 		<string>com.flipcash.app.openChat</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>30</integer>
+	<integer>31</integer>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
@@ -23,6 +23,11 @@ public struct Activity: Identifiable, Sendable, Equatable, Hashable {
     /// name for a user) from these.
     public let textSubstitutions: [TextSubstitution]
 
+    /// The other party in a peer activity (the recipient of a send/tip, the
+    /// sender of a received tip). `nil` for non-peer activity (deposits, buys,
+    /// withdrawals). Used to resolve an avatar and a richer name in feed rows.
+    public let counterparty: Counterparty?
+
     public var cancellableCashLinkMetadata: CashLinkMetadata? {
         switch state {
         case .pending:
@@ -37,7 +42,7 @@ public struct Activity: Identifiable, Sendable, Equatable, Hashable {
         return nil
     }
 
-    public init(id: PublicKey, state: State, kind: Kind, title: String, exchangedFiat: ExchangedFiat, date: Date, metadata: Metadata?, textSubstitutions: [TextSubstitution] = []) {
+    public init(id: PublicKey, state: State, kind: Kind, title: String, exchangedFiat: ExchangedFiat, date: Date, metadata: Metadata?, textSubstitutions: [TextSubstitution] = [], counterparty: Counterparty? = nil) {
         self.id = id
         self.state = state
         self.kind = kind
@@ -46,6 +51,50 @@ public struct Activity: Identifiable, Sendable, Equatable, Hashable {
         self.date = date
         self.metadata = metadata
         self.textSubstitutions = textSubstitutions
+        self.counterparty = counterparty
+    }
+}
+
+// MARK: - Counterparty -
+
+extension Activity {
+    /// The other party in a peer activity, as identified by the server.
+    public enum Counterparty: Sendable, Equatable, Hashable {
+        case user(UserID)
+        case phone(String)
+
+        public var userID: UserID? { if case .user(let id) = self { return id } else { return nil } }
+        public var phone: String? { if case .phone(let value) = self { return value } else { return nil } }
+
+        /// Rebuilds a counterparty from its persisted columns.
+        public init?(userID: UserID?, phone: String?) {
+            if let userID { self = .user(userID) }
+            else if let phone { self = .phone(phone) }
+            else { return nil }
+        }
+    }
+}
+
+extension Activity.Counterparty {
+    /// Extracts the counterparty from a send/receive notification's identifier
+    /// oneof; `nil` for metadata kinds that have no counterparty.
+    init?(_ proto: Flipcash_Activity_V1_Notification.OneOf_AdditionalMetadata?) {
+        switch proto {
+        case .directlySentCrypto(let metadata):
+            switch metadata.destinationIdentifier {
+            case .userID(let user): guard let id = try? UserID(data: user.value) else { return nil }; self = .user(id)
+            case .phone(let phone): self = .phone(phone.value)
+            case .none:             return nil
+            }
+        case .receivedCrypto(let metadata):
+            switch metadata.sourceIdentifier {
+            case .userID(let user): guard let id = try? UserID(data: user.value) else { return nil }; self = .user(id)
+            case .phone(let phone): self = .phone(phone.value)
+            case .none:             return nil
+            }
+        case .withdrewCrypto, .indirectlySentCrypto, .depositedCrypto, .boughtCrypto, .soldCrypto, .none:
+            return nil
+        }
     }
 }
 
@@ -156,7 +205,8 @@ extension Activity {
             exchangedFiat: try ExchangedFiat(proto.paymentAmount),
             date: proto.ts.date,
             metadata: .init(proto.additionalMetadata),
-            textSubstitutions: substitutions
+            textSubstitutions: substitutions,
+            counterparty: .init(proto.additionalMetadata)
         )
     }
 }


### PR DESCRIPTION
## What

Adds the **"Recent" activity preview** to the v2 Wallet (below the Add Money affordance) — the newest 3 activities across all tokens, ported from Android's wallet feed. Each row is enriched with the tipper's name + photo and token images/names.

Off `main` (all three v2 PRs merged).

## Changes

**Model + persistence**
- `Activity.Counterparty` (`.user(UserID)` / `.phone(String)`), extracted from the send/receive notification's identifier oneof.
- Persisted on the `activity` table (`counterpartyUserID` / `counterpartyPhone`) so DB-loaded rows can resolve an avatar + name without the (unpersisted) text substitutions. `SQLiteVersion` 30 → 31.
- `Database.getRecentActivities(limit:)` — the unified, cross-token feed.

**Wallet UI**
- `WalletActivityRow` — 40pt avatar (counterparty profile photo for tips, token image for deposits/buys, monogram fallback), title, relative timestamp, signed amount (± by kind).
- Tip titles resolve the counterparty name: **"Tipped {name}"** (sent) / **"Tip from {name}"** (received), falling back to the server title until the profile resolves.
- The "Recent" section reloads on `databaseDidChange`. Row tap → `router.push(.transactionHistory(mint))`.
- Hides the wallet scroll indicator.

## Testing

- `xcodebuild build`: **SUCCEEDED**.
- Verified on a populated account: enriched rows render with counterparty avatars/names, token images, and correct signed amounts.
