### PR TITLE
fix(wallet): separate stacked token cards to stop corner bleed

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/TokenCardStack.swift
+++ b/Flipcash/Core/Screens/Main/Home/TokenCardStack.swift
@@ -62,6 +62,9 @@ struct TokenCardStack: View {
                     TokenCardView(data: item, height: cardHeight)
                 }
                 .buttonStyle(.plain)
+                // Separate stacked cards so a card's rounded top corners read as
+                // sitting above the card behind, not bleeding its color/border through.
+                .shadow(color: .black.opacity(0.35), radius: 8, y: -2)
                 .visualEffect { [index] content, proxy in
                     content.offset(y: offset(for: index, stackTop: proxy.frame(in: .scrollView).minY))
                 }


### PR DESCRIPTION
## Problem

In the fanned token card deck, each card's rounded top corners revealed the **differently-colored card directly behind it** — including that card's white hairline border — through the corner notch. With contrasting token colors, this read as a color/white "bleed" at the corners.

It is **not** a border bug: the white ~10% inner border is intended on both platforms (Android's `surfaceVariant` is `White @ 12%`). The issue was that stacked cards had **no shadow separating the layers**, so adjacent cards touched directly at the corners.

## Fix

Add a subtle per-card shadow in `TokenCardStack`, cast slightly upward so each card visually sits above the one behind and the overlap seam is darkened:

```swift
.shadow(color: .black.opacity(0.35), radius: 8, y: -2)
```

The deck now reads as clean layered cards with no corner bleed.

## Testing

- `Flipcash` scheme built, installed, and run on the iPhone 17 simulator.
- Verified on the wallet screen: zoomed into card corners before/after — the contrasting-color/white-border bleed at the rounded corners is gone; cards separate cleanly.
