### PR TITLE
feat(chats): v2 Chats tab title + drop inline tip card button

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
@@ -86,7 +86,7 @@ private struct ChatTab: View {
     var body: some View {
         @Bindable var router = router
         NavigationStack(path: $router[.tips]) {
-            TipsScreen()
+            TipsScreen(isEmbedded: true)
                 .appRouterDestinations()
         }
         .environment(creationState)

--- a/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
@@ -14,28 +14,42 @@ struct TipConversationsScreen: View {
     @Environment(ConversationController.self) private var conversationController
     @Environment(AppRouter.self) private var router
 
+    /// See ``TipsScreen/isEmbedded`` — v2 drops the inline tip-card button and
+    /// leads with the large "Chats" title.
+    var isEmbedded: Bool = false
+
     var body: some View {
         Background(color: .backgroundMain) {
-            List {
-                Button("Show My Tip Card") {
-                    router.push(.tipcard)
+            VStack(alignment: .leading, spacing: 0) {
+                if isEmbedded {
+                    ChatsTabTitle()
                 }
-                .buttonStyle(.filled)
-                .accessibilityIdentifier("show-my-tipcard-button")
-                .listRowInsets(EdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20))
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
 
-                ForEach(conversationController.conversations(of: .tipDm)) { conversation in
-                    TipConversationRow(conversation: conversation) {
-                        router.push(.tipConversation(conversation.id))
+                List {
+                    // v1 only — v2 reaches the tip card from its own tab.
+                    if !isEmbedded {
+                        Button("Show My Tip Card") {
+                            router.push(.tipcard)
+                        }
+                        .buttonStyle(.filled)
+                        .accessibilityIdentifier("show-my-tipcard-button")
+                        .listRowInsets(EdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20))
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                    }
+
+                    ForEach(conversationController.conversations(of: .tipDm)) { conversation in
+                        TipConversationRow(conversation: conversation) {
+                            router.push(.tipConversation(conversation.id))
+                        }
                     }
                 }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
             }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
         }
-        .navigationTitle("Tips")
+        .navigationTitle(isEmbedded ? "" : "Tips")
+        .toolbar(isEmbedded ? .hidden : .automatic, for: .navigationBar)
         .toolbarTitleDisplayMode(.inline)
     }
 }

--- a/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
@@ -13,12 +13,33 @@ struct TipsScreen: View {
 
     @Environment(SessionContainer.self) private var sessionContainer
 
+    /// The v2 Chats tab: a large flush "Chats" title and no inline tip-card
+    /// button (the tip card has its own tab). Defaults to `false` — the v1 Tips
+    /// sheet keeps its inline nav-bar title and "Show My Tip Card" button.
+    var isEmbedded: Bool = false
+
     var body: some View {
         if sessionContainer.session.profile?.isTippable == true {
-            TipConversationsScreen()
+            TipConversationsScreen(isEmbedded: isEmbedded)
         } else {
-            TipsIntroScreen()
+            TipsIntroScreen(isEmbedded: isEmbedded)
         }
+    }
+}
+
+// MARK: - Chats title -
+
+/// The v2 large, flush start-aligned "Chats" tab title (Android parity —
+/// `screenTitleLarge` / `appTitleLarge`).
+struct ChatsTabTitle: View {
+    var body: some View {
+        Text("Chats")
+            .font(.appTitleLarge)
+            .foregroundStyle(Color.textMain)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+            .padding(.top, 8)
+            .padding(.bottom, 12)
     }
 }
 
@@ -28,44 +49,53 @@ private struct TipsIntroScreen: View {
 
     @Environment(AppRouter.self) private var router
 
+    let isEmbedded: Bool
+
     var body: some View {
         Background(color: .backgroundMain) {
-            VStack(spacing: 0) {
-                Spacer()
-
-                // The tab-bar asset carries a heavier stroke tuned for 40pt;
-                // at this size it needs the lighter one.
-                Image(.Icons.tipsLarge)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 120, height: 120)
-                    .foregroundStyle(Color.textMain)
-
-                Text("Receive Tips From Everyone")
-                    .font(.appTextLarge)
-                    .foregroundStyle(Color.textMain)
-                    .multilineTextAlignment(.center)
-                    .padding(.top, 32)
-
-                Text("Add your name to receive tips")
-                    .font(.appTextSmall)
-                    .foregroundStyle(Color.textSecondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.top, 8)
-
-                Spacer()
-
-                Button("Start Receiving Tips") {
-                    router.push(.profileName)
+            VStack(alignment: .leading, spacing: 0) {
+                if isEmbedded {
+                    ChatsTabTitle()
                 }
-                .buttonStyle(.filled)
-                .accessibilityIdentifier("start-receiving-tips-button")
-                .padding(.bottom, 20)
+
+                VStack(spacing: 0) {
+                    Spacer()
+
+                    // The tab-bar asset carries a heavier stroke tuned for 40pt;
+                    // at this size it needs the lighter one.
+                    Image(.Icons.tipsLarge)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 120, height: 120)
+                        .foregroundStyle(Color.textMain)
+
+                    Text("Receive Tips From Everyone")
+                        .font(.appTextLarge)
+                        .foregroundStyle(Color.textMain)
+                        .multilineTextAlignment(.center)
+                        .padding(.top, 32)
+
+                    Text("Add your name to receive tips")
+                        .font(.appTextSmall)
+                        .foregroundStyle(Color.textSecondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.top, 8)
+
+                    Spacer()
+
+                    Button("Start Receiving Tips") {
+                        router.push(.profileName)
+                    }
+                    .buttonStyle(.filled)
+                    .accessibilityIdentifier("start-receiving-tips-button")
+                    .padding(.bottom, 20)
+                }
+                .padding(.horizontal, 20)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .padding(.horizontal, 20)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .navigationTitle("Tips")
+        .navigationTitle(isEmbedded ? "" : "Tips")
+        .toolbar(isEmbedded ? .hidden : .automatic, for: .navigationBar)
         .toolbarTitleDisplayMode(.inline)
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Theme/AppFonts.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/AppFonts.swift
@@ -14,7 +14,11 @@ extension Font {
     public static let appDisplayCompact: Font = .default(size: 30, weight: .bold)
     public static let appDisplaySmall:  Font = .default(size: 24, weight: .bold)
     public static let appDisplayXS:     Font = .default(size: 20, weight: .bold)
-    
+
+    /// Large, flush start-aligned screen title (e.g. the v2 Chats tab). Mirrors
+    /// Android's `screenTitleLarge` type token.
+    public static let appTitleLarge:    Font = .default(size: 33.05, weight: .bold)
+
     public static let appKeyboard:      Font = .default(size: 30, weight: .regular)
     
     public static let appTitle:         Font = .default(size: 20, weight: .bold)
@@ -41,7 +45,10 @@ extension UIFont {
     public static let appDisplayMedium: UIFont = .default(size: 40, weight: .bold)
     public static let appDisplaySmall:  UIFont = .default(size: 24, weight: .bold)
     public static let appDisplayXS:     UIFont = .default(size: 20, weight: .bold)
-    
+
+    /// See `Font.appTitleLarge`.
+    public static let appTitleLarge:    UIFont = .default(size: 33.05, weight: .bold)
+
     public static let appKeyboard:      UIFont = .default(size: 30, weight: .regular)
     
     public static let appTitle:         UIFont = .default(size: 20, weight: .bold)


### PR DESCRIPTION
## What

Updates the **v2 Chats tab** (the tip conversations list) to match Android: a large flush "Chats" title and no inline tip-card button. **v2 only** — the v1 Tips sheet is unchanged.

## Changes

- **`appTitleLarge` type token** (`FlipcashUI/Theme/AppFonts.swift`) — AvenirNext-Bold, 33.05pt, mirroring Android's new `screenTitleLarge`, for large flush start-aligned screen titles. (No existing 33pt token — closest were `appDisplayCompact` 30 and `appDisplayMedium` 40.)
- **`isEmbedded` flag** on `TipsScreen` / `TipConversationsScreen` / `TipsIntroScreen` (same pattern as `TipcardScreen`). When embedded (v2):
  - hides the inline nav-bar title and leads with a large left-aligned **"Chats"** heading (`appTitleLarge`),
  - drops the **"Show My Tip Card"** button — the tip card has its own tab in v2.
  - v1 keeps its inline "Tips" title and the button.
- **`HomeTabView.ChatTab`** now hosts `TipsScreen(isEmbedded: true)`.

## Testing

- Verified on iPhone 17 (iOS 26): the Chat tab shows the large "Chats" title, no tip-card button, and the conversation list beneath.
