### PR TITLE
feat(tips): update Send a Tip modal layout

### DIFF
--- a/Flipcash/Core/Screens/Main/Bill/BillOverlayView.swift
+++ b/Flipcash/Core/Screens/Main/Bill/BillOverlayView.swift
@@ -161,18 +161,30 @@ private struct BillOverlayContent: View {
         .ignoresSafeArea()
     }
 
-    /// The resting vertical offset for the centered bill; a tipcard rises from
-    /// here only when the Send a Tip sheet would crowd it.
+    /// The resting vertical offset for a centered cash bill.
     private static let restingBillOffset = CGSize(width: 0, height: -30)
 
-    /// The gap kept between the tipcard's bottom edge and the sheet's top edge.
-    private static let tipcardSheetGap: CGFloat = 42
+    /// The tipcard rests centered on screen when presented as the scan/deep-link
+    /// overlay — and lifts only when the Send a Tip sheet comes up. (Cash bills
+    /// sit slightly above center.)
+    private static let restingTipcardOffset = CGSize(width: 0, height: 0)
+
+    /// When the Send a Tip sheet is up, the card lifts so its top sits ~25% down
+    /// the screen — pushed up clear of the sheet without floating too high above
+    /// it, leaving the lower area for the sheet.
+    private static let tipcardSheetTopInset: CGFloat = 0.25
+
+    /// Floor gap kept between the card's bottom and the sheet's top, used only if
+    /// a taller-than-designed sheet would otherwise crowd the card.
+    private static let tipcardSheetGap: CGFloat = 24
 
     private func billCenterOffset() -> CGSize {
         switch session.billState.bill {
         case .tipcard where sessionContainer.tipFlow.isSheetPresented:
             tipcardSheetOffset()
-        case .tipcard, .cash, nil:
+        case .tipcard:
+            Self.restingTipcardOffset
+        case .cash, nil:
             Self.restingBillOffset
         }
     }
@@ -180,16 +192,22 @@ private struct BillOverlayContent: View {
     private func tipcardSheetOffset() -> CGSize {
         guard tipSheetHeight > 0,
               let screen = UIApplication.shared.firstWindowScene?.screen.bounds else {
-            return Self.restingBillOffset
+            return Self.restingTipcardOffset
         }
 
         // The card is centered on the full screen (the canvas ignores safe area),
-        // so both edges are measured in screen coordinates from the top.
+        // so all edges are measured in screen coordinates from the top.
         let cardHeight = BillCanvas.tipcardSize(canvasWidth: preferredCanvasSize().width).height
+
+        // Lift the card to the design's upper placement (card top ~25% down).
+        let designOffset = screen.height * Self.tipcardSheetTopInset
+            + cardHeight / 2 - screen.height / 2
+
+        // …but rise further if a taller-than-designed sheet would still crowd it.
         let sheetTop = screen.height - tipSheetHeight
         let raised = sheetTop - Self.tipcardSheetGap - cardHeight / 2 - screen.height / 2
 
-        return CGSize(width: 0, height: min(Self.restingBillOffset.height, raised))
+        return CGSize(width: 0, height: min(designOffset, raised))
     }
 
     private func preferredCanvasSize() -> CGSize {

--- a/Flipcash/Core/Screens/Main/Tips/SendTipSheet.swift
+++ b/Flipcash/Core/Screens/Main/Tips/SendTipSheet.swift
@@ -31,9 +31,15 @@ struct SendTipSheet: View {
 
     var body: some View {
         VStack(spacing: 24) {
-            Text("Send a Tip")
-                .font(.appTextLarge)
-                .foregroundStyle(Color.textMain)
+            HStack {
+                Text("Send a Tip")
+                    .font(.appTextLarge)
+                    .foregroundStyle(Color.textMain)
+
+                Spacer()
+
+                currencySelector
+            }
 
             HStack(spacing: 8) {
                 presetChip(.low)
@@ -41,8 +47,6 @@ struct SendTipSheet: View {
                 presetChip(.high)
                 customChip
             }
-
-            currencyRow
 
             SwipeControl(text: "Swipe to Tip") {
                 try await tipFlow.swipeToTip()
@@ -106,23 +110,19 @@ struct SendTipSheet: View {
 
     // MARK: - Currency -
 
-    private var currencyRow: some View {
-        HStack(spacing: 6) {
-            Text("of")
-                .font(.appTextSmall)
-                .foregroundStyle(Color.textSecondary)
-
-            TokenSelectorButton(selectedBalance: tipFlow.submission?.selectedBalance) {
-                localSheet = .currencyPicker
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background {
-                Capsule()
-                    .fill(Color(white: 0.22))
-            }
-            .accessibilityIdentifier("tip-currency-row")
+    /// The tip currency, shown as a pill in the sheet header (Figma 8966-2649):
+    /// the token icon, name, and a chevron — no "of" label.
+    private var currencySelector: some View {
+        TokenSelectorButton(selectedBalance: tipFlow.submission?.selectedBalance) {
+            localSheet = .currencyPicker
         }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background {
+            Capsule()
+                .fill(Color.white.opacity(0.1))
+        }
+        .accessibilityIdentifier("tip-currency-row")
     }
 }
 
@@ -142,9 +142,9 @@ private struct TipAmountChip: View {
                 .minimumScaleFactor(0.5)
                 .foregroundStyle(isSelected ? Color.backgroundMain : Color.textMain)
                 .frame(maxWidth: .infinity)
-                .frame(height: 56)
-                .background(isSelected ? Color.textMain : Color(white: 0.22))
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .frame(height: 60)
+                .background(isSelected ? Color.textMain : Color.white.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
         .buttonStyle(.plain)
     }


### PR DESCRIPTION
## What

Updates the **Send a Tip** modal (shown when a tipcard is scanned or opened via a `app.flipcash.com/tip/…` deep link) to match the Figma design.

## Changes

**Send a Tip sheet** (`SendTipSheet.swift`))
- Title and currency selector now share one header row — "Send a Tip" on the left, the currency pill on the right.
- Removed the separate "of {currency}" row below the chips (the currency lives in the header now; no "of" label).
- Restyled the amount chips: `white @ 10%` fill, corner radius 10, height 60.

**Tipcard overlay placement** (`BillOverlayView.swift`)
- The tipcard rests **centered** on screen when presented as the scan/deep‑link overlay (previously shared the cash bill's slightly‑raised offset).
- When the Send a Tip sheet comes up, the card lifts to the design's upper placement (card top ~25% down the screen) so it sits clearly above the sheet, with a floor that raises it further only if a taller‑than‑designed sheet would crowd it. Cash bills are unaffected.

## Testing

- Builds and runs on the iPhone 17 simulator (iOS 26).
- Verified live via a real tip deep link (`app.flipcash.com/tip/…`): the Send a Tip sheet renders per the design and the tipcard sits pushed‑up above it.
