### PR TITLE
feat(add-money): push deposit destinations instead of showing sheets

### DIFF
--- a/Flipcash/Core/AppDelegate.swift
+++ b/Flipcash/Core/AppDelegate.swift
@@ -200,13 +200,17 @@ private extension AppDelegate {
         bar.titleTextAttributes = titleAttributes
 
         if #available(iOS 26, *) {
-            // iOS 26: Transparent background to allow Liquid Glass,
-            // but still apply custom title font and button styling
+            // iOS 26: use the system's default (Liquid Glass) bar background and
+            // only override the title fonts. A *transparent* background removes
+            // the bar's glass material, so the buttons have no stable bar-glass
+            // to composite against and the system repaints their glass during
+            // the push transition — that's the flicker as screens push/settle.
+            // The buttons are also left to the system (no `backButtonAppearance`)
+            // for the same reason.
             let barAppearance = UINavigationBarAppearance()
-            barAppearance.configureWithTransparentBackground()
+            barAppearance.configureWithDefaultBackground()
             barAppearance.titleTextAttributes = titleAttributes
             barAppearance.largeTitleTextAttributes = largeAttributes
-            barAppearance.backButtonAppearance = buttonAppearance
 
             bar.standardAppearance = barAppearance
             bar.scrollEdgeAppearance = barAppearance
@@ -235,14 +239,15 @@ private extension AppDelegate {
 // MARK: - UINavigationController -
 
 extension UINavigationController {
-    /// Remove the back button in all navigation stacks
+    /// Force every pushed screen's back button to the chevron-only (`.minimal`)
+    /// display mode. On iOS 26 the default mode carries the previous screen's
+    /// title as a back label that re-resolves during the push transition, which
+    /// flickers the back arrow as the route settles. Guarded so it only writes
+    /// when the value actually changes — `viewWillLayoutSubviews` runs on every
+    /// layout pass, and re-setting it each time would itself churn the bar.
     open override func viewWillLayoutSubviews() {
-        // Only execute on iOS 18 and below
-        if #available(iOS 26, *) {
-            return
-        }
-
-        for viewController in viewControllers {
+        for viewController in viewControllers
+        where viewController.navigationItem.backButtonDisplayMode != .minimal {
             viewController.navigationItem.backButtonDisplayMode = .minimal
         }
     }

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -165,8 +165,43 @@ extension View {
         navigationDestination(for: AppRouter.Destination.self) { destination in
             DestinationView(destination: destination)
         }
+        // The Add Money deposit flow pushes onto whichever stack launched it
+        // (wallet, settings, buy, chat, …) rather than opening its own sheet,
+        // so every app stack registers its steps here.
+        .navigationDestination(for: AddMoneyFlowStep.self) { step in
+            AddMoneyFlowStepDestination(step: step)
+        }
+        // The up-front debit-card verification (intro → phone → email) pushes
+        // onto the same stack ahead of the deposit flow.
+        .navigationDestination(for: OnrampVerificationPath.self) { path in
+            OnrampVerificationPushedStep(path: path)
+        }
         // Sheet-hosted stacks otherwise recognize swipe-back from anywhere; keep
         // it to the leading edge, matching the root stack and system behavior.
         .edgeOnlySwipeBack()
+    }
+}
+
+/// Renders a pushed Add Money deposit step on the app's shared stacks.
+/// Advancing pushes the next step onto the same stack.
+private struct AddMoneyFlowStepDestination: View {
+
+    let step: AddMoneyFlowStep
+
+    @Environment(AppRouter.self) private var router
+
+    var body: some View {
+        AddMoneyFlowDestination(step: step, onStep: { router.pushAny($0) })
+            .environment(\.dismissParentContainer, {
+                // v2 pushes the flow onto the host stack, so finishing pops back
+                // to that stack's root, returning to where it was launched. v1
+                // only reaches here over the buy sheet, where finishing dismisses
+                // the sheet as it always has.
+                if BetaFlags.shared.hasEnabled(.newUI) {
+                    router.popToRoot()
+                } else {
+                    router.dismissSheet()
+                }
+            })
     }
 }

--- a/Flipcash/Core/Navigation/AppRouter+NestedSheet.swift
+++ b/Flipcash/Core/Navigation/AppRouter+NestedSheet.swift
@@ -100,14 +100,9 @@ private struct BuySheetRoot: View {
             )
             .id(mint)
             .environment(\.dismissParentContainer, { router.dismissSheet() })
+            // Registers the shared destinations, including the Add Money
+            // deposit steps, so a buy-shortfall deposit pushes onto this stack.
             .appRouterDestinations()
-            // The dismiss env must be set at the registration: destination
-            // content doesn't inherit environment from the root view's inner
-            // modifiers.
-            .navigationDestination(for: AddMoneyFlowStep.self) { step in
-                AddMoneyFlowDestination(step: step, onStep: { router.pushAny($0) })
-                    .environment(\.dismissParentContainer, { router.dismissSheet() })
-            }
         }
     }
 }

--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -354,6 +354,19 @@ final class AppRouter {
         return true
     }
 
+    /// The stack the deposit flow pushes onto once a method is chosen from the
+    /// Add Money picker: the sheet directly beneath the picker, or — when the
+    /// picker is the root sheet over a v2 tab — that tab's stack. `nil` when
+    /// nothing sits beneath the picker (e.g. opened over the bare scanner via
+    /// the no-balance gate); the picker then falls back to its own flow sheet
+    /// since there is no navigation stack to host the push.
+    var addMoneyPushStack: Stack? {
+        if presentedSheets.count >= 2 {
+            return presentedSheets[presentedSheets.count - 2].stack
+        }
+        return activeTabStack
+    }
+
     /// Dismisses the topmost sheet. If only the root remains, this dismisses
     /// the root (same as the pre-nested behaviour). With nested sheets, only
     /// the topmost is popped — the root stays presented.

--- a/Flipcash/Core/Screens/Main/AddMoney/AddMoneyStartScreen.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/AddMoneyStartScreen.swift
@@ -65,26 +65,48 @@ struct AddMoneyStartScreen: View {
         .onChange(of: verificationViewModel == nil) { _, isNil in
             guard isNil, pendingCoinbaseAmount else { return }
             pendingCoinbaseAmount = false
+            let router = self.router
             Task { @MainActor in
                 try? await Task.delay(milliseconds: 400)
-                flowMethod = .coinbase
+                startFlow(.coinbase, using: router)
             }
         }
     }
 
-    /// Over the buy amount sheet the deposit flow pushes onto that sheet's
-    /// stack; everywhere else it opens as its own sheet on top. In v2 a
-    /// debit-card (Coinbase) deposit verifies phone/email first — the amount
-    /// flow opens only once verification passes (immediately if already
-    /// verified), so no empty sheet appears ahead of it.
+    /// Chooses a deposit method.
+    ///
+    /// In the v2 UI the flow pushes onto the navigation stack the picker was
+    /// launched from — matching the rest of the app — via `startFlow`, and a
+    /// debit-card (Coinbase) deposit verifies phone/email first so no empty
+    /// screen appears ahead of it (skipped over the buy sheet, already gated).
+    ///
+    /// The v1 UI keeps the sheet-based flow unchanged: the deposit opens as its
+    /// own sheet, except over the buy sheet where it pushes as it always has.
     private func select(_ method: DepositMethod) {
         Analytics.addMoneyMethodSelected(method: method)
-        if router.isAddMoneyOverBuy {
-            router.dismissSheet()
-            router.pushAny(AddMoneyFlowStep.method(method))
+        let router = self.router
+
+        guard BetaFlags.shared.hasEnabled(.newUI) else {
+            if router.isAddMoneyOverBuy {
+                dismissThenPush(AddMoneyFlowStep.method(method), using: router)
+            } else {
+                flowMethod = method
+            }
             return
         }
-        if method == .coinbase, BetaFlags.shared.hasEnabled(.newUI) {
+
+        guard method == .coinbase, !router.isAddMoneyOverBuy else {
+            startFlow(method, using: router)
+            return
+        }
+
+        // A debit-card deposit verifies phone/email up front. With a host stack
+        // the whole verification (intro → phone → email) pushes onto it ahead of
+        // the deposit flow; without one (over the bare scanner) it falls back to
+        // the sheet-based verification and sheet deposit flow.
+        if let stack = router.addMoneyPushStack {
+            startCoinbaseVerification(pushingOnto: stack, using: router)
+        } else {
             verificationCoordinator.runGated(
                 for: session,
                 bind: { verificationViewModel = $0 },
@@ -98,9 +120,68 @@ struct AddMoneyStartScreen: View {
                     }
                 }
             )
+        }
+    }
+
+    /// Enters the deposit flow for `method` in the v2 UI. When the picker sits
+    /// over an existing navigation stack (the common case) it dismisses the
+    /// picker and pushes the flow onto that stack so it reads like the rest of
+    /// the app's navigation. With no stack beneath it — the no-balance gate
+    /// opened over the bare scanner — it falls back to presenting the flow as
+    /// its own sheet.
+    private func startFlow(_ method: DepositMethod, using router: AppRouter) {
+        if router.addMoneyPushStack != nil {
+            dismissThenPush(AddMoneyFlowStep.method(method), using: router)
         } else {
             flowMethod = method
         }
+    }
+
+    /// Dismisses the picker, then pushes `value` onto the revealed stack once
+    /// the sheet's dismiss animation has cleared. Pushing while the partial
+    /// sheet is still sliding down runs the revealed stack's push animation at
+    /// the same time, which flickers the new screen's back arrow — so the push
+    /// waits for the sheet to settle (the app's dismiss-then-mutate pattern).
+    private func dismissThenPush<H: Hashable>(_ value: H, using router: AppRouter) {
+        router.dismissSheet()
+        Task { @MainActor in
+            try? await Task.sleep(for: AppRouter.dismissAnimationDuration)
+            router.pushAny(value)
+        }
+    }
+
+    /// v2 debit-card path with a host stack: pushes the verification flow
+    /// (intro → phone → email) onto `stack`, then the deposit amount flow — one
+    /// continuous push navigation. Skips straight to the deposit when the
+    /// profile is already verified. On completion it dismisses the picker (if
+    /// still up), unwinds the verification steps, and pushes the deposit.
+    private func startCoinbaseVerification(pushingOnto stack: AppRouter.Stack, using router: AppRouter) {
+        let baseline = router[stack].count
+        verificationCoordinator.runGated(
+            for: session,
+            bind: { vm in
+                guard let vm else { return }
+                vm.onAdvance = { router.pushAny($0) }
+                let first = vm.initialStep()
+                vm.rootPushedStep = first
+                dismissThenPush(first, using: router)
+            },
+            perform: {
+                if case .addMoney? = router.presentedSheet {
+                    // Already verified: the picker is still up. Dismiss it and
+                    // push the deposit once it clears (same anti-flicker beat).
+                    dismissThenPush(AddMoneyFlowStep.method(.coinbase), using: router)
+                } else {
+                    // Verified via the pushed steps: unwind them and push the
+                    // deposit inline on the already-visible stack.
+                    let depth = router[stack].count
+                    if depth > baseline {
+                        router.popLast(depth - baseline, on: stack)
+                    }
+                    router.pushAny(AddMoneyFlowStep.method(.coinbase))
+                }
+            }
+        )
     }
 
     /// The deposit methods to list — Pay (Coinbase) requires the onramp.
@@ -231,10 +312,12 @@ private struct AddMoneyMethodRow: View {
     }
 }
 
-// MARK: - Deposit flow (new full sheet on top of the prompt)
+// MARK: - Deposit flow
 
-/// A step of the deposit flow, hosted by `AddMoneyFlowSheet` or pushed onto
-/// the buy sheet's stack. `.method` is the per-method root.
+/// A step of the deposit flow. Normally pushed onto the stack the picker was
+/// launched from (registered in `appRouterDestinations`); only when no such
+/// stack exists is it hosted by the fallback `AddMoneyFlowSheet`. `.method` is
+/// the per-method root.
 enum AddMoneyFlowStep: Hashable {
     case method(DepositMethod)
     case phantomAmount
@@ -279,8 +362,9 @@ struct AddMoneyFlowDestination: View {
     }
 }
 
-/// The deposit flow presented as its own sheet, driving a local
-/// navigation path.
+/// Fallback host for the deposit flow when the picker has no navigation stack
+/// beneath it to push onto (the no-balance gate opened over the bare scanner).
+/// Presents the flow as its own sheet, driving a local navigation path.
 private struct AddMoneyFlowSheet: View {
 
     let method: DepositMethod
@@ -290,6 +374,9 @@ private struct AddMoneyFlowSheet: View {
     var body: some View {
         NavigationStack(path: $path) {
             AddMoneyFlowDestination(step: .method(method), onStep: { path.append($0) })
+                // The flow's per-method root is this sheet's root — it has no
+                // back arrow, so it owns the Close button.
+                .environment(\.presentedAsSheetRoot, true)
                 .navigationDestination(for: AddMoneyFlowStep.self) { step in
                     AddMoneyFlowDestination(step: step, onStep: { path.append($0) })
                 }
@@ -304,6 +391,7 @@ private struct AddMoneyFlowRoot: View {
 
     @Environment(SessionContainer.self) private var sessionContainer
     @Environment(\.dismissParentContainer) private var dismissParentContainer
+    @Environment(\.presentedAsSheetRoot) private var presentedAsSheetRoot
 
     var body: some View {
         Group {
@@ -326,8 +414,12 @@ private struct AddMoneyFlowRoot: View {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                CloseButton(action: dismissParentContainer)
+            // Pushed onto a stack the flow already has a back arrow; only the
+            // sheet-root presentation needs a Close button.
+            if presentedAsSheetRoot {
+                ToolbarItem(placement: .topBarTrailing) {
+                    CloseButton(action: dismissParentContainer)
+                }
             }
         }
     }

--- a/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
@@ -56,6 +56,30 @@ final class OnrampVerificationViewModel<P: PhoneVerifying, E: EmailVerifying>: V
     /// implementations.
     @ObservationIgnored var continuation: CheckedContinuation<Void, Error>?
 
+    // MARK: - Pushed navigation -
+
+    /// When set, step advances route through this sink — used to push the flow
+    /// onto the app's navigation stack — instead of the view-model-owned
+    /// `verificationPath`. Sheet hosts (`VerifyInfoScreen`) leave it nil and let
+    /// `verificationPath` drive their own `NavigationStack`.
+    @ObservationIgnored var onAdvance: (@MainActor (OnrampVerificationPath) -> Void)?
+
+    /// The first step pushed when the flow runs on the app's navigation stack.
+    /// The pushed host cancels the flow when this step is popped (the user
+    /// backed out of verification); later steps back within the flow.
+    @ObservationIgnored var rootPushedStep: OnrampVerificationPath?
+
+    /// Advances to `step` — pushing through `onAdvance` when the flow is hosted
+    /// on the app's navigation stack, otherwise appending to the sheet-owned
+    /// `verificationPath`.
+    private func advance(to step: OnrampVerificationPath) {
+        if let onAdvance {
+            onAdvance(step)
+        } else {
+            verificationPath.append(step)
+        }
+    }
+
     // MARK: - Init -
 
     /// Primary DI init — accepts any conformers of the verifier protocols.
@@ -71,7 +95,7 @@ final class OnrampVerificationViewModel<P: PhoneVerifying, E: EmailVerifying>: V
 
         phoneVerifier.onCodeRequested = { [weak self] in
             guard let self else { return }
-            verificationPath.append(.confirmPhoneNumberCode)
+            advance(to: .confirmPhoneNumberCode)
             Analytics.track(event: Analytics.OnrampEvent.showConfirmPhone)
         }
         phoneVerifier.onVerified = { [weak self] in
@@ -79,7 +103,7 @@ final class OnrampVerificationViewModel<P: PhoneVerifying, E: EmailVerifying>: V
         }
         emailVerifier.onCodeRequested = { [weak self] in
             guard let self else { return }
-            verificationPath.append(.confirmEmailCode)
+            advance(to: .confirmEmailCode)
             Analytics.track(event: Analytics.OnrampEvent.showConfirmEmail)
         }
         emailVerifier.onVerified = { [weak self] in
@@ -145,13 +169,13 @@ final class OnrampVerificationViewModel<P: PhoneVerifying, E: EmailVerifying>: V
     /// when both phone and email are needed, so phone entry is always next.
     func proceedFromIntro() {
         Analytics.track(event: Analytics.OnrampEvent.showEnterPhone)
-        verificationPath.append(.enterPhoneNumber)
+        advance(to: .enterPhoneNumber)
     }
 
     private func navigateToEmailOrFinish() {
         if !emailVerifier.isAlreadyVerified {
             Analytics.track(event: Analytics.OnrampEvent.showEnterEmail)
-            verificationPath.append(.enterEmail)
+            advance(to: .enterEmail)
             return
         }
 

--- a/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
@@ -86,3 +86,49 @@ struct VerifyInfoScreen<P: PhoneVerifying, E: EmailVerifying>: View {
         }
     }
 }
+
+/// Renders one verification step when the flow is pushed onto the app's
+/// navigation stack (v2) rather than hosted in `VerifyInfoScreen`'s own sheet
+/// stack. Mirrors the per-step switch above. The active view model comes from
+/// the coordinator's inline slot; the root step cancels the flow when it's
+/// popped — the user backed out of verification — while later steps back
+/// within the flow. Registered on every stack by `appRouterDestinations()`.
+struct OnrampVerificationPushedStep: View {
+
+    let path: OnrampVerificationPath
+
+    @Environment(VerificationCoordinator.self) private var coordinator
+
+    var body: some View {
+        if let viewModel = coordinator.currentInlineViewModel {
+            step(for: path, viewModel: viewModel)
+                .toolbarTitleDisplayMode(.inline)
+                .onDisappear {
+                    // Popping the root step means the user abandoned
+                    // verification; cancel to release the awaiting gate. A
+                    // no-op once the flow has finished (continuation cleared).
+                    if path == viewModel.rootPushedStep {
+                        viewModel.cancel()
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder
+    private func step(for path: OnrampVerificationPath, viewModel: OnrampVerification) -> some View {
+        switch path {
+        case .intro:
+            OnrampVerificationIntroScreen(onNext: { viewModel.proceedFromIntro() })
+        case .enterPhoneNumber:
+            EnterPhoneScreen(viewModel: viewModel.phoneVerifier)
+                .navigationTitle("Verify Phone Number")
+        case .confirmPhoneNumberCode:
+            ConfirmPhoneScreen(viewModel: viewModel.phoneVerifier)
+                .navigationTitle("Verify Phone Number")
+        case .enterEmail:
+            EnterEmailScreen(viewModel: viewModel.emailVerifier)
+        case .confirmEmailCode:
+            ConfirmEmailScreen(viewModel: viewModel.emailVerifier)
+        }
+    }
+}

--- a/Flipcash/Extensions/EnvironmentValues.swift
+++ b/Flipcash/Extensions/EnvironmentValues.swift
@@ -55,4 +55,11 @@ extension EnvironmentValues {
     /// the caller having to pass it explicitly. Default 0 is safe for any
     /// view not inside a router-driven sheet.
     @Entry var nestedSheetDepth: Int = 0
+
+    /// Whether the current flow screen sits at the root of a modal container
+    /// (a sheet) and therefore needs its own Close button, versus being pushed
+    /// onto a navigation stack where the system back button already provides an
+    /// exit. Sheet-root hosts set this to `true`; pushed hosts leave the default
+    /// `false` so a screen doesn't show both a Close button and a back arrow.
+    @Entry var presentedAsSheetRoot: Bool = false
 }

--- a/FlipcashTests/AddMoney/AddMoneyRoutingTests.swift
+++ b/FlipcashTests/AddMoney/AddMoneyRoutingTests.swift
@@ -96,4 +96,36 @@ struct AddMoneyRoutingTests {
         #expect(router.presentedSheets == [.discover, .buy(.usdc)])
         #expect(router[.buy].count == 1, "The deposit flow step must land on the buy sheet's stack")
     }
+
+    @Test("The deposit flow targets the sheet directly beneath the picker")
+    func addMoneyPushStack_overSheet_usesUnderlyingStack() {
+        let router = AppRouter()
+        router.present(.give)
+        router.presentAddMoney(.giveCash, source: .scanner)
+        #expect(router.addMoneyPushStack == .give)
+    }
+
+    @Test("Over the buy sheet the deposit flow targets the buy stack")
+    func addMoneyPushStack_overBuy_usesBuyStack() {
+        let router = AppRouter()
+        router.present(.discover)
+        router.presentNested(.buy(.usdc))
+        router.presentAddMoney(.buyCurrency, source: .buyShortfall)
+        #expect(router.addMoneyPushStack == .buy)
+    }
+
+    @Test("At root, the deposit flow targets the active tab's stack")
+    func addMoneyPushStack_rootOverTab_usesActiveTabStack() {
+        let router = AppRouter()
+        router.activeTabStack = .balance
+        router.presentAddMoney(.general, source: .balance)
+        #expect(router.addMoneyPushStack == .balance)
+    }
+
+    @Test("At root with no active tab, the deposit flow has nowhere to push")
+    func addMoneyPushStack_rootNoTab_isNil() {
+        let router = AppRouter()
+        router.presentAddMoney(.giveCash, source: .scanner)
+        #expect(router.addMoneyPushStack == nil)
+    }
 }

--- a/FlipcashTests/CameraPromptTests.swift
+++ b/FlipcashTests/CameraPromptTests.swift
@@ -18,7 +18,7 @@ struct CameraPromptTests {
         let prompt = try #require(CameraPrompt(status: .notDetermined, cameraEnabled: cameraEnabled))
         #expect(prompt == .requestPermission)
         #expect(prompt.buttonTitle == "Continue")
-        #expect(prompt.message == "Flipcash uses your camera to scan and grab cash")
+        #expect(prompt.message(embedded: false) == "Flipcash uses your camera to scan and grab cash")
     }
 
     @Test(
@@ -29,7 +29,7 @@ struct CameraPromptTests {
         let prompt = try #require(CameraPrompt(status: status, cameraEnabled: cameraEnabled))
         #expect(prompt == .openSettings)
         #expect(prompt.buttonTitle == "Open Settings")
-        #expect(prompt.message == "You need to turn on Camera in Settings to scan Codes")
+        #expect(prompt.message(embedded: false) == "You need to turn on Camera in Settings to scan Codes")
     }
 
     @Test("Authorized with auto-start off offers Start Camera")
@@ -37,7 +37,7 @@ struct CameraPromptTests {
         let prompt = try #require(CameraPrompt(status: .authorized, cameraEnabled: false))
         #expect(prompt == .startCamera)
         #expect(prompt.buttonTitle == "Start Camera")
-        #expect(prompt.message == "You need to start your camera to grab cash")
+        #expect(prompt.message(embedded: false) == "You need to start your camera to grab cash")
     }
 
     @Test("Authorized with the camera running shows no prompt")


### PR DESCRIPTION
## Summary

Reworks the **Add Money** deposit flow (v2 UI) to **push** onto the current navigation stack instead of stacking sheets, matching the rest of the app.

- Selecting a deposit method (Debit Card / Phantom / Other Wallet) dismisses the picker and **pushes** the deposit flow onto the stack it was launched from (wallet, settings, chat, buy, …).
- The up-front **debit-card verification** (intro → phone → email) now pushes onto the same stack ahead of the deposit flow, as one continuous navigation. Backing out of the pushed verification cancels the awaiting gate.
- **v1 is unchanged** (still sheet-based). A sheet fallback remains only when there is no host stack to push onto (the no-balance gate opened over the bare scanner).

## Details

- `AppRouter.addMoneyPushStack` resolves the stack beneath the picker (or the active tab's stack at root).
- `appRouterDestinations()` centrally registers `AddMoneyFlowStep` and `OnrampVerificationPath`, so any stack can host the flow (removes the buy-sheet's duplicate registration).
- `OnrampVerificationViewModel` gains an injectable navigation sink so its steps push onto the router in the pushed context, while the sheet/deeplink paths keep driving their own `verificationPath`.

## Fixes to nav chrome / polish

- **Presence-aware buttons** (`\.presentedAsSheetRoot`): flow screens show a Close button only at a sheet root and rely on the back arrow when pushed — fixes the Phantom screen showing *both* a back arrow and a Close button.
- **Back-arrow flicker (iOS 26 Liquid Glass):** use the system glass nav-bar background and force the chevron-only back button; sequence the entry push behind the picker's dismiss animation so the revealed back arrow no longer flickers.

## Incidental

- Updates a stale `CameraPromptTests` call (`message` → `message(embedded:)`) so the test target compiles.

## Test plan

- `Flipcash` builds clean for the iOS 26 simulator.
- `AddMoneyRoutingTests`, `OnrampVerificationViewModelTests`, `AddMoneyAmountViewModelTests`, `CameraPromptTests` pass (20/20 in the routing + verification run), including new `addMoneyPushStack` coverage.
- Manually verified on the iPhone 17 simulator: deposit destinations push (wallet/settings), verification pushes ahead of the amount, back-arrow flicker resolved, Phantom no longer shows a double button.
