### PR TITLE
feat(profile): add helper sublabel below display name input field

### DIFF
--- a/Flipcash/Core/Screens/Main/Profile/ProfileNameScreen.swift
+++ b/Flipcash/Core/Screens/Main/Profile/ProfileNameScreen.swift
@@ -45,6 +45,11 @@ struct ProfileNameScreen: View {
                     .padding(.top, 32)
                     .disabled(isSubmitting)
 
+                Text("This is how you'll appear to others")
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textSecondary)
+                    .padding(.top, 8)
+
                 Spacer()
 
                 if state.remainingCharacters < Self.countdownThreshold {

--- a/Flipcash/Core/Screens/Onboarding/OnboardingNameScreen.swift
+++ b/Flipcash/Core/Screens/Onboarding/OnboardingNameScreen.swift
@@ -45,6 +45,11 @@ struct OnboardingNameScreen: View {
                     .padding(.top, 32)
                     .disabled(viewModel.isSubmitting)
 
+                Text("This is how you'll appear to others")
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textSecondary)
+                    .padding(.top, 8)
+
                 Spacer()
 
                 if viewModel.remainingCharacters < Self.countdownThreshold {


### PR DESCRIPTION
## What

Adds a helper sublabel **"This is how you'll appear to others"** directly below the name text field on the display-name entry screen, per the new Figma design.

Applied to both entry points, which share an identical layout:
- `OnboardingNameScreen` (onboarding flow)
- `ProfileNameScreen` (tipcard profile-creation flow)

## Details

The sublabel uses the established secondary-caption idiom — `.font(.appTextSmall)` + `.foregroundStyle(Color.textSecondary)` — matching the existing character-countdown text on the same screens.

## Testing

- Full `Flipcash` scheme builds clean (no new warnings/errors) and runs on the iPhone 17 simulator.

The Android counterpart ships separately on `feat/display-name-sublabel` in code-android-app.