### PR TITLE
feat(onramp): verification intro + v2 Add Money sheet, verify before amount

### DIFF
--- a/Flipcash/Core/Controllers/Onramp/OnrampVerificationPath.swift
+++ b/Flipcash/Core/Controllers/Onramp/OnrampVerificationPath.swift
@@ -7,6 +7,9 @@ import FlipcashCore
 
 /// Navigation path for `VerifyInfoScreen`'s NavigationStack.
 enum OnrampVerificationPath: Hashable {
+    /// A combined explainer shown first (v2 only) when both phone and email
+    /// verification are required — matches Android's verification intro.
+    case intro
     case enterPhoneNumber
     case confirmPhoneNumberCode
     case enterEmail

--- a/Flipcash/Core/Screens/Main/AddMoney/AddMoneyStartScreen.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/AddMoneyStartScreen.swift
@@ -12,14 +12,24 @@ struct AddMoneyStartScreen: View {
 
     @Environment(AppRouter.self) private var router
     @Environment(Session.self) private var session
+    @Environment(VerificationCoordinator.self) private var verificationCoordinator
 
     @State private var flowMethod: DepositMethod?
+    /// The up-front (v2) Coinbase verification sheet, presented before the amount
+    /// screen; `nil` when not verifying.
+    @State private var verificationViewModel: OnrampVerification?
+    /// Set when verification passed while its sheet was still up — the amount
+    /// flow opens once that sheet finishes dismissing (avoids a sheet collision).
+    @State private var pendingCoinbaseAmount = false
 
     var body: some View {
+        // The v2 tab-bar UI uses the richer "Add Money With" cards (Figma /
+        // Android parity); v1 keeps the plain "Select Method" buttons.
+        let isV2 = BetaFlags.shared.hasEnabled(.newUI)
         PartialSheet {
             VStack(spacing: 12) {
                 HStack {
-                    Text("Select Method")
+                    Text(isV2 ? "Add Money With" : "Select Method")
                         .font(.appBarButton)
                         .foregroundStyle(Color.textMain)
                     Spacer()
@@ -27,27 +37,67 @@ struct AddMoneyStartScreen: View {
                 .padding(.vertical, 20)
 
                 ForEach(Self.visibleMethods(hasCoinbaseOnramp: session.hasCoinbaseOnramp), id: \.self) { method in
-                    AddMoneyMethodButton(method: method) { select(method) }
+                    if isV2 {
+                        AddMoneyMethodRow(method: method) { select(method) }
+                    } else {
+                        AddMoneyMethodButton(method: method) { select(method) }
+                    }
                 }
 
                 Button("Dismiss", action: { router.dismissSheet() })
                     .buttonStyle(.subtle)
             }
-            .padding()
+            .padding(.horizontal)
+            .padding(.top)
+            .padding(.bottom, isV2 ? 0 : 16)
         }
         .sheet(item: $flowMethod) { method in
             AddMoneyFlowSheet(method: method)
                 .environment(\.dismissParentContainer, { router.dismissSheet() })
         }
+        // Up-front (v2) Coinbase verification — presented directly over the
+        // picker, before the amount flow opens.
+        .sheet(item: $verificationViewModel.cancellingOnDismiss()) { vm in
+            VerifyInfoScreen(viewModel: vm)
+        }
+        // Verification finished while its sheet was up: once it has dismissed,
+        // open the amount flow (a short beat lets the sheet clear first).
+        .onChange(of: verificationViewModel == nil) { _, isNil in
+            guard isNil, pendingCoinbaseAmount else { return }
+            pendingCoinbaseAmount = false
+            Task { @MainActor in
+                try? await Task.delay(milliseconds: 400)
+                flowMethod = .coinbase
+            }
+        }
     }
 
     /// Over the buy amount sheet the deposit flow pushes onto that sheet's
-    /// stack; everywhere else it opens as its own sheet on top.
+    /// stack; everywhere else it opens as its own sheet on top. In v2 a
+    /// debit-card (Coinbase) deposit verifies phone/email first — the amount
+    /// flow opens only once verification passes (immediately if already
+    /// verified), so no empty sheet appears ahead of it.
     private func select(_ method: DepositMethod) {
         Analytics.addMoneyMethodSelected(method: method)
         if router.isAddMoneyOverBuy {
             router.dismissSheet()
             router.pushAny(AddMoneyFlowStep.method(method))
+            return
+        }
+        if method == .coinbase, BetaFlags.shared.hasEnabled(.newUI) {
+            verificationCoordinator.runGated(
+                for: session,
+                bind: { verificationViewModel = $0 },
+                perform: {
+                    // Already verified → `bind` never fired, so open immediately;
+                    // otherwise wait for the verify sheet to dismiss.
+                    if verificationViewModel == nil {
+                        flowMethod = .coinbase
+                    } else {
+                        pendingCoinbaseAmount = true
+                    }
+                }
+            )
         } else {
             flowMethod = method
         }
@@ -95,6 +145,83 @@ private struct AddMoneyMethodButton: View {
 
     /// Stable identifier for UI tests — the Apple-glyph "Pay" label is
     /// brittle to match by text.
+    private var accessibilityIdentifier: String {
+        switch method {
+        case .coinbase:    "apple-pay-method-button"
+        case .phantom:     "phantom-method-button"
+        case .otherWallet: "other-wallet-method-button"
+        }
+    }
+}
+
+/// The v2 "Add Money With" row: a titled/subtitled card with a trailing method
+/// glyph (Figma / Android parity).
+private struct AddMoneyMethodRow: View {
+
+    let method: DepositMethod
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.appTextMedium)
+                        .foregroundStyle(Color.textMain)
+                    Text(subtitle)
+                        .font(.appTextSmall)
+                        .foregroundStyle(Color.textSecondary)
+                }
+                .multilineTextAlignment(.leading)
+
+                Spacer(minLength: 12)
+
+                icon
+                    .foregroundStyle(Color.textMain)
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity)
+            .background(Color.white.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private var title: String {
+        switch method {
+        case .coinbase:    "Debit Card"
+        case .phantom:     "Phantom"
+        case .otherWallet: "Other Wallet"
+        }
+    }
+
+    private var subtitle: String {
+        switch method {
+        case .coinbase:    "Deposit funds from your debit card"
+        case .phantom:     "Deposit USDC from your Phantom wallet"
+        case .otherWallet: "Deposit USDC from a crypto wallet"
+        }
+    }
+
+    @ViewBuilder private var icon: some View {
+        switch method {
+        case .coinbase:
+            Text("\u{F8FF}Pay")
+                .font(.system(size: 22, weight: .semibold))
+        case .phantom:
+            Image.asset(.phantom)
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 28, height: 28)
+        case .otherWallet:
+            Image(systemName: "qrcode")
+                .font(.system(size: 24, weight: .regular))
+        }
+    }
+
     private var accessibilityIdentifier: String {
         switch method {
         case .coinbase:    "apple-pay-method-button"

--- a/Flipcash/Core/Screens/Onramp/OnrampVerificationIntroScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampVerificationIntroScreen.swift
@@ -1,0 +1,46 @@
+//
+//  OnrampVerificationIntroScreen.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+
+/// The combined explainer shown at the start of the on-ramp verification flow
+/// (v2) when both phone and email verification are required. Ported from
+/// Android's `VerificationIntroScreen`; "Next" advances to phone entry.
+struct OnrampVerificationIntroScreen: View {
+
+    let onNext: () -> Void
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            VStack(spacing: 0) {
+                Spacer()
+
+                Image(systemName: "person.crop.circle")
+                    .font(.system(size: 96, weight: .light))
+                    .foregroundStyle(Color.textMain)
+
+                Text("Verify Your Phone Number And Email To Continue")
+                    .font(.appTextLarge)
+                    .foregroundStyle(Color.textMain)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 24)
+
+                Text("This will allow you to add funds from your debit card")
+                    .font(.appTextMedium)
+                    .foregroundStyle(Color.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 12)
+
+                Spacer()
+
+                Button("Next", action: onNext)
+                    .buttonStyle(.filled)
+            }
+            .padding(.horizontal, 40)
+            .padding(.bottom, 20)
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
@@ -122,16 +122,30 @@ final class OnrampVerificationViewModel<P: PhoneVerifying, E: EmailVerifying>: V
 
     // MARK: - Navigation -
 
-    /// The first screen the verification sheet shows — phone if unverified
-    /// (unlikely), email otherwise. The sheet's root IS the first step;
-    /// there is no intro page.
+    /// The first screen the verification sheet shows. When both phone and email
+    /// are required, v2 leads with a combined intro (matching Android); v1 — and
+    /// any single-step case — goes straight to the needed step (phone if
+    /// unverified, email otherwise).
     func initialStep() -> OnrampVerificationPath {
-        if !phoneVerifier.isAlreadyVerified {
+        let needsPhone = !phoneVerifier.isAlreadyVerified
+        let needsEmail = !emailVerifier.isAlreadyVerified
+
+        if needsPhone && needsEmail && BetaFlags.shared.hasEnabled(.newUI) {
+            return .intro
+        }
+        if needsPhone {
             Analytics.track(event: Analytics.OnrampEvent.showEnterPhone)
             return .enterPhoneNumber
         }
         Analytics.track(event: Analytics.OnrampEvent.showEnterEmail)
         return .enterEmail
+    }
+
+    /// Advances from the intro to the first real step. The intro only appears
+    /// when both phone and email are needed, so phone entry is always next.
+    func proceedFromIntro() {
+        Analytics.track(event: Analytics.OnrampEvent.showEnterPhone)
+        verificationPath.append(.enterPhoneNumber)
     }
 
     private func navigateToEmailOrFinish() {

--- a/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
@@ -34,6 +34,8 @@ struct VerifyInfoScreen<P: PhoneVerifying, E: EmailVerifying>: View {
         NavigationStack(path: $viewModel.verificationPath) {
             Group {
                 switch initialStep {
+                case .intro:
+                    OnrampVerificationIntroScreen(onNext: { viewModel.proceedFromIntro() })
                 case .enterPhoneNumber, .confirmPhoneNumberCode:
                     EnterPhoneScreen(viewModel: viewModel.phoneVerifier)
                         .navigationTitle("Verify Phone Number")
@@ -51,6 +53,9 @@ struct VerifyInfoScreen<P: PhoneVerifying, E: EmailVerifying>: View {
             }
             .navigationDestination(for: OnrampVerificationPath.self) { path in
                 switch path {
+                case .intro:
+                    // Only ever the stack root, never pushed; handled for exhaustiveness.
+                    OnrampVerificationIntroScreen(onNext: { viewModel.proceedFromIntro() })
                 case .enterPhoneNumber:
                     EnterPhoneScreen(viewModel: viewModel.phoneVerifier)
                         .interactiveDismissDisabled()
@@ -71,6 +76,8 @@ struct VerifyInfoScreen<P: PhoneVerifying, E: EmailVerifying>: View {
         }
         .task {
             switch initialStep {
+            case .intro:
+                break // The intro tracks showEnterPhone when the user proceeds.
             case .enterPhoneNumber, .confirmPhoneNumberCode:
                 Analytics.track(event: Analytics.OnrampEvent.showEnterPhone)
             case .enterEmail, .confirmEmailCode:


### PR DESCRIPTION
## What

Adds a combined **verification intro** to the Coinbase (debit card / Apple Pay) on-ramp flow, moves verification **before amount entry**, and updates the v2 **"Add Money"** method picker — matching Android. **v2 only**; v1 behavior is unchanged.

## Changes

### Verification intro
- New `OnrampVerificationPath.intro` + `OnrampVerificationIntroScreen` — explainer with "Verify Your Phone Number And Email To Continue", the on-ramp subtitle "This will allow you to add funds from your debit card", and a "Next" button (ported from Android's `VerificationIntroScreen`).
- `initialStep()` leads with the intro **only when both phone AND email are needed and `newUI` is on** (mirrors Android's `buildVerificationInitialStack` `includePhone && includeEmail` gate). Single-step cases go straight to phone/email as before. "Next" → phone → email → proceed.

### Verify before amount
- Selecting **Debit Card** (Coinbase) in v2 runs the phone/email gate **at the picker**. The amount flow opens only once verification passes — immediately if already verified — so no empty sheet appears ahead of it. The verification/intro sheet pops directly over the picker; cancelling leaves the user on the picker. v1 keeps the submit-time gate on the amount screen.

### Add Money sheet (v2)
- Titled **"Add Money With"** with richer cards: **Debit Card** / "Deposit funds from your debit card" (Apple Pay), **Phantom** / "Deposit USDC from your Phantom wallet", **Other Wallet** / "Deposit USDC from a crypto wallet". Cards use white-10% surfaces on the sheet's `backgroundSecondary`; "Dismiss" below. v1 keeps the plain "Select Method" buttons.

## Notes

- The intro **illustration** is SF Symbol `person.crop.circle` (matches Android's line-art person-in-circle drawable). Can be swapped for the exact Figma/exported asset if desired.
- Verified on iPhone 17 (iOS 26): the "Add Money With" sheet renders with the new cards, and Debit Card jumps straight to the amount screen on an already-verified account (no empty sheet). The intro/gating logic mirrors Android and is exercised via `initialStep()`.
