### PR TITLE
fix(wallet): enrich received-tip activity rows from conversation members

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/WalletActivityRow.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletActivityRow.swift
@@ -123,12 +123,7 @@ struct WalletActivityRow: View {
     private func resolveCounterparty() async {
         switch activity.counterparty {
         case .user(let userID):
-            let profile = session.cachedUserProfile(for: userID)
-            counterpartyName = profile?.displayName
-            avatarBlurhash = profile?.profilePicture?.thumbnailBlurhash
-            guard let picture = profile?.profilePicture else { return }
-            await sessionContainer.tipAvatars.load(userID: userID, picture: picture)
-            avatarData = sessionContainer.tipAvatars.data(for: userID)
+            await resolveUser(userID)
         case .phone(let e164):
             let contact = sessionContainer.contactSyncController.resolvedContacts.onFlipcash.first { $0.phoneE164 == e164 }
             counterpartyName = contact?.displayName
@@ -136,5 +131,31 @@ struct WalletActivityRow: View {
         case .none:
             break
         }
+    }
+
+    /// A cached full profile (someone you've viewed or tipped) is authoritative;
+    /// otherwise fall back to the tip conversation's member, which carries the
+    /// name + picture for counterparties you've only *received* tips from (those
+    /// are never written to the profile cache). Without this, received tips show
+    /// the server title and a monogram instead of "Tip from <name>".
+    private func resolveUser(_ userID: UserID) async {
+        let picture: ProfilePicture?
+
+        if let profile = session.cachedUserProfile(for: userID) {
+            counterpartyName = profile.displayName
+            picture = profile.profilePicture
+        } else if let member = sessionContainer.conversationController.conversations
+            .flatMap(\.members)
+            .first(where: { $0.userID == userID }) {
+            counterpartyName = member.displayName.isEmpty ? nil : member.displayName
+            picture = member.profilePicture
+        } else {
+            picture = nil
+        }
+
+        avatarBlurhash = picture?.thumbnailBlurhash
+        guard let picture else { return }
+        await sessionContainer.tipAvatars.load(userID: userID, picture: picture)
+        avatarData = sessionContainer.tipAvatars.data(for: userID)
     }
 }


### PR DESCRIPTION
## What

Activity rows (the Wallet "Recent" preview and the full Activity history) weren't enriching **received** tips — they showed the server title + a monogram instead of "Tip from \<name\>" with the sender's avatar.

## Cause

`WalletActivityRow` resolved a peer counterparty only from the local profile cache (`Session.cachedUserProfile` → `database.getUserProfile`). That cache is written only when you **view** a profile (`UserProfileScreen`) or **send** someone a tip (`TipFlow`). Counterparties you've only **received** a tip from were never cached, so resolution returned `nil` and the row fell back to the server title.

## Fix

When the profile cache misses, fall back to the tip conversation's **member** (`ConversationController.conversations…members`), which carries the counterpart's `displayName` + `profilePicture`. This is the same source the chat list uses (`counterpartSeed`). Sent-tip / viewed-profile rows keep using the cached profile.

## Testing

- Built and installed on iPhone 17 (iOS 26). Received-tip rows now render "Tip from \<name\>" with the sender's avatar.

## Note

Resolution runs in `.task(id: activity.id)` (once per row appearance) against whatever conversations are loaded. The conversation feed loads at login so it's normally ready; if a row appears before the feed hydrates it will show the fallback until it next appears. Can be made to re-resolve on feed updates if that edge case matters.
