### PR TITLE
fix(deeplinks): route into tabs rather than over them

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -223,7 +223,19 @@ struct DeepLinkAction {
         case .currencyInfo(let mint):
             if let container = sessionAuthenticator.loggedInContainer {
                 Analytics.deeplinkRouted(kind: kind)
-                container.appRouter.navigate(to: .currencyInfo(mint))
+                let router = container.appRouter
+                if router.tabStacks.contains(.balance) {
+                    // v2: the wallet opens the token as its expanded card, so a
+                    // link lands exactly where tapping the card would — same
+                    // chrome, same dismissal. Pushing it instead gives a screen
+                    // with a back chevron that belongs to a stack the user never
+                    // navigated.
+                    router.setPath([], on: .balance)
+                    router.requestedTabStack = .balance
+                    router.requestedCardMint = mint
+                } else {
+                    router.navigate(to: .currencyInfo(mint))
+                }
             }
 
         case .chat(let conversationID):

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -280,6 +280,13 @@ struct DeepLinkAction {
                     }
                 }
                 let router = container.appRouter
+                // Discover is a push from the wallet in the tab UI, the same as
+                // its tile — its own sheet is the v1 route in.
+                if sheet == .discover, router.tabStacks.contains(.balance) {
+                    router.navigate(to: .discoverCurrencies)
+                    return
+                }
+
                 // A sheet whose stack a tab owns is that tab — `flipcash://balance`
                 // means "show me the wallet", and presenting the sheet puts the v1
                 // balance list over the wallet tab instead of selecting it.

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -279,7 +279,18 @@ struct DeepLinkAction {
                         return
                     }
                 }
-                container.appRouter.present(sheet)
+                let router = container.appRouter
+                // A sheet whose stack a tab owns is that tab — `flipcash://balance`
+                // means "show me the wallet", and presenting the sheet puts the v1
+                // balance list over the wallet tab instead of selecting it.
+                let stack = sheet.stack
+                if router.tabStacks.contains(stack) {
+                    while router.presentedSheet != nil { router.dismissSheet() }
+                    router.setPath([], on: stack)
+                    router.requestedTabStack = stack
+                } else {
+                    router.present(sheet)
+                }
             }
         }
     }

--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -66,6 +66,22 @@ final class AppRouter {
     /// sheet-first UI, where a sheet is always the push target.
     var activeTabStack: Stack?
 
+    /// The stacks a tab owns, registered by `HomeTabView`. A deep link into one
+    /// of these belongs on its tab, not in a sheet — the router itself has no
+    /// notion of tabs, so it is told.
+    var tabStacks: Set<Stack> = []
+
+    /// A token the wallet should open in its expanded card state, rather than
+    /// as a pushed screen. Deep links use this so following a link lands where
+    /// tapping the card would, chrome and dismissal included. The wallet clears
+    /// it once opened.
+    var requestedCardMint: PublicKey?
+
+    /// A tab the router wants brought forward, named by the stack it owns.
+    /// `HomeTabView` selects it and clears this. Deep-link routing only; nothing
+    /// else drives tab selection.
+    var requestedTabStack: Stack?
+
     /// The stack that `push`/`pop`-style calls target: the presented sheet's
     /// stack, or — when no sheet is up (a v2 tab is the active surface) — the
     /// active tab's stack.
@@ -432,6 +448,27 @@ final class AppRouter {
 
         var expected = NavigationPath()
         expected.append(destination)
+
+        // A stack a tab owns is reached by bringing that tab forward. Presenting
+        // its sheet instead lays a second copy of the surface over the tab that
+        // already holds it — a token link, for instance, ends up in a sheet with
+        // no tab bar rather than pushed on the wallet.
+        if tabStacks.contains(targetStack) {
+            let alreadyThere = presentedSheets.isEmpty
+                            && activeTabStack == targetStack
+                            && paths[targetStack, default: NavigationPath()] == expected
+            guard !alreadyThere else { return }
+
+            while !presentedSheets.isEmpty { dismissSheet() }
+            requestedTabStack = targetStack
+            setPath([destination], on: targetStack)
+            logger.info("Routed to tab stack", metadata: [
+                "stack": "\(targetStack)",
+                "destination": "\(destination)",
+            ])
+            return
+        }
+
         let alreadyThere = presentedSheets == [targetSheet]
                         && paths[targetStack, default: NavigationPath()] == expected
         guard !alreadyThere else { return }

--- a/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
@@ -67,7 +67,19 @@ struct HomeTabView: View {
             // The app-level sheet host lives here in v2 (ScanScreen suppresses its
             // own copy when embedded) so `router.present(_:)` works from any tab.
             .modifier(RootSheetHostModifier(enabled: true))
-            .onAppear { router.activeTabStack = selection.pushStack }
+            .onAppear {
+                router.activeTabStack = selection.pushStack
+                // Tells the router which stacks live behind tabs, so a deep link
+                // into one selects its tab instead of presenting it as a sheet.
+                router.tabStacks = Set(HomeTab.allCases.compactMap(\.pushStack))
+            }
+            .onChange(of: router.requestedTabStack) { _, requested in
+                guard let requested,
+                      let tab = HomeTab.allCases.first(where: { $0.pushStack == requested })
+                else { return }
+                selection = tab
+                router.requestedTabStack = nil
+            }
             .onChange(of: selection) { _, tab in router.activeTabStack = tab.pushStack }
             .onDisappear { router.activeTabStack = nil }
     }

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -179,6 +179,11 @@ private struct WalletScreenContent: View {
                     // so with a close box instead of a back chevron.
                 }
             }
+            .onChange(of: router.requestedCardMint) { _, mint in
+                guard let mint else { return }
+                openCardImmediately(mint)
+                router.requestedCardMint = nil
+            }
             .onGeometryChange(for: CGSize.self) { $0.size } action: { containerSize = $0 }
             .onGeometryChange(for: EdgeInsets.self) { $0.safeAreaInsets } action: { safeArea = $0 }
             // No top bar on the wallet root (per Figma) — the balance header
@@ -339,6 +344,29 @@ private struct WalletScreenContent: View {
             closeCard(resumingFrom: releasedAt)
         } else {
             withAnimation(.smooth(duration: 0.25)) { pageContentOpacity = 1 }
+        }
+    }
+
+    /// Arrives in the opened state without the travel — for a deep link, where
+    /// there is no tap to have come from and the card may not even be on screen
+    /// to start from. Everything lands where the opening animation would have
+    /// left it, so closing still puts the card back into the deck normally.
+    private func openCardImmediately(_ mint: PublicKey) {
+        transitionToken &+= 1
+
+        var immediate = Transaction()
+        immediate.disablesAnimations = true
+        withTransaction(immediate) {
+            heroOffset = 0
+            releasedPullOffset = 0
+            expansionProgress = 1
+            deckOpacity = 0
+            pageContentOpacity = 1
+            expandingMint = mint
+            hiddenMint = mint
+            cardExpansion.isExpanded = true
+            pageIsBuilt = true
+            heavyContentReady = true
         }
     }
 


### PR DESCRIPTION
`AppRouter.navigate(to:)` presents a destination's stack as a sheet. That was right when balance, tips and discover *were* sheets over the scan screen — in the tab UI the first two are tabs, so a link into one laid a second copy of that surface over the tab already holding it.

Verified on the simulator before the fix: `flipcash://token/<mint>` opened currency info inside a sheet (back chevron into a stack the user never navigated, no tab bar), and `flipcash://balance` opened the **v1 balance list** over the wallet tab.

## The change

The router has no notion of tabs, so it is told rather than taught: `HomeTabView` registers which stacks sit behind tabs and selects one when the router asks. All three entry points honour that now — `navigate(to:)`, the direct `present(sheet)` path `flipcash://balance` uses, and discover.

- **token** opens the wallet's **expanded card** rather than pushing, so a link lands where tapping the card would — same chrome, same close, same pull-to-dismiss. It arrives already open (there is no tap to have travelled from, and the card may not be on screen), but in the state the opening animation would have left, so closing still returns the card to the deck.
- **balance** selects the wallet tab instead of presenting the v1 list over it.
- **discover** pushes on the wallet tab, matching its tile. Its destination already belongs to the wallet's stack, so this asks for the destination instead of the sheet and the tab routing does the rest.

The genuinely modal links — give, chat-send-cash, tip — are untouched.

## Verified on the simulator

| Link | Result |
|---|---|
| `token/<mint>` | wallet tab, expanded card; closing restores the deck |
| `balance` | wallet tab with deck and tab bar (was the v1 sheet) |
| `discover` | pushed on the wallet tab, back chevron (was a sheet with an X) |
| `chat/<id>` | correct conversation, pushed on the chat tab |
| `give` | sheet, unchanged |

Existing suite green.

**Not verified:** the auth-gated links (`login`, `cash`, `verify`, `tip/<uuid>`, `chat/<id>/send`) need payloads or a logged-out state and were not exercised; none of them touch the changed code.
