### PR TITLE
feat(bills): render bills and tipcards over all content at the app root

### DIFF
--- a/Flipcash/Core/ContainerScreen.swift
+++ b/Flipcash/Core/ContainerScreen.swift
@@ -34,14 +34,24 @@ struct ContainerScreen: View {
                     .transition(.opacity)
 
                 case .loggedIn(let sessionContainer):
-                    Group {
-                        if betaFlags.hasEnabled(.newUI) {
-                            HomeTabView()
-                        } else {
-                            ScanScreen()
+                    ZStack {
+                        Group {
+                            if betaFlags.hasEnabled(.newUI) {
+                                HomeTabView()
+                            } else {
+                                ScanScreen()
+                            }
                         }
+                        .modifier(OnrampHostModifier())
+
+                        // Bills / tipcards render at the app root (over both the v1
+                        // scanner and the v2 tab bar) so a bill set by a push or deep
+                        // link appears over whatever tab is showing, not buried in the
+                        // unmounted Scan tab. Mirrors Android's app-root BillOverlay.
+                        // Kept a sibling *inside* the injected scope (rather than an
+                        // `.overlay` on the Group) so it inherits `SessionContainer`.
+                        BillOverlayView()
                     }
-                    .modifier(OnrampHostModifier())
                     .injectingEnvironment(from: sessionContainer)
                     .transition(.opacity)
                 }

--- a/Flipcash/Core/Screens/Main/Bill/BillOverlayView.swift
+++ b/Flipcash/Core/Screens/Main/Bill/BillOverlayView.swift
@@ -1,0 +1,261 @@
+//
+//  BillOverlayView.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+import FlipcashCore
+
+/// Renders the cash bill / tipcard (plus the bill designer and the
+/// received-cash / send-tip sheets) at the app root, so a presented bill appears
+/// over ANY content — mirroring Android's app-root `BillOverlay`. It is driven
+/// entirely by the app-scoped `session.billState`, so a cash-link push or deep
+/// link that sets a bill while the user is on the Wallet/Chat/Tip Card tab now
+/// renders on screen instead of in the buried Scan tab.
+///
+/// Mounted once by `ContainerScreen`, above both the v1 scanner root and the v2
+/// `HomeTabView`. It is transparent and non-interactive when no bill is present.
+struct BillOverlayView: View {
+
+    @Environment(SessionContainer.self) private var sessionContainer
+
+    var body: some View {
+        BillOverlayContent(sessionContainer: sessionContainer)
+    }
+}
+
+private struct BillOverlayContent: View {
+
+    @Bindable private var session: Session
+    private let sessionContainer: SessionContainer
+
+    /// Primary bill-action button loading state; outlives individual bills.
+    @State private var sendButtonState: ButtonState = .normal
+    @State private var sendButtonTask: Task<Void, Never>?
+    @State private var billDesignerColors: [Color] = ColorEditorControl.randomDerivedColors()
+    /// The Send-a-Tip sheet's measured height, used to raise the tipcard clear of it.
+    @State private var tipSheetHeight: CGFloat = 0
+
+    init(sessionContainer: SessionContainer) {
+        self.sessionContainer = sessionContainer
+        self.session          = sessionContainer.session
+    }
+
+    var body: some View {
+        // The bill surface keeps `.ignoresSafeArea()` on itself, not on this root:
+        // as a sibling of the tab NavigationStacks, an overlay whose *root* ignored
+        // the safe area would flatten the Liquid Glass of the nav bars beneath it
+        // on iOS 26. Nested one level down, the bill still fills the screen while
+        // the bars keep their glass. The received-cash / send-tip sheets host here
+        // (a `.sheet` modifier adds nothing to the layer tree until it presents).
+        ZStack {
+            billSurface
+        }
+        // Reset button state on bill dismissal — `sendButtonState` outlives
+        // individual bills.
+        .onChange(of: session.billState.bill) { _, newBill in
+            guard newBill == nil else { return }
+            sendButtonTask?.cancel()
+            sendButtonTask = nil
+            sendButtonState = .normal
+        }
+        .sheet(item: $session.valuation) { valuation in
+            PartialSheet(background: .clear, canAccessBackground: true) {
+                ModalCashReceived(
+                    title: "You received",
+                    fiat: valuation.exchangedFiat.nativeAmount,
+                    currencyName: valuation.mintMetadata?.name ?? "currency",
+                    currencyImageURL: valuation.mintMetadata?.imageURL,
+                    actionTitle: "Put in Wallet",
+                    dismissAction: dismissBill
+                )
+            }
+            .interactiveDismissDisabled()
+        }
+        // Send a Tip over the scanned tipcard. A swipe-down cancels the whole
+        // flow — the card comes down with the sheet.
+        .sheet(isPresented: Binding(
+            get: { sessionContainer.tipFlow.isSheetPresented },
+            set: { isPresented in
+                if !isPresented {
+                    sessionContainer.tipFlow.cancel()
+                }
+            }
+        )) {
+            PartialSheet(
+                background: Color(red: 0.1, green: 0.1, blue: 0.1).opacity(0.7),
+                canAccessBackground: true
+            ) {
+                SendTipSheet(tipFlow: sessionContainer.tipFlow)
+                    // The sheet content's intrinsic height — the value
+                    // `PartialSheet` feeds its `.height` detent, so the sheet's
+                    // top sits at `screenHeight` minus this. Measured on the
+                    // content (not the detent-driven container, which briefly
+                    // fills the screen on present) so the tipcard's clearance is
+                    // stable and the card is nudged rather than flung.
+                    .background {
+                        GeometryReader { proxy in
+                            Color.clear
+                                .onAppear { tipSheetHeight = proxy.size.height }
+                                .onChange(of: proxy.size.height) { _, height in tipSheetHeight = height }
+                        }
+                    }
+            }
+        }
+    }
+
+    // MARK: - Surface -
+
+    /// A dimmed backdrop is drawn behind a bill/tipcard when it is presented over
+    /// a non-scanner surface (a wallet/chat push, a received cash link) so the
+    /// underlying screen recedes, matching Android. Over the scanner the camera
+    /// stays visible instead — no scrim.
+    private var showsScrim: Bool {
+        session.isShowingBill && !session.isScannerForeground
+    }
+
+    /// The full-screen bill surface. The `BillCanvas` is always mounted (parked
+    /// off-screen when idle) so it can drive the slide/pop in and out animations.
+    private var billSurface: some View {
+        ZStack {
+            if showsScrim {
+                Color.black.opacity(0.6)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+            }
+
+            billView()
+
+            if session.billState.bill != nil {
+                billActions()
+                    .zIndex(1)
+                    .transition(.opacity)
+            }
+
+            if session.isShowingBillDesigner {
+                BillDesignerOverlay(colors: $billDesignerColors)
+                    .zIndex(2)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .ignoresSafeArea()
+        .animation(.easeInOut(duration: 0.15), value: session.billState.bill == nil)
+        // Ramp the scrim with the bill's slide-in (BillCanvas uses a 0.6s spring),
+        // so the backdrop and the card arrive together.
+        .animation(.spring(response: 0.6, dampingFraction: 0.6), value: showsScrim)
+        .animation(.spring(response: 0.4, dampingFraction: 0.85), value: session.isShowingBillDesigner)
+    }
+
+    // MARK: - Bill -
+
+    @ViewBuilder private func billView() -> some View {
+        BillCanvas(
+            state: session.presentationState,
+            centerOffset: billCenterOffset(),
+            preferredCanvasSize: preferredCanvasSize(),
+            bill: session.billState.bill,
+            dismissHandler: dismissBill
+        )
+        .allowsHitTesting(session.presentationState.isPresenting)
+        .ignoresSafeArea()
+    }
+
+    /// The resting vertical offset for the centered bill; a tipcard rises from
+    /// here only when the Send a Tip sheet would crowd it.
+    private static let restingBillOffset = CGSize(width: 0, height: -30)
+
+    /// The gap kept between the tipcard's bottom edge and the sheet's top edge.
+    private static let tipcardSheetGap: CGFloat = 42
+
+    private func billCenterOffset() -> CGSize {
+        switch session.billState.bill {
+        case .tipcard where sessionContainer.tipFlow.isSheetPresented:
+            tipcardSheetOffset()
+        case .tipcard, .cash, nil:
+            Self.restingBillOffset
+        }
+    }
+
+    private func tipcardSheetOffset() -> CGSize {
+        guard tipSheetHeight > 0,
+              let screen = UIApplication.shared.firstWindowScene?.screen.bounds else {
+            return Self.restingBillOffset
+        }
+
+        // The card is centered on the full screen (the canvas ignores safe area),
+        // so both edges are measured in screen coordinates from the top.
+        let cardHeight = BillCanvas.tipcardSize(canvasWidth: preferredCanvasSize().width).height
+        let sheetTop = screen.height - tipSheetHeight
+        let raised = sheetTop - Self.tipcardSheetGap - cardHeight / 2 - screen.height / 2
+
+        return CGSize(width: 0, height: min(Self.restingBillOffset.height, raised))
+    }
+
+    private func preferredCanvasSize() -> CGSize {
+        guard var rect = UIApplication.shared.firstWindowScene?.screen.bounds else {
+            return .zero
+        }
+
+        rect.size.height -= 70.0 // Bottom bar / tab bar
+
+        return rect.insetBy(dx: 20, dy: 20).size
+    }
+
+    // MARK: - Actions -
+
+    @ViewBuilder private func billActions() -> some View {
+        VStack {
+            Spacer()
+
+            GlassContainer(spacing: 30) {
+                billActionButtons
+            }
+        }
+        // The surface ignores the safe area, so lift the buttons clear of the
+        // home indicator and up off the very bottom edge.
+        .padding(.bottom, 48)
+    }
+
+    private var billActionButtons: some View {
+        HStack(alignment: .center, spacing: 30) {
+            if let primaryAction = session.billState.primaryAction {
+                CapsuleButton(
+                    state: sendButtonState,
+                    asset: primaryAction.asset,
+                    title: primaryAction.title
+                ) {
+                    sendButtonTask?.cancel()
+                    sendButtonTask = Task {
+                        sendButtonState = .loading
+                        do {
+                            try await primaryAction.action()
+                            try await Task.delay(milliseconds: 1000)
+                        } catch {}
+                        sendButtonState = .normal
+                    }
+                }
+            }
+
+            if let secondaryAction = session.billState.secondaryAction {
+                CapsuleButton(
+                    state: .normal,
+                    asset: secondaryAction.asset,
+                    title: secondaryAction.title
+                ) {
+                    secondaryAction.action()
+                }
+                .accessibilityLabel(secondaryAction.title ?? "Cancel")
+            }
+        }
+    }
+
+    private func dismissBill() {
+        switch session.billState.bill {
+        case .tipcard:
+            sessionContainer.tipFlow.cancel()
+        case .cash, nil:
+            session.dismissCashBill(style: .slide)
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
@@ -19,8 +19,21 @@ import FlipcashUI
 struct HomeTabView: View {
 
     @Environment(AppRouter.self) private var router
+    @Environment(SessionContainer.self) private var sessionContainer
 
     @State private var selection: HomeTab = .initial
+
+    /// The floating bar is a ZStack sibling, so it hovers over anything a tab
+    /// pushes. Hide it whenever the active tab has pushed a screen (e.g. Wallet →
+    /// Currency Info → Give) so that screen owns the full height, and while a
+    /// bill/tipcard is up (the app-root overlay owns the screen then, as the v1
+    /// bill replaced the bottom bar). Sheets already cover the bar, so only
+    /// in-tab pushes need handling here.
+    private var isTabBarHidden: Bool {
+        if sessionContainer.session.isShowingBill { return true }
+        guard let stack = selection.pushStack else { return false }
+        return !router[stack].isEmpty
+    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -28,15 +41,19 @@ struct HomeTabView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .transition(.opacity)
 
-            HomeTabBar(selection: $selection)
-                // Figma insets the pill ~42pt from each edge (318pt wide on the
-                // 402pt frame); a fixed margin keeps the floating look across
-                // device widths.
-                .padding(.horizontal, 42)
-                .padding(.bottom, 8)
+            if !isTabBarHidden {
+                HomeTabBar(selection: $selection)
+                    // Figma insets the pill ~42pt from each edge (318pt wide on the
+                    // 402pt frame); a fixed margin keeps the floating look across
+                    // device widths.
+                    .padding(.horizontal, 42)
+                    .padding(.bottom, 8)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
         .background(Color.backgroundMain)
         .animation(.easeInOut(duration: 0.2), value: selection)
+        .animation(.easeInOut(duration: 0.2), value: isTabBarHidden)
         // The app-level sheet host lives here in v2 (ScanScreen suppresses its
         // own copy when embedded) so `router.present(_:)` works from any tab.
         .modifier(RootSheetHostModifier(enabled: true))

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -40,14 +40,6 @@ private struct ScanScreenContent: View {
 
     @State private var cameraAuthorizer = CameraAuthorizer()
 
-    @State private var sendButtonState: ButtonState = .normal
-    @State private var sendButtonTask: Task<Void, Never>?
-    @State private var billDesignerColors: [Color] = ColorEditorControl.randomDerivedColors()
-
-    /// The presented Send a Tip sheet's full height (0 while absent), measured to
-    /// keep a fixed gap between the tipcard and the sheet's top edge.
-    @State private var tipSheetHeight: CGFloat = 0
-
     private var toast: String? {
         if let toast = session.toast {
             let formatted = toast.amount.formatted()
@@ -97,8 +89,6 @@ private struct ScanScreenContent: View {
                     )
             }
             
-            billView()
-            
             if showControls {
                 // Any actionable views need to be positioned
                 // in front of the BillCanvas, otherwise it
@@ -110,84 +100,34 @@ private struct ScanScreenContent: View {
                     .zIndex(1)
                     .transition(.opacity)
                 }
-            
+
                 interfaceView()
                     .zIndex(1)
                     .transition(.opacity)
-            } else {
-                billActions()
-                    .zIndex(1)
-                    .transition(.opacity)
-            }
-
-            if session.isShowingBillDesigner {
-                BillDesignerOverlay(colors: $billDesignerColors)
-                    .zIndex(2)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
         .background(Color.backgroundMain)
         .animation(.easeInOut(duration: 0.15), value: showControls)
         .animation(.easeInOut(duration: 0.3), value: preferences.cameraEnabled)
-        .animation(.spring(response: 0.4, dampingFraction: 0.85), value: session.isShowingBillDesigner)
         .ignoresSafeArea(.keyboard)
-        .sheet(item: $session.valuation) { valuation in
-            PartialSheet(background: .clear, canAccessBackground: true) {
-                ModalCashReceived(
-                    title: "You received",
-                    fiat: valuation.exchangedFiat.nativeAmount,
-                    currencyName: valuation.mintMetadata?.name ?? "currency",
-                    currencyImageURL: valuation.mintMetadata?.imageURL,
-                    actionTitle: "Put in Wallet",
-                    dismissAction: dismissBill
-                )
-            }
-            .interactiveDismissDisabled()
-        }
-        // Send a Tip over the scanned tipcard. A swipe-down cancels the whole
-        // flow — the card comes down with the sheet.
-        .sheet(isPresented: Binding(
-            get: { sessionContainer.tipFlow.isSheetPresented },
-            set: { isPresented in
-                if !isPresented {
-                    sessionContainer.tipFlow.cancel()
-                }
-            }
-        )) {
-            PartialSheet(
-                background: Color(red: 0.1, green: 0.1, blue: 0.1).opacity(0.7),
-                canAccessBackground: true
-            ) {
-                SendTipSheet(tipFlow: sessionContainer.tipFlow)
-                    // The sheet content's intrinsic height — the value
-                    // `PartialSheet` feeds its `.height` detent, so the sheet's
-                    // top sits at `screenHeight` minus this. Measured on the
-                    // content (not the detent-driven container, which briefly
-                    // fills the screen on present) so the tipcard's clearance is
-                    // stable and the card is nudged rather than flung.
-                    .background {
-                        GeometryReader { proxy in
-                            Color.clear
-                                .onAppear { tipSheetHeight = proxy.size.height }
-                                .onChange(of: proxy.size.height) { _, height in tipSheetHeight = height }
-                        }
-                    }
-            }
-        }
         // The app-level `router.rootSheet` host (RoutedSheet + tip-resume + the
         // bill-dismiss hook). Owned here for the v1 root; when embedded as a v2
         // tab, `HomeTabView` owns it instead, so this suppresses its own to avoid
         // presenting the same sheet twice.
+        //
+        // The bill / tipcard surface itself (BillCanvas, actions, designer, and
+        // the received-cash / send-tip sheets) is hoisted to `BillOverlayView` at
+        // the app root — see `ContainerScreen` — so a pushed bill renders over any
+        // tab, not only when this scanner is the mounted surface. `showControls`
+        // still hides the scanner chrome while a bill is up.
         .modifier(RootSheetHostModifier(enabled: !isEmbedded))
-        // Reset button state on bill dismissal — `sendButtonState` outlives individual bills.
-        .onChange(of: session.billState.bill) { _, newBill in
-            guard newBill == nil else { return }
-            sendButtonTask?.cancel()
-            sendButtonTask = nil
-            sendButtonState = .normal
-        }
+        // Tells the app-root bill overlay the camera is behind it, so a grabbed
+        // bill shows over the live camera without a scrim (v1, or the v2 Scan
+        // tab). Any other surface gets the scrim.
+        .onAppear { session.isScannerForeground = true }
+        .onDisappear { session.isScannerForeground = false }
     }
-    
+
     @ViewBuilder private func cameraViewport() -> some View {
         CameraViewport(
             session: viewModel.cameraSession,
@@ -200,63 +140,6 @@ private struct ScanScreenContent: View {
         .onDisappear {
             viewModel.stopCamera()
         }
-    }
-    
-    @ViewBuilder private func billView() -> some View {
-        BillCanvas(
-            state: session.presentationState,
-            centerOffset: billCenterOffset(),
-            preferredCanvasSize: preferredCanvasSize(),
-            bill: session.billState.bill,
-            dismissHandler: dismissBill
-        )
-        .allowsHitTesting(session.presentationState.isPresenting)
-        .ignoresSafeArea()
-    }
-
-    /// The resting vertical offset for the centered bill; a tipcard rises from
-    /// here only when the Send a Tip sheet would crowd it.
-    private static let restingBillOffset = CGSize(width: 0, height: -30)
-
-    /// The gap kept between the tipcard's bottom edge and the sheet's top edge.
-    private static let tipcardSheetGap: CGFloat = 42
-
-    /// A tipcard rises to hold ``tipcardSheetGap`` above the Send a Tip sheet,
-    /// and no more — a short sheet that already clears the resting card, or the
-    /// card shown alone (before the sheet, or behind a blocked balance gate),
-    /// leaves it at the resting height.
-    private func billCenterOffset() -> CGSize {
-        switch session.billState.bill {
-        case .tipcard where sessionContainer.tipFlow.isSheetPresented:
-            tipcardSheetOffset()
-        case .tipcard, .cash, nil:
-            Self.restingBillOffset
-        }
-    }
-
-    private func tipcardSheetOffset() -> CGSize {
-        guard tipSheetHeight > 0,
-              let screen = UIApplication.shared.firstWindowScene?.screen.bounds else {
-            return Self.restingBillOffset
-        }
-
-        // The card is centered on the full screen (the canvas ignores safe area),
-        // so both edges are measured in screen coordinates from the top.
-        let cardHeight = BillCanvas.tipcardSize(canvasWidth: preferredCanvasSize().width).height
-        let sheetTop = screen.height - tipSheetHeight
-        let raised = sheetTop - Self.tipcardSheetGap - cardHeight / 2 - screen.height / 2
-
-        return CGSize(width: 0, height: min(Self.restingBillOffset.height, raised))
-    }
-
-    private func preferredCanvasSize() -> CGSize {
-        guard var rect = UIApplication.shared.firstWindowScene?.screen.bounds else {
-            return .zero
-        }
-
-        rect.size.height -= 70.0 // Bottom bar
-
-        return rect.insetBy(dx: 20, dy: 20).size
     }
     
     private func performCameraPromptAction(_ prompt: CameraPrompt) {
@@ -298,50 +181,6 @@ private struct ScanScreenContent: View {
         }
         .opacity(session.isShowingBillDesigner ? 0 : 1)
     }
-    
-    @ViewBuilder private func billActions() -> some View {
-        VStack {
-            Spacer()
-            
-            GlassContainer(spacing: 30) {
-                billActionButtons
-            }
-        }
-        .padding(.bottom, 10)
-    }
-    
-    private var billActionButtons: some View {
-        HStack(alignment: .center, spacing: 30) {
-            if let primaryAction = session.billState.primaryAction {
-                CapsuleButton(
-                    state: sendButtonState,
-                    asset: primaryAction.asset,
-                    title: primaryAction.title
-                ) {
-                    sendButtonTask?.cancel()
-                    sendButtonTask = Task {
-                        sendButtonState = .loading
-                        do {
-                            try await primaryAction.action()
-                            try await Task.delay(milliseconds: 1000)
-                        } catch {}
-                        sendButtonState = .normal
-                    }
-                }
-            }
-
-            if let secondaryAction = session.billState.secondaryAction {
-                CapsuleButton(
-                    state: .normal,
-                    asset: secondaryAction.asset,
-                    title: secondaryAction.title
-                ) {
-                    secondaryAction.action()
-                }
-                .accessibilityLabel(secondaryAction.title ?? "Cancel")
-            }
-        }
-    }
 
     // MARK: - Actions -
 
@@ -352,15 +191,6 @@ private struct ScanScreenContent: View {
             return
         }
         router.present(.give)
-    }
-
-    private func dismissBill() {
-        switch session.billState.bill {
-        case .tipcard:
-            sessionContainer.tipFlow.cancel()
-        case .cash, nil:
-            session.dismissCashBill(style: .slide)
-        }
     }
 }
 

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -57,6 +57,12 @@ class Session {
     /// the scan screen. Toggled by the Settings → Advanced Features row.
     var isShowingBillDesigner: Bool = false
 
+    /// Whether the scanner camera surface is currently foreground. The app-root
+    /// bill overlay suppresses its scrim while true, so a grabbed bill shows over
+    /// the live camera (as it always has) rather than a dimmed backdrop; over any
+    /// other surface (a wallet/chat push receiving a cash link) the scrim shows.
+    var isScannerForeground: Bool = false
+
     // MARK: - User State -
 
     /// Server-fetched user profile.


### PR DESCRIPTION
## What

In the v2 tab-bar UI, cash bills and tipcards rendered inside `ScanScreen`'s `ZStack`. A bill set by a push or deep link (an incoming cash link) while the user was on the Wallet/Chat/Tip Card tab wrote to `session.billState` but rendered in the unmounted Scan tab — so nothing appeared on screen.

This hoists the bill/tipcard surface to the **app root**, mirroring Android's app-root `BillOverlay`.

## Changes

- **New `BillOverlayView`** — the `BillCanvas`, the primary/secondary bill actions, the bill designer, and the received-cash / send-tip sheets, extracted out of `ScanScreen` and mounted **once** by `ContainerScreen` above both the v1 scanner and the v2 `HomeTabView`. Driven entirely by the app-scoped `session.billState`, so a bill renders over whatever surface is showing. `ScanScreen` keeps its `showControls` gate so its scanner chrome still hides while a bill is up.
- **iOS 26 nav-bar glass** — the overlay keeps `.ignoresSafeArea()` on its inner surface, not its root. As a sibling of the tab `NavigationStack`s, an overlay whose *root* ignored the safe area flattened the Liquid Glass of the nav-bar back/title buttons beneath it; nested one level down, the bill still fills the screen and the bars keep their glass.
- **Scrim** — a dimmed backdrop is drawn behind the bill when it's presented over a non-scanner surface (a wallet/chat push, a received cash link), ramping in with the bill's slide. Over the scanner the live camera stays visible instead — gated by the new `Session.isScannerForeground`, set by `ScanScreen`.
- **Tab bar** — the floating bar hides whenever the active tab has pushed a screen (e.g. Wallet → Currency Info → Give) or while a bill is presenting, so the pushed screen / bill owns the full height instead of the bar hovering over it.

## Testing

- Verified on iPhone 16 Pro (iOS 18) and iPhone 17 (iOS 26) simulators.
- Give → cash bill renders full-screen over the wallet/currency-info surface, with the scrim behind and the tab bar hidden; dismiss returns cleanly to the underlying screen.
- Confirmed the pushed Currency Info nav bar keeps its Liquid Glass back/share buttons on iOS 26.
- v1 scanner bill flow unchanged (bill over the live camera, no scrim).
