### PR TITLE
fix(scan): prevent black flash when opening the camera tab

### DIFF
--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -81,12 +81,7 @@ private struct ScanScreenContent: View {
         ZStack {
             if cameraPrompt == nil {
                 cameraViewport()
-                    .transition(
-                        .asymmetric(
-                            insertion: .opacity.animation(.easeInOut(duration: 0.2).delay(0.3)),
-                            removal: .identity
-                        )
-                    )
+                    .transition(.identity)
             }
             
             if showControls {
@@ -133,6 +128,11 @@ private struct ScanScreenContent: View {
             session: viewModel.cameraSession,
             enableGestures: true
         )
+        // Cross-fade the live preview in only once the first frame arrives, over
+        // the dark placeholder — so the camera warm-up after a tab switch never
+        // shows a black frame. See `ScanViewModel.isPreviewReady`.
+        .opacity(viewModel.isPreviewReady ? 1 : 0)
+        .animation(.easeInOut(duration: 0.25), value: viewModel.isPreviewReady)
         .toolbarVisibility(.hidden, for: .navigationBar)
         .onAppear {
             viewModel.configureCameraSession()

--- a/Flipcash/Core/Screens/Main/ScanViewModel.swift
+++ b/Flipcash/Core/Screens/Main/ScanViewModel.swift
@@ -19,6 +19,12 @@ class ScanViewModel {
 
     @ObservationIgnored let cameraSession: CameraSession<CodeExtractor>
 
+    /// `true` once the capture session has delivered its first frame. Drives the
+    /// preview's cross-fade so the camera warm-up (after a tab switch) shows the
+    /// dark placeholder instead of popping in from black. `extraction` fires once
+    /// per frame, so its first emission is the first rendered frame.
+    private(set) var isPreviewReady: Bool = false
+
     @ObservationIgnored private let session: Session
     @ObservationIgnored private let tipFlow: TipFlow
 
@@ -49,14 +55,21 @@ class ScanViewModel {
     
     func stopCamera() {
         cameraSession.stop()
+        // Re-arm the cross-fade so a subsequent start fades in on its first frame.
+        isPreviewReady = false
     }
     
     // MARK: - Scanning -
     
     private func registerCodeExtractorObserver() {
         cameraSession.extraction.sink { [weak self] payload in
+            guard let self else { return }
+            // First frame in — reveal the preview.
+            if !self.isPreviewReady {
+                self.isPreviewReady = true
+            }
             if let payload = payload {
-                self?.didScan(payload)
+                self.didScan(payload)
             }
         }
         .store(in: &cancellables)

--- a/FlipcashUI/Sources/FlipcashUI/Camera/CameraPreviewView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Camera/CameraPreviewView.swift
@@ -164,6 +164,14 @@ public class _CameraPreviewView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
+        // Paint the view and preview layer with the app background instead of the
+        // preview layer's default black. During the capture session's warm-up on
+        // a tab switch (before the first sample buffer arrives) this makes the
+        // gap blend into the dark UI rather than flashing black.
+        let background = UIColor(Color.backgroundMain)
+        backgroundColor = background
+
+        previewLayer.backgroundColor = background.cgColor
         previewLayer.videoGravity = .resizeAspectFill
         layer.addSublayer(previewLayer)
 


### PR DESCRIPTION
## Problem

Switching **to** the scan/camera tab from any other tab briefly flashes **black** before the live preview appears.

**Root cause:** the scan tab's `ScanScreen` is torn down when you leave it and recreated when you return, which **stops** the `AVCaptureSession` on exit and **restarts** it on entry. `startRunning()` is asynchronous and takes ~100–300ms to deliver the first frame; during that warm-up the `AVCaptureVideoPreviewLayer` renders its default **black**. The previous reveal used a fixed `0.3s` delayed opacity fade that wasn't tied to the camera actually being ready, so the black frame could still show through.

## Fix

1. **`CameraPreviewView`** — paint the preview view and its `AVCaptureVideoPreviewLayer` with `backgroundMain` (#191A1A) instead of the default black, so any warm-up gap blends into the dark UI rather than flashing black.
2. **`ScanViewModel`** — add `isPreviewReady`, flipped `true` on the first `extraction` emission. `extraction` fires once per frame, so its first emission is exactly the first rendered frame. Re-armed to `false` in `stopCamera()`.
3. **`ScanScreen`** — cross-fade the preview in on `isPreviewReady` (over the dark placeholder), replacing the fixed `0.3s` delayed reveal. The live image now fades in precisely when the first frame is ready, regardless of warm-up duration.

Net effect: no black flash, and the reveal is synchronized to real camera content instead of a timing guess.

## Testing
- Builds clean on the `Flipcash` scheme.
- Note: the iOS **Simulator has no live camera**, so the warm-up/flash can only be fully verified on a device — on the sim the scan tab simply shows the dark placeholder.
