### PR TITLE
fix(access-key): remove white outline on card corners

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Views/AccessKey.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/AccessKey.swift
@@ -93,9 +93,8 @@ public struct AccessKey: View {
                 }
                     .padding([.top, .bottom], 60)
             )
-            .clipped()
-            .clipShape(.rect(cornerRadius: 10))
             .drawingGroup()
+            .clipShape(.rect(cornerRadius: 10))
             .frame(maxWidth: 255)
     }
 }


### PR DESCRIPTION
## Problem

The access key card (shown in onboarding backup, Settings → access key backup, and the photo-save snapshot) rendered a faint **white outline at its rounded corners** — a visible rendering glitch.

## Cause

In `AccessKey.swift` the final layering was:

```swift
.clipped()                            // hard square clip → near-white (0.85) base at corners
.clipShape(.rect(cornerRadius: 10))   // rounds it, antialiasing over that opaque square
.drawingGroup()                       // rasterizes AFTER the clip → light corner halo
```

`.drawingGroup()` applied *after* `.clipShape` is the classic SwiftUI source of a light fringe at rounded corners (offscreen-buffer edge pixels bleed through the mask). The redundant `.clipped()` made it worse by stamping a hard square whose corners are the near-white (0.85) base fill, which the rounded clip then antialiased over.

## Fix

Rasterize the full metallic card with `.drawingGroup()` first, then apply the rounded `.clipShape` as the **final** compositing op so corners antialias cleanly against the transparent parent. The redundant `.clipped()` is removed.

```swift
.drawingGroup()
.clipShape(.rect(cornerRadius: 10))
```

The grey base fill (which brightens the metallic sheen through the blur) is untouched, so the card's look is otherwise unchanged.

## Testing

- `FlipcashUI` scheme builds clean for the simulator.
- Full `Flipcash` app built, installed, and launched on the iPhone 17 simulator.
