### PR TITLE
fix(currency info): match the title pill's height to the chrome buttons

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -345,7 +345,7 @@ private struct CurrencyInfoScreenContent: View {
                 Image(systemName: "xmark")
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundStyle(Color.textMain)
-                    .frame(width: 44, height: 44)
+                    .frame(width: Self.overlayBarHeight, height: Self.overlayBarHeight)
                     // Hit-test the whole target, not just the glyph.
                     .contentShape(Circle())
                     .modifier(CircleGlass())
@@ -364,7 +364,7 @@ private struct CurrencyInfoScreenContent: View {
                     Image(systemName: "square.and.arrow.up")
                         .font(.system(size: 17, weight: .semibold))
                         .foregroundStyle(Color.textMain)
-                        .frame(width: 44, height: 44)
+                        .frame(width: Self.overlayBarHeight, height: Self.overlayBarHeight)
                         .contentShape(Circle())
                         .modifier(CircleGlass())
                 }
@@ -413,7 +413,10 @@ private struct CurrencyInfoScreenContent: View {
                 // and swallows most of the trailing padding the spec calls for.
                 .padding(.leading, 8)
                 .padding(.trailing, 20)
-                .padding(.vertical, 4)
+                // Sized to the chrome height rather than left to hug its two
+                // lines of text, which left the capsule a few points shorter
+                // than the round buttons either side of it.
+                .frame(height: Self.overlayBarHeight)
                 .modifier(CapsuleGlass())
             } else {
                 CurrencyLabel(


### PR DESCRIPTION
The scroll-revealed title pill hugged its own two lines of text, coming out a few points shorter than the round close and share buttons either side of it.

It now takes the same `overlayBarHeight` constant the buttons do, so the three line up regardless of the label — including the single-line USDF/Dollars pill, whose height no longer depends on having one line instead of two.

The buttons were separately hardcoding `44` rather than reading that constant, which is how the two drifted apart; they now share it.

## Testing

Verified on the simulator with contrast-amplified captures, since the Liquid Glass edges are too subtle to measure at normal exposure — capsule and both circles now align top and bottom. Existing currency-info flow (open → scroll → close) passes.

Not visually confirmed on Dollars: that page is short enough (no chart) that the simulator bounces back before the title reveals. The height is now content-independent, so one line and two behave identically, but worth a glance on device.