### PR TITLE
feat(currency info): pull down at the top to close

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoContentV2.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoContentV2.swift
@@ -57,6 +57,11 @@ struct CurrencyInfoContentV2: View {
     /// Fires when the hero card's title scrolls out from under the toolbar, so
     /// the screen can reveal its own title.
     let onScrolledPastTitle: (Bool) -> Void
+    /// How far the content has been pulled past its top, and how far it had been
+    /// pulled when the finger lifted. A host that can be dismissed uses the
+    /// second to decide whether the pull was a close.
+    var onPulledDown: (CGFloat) -> Void = { _ in }
+    var onPullEnded: (CGFloat) -> Void = { _ in }
     /// False when the host already shows the card (the wallet keeps it on screen
     /// while the detail rises beneath it), so it is not drawn twice.
     var showsHeroCard: Bool = true
@@ -74,6 +79,10 @@ struct CurrencyInfoContentV2: View {
     private static let recentPreviewCount = 3
     /// Scroll distance that puts the hero card's title row behind the toolbar.
     private static let titleHandoffOffset: CGFloat = 52
+
+    /// The live pull distance, kept so the phase change can report the value the
+    /// finger lifted at — the geometry callback has stopped firing by then.
+    @State private var pullDistance: CGFloat = 0
 
     private var isUSDF: Bool { metadata.mint == .usdf }
     private var isOwned: Bool { viewModel.balance.hasDisplayableValue }
@@ -162,6 +171,22 @@ struct CurrencyInfoContentV2: View {
             geometry.contentOffset.y + geometry.contentInsets.top > Self.titleHandoffOffset
         } action: { _, scrolledPast in
             onScrolledPastTitle(scrolledPast)
+        }
+        // Pull-to-close rides the scroll view's own overscroll rather than a
+        // drag gesture of its own: a gesture layered over a scroll view has to
+        // guess when it is competing with a scroll, whereas overscroll only
+        // exists once the content is already at its top.
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            max(0, -(geometry.contentOffset.y + geometry.contentInsets.top))
+        } action: { _, pulled in
+            pullDistance = pulled
+            onPulledDown(pulled)
+        }
+        .onScrollPhaseChange { _, phase in
+            // The finger has left the glass; the scroll view is about to spring
+            // the content back, so this is the moment to judge the pull.
+            guard phase != .interacting else { return }
+            onPullEnded(pullDistance)
         }
         // Started immediately rather than after the transition: the read itself
         // runs off the main thread, so it costs the animation nothing, and it

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -31,7 +31,16 @@ struct CurrencyInfoScreen: View {
         /// it. The card is the screen's own from the first frame — it is never a
         /// copy laid over the top — so it scrolls with the content immediately
         /// and there is no hand-over to mistime.
-        case overlay(onClose: () -> Void, heroOffset: CGFloat = 0, contentOpacity: Double = 1)
+        /// `onPull` reports a pull-to-close in progress, 0 to 1, so the host can
+        /// run its opening transition backwards under the finger; `onPullEnded`
+        /// says whether the finger lifted past the point of no return.
+        case overlay(
+            onClose: () -> Void,
+            heroOffset: CGFloat = 0,
+            contentOpacity: Double = 1,
+            onPull: (CGFloat) -> Void = { _ in },
+            onPullEnded: (Bool, CGFloat) -> Void = { _, _ in }
+        )
         /// Laid out inline beneath the card the wallet keeps on screen, so it
         /// draws neither the hero card nor any top chrome.
         case inline
@@ -71,6 +80,9 @@ private struct CurrencyInfoScreenContent: View {
     /// New UI: the toolbar title only appears once the hero card's own title has
     /// scrolled out of view (Apple Wallet / App Store behaviour).
     @State private var showsToolbarTitle: Bool = false
+    /// How far through a pull-to-close the content currently is, 0 to 1. Used to
+    /// fade the chrome so the gesture is legible before it commits.
+    @State private var pullProgress: CGFloat = 0
 
     let session: Session
 
@@ -97,21 +109,32 @@ private struct CurrencyInfoScreenContent: View {
 
     /// Overlay hosting draws its own chrome; pushed hosting uses `.toolbar`.
     private var overlayClose: (() -> Void)? {
-        if case .overlay(let onClose, _, _) = presentation { return onClose }
+        if case .overlay(let onClose, _, _, _, _) = presentation { return onClose }
         return nil
     }
 
     /// How far the hero card is displaced from its resting slot while the host
     /// animates it in.
     private var heroOffset: CGFloat {
-        if case .overlay(_, let offset, _) = presentation { return offset }
+        if case .overlay(_, let offset, _, _, _) = presentation { return offset }
         return 0
     }
 
     /// Everything except the hero card, which the host brings in behind it.
     private var contentOpacity: Double {
-        if case .overlay(_, _, let opacity) = presentation { return opacity }
+        if case .overlay(_, _, let opacity, _, _) = presentation { return opacity }
         return 1
+    }
+
+    /// Reports a pull-to-close to the host, which owns the transition it undoes.
+    private var onPull: (CGFloat) -> Void {
+        if case .overlay(_, _, _, let onPull, _) = presentation { return onPull }
+        return { _ in }
+    }
+
+    private var onPullEnded: (Bool, CGFloat) -> Void {
+        if case .overlay(_, _, _, _, let onEnded) = presentation { return onEnded }
+        return { _, _ in }
     }
 
     /// The wallet keeps its own card above an inline-hosted screen.
@@ -187,7 +210,10 @@ private struct CurrencyInfoScreenContent: View {
     // MARK: - Body -
 
     var body: some View {
-        Background(color: .backgroundMain) {
+        // Overlay hosting supplies its own backing, which it fades as the screen
+        // arrives and again as a pull-to-close recedes. Filling here too would
+        // sit above the wallet and hide the deck the pull is uncovering.
+        Background(color: overlayClose == nil ? .backgroundMain : .clear) {
             switch viewModel.loadingState {
             case .loading:
                 CurrencyInfoLoadingView()
@@ -214,6 +240,20 @@ private struct CurrencyInfoScreenContent: View {
                             withAnimation(.easeInOut(duration: 0.2)) {
                                 showsToolbarTitle = scrolledPast
                             }
+                        },
+                        onPulledDown: { pulled in
+                            guard overlayClose != nil else { return }
+                            let progress = min(1, pulled / Self.pullToCloseDistance)
+                            pullProgress = progress
+                            onPull(progress)
+                        },
+                        onPullEnded: { pulled in
+                            guard overlayClose != nil else { return }
+                            let passed = pulled >= Self.pullToCloseDistance
+                            if !passed {
+                                withAnimation(.smooth(duration: 0.25)) { pullProgress = 0 }
+                            }
+                            onPullEnded(passed, pulled)
                         },
                         showsHeroCard: showsHeroCard,
                         heroOffset: heroOffset,
@@ -261,8 +301,10 @@ private struct CurrencyInfoScreenContent: View {
                 overlayChrome
                     .frame(height: Self.overlayBarHeight)
                     // Arrives with the rest of the screen; only the card itself
-                    // is held at full strength through the opening.
-                    .opacity(contentOpacity)
+                    // is held at full strength through the opening. Fades again
+                    // as a pull-to-close builds, so the gesture is legible
+                    // before it commits.
+                    .opacity(contentOpacity * (1 - pullProgress))
             }
         }
         .toolbar(usesToolbar ? .automatic : .hidden, for: .navigationBar)
@@ -320,6 +362,11 @@ private struct CurrencyInfoScreenContent: View {
 
     /// Height of the chrome an overlay draws in place of the navigation bar.
     fileprivate static let overlayBarHeight: CGFloat = 44
+
+    /// How far the content has to be pulled past its top to count as a close —
+    /// far enough that an overscroll bounce at the end of a flick cannot reach
+    /// it by accident.
+    private static let pullToCloseDistance: CGFloat = 110
 
     /// Top inset for overlay hosting. The wallet parks the opened card at
     /// `WalletCardGeometry.openCardTopInset`; the content adds 8pt of its own

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoScreen.swift
@@ -210,10 +210,13 @@ private struct CurrencyInfoScreenContent: View {
     // MARK: - Body -
 
     var body: some View {
-        // Overlay hosting supplies its own backing, which it fades as the screen
-        // arrives and again as a pull-to-close recedes. Filling here too would
-        // sit above the wallet and hide the deck the pull is uncovering.
-        Background(color: overlayClose == nil ? .backgroundMain : .clear) {
+        // Fades with the rest of the screen when hosted as an overlay. Held
+        // opaque instead, it covers the wallet the instant the screen is built,
+        // so the deck never visibly clears and the content simply materialises
+        // over black while the card is still travelling. The host fades the
+        // wallet out first, so this comes up over an already-dark screen rather
+        // than cross-fading with a visible one.
+        Background(color: overlayClose == nil ? .backgroundMain : .backgroundMain.opacity(contentOpacity)) {
             switch viewModel.loadingState {
             case .loading:
                 CurrencyInfoLoadingView()

--- a/Flipcash/Core/Screens/Main/Home/TokenCardStack.swift
+++ b/Flipcash/Core/Screens/Main/Home/TokenCardStack.swift
@@ -56,6 +56,9 @@ struct TokenCardStack: View {
     var hiddenMint: PublicKey? = nil
     /// Where the opened card comes to rest, leaving room for the chrome above it.
     var openTopInset: CGFloat = 0
+    /// Extra displacement for the opened card, used to pick it up exactly where a
+    /// pull-to-close let go of it rather than at its open slot.
+    var openExtraOffset: CGFloat = 0
     /// Reports the tapped card along with its current on-screen top edge, so the
     /// caller can work out the lift.
     var onCardTap: (TokenCardData, CGFloat) -> Void = { _, _ in }
@@ -96,7 +99,7 @@ struct TokenCardStack: View {
                 // Resting fan, and the reorganisation when a card is opened, are
                 // both expressed here so they interpolate as one animation.
                 .opacity(item.mint == hiddenMint ? 0 : 1)
-                .visualEffect { [index, expandingIndex, containerHeight, expansionProgress, openTopInset] content, proxy in
+                .visualEffect { [index, expandingIndex, containerHeight, expansionProgress, openTopInset, openExtraOffset] content, proxy in
                     let rect = proxy.frame(in: .scrollView)
                     let fan = offset(for: index, stackTop: rect.minY)
 
@@ -109,7 +112,7 @@ struct TokenCardStack: View {
                     // them — the cards above gather onto exactly the spot the
                     // opened one lands, which is what makes them read as
                     // collapsing into it.
-                    let open = openTopInset - rect.minY
+                    let open = openTopInset - rect.minY + openExtraOffset
 
                     // The opened card travels there and keeps its place in the
                     // deck's z-order the whole way. That ordering is what makes

--- a/Flipcash/Core/Screens/Main/Home/TokenCardStack.swift
+++ b/Flipcash/Core/Screens/Main/Home/TokenCardStack.swift
@@ -11,8 +11,8 @@ import FlipcashCore
 /// scroll view scrolls up — Apple Wallet style. Once the balance header has
 /// scrolled off, the back card (index 0) reaches the top and pins there; the
 /// remaining cards each collapse up into it in turn, tightening the fan from
-/// `fannedReveal` to `collapsedReveal`. When the deck is fully collapsed it holds
-/// briefly, then releases and scrolls off with the rest of the content.
+/// `fannedReveal` to `collapsedReveal`. Once fully collapsed it scrolls off with
+/// the rest of the content.
 ///
 /// Placement is driven entirely per-card by SwiftUI's `visualEffect`, reading
 /// each card's own `frame(in: .scrollView).minY`. There is no shared scroll
@@ -27,7 +27,13 @@ struct TokenCardStack: View {
     /// behind it (no slivers), Apple Wallet style.
     static let defaultCollapsedReveal: CGFloat = 0
     /// How long (in scroll px) the fully-collapsed deck holds before releasing.
-    static let defaultCollapsedHold: CGFloat = 24
+    ///
+    /// Zero: the deck collapses and then scrolls away like any other content.
+    /// Any hold pins the front card while the rest of the page keeps scrolling
+    /// past it, so whatever follows the stack creeps that far into the cards
+    /// before settling — the deck spends the distance but its reserved box does
+    /// not, and nothing below it can tell.
+    static let defaultCollapsedHold: CGFloat = 0
 
     let items: [TokenCardData]
     var cardHeight: CGFloat = 224
@@ -71,7 +77,9 @@ struct TokenCardStack: View {
         return items.firstIndex { $0.mint == expandingMint }
     }
 
-    /// Always the fanned height, so the scroll range stays stable while cards collapse.
+    /// Always the fanned height, so the scroll range stays stable while the
+    /// cards collapse, and so the deck's bottom edge tracks the box exactly —
+    /// anything following the stack keeps its distance the whole way.
     private var stackHeight: CGFloat {
         items.isEmpty ? 0 : cardHeight + fannedReveal * CGFloat(items.count - 1)
     }
@@ -79,8 +87,7 @@ struct TokenCardStack: View {
     private let collapsedHold: CGFloat = defaultCollapsedHold
 
     /// The stack-top position (in `.scrollView` space) at which the deck freezes
-    /// and rides the scroll off: the last card's fully-collapsed point, less a
-    /// short hold.
+    /// and rides the scroll off: the last card's fully-collapsed point.
     private nonisolated var releaseTop: CGFloat {
         let lastIndex = CGFloat(max(items.count - 1, 0))
         let fullyCollapsed = pinInset - lastIndex * (fannedReveal - collapsedReveal)

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -106,6 +106,8 @@ private struct WalletScreenContent: View {
     /// Rows of recent activity previewed on the wallet (the rest lives on the
     /// per-token transaction history).
     private static let recentPreviewCount = 3
+    /// How far below the status bar content returns to full strength.
+    private static let topFadeLength: CGFloat = 20
 
     init(sessionContainer: SessionContainer, onScanTipCard: @escaping () -> Void) {
         self.session = sessionContainer.session
@@ -235,7 +237,6 @@ private struct WalletScreenContent: View {
         withAnimation(.smooth(duration: Self.liftDuration), completionCriteria: .removed) {
             heroOffset = 0
             expansionProgress = 1
-            deckOpacity = 0
         } completion: {
             guard token == transitionToken else { return }
             // Everything has come to rest, so the chart can fetch its points and
@@ -243,16 +244,19 @@ private struct WalletScreenContent: View {
             heavyContentReady = true
         }
 
-        Task {
-            // The card leads; the page follows it in, so the motion reads as one
-            // gesture instead of the content arriving on its own. Sized to finish
-            // just before the card lands, so the hero card it hands over to is
-            // fully opaque by then.
-            try? await Task.sleep(for: .seconds(Self.pageFollowDelay))
-            guard token == transitionToken else { return }
-            withAnimation(.smooth(duration: Self.liftDuration - Self.pageFollowDelay)) {
-                pageContentOpacity = 1
-            }
+        // The wallet clears ahead of the deck it belongs to, so the screen is
+        // already dark by the time the page starts coming up. Fading the two
+        // across each other instead shows the balance and the cards straight
+        // through the tiles for the length of the overlap.
+        withAnimation(.easeOut(duration: Self.walletFadeDuration)) { deckOpacity = 0 }
+
+        // The card leads and the page follows it in, sharing its curve so the
+        // two read as one movement. Delayed rather than dispatched later, so
+        // both are committed in the same frame and cannot drift apart, and run
+        // long enough that the page is not sitting complete while the card is
+        // still travelling.
+        withAnimation(.smooth(duration: Self.liftDuration).delay(Self.pageFollowDelay)) {
+            pageContentOpacity = 1
         }
     }
 
@@ -379,6 +383,9 @@ private struct WalletScreenContent: View {
     }
 
     private static let liftDuration: TimeInterval = 0.32
+    /// The wallet is gone before the page starts arriving, so the two never
+    /// cross-fade over each other.
+    private static let walletFadeDuration: TimeInterval = 0.16
     /// How far behind the card the page follows.
     private static let pageFollowDelay: TimeInterval = 0.20
 
@@ -451,6 +458,19 @@ private struct WalletScreenContent: View {
         // that tail: a swipe found a disabled scroll view and fell through to
         // the card underneath as a tap.
         .scrollDisabled(pageIsBuilt)
+        // Fades what scrolls up into the status bar. `scrollEdgeEffectStyle` is
+        // drawn by a navigation bar's background and the wallet hides its bar,
+        // so the effect never renders here — the fade has to be drawn.
+        .overlay(alignment: .top) {
+            LinearGradient(
+                colors: [Color.backgroundMain, Color.backgroundMain.opacity(0)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: safeArea.top + Self.topFadeLength)
+            .ignoresSafeArea(edges: .top)
+            .allowsHitTesting(false)
+        }
     }
 
     private var header: some View {

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -66,6 +66,10 @@ private struct WalletScreenContent: View {
     @State private var pageIsBuilt = false
     /// Fades the wallet — balance header included — out behind the opening card.
     @State private var deckOpacity: Double = 1
+    /// Where a pull-to-close let go of the card, so the deck picks it up there
+    /// rather than snapping it back to its open slot first. Animated to zero as
+    /// the close carries it home.
+    @State private var releasedPullOffset: CGFloat = 0
     /// Drives the deck's reorganisation, 0 (resting) to 1 (cleared), animated in
     /// lockstep with the card's flight so the two read as one gesture.
     @State private var expansionProgress: CGFloat = 0
@@ -143,9 +147,11 @@ private struct WalletScreenContent: View {
                     CurrencyInfoScreen(
                         mint: expandingMint,
                         presentation: .overlay(
-                            onClose: closeCard,
+                            onClose: { closeCard() },
                             heroOffset: heroOffset,
-                            contentOpacity: pageContentOpacity
+                            contentOpacity: pageContentOpacity,
+                            onPull: scrubDismiss,
+                            onPullEnded: endDismiss
                         ),
                         defersHeavyContent: !heavyContentReady
                     )
@@ -254,7 +260,7 @@ private struct WalletScreenContent: View {
     /// wallet root hides.
     private func openCardChrome(mint: PublicKey) -> some View {
         HStack {
-            Button(action: closeCard) {
+            Button { closeCard() } label: {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundStyle(Color.textMain)
@@ -288,10 +294,42 @@ private struct WalletScreenContent: View {
         .transition(.opacity)
     }
 
+    /// Runs the opening backwards under a pull-to-close, so the screen recedes
+    /// Recedes the screen under a pull-to-close: the info content and chrome
+    /// fade out. The deck is deliberately left as it
+    /// is — reassembling it under the finger leaves the card nothing to hand
+    /// over to when the drag ends, and the stack reading through a half-faded
+    /// page is not what the gesture should look like anyway. It comes back on
+    /// release, carrying the card home with it.
+    ///
+    /// The card's *position* is left alone too: the scroll view's overscroll
+    /// already carries it down a point per point, and driving its journey back
+    /// to the deck on top of that sends it several times faster than the drag.
+    ///
+    /// Un-animated on purpose. This tracks a finger, so each update is the
+    /// current position rather than something to interpolate towards.
+    private func scrubDismiss(_ progress: CGFloat) {
+        guard expandingMint != nil else { return }
+        var tracking = Transaction()
+        tracking.disablesAnimations = true
+        withTransaction(tracking) { pageContentOpacity = 1 - progress }
+    }
+
+    /// The finger lifted: either carry the dismissal through, or put everything
+    /// back where it was.
+    private func endDismiss(_ passedThreshold: Bool, _ releasedAt: CGFloat) {
+        guard expandingMint != nil else { return }
+        if passedThreshold {
+            closeCard(resumingFrom: releasedAt)
+        } else {
+            withAnimation(.smooth(duration: 0.25)) { pageContentOpacity = 1 }
+        }
+    }
+
     /// Closes a token: the reverse of opening. The page drops away and the deck
     /// takes its card back, sliding it down into its own slot and under the
     /// cards stacked on top of it — put back, rather than simply vanishing.
-    private func closeCard() {
+    private func closeCard(resumingFrom pullOffset: CGFloat = 0) {
         guard expandingMint != nil else { return }
         transitionToken &+= 1
         let token = transitionToken
@@ -304,6 +342,10 @@ private struct WalletScreenContent: View {
         handback.disablesAnimations = true
         withTransaction(handback) {
             hiddenMint = nil
+            // Hand the card over at the height the finger left it at, so the
+            // close picks up from there instead of jumping back to the open slot
+            // and replaying from the top.
+            releasedPullOffset = pullOffset
             pageContentOpacity = 0
             pageIsBuilt = false
             heavyContentReady = false
@@ -320,6 +362,7 @@ private struct WalletScreenContent: View {
         withAnimation(.smooth(duration: Self.liftDuration), completionCriteria: .removed) {
             expansionProgress = 0
             deckOpacity = 1
+            releasedPullOffset = 0
         } completion: {
             // Only if this close is still the current transition: tapping a card
             // again while it settles starts an open, and clearing the anchor then
@@ -377,6 +420,7 @@ private struct WalletScreenContent: View {
                         containerHeight: containerSize.height,
                         hiddenMint: hiddenMint,
                         openTopInset: WalletCardGeometry.openCardTopInset,
+                        openExtraOffset: releasedPullOffset,
                         onCardTap: openCard
                     )
                 }
@@ -401,7 +445,12 @@ private struct WalletScreenContent: View {
             }
             .padding(.horizontal, 20)
         }
-        .scrollDisabled(expandingMint != nil)
+        // Gated on the page being up rather than on `expandingMint`, which is
+        // held until the closing spring is fully removed — a good deal later
+        // than it looks finished. Tying the lock to it left the wallet inert for
+        // that tail: a swipe found a disabled scroll view and fell through to
+        // the card underneath as a tap.
+        .scrollDisabled(pageIsBuilt)
     }
 
     private var header: some View {


### PR DESCRIPTION
Two related pieces of work on the wallet and the screen it opens.

## Pull down at the top to close

Dragging the currency info screen down from its top returns the card to the wallet. The info content and chrome fade out under the finger; release past the point of no return and the deck comes back and carries the card into its slot, release short of it and the content fades back in.

It rides the scroll view's own overscroll rather than a `DragGesture` layered over it — a gesture would have to work out whether it was competing with a scroll, whereas overscroll only exists once the content is already at its top, which is exactly the condition for the close. The threshold sits past what an overscroll bounce reaches at the end of a flick, so scrolling down and flicking back to the top does not dismiss.

Two things that read badly and are easy to reintroduce:

- **The card's position is not driven by the drag.** Overscroll already moves it a point per point; adding its journey back to the deck on top sends it several times faster than the finger — its slot can be a few hundred points down the deck while the pull is barely a hundred. The deck is left alone during the drag for the same reason: unwinding it early leaves the card nothing to hand over to on release.
- **The close resumes from where the finger let go**, rather than snapping the card back to the open slot and replaying from the top.

The wallet's scroll lock now follows the page rather than the opened mint, which is held until the closing spring is fully *removed* — well after it looks finished. That left the wallet inert for the tail, so a swipe found a disabled scroll view and fell through to the card underneath as a tap.

## Deck hold, top fade, and the entrance

- **The collapsed deck no longer holds before releasing.** For the length of that hold the front card stood still while the page scrolled past it, and since the stack reserves its fanned height either way, nothing below could tell — the Recent section crept that far into the cards and stayed there.
- **The wallet draws its own top fade.** `scrollEdgeEffectStyle` is rendered by a navigation bar's background and the wallet hides its bar, so the effect never appeared and content met the status bar at full strength.
- **The entrance no longer cross-fades the wallet with the screen coming over it.** The wallet clears first on a shorter curve so the page arrives over an already-dark screen; previously the balance and cards read straight through the tiles. The screen's backing fades with its content instead of being opaque from the moment it is built, and the content is timed off the card's curve so it is not sitting complete while the card is still travelling.

## Testing

Maestro, on simulator: pull far → closes; pull a little → springs back; scroll down then flick back to top → stays open; swipe immediately after the close → scrolls rather than opening a card. Plus the existing suite — open/close on top, middle and deep cards, scroll immediately after opening, history push and back, and 30 rapid open/close cycles with the header and tab bar intact.
