### PR TITLE
fix(tipcard): tighten the gap before the name, and let it wrap

### DIFF
--- a/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
@@ -37,21 +37,34 @@ struct TipcardView: View {
                 .foregroundStyle(Color.white)
                 .frame(width: codeDimension, height: codeDimension)
 
-            HStack(spacing: 8) {
-                Text("Tip")
-
+            Group {
                 if includePhoto {
-                    avatarImage
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: avatarDimension, height: avatarDimension)
-                        .foregroundStyle(Color.textSecondary)
-                        .clipShape(Circle())
-                }
+                    HStack(spacing: 8) {
+                        Text("Tip")
 
-                Text(name)
-                    .lineLimit(1)
+                        avatarImage
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: avatarDimension, height: avatarDimension)
+                            .foregroundStyle(Color.textSecondary)
+                            .clipShape(Circle())
+
+                        Text(name)
+                    }
+                } else {
+                    // Set as one string rather than two views in a stack: with
+                    // no avatar between them the stack's gap stands in for the
+                    // space, and at this size it is half again as wide as the
+                    // font's own — enough to read as a double space.
+                    Text("Tip \(name)")
+                }
             }
+            // Long names get a second line before being cut, rather than being
+            // truncated on the first.
+            .lineLimit(2)
+            .truncationMode(.tail)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, size.width * 0.08)
             .font(.appDisplayXS)
             .foregroundStyle(Color.textMain)
             .padding(.top, size.height * 0.06)


### PR DESCRIPTION
The tip card set `Tip` and the name as two views in an `HStack(spacing: 8)`, so the stack's gap stood in for the space between them. That 8pt was sized around the avatar that used to sit between the two — and `includePhoto` is off by default. At 20pt the font's own space is roughly 5pt, so the gap rendered about 1.5x too wide and read as a double space.

With no avatar the phrase is now a single string, so the spacing is the font's own. The avatar variant keeps the stack unchanged.

The name also now wraps to a second line before being cut, truncating at the end, with a horizontal inset so it wraps inside the card rather than running to its edges.