### PR TITLE
fix(wallet): use 12pt medium radius for token card

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/TokenCardView.swift
+++ b/Flipcash/Core/Screens/Main/Home/TokenCardView.swift
@@ -66,7 +66,7 @@ struct TokenCardView: View {
         )
     }
 
-    private static let cornerRadius: CGFloat = 20
+    private static let cornerRadius: CGFloat = Metrics.boxRadius   // 12 — medium shape
     private static let fallback = Color(hex: "#06450F")!
     private static let usdfGradient = [Color(hex: "#C4980B")!, Color(hex: "#B06B00")!]
 


### PR DESCRIPTION
## What

The new-UI wallet token card (the collapsing "deck" on the Home/Wallet screen) was rendering with a hardcoded **20pt** corner radius. Switch it to the design system's **medium** shape token — `Metrics.boxRadius` (12pt) — so it matches the intended design and stays consistent with other medium-radius surfaces (e.g. `CardButtonStyle`, `BorderedContainer`).

## Change

`Flipcash/Core/Screens/Main/Home/TokenCardView.swift` — the radius is defined once as a private static and consumed twice (gradient fill + stroke border), so a single edit fixes both:

```diff
-private static let cornerRadius: CGFloat = 20
+private static let cornerRadius: CGFloat = Metrics.boxRadius   // 12 — medium shape
```

`Metrics` is already imported via `FlipcashUI`; no new import needed.

## Out of scope

- The appreciation pill's 6pt radius — separate small element, unchanged.
- `TokenCardStack` layout/animation — unaffected.

## Verification

- `build_sim` (Flipcash scheme) succeeds — no errors.
- Installed and launched on the iPhone 17 simulator; token card corners now render at the tighter 12pt medium radius.