### PR TITLE
fix(onboarding): use 12pt box shape token for funnel card

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/OnboardingFunnel.swift
+++ b/Flipcash/Core/Screens/Main/Home/OnboardingFunnel.swift
@@ -66,7 +66,7 @@ struct OnboardingFunnelView: View {
                 }
             }
             .background(Color.white.opacity(0.05))
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: Metrics.boxRadius, style: .continuous))
         }
     }
 


### PR DESCRIPTION
## Change

The wallet onboarding funnel card (`OnboardingFunnelView`) hardcoded a `16` pt corner radius. Switch it to the design system's medium **box** shape token — `Metrics.boxRadius` (12 pt) — so it matches the token card (#575) and other medium-radius surfaces.

```swift
.clipShape(RoundedRectangle(cornerRadius: Metrics.boxRadius, style: .continuous))
```

## Testing

- `Flipcash` scheme builds clean for the simulator.
