### PR TITLE
feat(wallet): v2 card-stack collapse + appreciation pill

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/TokenCardStack.swift
+++ b/Flipcash/Core/Screens/Main/Home/TokenCardStack.swift
@@ -7,25 +7,34 @@ import SwiftUI
 import FlipcashCore
 
 /// A vertical stack of ``TokenCardView``s that fans out (each card revealing its
-/// `fannedReveal` header) and **collapses, then scrolls off** as the enclosing
-/// scroll view scrolls up: cards pin at the top and tighten from the fanned gap
-/// to `collapsedReveal` (a growing deck); once fully collapsed the deck releases
-/// and scrolls off with the rest of the content. Ported from Android's
-/// `TokenCardStack` custom `Layout` — reimplemented with `offset` placement so it
-/// works on the iOS 15 deployment target (which predates SwiftUI's `Layout`).
+/// `fannedReveal` header) and **collapses into its back card** as the enclosing
+/// scroll view scrolls up — Apple Wallet style. Once the balance header has
+/// scrolled off, the back card (index 0) reaches the top and pins there; the
+/// remaining cards each collapse up into it in turn, tightening the fan from
+/// `fannedReveal` to `collapsedReveal`. When the deck is fully collapsed it holds
+/// briefly, then releases and scrolls off with the rest of the content.
 ///
-/// The measured height is always the *fanned* height, so the enclosing scroll
-/// view's range is stable — cards are only repositioned, never resized.
-/// `scrolledPast` is the px the stack's top has scrolled above the viewport top;
-/// the parent measures it and passes it in (see `WalletScreen`).
+/// Placement is driven entirely per-card by SwiftUI's `visualEffect`, reading
+/// each card's own `frame(in: .scrollView).minY`. There is no shared scroll
+/// state — the parent just renders the stack. The frame is reserved at the
+/// *fanned* height so the scroll range stays stable while cards reposition.
 struct TokenCardStack: View {
+
+    /// Per-card reveal when the deck is fanned open (at rest).
+    static let defaultFannedReveal: CGFloat = 64
+    /// Per-card reveal when the deck is fully collapsed: 0, so the cards stack
+    /// exactly and only the front card shows — the back cards hide completely
+    /// behind it (no slivers), Apple Wallet style.
+    static let defaultCollapsedReveal: CGFloat = 0
+    /// How long (in scroll px) the fully-collapsed deck holds before releasing.
+    static let defaultCollapsedHold: CGFloat = 24
 
     let items: [TokenCardData]
     var cardHeight: CGFloat = 224
-    var fannedReveal: CGFloat = 64
-    var collapsedReveal: CGFloat = 12
+    var fannedReveal: CGFloat = defaultFannedReveal
+    var collapsedReveal: CGFloat = defaultCollapsedReveal
+    /// Where the back card pins, measured from the top of the scroll viewport.
     var pinInset: CGFloat = 0
-    var scrolledPast: CGFloat = 0
     var onCardTap: (TokenCardData) -> Void = { _ in }
 
     /// Always the fanned height, so the scroll range stays stable while cards collapse.
@@ -33,31 +42,52 @@ struct TokenCardStack: View {
         items.isEmpty ? 0 : cardHeight + fannedReveal * CGFloat(items.count - 1)
     }
 
-    /// Scroll distance at which every card has finished collapsing (the last pins last).
-    private var collapseComplete: CGFloat {
-        max(0, CGFloat(items.count - 1) * (fannedReveal - collapsedReveal) - pinInset)
+    private let collapsedHold: CGFloat = defaultCollapsedHold
+
+    /// The stack-top position (in `.scrollView` space) at which the deck freezes
+    /// and rides the scroll off: the last card's fully-collapsed point, less a
+    /// short hold.
+    private nonisolated var releaseTop: CGFloat {
+        let lastIndex = CGFloat(max(items.count - 1, 0))
+        let fullyCollapsed = pinInset - lastIndex * (fannedReveal - collapsedReveal)
+        return fullyCollapsed - collapsedHold
     }
 
     var body: some View {
-        // Cap `past` at collapseComplete: once fully collapsed the deck stops
-        // pinning and the frozen layout scrolls off with the content.
-        let past = min(max(scrolledPast, 0), collapseComplete)
         ZStack(alignment: .top) {
             ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-                let fannedY = CGFloat(index) * fannedReveal
-                let pinnedY = past + pinInset + CGFloat(index) * collapsedReveal
                 Button {
                     onCardTap(item)
                 } label: {
                     TokenCardView(data: item, height: cardHeight)
                 }
                 .buttonStyle(.plain)
-                .offset(y: max(fannedY, pinnedY))
+                .visualEffect { [index] content, proxy in
+                    content.offset(y: offset(for: index, stackTop: proxy.frame(in: .scrollView).minY))
+                }
                 // Cards drawn front-to-back so the last (highest-value) sits on top.
                 .zIndex(Double(index))
             }
         }
         .frame(maxWidth: .infinity)
         .frame(height: stackHeight, alignment: .top)
+    }
+
+    /// Per-card vertical offset, relative to the card's own layout position (all
+    /// cards are laid out coincident at the stack top, so every card sees the same
+    /// `stackTop`). The fan, the collapse-into-back-card, and the release all fall
+    /// out of this one input.
+    ///
+    /// - `stackTop` falls as the user scrolls up. While it's above `pinInset`, the
+    ///   card rides at its fanned position. Once the card's fanned top would cross
+    ///   its collapsed slot (`pinInset + index · collapsedReveal`), it pins there —
+    ///   the back card first, then each card in turn. Below `releaseTop` the input
+    ///   is clamped, freezing the offset so the collapsed deck scrolls off.
+    private nonisolated func offset(for index: Int, stackTop: CGFloat) -> CGFloat {
+        let fannedY = CGFloat(index) * fannedReveal
+        let collapsedSlot = pinInset + CGFloat(index) * collapsedReveal
+        let effectiveTop = max(stackTop, releaseTop)
+        let restingTop = max(effectiveTop + fannedY, collapsedSlot)
+        return restingTop - effectiveTop
     }
 }

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -4,7 +4,6 @@
 //
 
 import SwiftUI
-import UIKit
 import FlipcashUI
 import FlipcashCore
 
@@ -25,13 +24,6 @@ struct WalletScreen: View {
     }
 }
 
-/// The header block's height — the scroll distance at which the stack reaches
-/// the top and the collapse begins. Measured once at layout (scroll-independent).
-private struct HeaderHeightKey: PreferenceKey {
-    static var defaultValue: CGFloat = 150
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
-}
-
 private struct WalletScreenContent: View {
 
     @Environment(AppRouter.self) private var router
@@ -48,16 +40,10 @@ private struct WalletScreenContent: View {
     @State private var hasTipped: Bool
     /// The unified recent-activity preview (newest first).
     @State private var recentActivities: [Activity]
-    @State private var scrolledPast: CGFloat = 0
 
     /// Rows of recent activity previewed on the wallet (the rest lives on the
     /// per-token transaction history).
     private static let recentPreviewCount = 3
-    /// The height of everything above the card stack (header + funnel) — the
-    /// scroll distance before the stack reaches the top. Collapse starts past it.
-    @State private var headerHeight: CGFloat = 150
-    /// The scroll view's content offset at rest, captured on the first KVO tick.
-    @State private var restOffset: CGFloat?
 
     init(sessionContainer: SessionContainer, onScanTipCard: @escaping () -> Void) {
         self.session = sessionContainer.session
@@ -109,12 +95,15 @@ private struct WalletScreenContent: View {
     private var walletContent: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(spacing: 0) {
-                // Header + funnel scroll off before the stack collapses, so their
-                // combined height (scroll-independent, measured once at layout) is
-                // the collapse threshold.
+                // Header + funnel scroll off first; the card stack then reaches the
+                // top and collapses into its back card. The stack measures the
+                // scroll itself (via `.visualEffect`), so no height plumbing here.
                 VStack(spacing: 0) {
                     header
-                        .padding(.vertical, 30)
+                        // Figma (8966:1578) drops the balance well down the screen —
+                        // most of the extra space sits above it, less below.
+                        .padding(.top, 96)
+                        .padding(.bottom, 44)
 
                     if !isOnboardingComplete {
                         OnboardingFunnelView(
@@ -125,16 +114,10 @@ private struct WalletScreenContent: View {
                         .padding(.bottom, 20)
                     }
                 }
-                .background(
-                    GeometryReader { proxy in
-                        Color.clear.preference(key: HeaderHeightKey.self, value: proxy.size.height)
-                    }
-                )
 
                 if !cards.isEmpty {
                     TokenCardStack(
                         items: cards,
-                        scrolledPast: scrolledPast,
                         onCardTap: { router.push(.currencyInfo($0.mint)) }
                     )
                 }
@@ -143,7 +126,7 @@ private struct WalletScreenContent: View {
                 // users use the funnel's own "Add Money" step instead.
                 if hasAddedMoney {
                     addMoneyButton
-                        .padding(.top, 24)
+                        .padding(.vertical, 24)
                 }
 
                 if !recentActivities.isEmpty {
@@ -154,24 +137,14 @@ private struct WalletScreenContent: View {
                 Color.clear.frame(height: 96)
             }
             .padding(.horizontal, 20)
-            // The underlying UIScrollView's contentOffset updates on every scroll
-            // frame — SwiftUI preferences in scroll content only fire at layout —
-            // so it, not a GeometryReader, is what drives the collapse. Once the
-            // scroll passes the header (the stack reaches the top), the excess is
-            // how far the stack has scrolled past the top.
-            .background(ScrollOffsetReader { offsetY in
-                if restOffset == nil { restOffset = offsetY }
-                scrolledPast = max(0, (offsetY - (restOffset ?? 0)) - headerHeight)
-            })
         }
-        .onPreferenceChange(HeaderHeightKey.self) { headerHeight = $0 }
     }
 
     private var header: some View {
         VStack(spacing: 4) {
             BalanceHeaderButton(balance: total)
                 .frame(height: 60)
-            ValueAppreciation(amount: appreciation.amount, isPositive: appreciation.isPositive)
+            ValueAppreciation(amount: appreciation.amount, isPositive: appreciation.isPositive, style: .pill)
         }
     }
 
@@ -281,51 +254,5 @@ private struct WalletScreenContent: View {
         )
 
         return (cards, total, appreciation, session.hasEverAddedMoney(), session.hasEverTipped())
-    }
-}
-
-/// Reports the enclosing `UIScrollView`'s vertical content offset on every scroll
-/// frame. SwiftUI preferences on scroll content only fire at layout time (not
-/// during scroll), so this KVO bridge is what makes the card stack collapse.
-private struct ScrollOffsetReader: UIViewRepresentable {
-
-    let onChange: (CGFloat) -> Void
-
-    func makeUIView(context: Context) -> UIView {
-        let view = UIView(frame: .zero)
-        view.isUserInteractionEnabled = false
-        // The scroll view isn't in the hierarchy yet during makeUIView; defer.
-        DispatchQueue.main.async { context.coordinator.attach(from: view) }
-        return view
-    }
-
-    func updateUIView(_ uiView: UIView, context: Context) {}
-
-    func makeCoordinator() -> Coordinator { Coordinator(onChange: onChange) }
-
-    // KVO on `contentOffset` fires on the main thread for a UIScrollView; the
-    // unchecked conformance documents that the stored closure is only ever
-    // touched there.
-    final class Coordinator: @unchecked Sendable {
-        private let onChange: (CGFloat) -> Void
-        private var observation: NSKeyValueObservation?
-
-        init(onChange: @escaping (CGFloat) -> Void) { self.onChange = onChange }
-
-        func attach(from view: UIView) {
-            var current: UIView? = view.superview
-            while let candidate = current {
-                if let scrollView = candidate as? UIScrollView {
-                    observation = scrollView.observe(\.contentOffset, options: [.initial, .new]) { [weak self] _, change in
-                        guard let self, let y = change.newValue?.y else { return }
-                        MainActor.assumeIsolated { self.onChange(y) }
-                    }
-                    return
-                }
-                current = candidate.superview
-            }
-        }
-
-        deinit { observation?.invalidate() }
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Views/ValueAppreciation.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/ValueAppreciation.swift
@@ -9,16 +9,27 @@ import SwiftUI
 import FlipcashCore
 
 public struct ValueAppreciation: View {
+
+    /// Visual treatment. `classic` is the v1 green/red sentiment chip used by the
+    /// legacy balance and currency-info screens; `pill` is the v2 neutral bordered
+    /// pill (Figma 8966:1583) used only by the new Wallet UI.
+    public enum Style {
+        case classic
+        case pill
+    }
+
     public let amount: FiatAmount
     public let isPositive: Bool
+    public let style: Style
     private let isNegligible: Bool
     private var prefix: String {
         guard !isNegligible else { return "" }
         return isPositive ? "+" : "-"
     }
 
-    public init(amount: FiatAmount, isPositive: Bool) {
+    public init(amount: FiatAmount, isPositive: Bool, style: Style = .classic) {
         self.amount = amount
+        self.style = style
         self.isNegligible = amount.value < 0.01
         // Amounts smaller than one cent (e.g. 0.001) are treated as positive
         // to avoid displaying negligible negative rounding artifacts.
@@ -28,11 +39,20 @@ public struct ValueAppreciation: View {
             self.isPositive = isPositive
         }
     }
-    
+
     public var body: some View {
+        switch style {
+        case .classic:
+            classicBody
+        case .pill:
+            pillBody
+        }
+    }
+
+    private var classicBody: some View {
         let color = isPositive ? Color.Sentiment.positive : Color.Sentiment.negative
-        
-        HStack {
+
+        return HStack {
             Text("\(prefix)\(amount.formatted())")
                 .foregroundStyle(color)
                 .padding(4)
@@ -41,7 +61,7 @@ public struct ValueAppreciation: View {
                         .fill(color)
                         .opacity(0.2)
                 }
-            
+
             Group {
                 if isPositive {
                     Text("from currency appreciation")
@@ -52,6 +72,26 @@ public struct ValueAppreciation: View {
                 .foregroundStyle(Color.textSecondary)
         }
             .font(.appTextSmall)
+            .padding(.bottom, 30)
+    }
+
+    // v2 (Figma 8966:1583): a neutral bordered pill — no green/red fill — with the
+    // signed delta and a short label, both in secondary text. The (i) info icon in
+    // the design is intentionally omitted for now.
+    private var pillBody: some View {
+        HStack(spacing: 4) {
+            Text("\(prefix)\(amount.formatted())")
+                .padding(.horizontal, 4)
+                .padding(.vertical, 3)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                }
+
+            Text(isPositive ? "from appreciation" : "from depreciation")
+        }
+            .font(.appTextSmall)
+            .foregroundStyle(Color.textSecondary)
             .padding(.bottom, 30)
     }
 }


### PR DESCRIPTION
## What

Two v2 Wallet changes plus supporting layout tweaks.

### Card stack — Apple Wallet–style collapse
`TokenCardStack` now fans open at rest and **collapses into its back card** as you scroll:
- Placement is driven per-card by SwiftUI `.visualEffect`, reading each card's own `frame(in: .scrollView).minY` — no shared scroll state.
- Once the balance header scrolls off, the back card pins at the top and the rest collapse into it (`fannedReveal` 64 → `collapsedReveal` 0, so back cards hide **behind** the front card with no slivers), then the deck releases and scrolls off.
- Removes the previous `ScrollOffsetReader` (`UIScrollView` KVO bridge) + `HeaderHeightKey` PreferenceKey plumbing from `WalletScreen`.

### Appreciation label — v2 pill, gated to new UI
`ValueAppreciation` gains a `Style` enum:
- `.pill` — v2 neutral bordered pill (Figma `8966:1583`), used **only** by the new `WalletScreen`.
- `.classic` — the existing green/red sentiment chip; remains the default, so `BalanceScreen` (v1) and `CurrencyInfoHeaderSection` are unchanged.

### WalletScreen layout
- v2 header spacing: balance `.padding(.top, 96)` / `.padding(.bottom, 44)` (Figma `8966:1578`).
- Add Money row gets balanced vertical padding.

## Testing
- Builds clean on the `Flipcash` scheme (iPhone 17 sim, iOS 26.2).
- Scroll/collapse verified interactively via Maestro-driven scroll capture.

## Follow-up
- Android to be updated to match.
