### PR TITLE
fix(wallet): match the balance header's top spacing to Android

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -106,6 +106,18 @@ private struct WalletScreenContent: View {
     /// Rows of recent activity previewed on the wallet (the rest lives on the
     /// per-token transaction history).
     private static let recentPreviewCount = 3
+
+    /// Where the balance sits, measured from the top of the screen rather than
+    /// from the top of this scroll view — 20pt of list inset plus the spec's
+    /// 96pt, which is how far down Android puts it. Android draws its list edge
+    /// to edge and insets the content, so its 96 starts under the status bar;
+    /// laying out below the safe area here and adding the same 96 puts the
+    /// balance a whole status bar lower than it sits on Android.
+    private static let headerTopFromScreenEdge: CGFloat = 116
+
+    private var headerTopPadding: CGFloat {
+        max(0, Self.headerTopFromScreenEdge - safeArea.top)
+    }
     /// How far below the status bar content returns to full strength.
     private static let topFadeLength: CGFloat = 20
 
@@ -401,7 +413,7 @@ private struct WalletScreenContent: View {
                     header
                         // Figma (8966:1578) drops the balance well down the screen —
                         // most of the extra space sits above it, less below.
-                        .padding(.top, 96)
+                        .padding(.top, headerTopPadding)
                         .padding(.bottom, 44)
 
                     if !isOnboardingComplete {


### PR DESCRIPTION
Both platforms take the same 96 from the spec, but they measure it from different places.

Android's list draws edge to edge and insets its content, so its 96 starts 20dp from the top of the *screen*, under the status bar — putting the balance about 116dp down. iOS lays its scroll view out below the safe area, so the same 96 lands the balance a whole status bar lower, about 158pt on a device with a Dynamic Island.

This measures from the screen edge and subtracts the safe area, so the balance sits in the same place on both regardless of how tall the status bar is on a given device.

## Verification

Measured against the Android app running on the same account, same balances:

| | Balance top edge |
|---|---|
| Android | 131 dp |
| iOS (after) | 128 pt |
| iOS (before) | ~170 pt |

The remaining 3 is within the noise of measuring a text baseline across two font stacks.
