### PR TITLE
feat(wallet): full activity history behind the Recent section

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter+Destination.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Destination.swift
@@ -25,6 +25,9 @@ extension AppRouter {
         case currencyCreationSummary
         case currencyCreationWizard
         case transactionHistory(PublicKey)
+        /// The unified, cross-token activity history — the "dive in" from the
+        /// Wallet's Recent section. `transactionHistory` is the per-token slice.
+        case activity
         case give(PublicKey)
         /// Skips the picker step in the withdraw flow and lands the user on
         /// `WithdrawIntroScreen` with the currency pre-selected. Pushed from
@@ -71,7 +74,7 @@ extension AppRouter {
             switch self {
             case .currencyInfo, .currencyInfoForDeposit, .discoverCurrencies,
                  .currencyCreationSummary, .currencyCreationWizard,
-                 .transactionHistory, .give, .withdrawCurrency,
+                 .transactionHistory, .activity, .give, .withdrawCurrency,
                  .usdcDepositEducation, .usdcDepositAddress:
                 return .balance
             case .settingsMyAccount, .settingsAdvancedFeatures, .settingsAdvancedBetaFeatures,
@@ -97,6 +100,7 @@ extension AppRouter {
             case .currencyCreationSummary:      "currencyCreationSummary"
             case .currencyCreationWizard:       "currencyCreationWizard"
             case .transactionHistory:           "transactionHistory"
+            case .activity:                     "activity"
             case .give:                         "give"
             case .withdrawCurrency:             "withdrawCurrency"
             case .usdcDepositEducation:         "usdcDepositEducation"
@@ -136,7 +140,8 @@ extension AppRouter {
                 return conversationID.description
             case .userProfile(let userID):
                 return userID.uuidString
-            case .discoverCurrencies, .currencyCreationSummary, .currencyCreationWizard,
+            case .activity,
+                 .discoverCurrencies, .currencyCreationSummary, .currencyCreationWizard,
                  .usdcDepositEducation, .usdcDepositAddress,
                  .settingsMyAccount, .settingsAdvancedFeatures, .settingsAdvancedBetaFeatures,
                  .settingsAppSettings, .settingsBetaFlags, .settingsAccountSelection,

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -49,6 +49,9 @@ struct DestinationView: View {
         case .transactionHistory(let mint):
             TransactionHistoryScreen(mint: mint)
 
+        case .activity:
+            ActivityHistoryScreen()
+
         case .give(let mint):
             // `.id(mint)` for the same reason as `.currencyInfo` above —
             // a deeplink replacing `.give(A)` with `.give(B)` must build a

--- a/Flipcash/Core/Screens/Main/Home/ActivityHistoryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/ActivityHistoryScreen.swift
@@ -1,0 +1,70 @@
+//
+//  ActivityHistoryScreen.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+import FlipcashCore
+
+/// The unified, cross-token activity history — the "dive in" from the Wallet's
+/// Recent section. Lists every activity (newest first) with the same enriched
+/// rows as the wallet preview. Rows are non-interactive; the per-token
+/// ``TransactionHistoryScreen`` remains the place to cancel a pending cash link.
+struct ActivityHistoryScreen: View {
+
+    @Environment(SessionContainer.self) private var sessionContainer
+    @Environment(HistoryController.self) private var historyController
+
+    var body: some View {
+        ActivityHistoryContent(session: sessionContainer.session, historyController: historyController)
+    }
+}
+
+private struct ActivityHistoryContent: View {
+
+    private let session: Session
+    private let historyController: HistoryController
+
+    /// The full local history. The server sync pages the complete set into the
+    /// local DB, so this cap matches the per-token history's own 1024 ceiling.
+    private static let historyLimit = 1024
+
+    @State private var activities: [Activity]
+
+    init(session: Session, historyController: HistoryController) {
+        self.session = session
+        self.historyController = historyController
+        // Seed synchronously from the local DB so the list shows immediately,
+        // then `sync()` refreshes it from the server.
+        _activities = State(initialValue: session.recentActivities(limit: Self.historyLimit))
+    }
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            if activities.isEmpty {
+                Text("No activity yet")
+                    .font(.appTextMedium)
+                    .foregroundStyle(Color.textSecondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView(.vertical, showsIndicators: false) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(activities) { activity in
+                            WalletActivityRow(activity: activity)
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                }
+            }
+        }
+        .navigationTitle("Activity")
+        .toolbarTitleDisplayMode(.inline)
+        .onAppear { historyController.sync() }
+        // A sync writes new rows to the local DB independently of any balance
+        // change, so reload the slice on any DB change.
+        .onReceive(NotificationCenter.default.publisher(for: .databaseDidChange)) { _ in
+            activities = session.recentActivities(limit: Self.historyLimit)
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
@@ -19,8 +19,21 @@ import FlipcashUI
 struct HomeTabView: View {
 
     @Environment(AppRouter.self) private var router
+    @Environment(SessionContainer.self) private var sessionContainer
 
     @State private var selection: HomeTab = .initial
+
+    /// The floating bar is a ZStack sibling, so it hovers over anything a tab
+    /// pushes. Hide it whenever the active tab has pushed a screen (e.g. Wallet →
+    /// Currency Info → Give) so that screen owns the full height, and while a
+    /// bill/tipcard is up (the app-root overlay owns the screen then, as the v1
+    /// bill replaced the bottom bar). Sheets already cover the bar, so only
+    /// in-tab pushes need handling here.
+    private var isTabBarHidden: Bool {
+        if sessionContainer.session.isShowingBill { return true }
+        guard let stack = selection.pushStack else { return false }
+        return !router[stack].isEmpty
+    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -28,15 +41,19 @@ struct HomeTabView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .transition(.opacity)
 
-            HomeTabBar(selection: $selection)
-                // Figma insets the pill ~42pt from each edge (318pt wide on the
-                // 402pt frame); a fixed margin keeps the floating look across
-                // device widths.
-                .padding(.horizontal, 42)
-                .padding(.bottom, 8)
+            if !isTabBarHidden {
+                HomeTabBar(selection: $selection)
+                    // Figma insets the pill ~42pt from each edge (318pt wide on the
+                    // 402pt frame); a fixed margin keeps the floating look across
+                    // device widths.
+                    .padding(.horizontal, 42)
+                    .padding(.bottom, 8)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
         .background(Color.backgroundMain)
         .animation(.easeInOut(duration: 0.2), value: selection)
+        .animation(.easeInOut(duration: 0.2), value: isTabBarHidden)
         // The app-level sheet host lives here in v2 (ScanScreen suppresses its
         // own copy when embedded) so `router.present(_:)` works from any tab.
         .modifier(RootSheetHostModifier(enabled: true))

--- a/Flipcash/Core/Screens/Main/Home/WalletActivityRow.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletActivityRow.swift
@@ -16,7 +16,6 @@ import FlipcashCore
 struct WalletActivityRow: View {
 
     let activity: Activity
-    var onTap: () -> Void = {}
 
     @Environment(SessionContainer.self) private var sessionContainer
     private var session: Session { sessionContainer.session }
@@ -28,33 +27,29 @@ struct WalletActivityRow: View {
     @State private var avatarBlurhash: String?
 
     var body: some View {
-        Button(action: onTap) {
-            HStack(spacing: 12) {
-                avatar
-                    .frame(width: 40, height: 40)
-                    .clipShape(Circle())
+        HStack(spacing: 12) {
+            avatar
+                .frame(width: 40, height: 40)
+                .clipShape(Circle())
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(displayTitle)
-                        .font(.appTextMedium)
-                        .foregroundStyle(Color.textMain)
-                        .lineLimit(1)
-                    Text(activity.date.formattedRelatively(useTimeForToday: true))
-                        .font(.appTextSmall)
-                        .foregroundStyle(Color.textSecondary)
-                }
-
-                Spacer(minLength: 8)
-
-                Text(signedAmount)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(displayTitle)
                     .font(.appTextMedium)
                     .foregroundStyle(Color.textMain)
                     .lineLimit(1)
+                Text(activity.date.formattedRelatively(useTimeForToday: true))
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textSecondary)
             }
-            .padding(.vertical, 10)
-            .contentShape(Rectangle())
+
+            Spacer(minLength: 8)
+
+            Text(signedAmount)
+                .font(.appTextMedium)
+                .foregroundStyle(Color.textMain)
+                .lineLimit(1)
         }
-        .buttonStyle(.plain)
+        .padding(.vertical, 10)
         .task(id: activity.id) { await resolveCounterparty() }
     }
 

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -192,17 +192,29 @@ private struct WalletScreenContent: View {
 
     private var recentActivitySection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("Recent")
-                .font(.appTextLarge)
-                .foregroundStyle(Color.textMain)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.top, 24)
-                .padding(.bottom, 4)
+            // The header is the "dive in" affordance — tapping it (or the
+            // chevron) opens the full cross-token activity history. The rows
+            // themselves are a non-interactive preview.
+            Button {
+                router.push(.activity)
+            } label: {
+                HStack(spacing: 6) {
+                    Text("Recent")
+                        .font(.appTextLarge)
+                        .foregroundStyle(Color.textMain)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Color.textSecondary)
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 24)
+            .padding(.bottom, 4)
 
             ForEach(recentActivities) { activity in
-                WalletActivityRow(activity: activity) {
-                    router.push(.transactionHistory(activity.exchangedFiat.mint))
-                }
+                WalletActivityRow(activity: activity)
             }
         }
     }


### PR DESCRIPTION
## What

The Wallet's "Recent" preview rows each pushed the **per-token** transaction history — an odd target for a unified, cross-token preview. This makes the preview display-only and adds a "dive in" chevron on the **Recent** header that opens the full activity history.

## Changes

- **`WalletActivityRow`** — drops its `Button`/`onTap` wrapper; it's a display-only preview row now.
- **Recent header** — becomes a button with a trailing chevron that pushes the new `.activity` destination.
- **New `ActivityHistoryScreen`** — lists every activity (newest first) across all tokens using the same enriched rows. Seeds synchronously from the local DB and refreshes via `HistoryController.sync()` (which pages the full server history into the DB), reloading on any DB change.
- The per-token `TransactionHistoryScreen` is unchanged and still owns pending cash-link cancellation.

## Testing

- Verified on iPhone 17 (iOS 26): Recent rows are inert; tapping the Recent header opens **Activity** with the full cross-token history (Tipped / Received / Sent / Cancelled …), scrolling through the whole set.

## Note

On this branch the floating tab bar still hovers over the pushed Activity screen — that's the existing v2 behavior on `main`, fixed globally by #565 (tab bar hides on pushed screens). Orthogonal to this PR.
