### PR TITLE
feat(wallet): tile shortcuts + floating glass discovery

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyCreationPromoCard.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyCreationPromoCard.swift
@@ -7,7 +7,18 @@ import SwiftUI
 import FlipcashUI
 
 struct CurrencyCreationPromoCard: View {
+    /// The card's background treatment. `.solid` is the inline list row (legacy
+    /// UI); `.glass` is the Liquid Glass surface used when the card floats pinned
+    /// to the bottom in the new UI, letting the list blur through behind it.
+    enum Surface {
+        case solid
+        case glass
+    }
+
+    var surface: Surface = .solid
     let action: () -> Void
+
+    private let cornerRadius: CGFloat = 16
 
     var body: some View {
         Button(action: action) {
@@ -32,13 +43,50 @@ struct CurrencyCreationPromoCard: View {
                     .scaledToFit()
                     .frame(width: 120)
             }
-            .background(Color.backgroundRow)
-            .compositingGroup()
-            .clipShape(.rect(cornerRadius: 16))
+            .modifier(SurfaceBackground(surface: surface, cornerRadius: cornerRadius))
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("discover-create-currency-card")
         .padding(.horizontal, 20)
         .padding(.top, 16)
+    }
+}
+
+/// Paints the promo card's background: an opaque row fill for `.solid`, the app's
+/// Liquid Glass surface for `.glass`. Both clip the bill artwork to the corners.
+private struct SurfaceBackground: ViewModifier {
+    let surface: CurrencyCreationPromoCard.Surface
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        switch surface {
+        case .solid:
+            content
+                .background(Color.backgroundRow)
+                .compositingGroup()
+                .clipShape(.rect(cornerRadius: cornerRadius))
+        case .glass:
+            // Liquid Glass, tinted a touch lighter to match the Figma surface
+            // (~white @ 10% over the dark list) rather than the dimmer default.
+            if #available(iOS 26, *) {
+                content
+                    .clipShape(.rect(cornerRadius: cornerRadius))
+                    .glassEffect(
+                        .regular.tint(.white.opacity(0.05)).interactive(),
+                        in: .rect(cornerRadius: cornerRadius)
+                    )
+            } else {
+                // No Liquid Glass below iOS 26 — fall back to an opaque card at
+                // the same surface tone so the list can't show through it.
+                content
+                    .background {
+                        ZStack {
+                            Color.backgroundMain
+                            Color.white.opacity(0.10)
+                        }
+                    }
+                    .clipShape(.rect(cornerRadius: cornerRadius))
+            }
+        }
     }
 }

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
@@ -10,6 +10,9 @@ import FlipcashUI
 struct CurrencyDiscoveryRow: View {
     let rank: Int
     let mint: MintMetadata
+    /// Drives which metric is prominent (trailing value + delta) and which is the
+    /// secondary line under the name. Holders for now — see ``RankingSystem``.
+    var rankingSystem: RankingSystem = .holders
 
     var body: some View {
         HStack(spacing: 12) {
@@ -31,42 +34,82 @@ struct CurrencyDiscoveryRow: View {
                     .foregroundStyle(Color.textMain)
                     .lineLimit(1)
 
-                if let marketCap = mint.launchpadMetadata?.marketCap, marketCap > 0 {
-                    Text(marketCap, format: .compactCurrency(code: .usd))
-                        .font(.appTextSmall)
-                        .foregroundStyle(Color.textSecondary)
-                        .contentTransition(.numericText())
-                }
+                secondaryLine
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textSecondary)
+                    .contentTransition(.numericText())
             }
 
             Spacer()
 
-            if let metrics = mint.holderMetrics {
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text("\(metrics.currentHolders, format: .number.notation(.compactName)) \(metrics.currentHolders == 1 ? "person" : "people")") 
-                        .font(.appTextSmall)
-                        .foregroundStyle(Color.textMain)
-                        .contentTransition(.numericText())
+            VStack(alignment: .trailing, spacing: 2) {
+                primaryValue
+                    .font(.appTextMedium)
+                    .foregroundStyle(Color.textMain)
+                    .contentTransition(.numericText())
 
-                    if let weeklyDelta = metrics.holderDeltas.first(where: { $0.range == .lastWeek }) {
-                        Text(Self.formatDelta(weeklyDelta.delta))
-                            .font(.appTextSmall)
-                            .foregroundStyle(weeklyDelta.delta > 0 ? Color.Sentiment.positive : Color.Sentiment.neutral)
-                            .contentTransition(.numericText())
-                    }
-                }
+                deltaLine
             }
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
         .contentShape(Rectangle())
     }
+
+    /// The secondary metric shown under the name: the one the list is *not* ranked by.
+    @ViewBuilder private var secondaryLine: some View {
+        switch rankingSystem {
+        case .holders:
+            marketCapText
+        case .marketCap:
+            holdersText
+        }
+    }
+
+    /// The prominent, ranked metric shown trailing.
+    @ViewBuilder private var primaryValue: some View {
+        switch rankingSystem {
+        case .holders:
+            holdersText
+        case .marketCap:
+            marketCapText
+        }
+    }
+
+    /// The weekly change in the ranked metric.
+    @ViewBuilder private var deltaLine: some View {
+        switch rankingSystem {
+        case .holders:
+            if let metrics = mint.holderMetrics,
+               let weekly = metrics.holderDeltas.first(where: { $0.range == .lastWeek }) {
+                Text(Self.formatHolderDelta(weekly.delta))
+                    .font(.appTextSmall)
+                    .foregroundStyle(weekly.delta > 0 ? Color.Sentiment.positive : Color.Sentiment.neutral)
+                    .contentTransition(.numericText())
+            }
+        case .marketCap:
+            // Needs a market-cap weekly delta from the Discover API; not yet available.
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder private var holdersText: some View {
+        if let metrics = mint.holderMetrics {
+            Text("\(metrics.currentHolders, format: .number.notation(.compactName)) \(metrics.currentHolders == 1 ? "person" : "people")")
+        }
+    }
+
+    @ViewBuilder private var marketCapText: some View {
+        if let marketCap = mint.launchpadMetadata?.marketCap, marketCap > 0 {
+            Text(marketCap, format: .compactCurrency(code: .usd))
+        }
+    }
 }
 
 // MARK: - Formatting -
 
 private extension CurrencyDiscoveryRow {
-    static func formatDelta(_ delta: Int64) -> String {
+    static func formatHolderDelta(_ delta: Int64) -> String {
         let sign = delta >= 0 ? "+" : ""
         let compact = delta.formatted(.number.notation(.compactName))
         return "\(sign)\(compact) this week"

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryScreen.swift
@@ -11,11 +11,15 @@ struct CurrencyDiscoveryScreen: View {
 
     @Environment(AppRouter.self) private var router
 
+    /// The new tab-bar UI floats the creation promo at the bottom; the legacy UI
+    /// keeps it as the first row above the leaderboard.
+    private var floatsPromo: Bool { BetaFlags.shared.hasEnabled(.newUI) }
+
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                CurrencyCreationPromoCard {
-                    router.push(.currencyCreationSummary)
+                if !floatsPromo {
+                    promoCard
                 }
 
                 LeaderboardSectionTitle()
@@ -28,7 +32,22 @@ struct CurrencyDiscoveryScreen: View {
             }
         }
         .background(Color.backgroundMain)
+        .safeAreaInset(edge: .bottom) {
+            if floatsPromo {
+                // Floats over the list as Liquid Glass; the rows blur through behind it.
+                CurrencyCreationPromoCard(surface: .glass) {
+                    router.push(.currencyCreationSummary)
+                }
+                .padding(.bottom, 8)
+            }
+        }
         .navigationTitle("Discover Currencies")
         .toolbarTitleDisplayMode(.inline)
+    }
+
+    private var promoCard: some View {
+        CurrencyCreationPromoCard {
+            router.push(.currencyCreationSummary)
+        }
     }
 }

--- a/Flipcash/Core/Screens/Main/Currency Discovery/RankingSystem.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/RankingSystem.swift
@@ -1,0 +1,20 @@
+//
+//  RankingSystem.swift
+//  Flipcash
+//
+
+import Foundation
+
+/// The metric the discovery leaderboard ranks by, which also drives what each
+/// row's prominent value and weekly delta represent.
+///
+/// Market-cap ranking is the intended direction for the new UI, but the Discover
+/// API only returns a *holder* weekly delta (`HolderMetrics.holderDeltas`) and a
+/// point-in-time market cap — there is no market-cap delta yet. Until that lands
+/// we rank by holders in both UIs.
+enum RankingSystem {
+    /// Rank by holder count; the weekly delta is the change in holders.
+    case holders
+    /// Rank by market capitalization; the weekly delta is the change in market cap.
+    case marketCap
+}

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -122,15 +122,15 @@ private struct WalletScreenContent: View {
                     )
                 }
 
-                // Returning users (already funded) get a plain add-money row; new
-                // users use the funnel's own "Add Money" step instead.
-                if hasAddedMoney {
-                    addMoneyButton
-                        .padding(.vertical, 24)
-                }
-
                 if !recentActivities.isEmpty {
                     recentActivitySection
+                }
+
+                // Returning users (already funded) get the tile shortcuts below
+                // the activity; new users use the funnel's own steps instead.
+                if hasAddedMoney {
+                    walletTiles
+                        .padding(.top, 24)
                 }
 
                 // Bottom inset so the last card clears the floating tab bar.
@@ -148,17 +148,37 @@ private struct WalletScreenContent: View {
         }
     }
 
-    private var addMoneyButton: some View {
-        Button {
-            router.presentAddMoney(.general, source: .balance)
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: "plus.circle")
-                Text("Add Money")
+    private var walletTiles: some View {
+        HStack(spacing: 12) {
+            walletTile(icon: "plus.circle", title: "Add Money") {
+                router.presentAddMoney(.general, source: .balance)
             }
-            .font(.appTextMedium)
-            .foregroundStyle(Color.textSecondary)
-            .frame(maxWidth: .infinity)
+            walletTile(icon: "globe", title: "Discover Currencies") {
+                router.push(.discoverCurrencies)
+            }
+        }
+    }
+
+    /// A tile-style entry point: icon top-leading, label pinned bottom-leading,
+    /// inside a translucent rounded card. Two pair side by side in a row.
+    private func walletTile(icon: String, title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 0) {
+                Image(systemName: icon)
+                    .font(.system(size: 22, weight: .regular))
+                    .foregroundStyle(Color.textMain)
+                Spacer(minLength: 24)
+                Text(title)
+                    .font(.appTextMedium)
+                    .foregroundStyle(Color.textMain)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(height: 96)
+            .padding(16)
+            .background(Color.white.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: Metrics.boxRadius, style: .continuous))
         }
         .buttonStyle(.plain)
     }


### PR DESCRIPTION
## Wallet

- Removed the inline **Add Money** row below the card stack.
- Added an **Add Money** + **Discover Currencies** tile row below the recent-activity list, shown for funded users (same `hasAddedMoney` gate as the old row). Tiles use a white @ 10% surface with icon top-leading and label bottom-leading (per mockup).

## Currency Discovery

- The **new UI** floats the "Create Your Own Currency" promo card pinned to the bottom as **Liquid Glass** (`glassEffect` on iOS 26, tinted `white @ 0.05` to match the Figma surface), so the leaderboard blurs through behind it. Below iOS 26 it falls back to an **opaque** card at the same tone. The **legacy UI** keeps the card as the first row above the leaderboard.
- Introduced `RankingSystem` (`holders` / `marketCap`) that drives each leaderboard row's prominent value + weekly delta, with the *other* metric shown as the secondary line under the name.
  - **Ranked by holders for now**: holder count + holder weekly delta on the right, market cap as the secondary line.
  - The `marketCap` branch is wired for the value/secondary line; its **delta is stubbed** because the Discover API (`MintMetadata`) only returns a *holder* weekly delta and a point-in-time market cap — there is no market-cap delta field yet. Flip the row default to `.marketCap` once the backend provides one.

## Testing

Built, installed, and run on the iPhone 17 simulator (iOS 26). Verified on-device:
- Floating Liquid Glass promo card (surface tuned against the Figma render).
- Leaderboard row renders holders-ranked (count + delta trailing, market cap secondary).
