### PR TITLE
feat(tipcard): v2 tip card screen + menu button

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
@@ -107,7 +107,7 @@ private struct TipCardTab: View {
     var body: some View {
         NavigationStack {
             if sessionContainer.session.profile?.isTippable == true {
-                TipcardScreen()
+                TipcardScreen(isEmbedded: true)
             } else {
                 TipCardSetupPrompt(onSetUp: onSetUp)
             }

--- a/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
@@ -13,6 +13,12 @@ struct TipcardScreen: View {
 
     @Environment(Container.self) private var container
     @Environment(SessionContainer.self) private var sessionContainer
+    @Environment(AppRouter.self) private var router
+
+    /// The v2 tab presentation (Figma 8966:2745): a bare centered card with a
+    /// menu button, no header/nav. Defaults to false — the v1 push keeps its
+    /// header, share row, and nav title.
+    var isEmbedded: Bool = false
 
     @State private var avatar: UIImage?
     @State private var exportImage: Image?
@@ -26,59 +32,94 @@ struct TipcardScreen: View {
 
     var body: some View {
         Background(color: .backgroundMain) {
-            VStack(spacing: 0) {
-                Text("Share Your Tip Card to Get Tipped")
-                    .font(.appTextLarge)
-                    .foregroundStyle(Color.textMain)
-                    .multilineTextAlignment(.center)
-                    .padding(.top, 20)
-                    .padding(.horizontal, 20)
-
-                Spacer()
-
-                card
-
-                Spacer()
-
-                HStack(spacing: 40) {
-                    Button {
-                        shareTipCard()
-                    } label: {
-                        TipcardAction(icon: .Icons.share, title: "Share")
-                    }
-                    .accessibilityIdentifier("tipcard-share-button")
-
-//                    // Always present so the row never reflows; disabled until
-//                    // the card has rendered with the photo — `ImageRenderer`
-//                    // is synchronous, so an earlier export would bake in the
-//                    // placeholder.
-//                    if let exportImage {
-//                        ShareLink(
-//                            item: exportImage,
-//                            preview: SharePreview("My Tipcard", image: exportImage)
-//                        ) {
-//                            TipcardAction(icon: .Icons.export, title: "Export")
-//                        }
-//                        .accessibilityIdentifier("tipcard-export-button")
-//                    } else {
-//                        TipcardAction(icon: .Icons.export, title: "Export")
-//                            .opacity(0.4)
-//                            .accessibilityIdentifier("tipcard-export-button")
-//                            .accessibilityAddTraits(.isButton)
-//                            .accessibilityHint("Preparing the card image")
-//                    }
-                }
-                .padding(.bottom, 40)
+            if isEmbedded {
+                embeddedContent
+            } else {
+                legacyContent
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .navigationTitle("My Tip Card")
+        .navigationTitle(isEmbedded ? "" : "My Tip Card")
+        .toolbar(isEmbedded ? .hidden : .automatic, for: .navigationBar)
         .toolbarTitleDisplayMode(.inline)
         .task(id: profilePicture?.thumbnailBlobID) {
             previewCache.warm(TipCode.Payload(userID: sessionContainer.session.userID))
             await loadAvatar()
             renderExportImage()
         }
+    }
+
+    // MARK: - v2 (embedded) -
+
+    /// The Figma v2 tip card: the card centered, tap-to-share, with a menu button
+    /// in the top-right (the v1 scanner's settings entry, brought here so the v2
+    /// tab-bar UI has a way into Settings).
+    private var embeddedContent: some View {
+        ZStack(alignment: .top) {
+            VStack(spacing: 0) {
+                Spacer()
+                card?
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: shareTipCard)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            HStack {
+                Spacer()
+                settingsButton
+            }
+            .padding(.horizontal, 20)
+        }
+    }
+
+    private var settingsButton: some View {
+        Button {
+            router.present(.settings)
+        } label: {
+            if #available(iOS 26, *) {
+                Image.asset(.hamburger)
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(Color.textMain)
+                    .frame(width: 32, height: 32)
+            } else {
+                Image.asset(.hamburger)
+                    .foregroundStyle(Color.textMain)
+                    .frame(width: 44, height: 44)
+            }
+        }
+        .liquidGlassButtonStyle(shape: .circle)
+        .accessibilityLabel("Settings")
+    }
+
+    // MARK: - v1 (pushed) -
+
+    private var legacyContent: some View {
+        VStack(spacing: 0) {
+            Text("Share Your Tip Card to Get Tipped")
+                .font(.appTextLarge)
+                .foregroundStyle(Color.textMain)
+                .multilineTextAlignment(.center)
+                .padding(.top, 20)
+                .padding(.horizontal, 20)
+
+            Spacer()
+
+            card
+
+            Spacer()
+
+            HStack(spacing: 40) {
+                Button {
+                    shareTipCard()
+                } label: {
+                    TipcardAction(icon: .Icons.share, title: "Share")
+                }
+                .accessibilityIdentifier("tipcard-share-button")
+            }
+            .padding(.bottom, 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Content -


### PR DESCRIPTION
## What

Updates the **Tip Card tab** to match the Figma v2 design (node 8966:2745) and adds a menu button that gives the v2 tab-bar UI its first way into Settings.

Off `main`.

## Changes

- `TipcardScreen(isEmbedded:)` — in the v2 tab, the card is centered on its own (tap it to share), with **no** "Share Your Tip Card…" header, share-button row, or nav title, matching Figma. The v1 pushed presentation (from Tips → "Show My Tip Card") is unchanged: header, share button, and "My Tip Card" title.
- **Menu (hamburger) button** top-right — the same control as the v1 scanner's top bar (glass circle) — wired to `router.present(.settings)`. Since hiding the scanner chrome removed the only Settings entry point in v2, this restores access to Settings/logout from the Tip Card tab for now.
