### PR TITLE
feat: You tab (tip card + settings landing)

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter+Stack.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Stack.swift
@@ -22,6 +22,7 @@ extension AppRouter {
         case downloadApp
         case sendAmount
         case tips
+        case you
 
         /// The sheet a stack is presented in. Cross-stack navigation uses
         /// this to know which top-level modal to surface.
@@ -41,6 +42,7 @@ extension AppRouter {
             case .downloadApp:  .downloadApp
             case .sendAmount:   nil
             case .tips:         .tips
+            case .you:          nil // a tab stack, entered by tab selection, never via navigate(to:)
             }
         }
 
@@ -55,6 +57,7 @@ extension AppRouter {
             case .downloadApp:  "downloadApp"
             case .sendAmount:   "sendAmount"
             case .tips:         "tips"
+            case .you:          "you"
             }
         }
     }

--- a/Flipcash/Core/Screens/Main/Home/HomeTab.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTab.swift
@@ -38,7 +38,7 @@ enum HomeTab: Int, CaseIterable, Identifiable, Hashable {
         case .scan:    return "Scan"
         case .wallet:  return "Wallet"
         case .chat:    return "Chat"
-        case .tipCard: return "Tip Card"
+        case .tipCard: return "You"
         }
     }
 }

--- a/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
@@ -162,9 +162,10 @@ private extension HomeTab {
     /// never push (Tip Card owns a local stack).
     var pushStack: AppRouter.Stack? {
         switch self {
-        case .wallet:         return .balance
-        case .chat:           return .tips
-        case .scan, .tipCard: return nil
+        case .wallet:  return .balance
+        case .chat:    return .tips
+        case .tipCard: return .you
+        case .scan:    return nil
         }
     }
 }
@@ -197,17 +198,22 @@ private struct ChatTab: View {
 /// add-your-name flow lives (avoiding a duplicate profile-creation push here).
 private struct TipCardTab: View {
 
+    @Environment(AppRouter.self) private var router
     @Environment(SessionContainer.self) private var sessionContainer
 
     let onSetUp: () -> Void
 
     var body: some View {
-        NavigationStack {
-            if sessionContainer.session.profile?.isTippable == true {
-                TipcardScreen(isEmbedded: true)
-            } else {
-                TipCardSetupPrompt(onSetUp: onSetUp)
+        @Bindable var router = router
+        NavigationStack(path: $router[.you]) {
+            Group {
+                if sessionContainer.session.profile?.isTippable == true {
+                    YouScreen()
+                } else {
+                    TipCardSetupPrompt(onSetUp: onSetUp)
+                }
             }
+            .appRouterDestinations()
         }
     }
 }

--- a/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
@@ -13,12 +13,6 @@ struct TipcardScreen: View {
 
     @Environment(Container.self) private var container
     @Environment(SessionContainer.self) private var sessionContainer
-    @Environment(AppRouter.self) private var router
-
-    /// The v2 tab presentation (Figma 8966:2745): a bare centered card with a
-    /// menu button, no header/nav. Defaults to false — the v1 push keeps its
-    /// header, share row, and nav title.
-    var isEmbedded: Bool = false
 
     @State private var avatar: UIImage?
     @State private var exportImage: Image?
@@ -32,14 +26,9 @@ struct TipcardScreen: View {
 
     var body: some View {
         Background(color: .backgroundMain) {
-            if isEmbedded {
-                embeddedContent
-            } else {
-                legacyContent
-            }
+            legacyContent
         }
-        .navigationTitle(isEmbedded ? "" : "My Tip Card")
-        .toolbar(isEmbedded ? .hidden : .automatic, for: .navigationBar)
+        .navigationTitle("My Tip Card")
         .toolbarTitleDisplayMode(.inline)
         .task(id: profilePicture?.thumbnailBlobID) {
             previewCache.warm(TipCode.Payload(userID: sessionContainer.session.userID))
@@ -47,52 +36,6 @@ struct TipcardScreen: View {
             renderExportImage()
         }
     }
-
-    // MARK: - v2 (embedded) -
-
-    /// The Figma v2 tip card: the card centered, tap-to-share, with a menu button
-    /// in the top-right (the v1 scanner's settings entry, brought here so the v2
-    /// tab-bar UI has a way into Settings).
-    private var embeddedContent: some View {
-        ZStack(alignment: .top) {
-            VStack(spacing: 0) {
-                Spacer()
-                card?
-                    .contentShape(Rectangle())
-                    .onTapGesture(perform: shareTipCard)
-                Spacer()
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-            HStack {
-                Spacer()
-                settingsButton
-            }
-            .padding(.horizontal, 20)
-        }
-    }
-
-    private var settingsButton: some View {
-        Button {
-            router.present(.settings)
-        } label: {
-            if #available(iOS 26, *) {
-                Image.asset(.hamburger)
-                    .resizable()
-                    .scaledToFit()
-                    .foregroundStyle(Color.textMain)
-                    .frame(width: 32, height: 32)
-            } else {
-                Image.asset(.hamburger)
-                    .foregroundStyle(Color.textMain)
-                    .frame(width: 44, height: 44)
-            }
-        }
-        .liquidGlassButtonStyle(shape: .circle)
-        .accessibilityLabel("Settings")
-    }
-
-    // MARK: - v1 (pushed) -
 
     private var legacyContent: some View {
         VStack(spacing: 0) {

--- a/Flipcash/Core/Screens/Main/You/YouScreen.swift
+++ b/Flipcash/Core/Screens/Main/You/YouScreen.swift
@@ -34,6 +34,12 @@ struct YouScreen: View {
                     card?
                         .contentShape(Rectangle())
                         .onTapGesture(perform: presentFullScreen)
+                        // Hide the in-page card while its expanded copy is up in the
+                        // app-root bill overlay, so it doesn't ghost through the
+                        // overlay's scrim. Opacity (not removal) keeps the layout
+                        // stable so nothing reflows on dismiss.
+                        .opacity(sessionContainer.session.isShowingBill ? 0 : 1)
+                        .animation(.easeInOut(duration: 0.2), value: sessionContainer.session.isShowingBill)
                         .padding(.top, 24)
 
                     Button(action: shareTipCard) {

--- a/Flipcash/Core/Screens/Main/You/YouScreen.swift
+++ b/Flipcash/Core/Screens/Main/You/YouScreen.swift
@@ -1,0 +1,155 @@
+//
+//  YouScreen.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+/// The "You" tab (Figma 9217:114237): the user's tip card, a share button, and
+/// the settings list — the tab-bar entry into My Account / App Settings /
+/// Advanced. Tapping the card presents it full screen via the app-root bill
+/// overlay (`Session.presentOwnTipcard`). Settings rows push onto the tab's
+/// `.you` stack, so they never touch the v1 scanner's Settings sheet.
+struct YouScreen: View {
+
+    @Environment(SessionContainer.self) private var sessionContainer
+    @Environment(AppRouter.self) private var router
+    @Environment(BetaFlags.self) private var betaFlags
+
+    /// Warms the share-sheet preview image ahead of the share tap so it never
+    /// lands on the tap; keyed by user.
+    @State private var previewCache = TipCodePreviewCache()
+    @State private var debugTapCount: Int = 0
+
+    /// The on-screen card width; tuned to the Figma placement (card near the top).
+    private static let cardWidth: CGFloat = 230
+    private let rowInsets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 0) {
+                    card?
+                        .contentShape(Rectangle())
+                        .onTapGesture(perform: presentFullScreen)
+                        .padding(.top, 24)
+
+                    Button(action: shareTipCard) {
+                        Text("Share as a Link")
+                            .font(.appTextMedium)
+                            .foregroundStyle(Color.textMain)
+                            .padding(.vertical, 12)
+                            .padding(.horizontal, 24)
+                            .background(Color.backgroundRow, in: Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 24)
+                    .accessibilityIdentifier("you-share-button")
+
+                    settingsList
+                        .padding(.top, 32)
+                }
+                .padding(.horizontal, 20)
+            }
+            .safeAreaInset(edge: .bottom) { versionFooter }
+        }
+        .task(id: profilePicture?.thumbnailBlobID) {
+            previewCache.warm(TipCode.Payload(userID: sessionContainer.session.userID))
+        }
+    }
+
+    // MARK: - Settings list -
+
+    private var settingsList: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SettingsRow(asset: .myAccount, title: "My Account", insets: rowInsets) {
+                router.push(.settingsMyAccount)
+            }
+            SettingsRow(asset: .settings, title: "App Settings", insets: rowInsets) {
+                router.push(.settingsAppSettings)
+            }
+            SettingsRow(asset: .sliders, title: "Advanced", insets: rowInsets) {
+                router.push(.settingsAdvancedFeatures)
+            }
+            if betaFlags.accessGranted {
+                SettingsRow(asset: .debug, title: "Beta Features", badge: .beta, insets: rowInsets) {
+                    router.push(.settingsBetaFlags)
+                }
+                SettingsRow(asset: .switchAccounts, title: "Switch Accounts", badge: .beta, insets: rowInsets) {
+                    router.push(.settingsAccountSelection)
+                }
+            }
+        }
+        .font(.appDisplayXS)
+        .foregroundStyle(Color.textMain)
+    }
+
+    private var versionFooter: some View {
+        Button {
+            handleVersionTap()
+        } label: {
+            Text("Version \(AppMeta.version) • Build \(AppMeta.build)")
+                .lineLimit(1)
+                .font(.appTextHeading)
+                .foregroundStyle(Color.textSecondary)
+                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 20)
+    }
+
+    // MARK: - Content -
+
+    private var profile: Profile? { sessionContainer.session.profile }
+    private var profilePicture: ProfilePicture? { profile?.profilePicture }
+
+    private var codeData: Data {
+        TipCode.Payload(userID: sessionContainer.session.userID).codeData()
+    }
+
+    private var url: URL { .tipcard(for: sessionContainer.session.userID) }
+
+    private var card: TipcardView? {
+        guard let name = profile?.displayName, !name.isEmpty else { return nil }
+        return TipcardView(
+            size: CGSize(width: Self.cardWidth, height: Self.cardWidth * TipcardView.aspectRatio),
+            name: name,
+            avatar: nil,
+            codeData: codeData,
+            tintOpacity: 0.36
+        )
+    }
+
+    // MARK: - Actions -
+
+    private func presentFullScreen() {
+        guard let name = profile?.displayName, !name.isEmpty else { return }
+        sessionContainer.session.presentOwnTipcard(codeData: codeData, name: name, avatar: nil)
+    }
+
+    private var shareTitle: String {
+        if let name = profile?.displayName, !name.isEmpty { "Tip \(name)" } else { "My Tip Card" }
+    }
+
+    private func shareTipCard() {
+        let item = TipCodeShareItem(
+            url: url,
+            title: shareTitle,
+            preview: previewCache.preview(for: sessionContainer.session.userID)
+        )
+        ShareSheet.present(activityItem: item) { _ in }
+    }
+
+    private func handleVersionTap() {
+        if debugTapCount >= 9 {
+            betaFlags.setAccessGranted(!betaFlags.accessGranted)
+            debugTapCount = 0
+        } else {
+            debugTapCount += 1
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/You/YouScreen.swift
+++ b/Flipcash/Core/Screens/Main/You/YouScreen.swift
@@ -56,10 +56,14 @@ struct YouScreen: View {
 
                     settingsList
                         .padding(.top, 32)
+
+                    // v2 scrolls the version string with the content rather than
+                    // pinning it above the tab bar (the v1 Settings sheet pinned it).
+                    versionFooter
+                        .padding(.top, 32)
                 }
                 .padding(.horizontal, 20)
             }
-            .safeAreaInset(edge: .bottom) { versionFooter }
         }
         .task(id: profilePicture?.thumbnailBlobID) {
             previewCache.warm(TipCode.Payload(userID: sessionContainer.session.userID))
@@ -105,7 +109,6 @@ struct YouScreen: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, 20)
     }
 
     // MARK: - Content -

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -1385,6 +1385,19 @@ class Session {
         }
     }
     
+    /// Presents the signed-in user's own tip card full screen through the
+    /// app-root bill overlay — the same surface a scanned recipient's card uses
+    /// (`TipFlow.present`), but with no `SendAmountViewModel`, balance gate, or
+    /// Send-a-Tip sheet, since you can't tip yourself. Drag-to-dismiss is handled
+    /// by `BillOverlayView.dismissBill`, whose `.tipcard` branch calls
+    /// `tipFlow.cancel()` → `dismissCashBill(.slide)` (a no-op cancel with no
+    /// active submission). Guarded so a double-tap doesn't churn a live bill.
+    func presentOwnTipcard(codeData: Data, name: String, avatar: UIImage?) {
+        guard !isShowingBill else { return }
+        billState = BillState(bill: .tipcard(codeData: codeData, name: name, avatar: avatar))
+        presentationState = .visible(.pop)
+    }
+
     func dismissCashBill(style: PresentationState.Style) {
         sendOperation?.cancel()
         sendOperation = nil

--- a/FlipcashTests/Navigation/YouTabRoutingTests.swift
+++ b/FlipcashTests/Navigation/YouTabRoutingTests.swift
@@ -1,0 +1,29 @@
+//
+//  YouTabRoutingTests.swift
+//  FlipcashTests
+//
+
+import SwiftUI
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("You tab routing")
+struct YouTabRoutingTests {
+
+    @Test("the .you stack is a tab stack, not a sheet")
+    func youStack_hasNoSheet() {
+        #expect(AppRouter.Stack.you.sheet == nil)
+        #expect(AppRouter.Stack.you.description == "you")
+    }
+
+    @Test("pushing a settings destination while the You tab is active lands on .you")
+    func push_onActiveYouTab_landsOnYouStack() {
+        let router = AppRouter()
+        router.activeTabStack = .you
+        router.push(.settingsMyAccount)
+        #expect(router[.you] == AppRouter.navigationPath(.settingsMyAccount))
+        #expect(router[.settings].isEmpty) // never leaks onto the Settings sheet's stack
+    }
+}

--- a/FlipcashTests/PresentOwnTipcardTests.swift
+++ b/FlipcashTests/PresentOwnTipcardTests.swift
@@ -1,0 +1,52 @@
+//
+//  PresentOwnTipcardTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Session.presentOwnTipcard")
+struct PresentOwnTipcardTests {
+
+    private func makeSession() throws -> Session {
+        try SessionContainer.makeTest(holdings: []).session
+    }
+
+    @Test("presents the tipcard bill with a pop and marks a bill showing")
+    func present_setsTipcardBill() throws {
+        let session = try makeSession()
+        let code = Data([1, 2, 3])
+
+        session.presentOwnTipcard(codeData: code, name: "Ada", avatar: nil)
+
+        #expect(session.billState.bill == .tipcard(codeData: code, name: "Ada", avatar: nil))
+        #expect(session.presentationState == .visible(.pop))
+        #expect(session.isShowingBill)
+    }
+
+    @Test("is a no-op while a bill is already showing")
+    func present_whileShowing_isNoop() throws {
+        let session = try makeSession()
+        let first = Data([1])
+        session.presentOwnTipcard(codeData: first, name: "Ada", avatar: nil)
+
+        session.presentOwnTipcard(codeData: Data([9]), name: "Grace", avatar: nil)
+
+        #expect(session.billState.bill == .tipcard(codeData: first, name: "Ada", avatar: nil))
+    }
+
+    @Test("dismissing clears the bill")
+    func dismiss_clearsBill() throws {
+        let session = try makeSession()
+        session.presentOwnTipcard(codeData: Data([1]), name: "Ada", avatar: nil)
+
+        session.dismissCashBill(style: .slide)
+
+        #expect(session.billState.bill == nil)
+        #expect(!session.isShowingBill)
+    }
+}

--- a/docs/superpowers/plans/2026-08-17-you-tab.md
+++ b/docs/superpowers/plans/2026-08-17-you-tab.md
@@ -1,0 +1,605 @@
+# "You" Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the `.tipCard` tab into a "You" landing page — a tip card you tap to present full screen, a "Share as a Link" button, and the settings list rows inlined from the Settings sheet.
+
+**Architecture:** A new `YouScreen` composes `TipcardView` + a share button + `SettingsRow`s. It lives in the tip-card tab hosted by a `NavigationStack` bound to a new dedicated `AppRouter.Stack.you`, so its settings-row pushes never collide with the v1 scanner's Settings sheet (`.settings`). Tapping the card drives the existing app-root bill overlay (`session.billState`) via a new `Session.presentOwnTipcard(...)`, reusing the scanned-tipcard presenter minus the Send-a-Tip machinery.
+
+**Tech Stack:** Swift 6.1, SwiftUI, `@Observable`, Swift Testing (`import Testing`), Xcode project driven by `./Scripts/build.sh` and `./Scripts/test.sh`.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-you-tab-design.md` (Spec 1 of 2). The Wallet grid + Discover changes are Spec 2 and out of scope here.
+
+---
+
+## File Structure
+
+**Create:**
+- `Flipcash/Core/Screens/Main/You/YouScreen.swift` — the "You" tab surface (card + share + settings list + version footer).
+- `FlipcashTests/Navigation/YouTabRoutingTests.swift` — routing test for the `.you` stack.
+- `FlipcashTests/PresentOwnTipcardTests.swift` — `Session.presentOwnTipcard` behavior.
+
+**Modify:**
+- `Flipcash/Core/Navigation/AppRouter+Stack.swift` — add `case you` (+ `sheet`/`description` arms).
+- `Flipcash/Core/Session/Session.swift` — add `presentOwnTipcard(codeData:name:avatar:)`.
+- `Flipcash/Core/Screens/Main/Home/HomeTab.swift` — relabel `.tipCard` accessibility to "You".
+- `Flipcash/Core/Screens/Main/Home/HomeTabView.swift` — `HomeTab.pushStack` maps `.tipCard → .you`; `TipCardTab` hosts `YouScreen` in a `.you`-bound `NavigationStack`.
+- `Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift` — remove the now-unused `isEmbedded` branch (cleanup).
+
+**Unchanged (intentionally):** `SettingsScreen.swift` (still presented by the v1 scanner), `BillOverlayView.swift` (its `.tipcard` dismiss path already handles the own-card case).
+
+---
+
+## Task 1: Add the dedicated `.you` routing stack
+
+**Files:**
+- Modify: `Flipcash/Core/Navigation/AppRouter+Stack.swift`
+- Test: `FlipcashTests/Navigation/YouTabRoutingTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `FlipcashTests/Navigation/YouTabRoutingTests.swift`:
+
+```swift
+//
+//  YouTabRoutingTests.swift
+//  FlipcashTests
+//
+
+import SwiftUI
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("You tab routing")
+struct YouTabRoutingTests {
+
+    @Test("the .you stack is a tab stack, not a sheet")
+    func youStack_hasNoSheet() {
+        #expect(AppRouter.Stack.you.sheet == nil)
+        #expect(AppRouter.Stack.you.description == "you")
+    }
+
+    @Test("pushing a settings destination while the You tab is active lands on .you")
+    func push_onActiveYouTab_landsOnYouStack() {
+        let router = AppRouter()
+        router.activeTabStack = .you
+        router.push(.settingsMyAccount)
+        #expect(router[.you] == AppRouter.navigationPath(.settingsMyAccount))
+        #expect(router[.settings].isEmpty) // never leaks onto the Settings sheet's stack
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./Scripts/test.sh FlipcashTests/YouTabRoutingTests`
+Expected: FAIL — compile error, `AppRouter.Stack` has no member `you`.
+
+- [ ] **Step 3: Add the `.you` case**
+
+In `Flipcash/Core/Navigation/AppRouter+Stack.swift`, add `case you` to the enum and an arm to both switches. Result:
+
+```swift
+    enum Stack: Hashable, CaseIterable, Sendable, CustomStringConvertible {
+        case balance
+        case settings
+        case give
+        case discover
+        case buy
+        case addMoney
+        case downloadApp
+        case sendAmount
+        case tips
+        case you
+
+        var sheet: SheetPresentation? {
+            switch self {
+            case .balance:      .balance
+            case .settings:     .settings
+            case .give:         .give
+            case .discover:     .discover
+            case .buy:          nil
+            case .addMoney:     nil
+            case .downloadApp:  .downloadApp
+            case .sendAmount:   nil
+            case .tips:         .tips
+            case .you:          nil // a tab stack, entered by tab selection, never via navigate(to:)
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .balance:      "balance"
+            case .settings:     "settings"
+            case .give:         "give"
+            case .discover:     "discover"
+            case .buy:          "buy"
+            case .addMoney:     "addMoney"
+            case .downloadApp:  "downloadApp"
+            case .sendAmount:   "sendAmount"
+            case .tips:         "tips"
+            case .you:          "you"
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./Scripts/test.sh FlipcashTests/YouTabRoutingTests`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Flipcash/Core/Navigation/AppRouter+Stack.swift FlipcashTests/Navigation/YouTabRoutingTests.swift
+git commit -m "feat(you-tab): add dedicated .you navigation stack"
+```
+
+---
+
+## Task 2: `Session.presentOwnTipcard`
+
+Presents the user's own tip card through the app-root bill overlay, reusing the scanned-tipcard surface but with no submission/sheet. Dismissal already works: `BillOverlayView.dismissBill` routes a `.tipcard` bill through `tipFlow.cancel()`, which with no active submission falls through to `session.dismissCashBill(style: .slide)`.
+
+**Files:**
+- Modify: `Flipcash/Core/Session/Session.swift`
+- Test: `FlipcashTests/PresentOwnTipcardTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `FlipcashTests/PresentOwnTipcardTests.swift`:
+
+```swift
+//
+//  PresentOwnTipcardTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Session.presentOwnTipcard")
+struct PresentOwnTipcardTests {
+
+    private func makeSession() throws -> Session {
+        try SessionContainer.makeTest(holdings: []).session
+    }
+
+    @Test("presents the tipcard bill with a pop and marks a bill showing")
+    func present_setsTipcardBill() throws {
+        let session = try makeSession()
+        let code = Data([1, 2, 3])
+
+        session.presentOwnTipcard(codeData: code, name: "Ada", avatar: nil)
+
+        #expect(session.billState.bill == .tipcard(codeData: code, name: "Ada", avatar: nil))
+        #expect(session.presentationState == .visible(.pop))
+        #expect(session.isShowingBill)
+    }
+
+    @Test("is a no-op while a bill is already showing")
+    func present_whileShowing_isNoop() throws {
+        let session = try makeSession()
+        let first = Data([1])
+        session.presentOwnTipcard(codeData: first, name: "Ada", avatar: nil)
+
+        session.presentOwnTipcard(codeData: Data([9]), name: "Grace", avatar: nil)
+
+        #expect(session.billState.bill == .tipcard(codeData: first, name: "Ada", avatar: nil))
+    }
+
+    @Test("dismissing clears the bill")
+    func dismiss_clearsBill() throws {
+        let session = try makeSession()
+        session.presentOwnTipcard(codeData: Data([1]), name: "Ada", avatar: nil)
+
+        session.dismissCashBill(style: .slide)
+
+        #expect(session.billState.bill == nil)
+        #expect(!session.isShowingBill)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./Scripts/test.sh FlipcashTests/PresentOwnTipcardTests`
+Expected: FAIL — compile error, `Session` has no member `presentOwnTipcard`.
+
+- [ ] **Step 3: Add the method**
+
+In `Flipcash/Core/Session/Session.swift`, add near `dismissCashBill` (search for `func dismissCashBill`):
+
+```swift
+    /// Presents the signed-in user's own tip card full screen through the
+    /// app-root bill overlay — the same surface a scanned recipient's card uses
+    /// (`TipFlow.present`), but with no `SendAmountViewModel`, balance gate, or
+    /// Send-a-Tip sheet, since you can't tip yourself. Drag-to-dismiss is handled
+    /// by `BillOverlayView.dismissBill`, whose `.tipcard` branch calls
+    /// `tipFlow.cancel()` → `dismissCashBill(.slide)` (a no-op cancel with no
+    /// active submission). Guarded so a double-tap doesn't churn a live bill.
+    func presentOwnTipcard(codeData: Data, name: String, avatar: UIImage?) {
+        guard !isShowingBill else { return }
+        billState = BillState(bill: .tipcard(codeData: codeData, name: name, avatar: avatar))
+        presentationState = .visible(.pop)
+    }
+```
+
+If `UIImage` isn't in scope, add `import UIKit` (the file already imports SwiftUI, which re-exports UIKit on iOS — only add if the build flags it).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./Scripts/test.sh FlipcashTests/PresentOwnTipcardTests`
+Expected: PASS (all three tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Flipcash/Core/Session/Session.swift FlipcashTests/PresentOwnTipcardTests.swift
+git commit -m "feat(you-tab): present own tip card via the bill overlay"
+```
+
+---
+
+## Task 3: Build `YouScreen`
+
+The tab surface. Pure SwiftUI; this repo has no snapshot infra, so verification is a build + manual pass (Task 6). Share logic mirrors `TipcardScreen`'s (kept local rather than shared — the two screens have different lifecycles; the duplication is ~15 lines).
+
+**Files:**
+- Create: `Flipcash/Core/Screens/Main/You/YouScreen.swift`
+
+- [ ] **Step 1: Create the file**
+
+```swift
+//
+//  YouScreen.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+/// The "You" tab (Figma 9217:114237): the user's tip card, a share button, and
+/// the settings list — the tab-bar entry into My Account / App Settings /
+/// Advanced. Tapping the card presents it full screen via the app-root bill
+/// overlay (`Session.presentOwnTipcard`). Settings rows push onto the tab's
+/// `.you` stack, so they never touch the v1 scanner's Settings sheet.
+struct YouScreen: View {
+
+    @Environment(SessionContainer.self) private var sessionContainer
+    @Environment(AppRouter.self) private var router
+    @Environment(BetaFlags.self) private var betaFlags
+
+    /// Warms the share-sheet preview image ahead of the share tap so it never
+    /// lands on the tap; keyed by user.
+    @State private var previewCache = TipCodePreviewCache()
+    @State private var debugTapCount: Int = 0
+
+    /// The on-screen card width; tuned to the Figma placement (card near the top).
+    private static let cardWidth: CGFloat = 230
+    private let rowInsets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 0) {
+                    card?
+                        .contentShape(Rectangle())
+                        .onTapGesture(perform: presentFullScreen)
+                        .padding(.top, 24)
+
+                    Button(action: shareTipCard) {
+                        Text("Share as a Link")
+                            .font(.appTextMedium)
+                            .foregroundStyle(Color.textMain)
+                            .padding(.vertical, 12)
+                            .padding(.horizontal, 24)
+                            .background(Color.backgroundRow, in: Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 24)
+                    .accessibilityIdentifier("you-share-button")
+
+                    settingsList
+                        .padding(.top, 32)
+                }
+                .padding(.horizontal, 20)
+            }
+            .safeAreaInset(edge: .bottom) { versionFooter }
+        }
+        .task(id: profilePicture?.thumbnailBlobID) {
+            previewCache.warm(TipCode.Payload(userID: sessionContainer.session.userID))
+        }
+    }
+
+    // MARK: - Settings list -
+
+    private var settingsList: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SettingsRow(asset: .myAccount, title: "My Account", insets: rowInsets) {
+                router.push(.settingsMyAccount)
+            }
+            SettingsRow(asset: .settings, title: "App Settings", insets: rowInsets) {
+                router.push(.settingsAppSettings)
+            }
+            SettingsRow(asset: .sliders, title: "Advanced", insets: rowInsets) {
+                router.push(.settingsAdvancedFeatures)
+            }
+            if betaFlags.accessGranted {
+                SettingsRow(asset: .debug, title: "Beta Features", badge: .beta, insets: rowInsets) {
+                    router.push(.settingsBetaFlags)
+                }
+                SettingsRow(asset: .switchAccounts, title: "Switch Accounts", badge: .beta, insets: rowInsets) {
+                    router.push(.settingsAccountSelection)
+                }
+            }
+        }
+        .font(.appDisplayXS)
+        .foregroundStyle(Color.textMain)
+    }
+
+    private var versionFooter: some View {
+        Button {
+            handleVersionTap()
+        } label: {
+            Text("Version \(AppMeta.version) • Build \(AppMeta.build)")
+                .lineLimit(1)
+                .font(.appTextHeading)
+                .foregroundStyle(Color.textSecondary)
+                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 20)
+    }
+
+    // MARK: - Content -
+
+    private var profile: Profile? { sessionContainer.session.profile }
+    private var profilePicture: ProfilePicture? { profile?.profilePicture }
+
+    private var codeData: Data {
+        TipCode.Payload(userID: sessionContainer.session.userID).codeData()
+    }
+
+    private var url: URL { .tipcard(for: sessionContainer.session.userID) }
+
+    private var card: TipcardView? {
+        guard let name = profile?.displayName, !name.isEmpty else { return nil }
+        return TipcardView(
+            size: CGSize(width: Self.cardWidth, height: Self.cardWidth * TipcardView.aspectRatio),
+            name: name,
+            avatar: nil,
+            codeData: codeData,
+            tintOpacity: 0.36
+        )
+    }
+
+    // MARK: - Actions -
+
+    private func presentFullScreen() {
+        guard let name = profile?.displayName, !name.isEmpty else { return }
+        sessionContainer.session.presentOwnTipcard(codeData: codeData, name: name, avatar: nil)
+    }
+
+    private var shareTitle: String {
+        if let name = profile?.displayName, !name.isEmpty { "Tip \(name)" } else { "My Tip Card" }
+    }
+
+    private func shareTipCard() {
+        let item = TipCodeShareItem(
+            url: url,
+            title: shareTitle,
+            preview: previewCache.preview(for: sessionContainer.session.userID)
+        )
+        ShareSheet.present(activityItem: item) { _ in }
+    }
+
+    private func handleVersionTap() {
+        if debugTapCount >= 9 {
+            betaFlags.setAccessGranted(!betaFlags.accessGranted)
+            debugTapCount = 0
+        } else {
+            debugTapCount += 1
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `./Scripts/build.sh`
+Expected: BUILD SUCCEEDED. `YouScreen` isn't referenced yet (Task 4 wires it) — this step only proves the view compiles against the real APIs.
+
+If the build flags `TipCodeShareItem`'s initializer label or `previewCache.preview(for:)`'s signature, reconcile against `Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift` (`shareTipCard`) and `TipCodePreviewRenderer.swift` — this screen deliberately mirrors those exact call sites.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Flipcash/Core/Screens/Main/You/YouScreen.swift
+git commit -m "feat(you-tab): add YouScreen (card + share + settings list)"
+```
+
+---
+
+## Task 4: Wire the You tab + relabel
+
+**Files:**
+- Modify: `Flipcash/Core/Screens/Main/Home/HomeTab.swift`
+- Modify: `Flipcash/Core/Screens/Main/Home/HomeTabView.swift`
+
+- [ ] **Step 1: Relabel the tab**
+
+In `Flipcash/Core/Screens/Main/Home/HomeTab.swift`, change only the `.tipCard` accessibility label (keep `iconName` as `"NavTipCard"`):
+
+```swift
+    var accessibilityLabel: String {
+        switch self {
+        case .scan:    return "Scan"
+        case .wallet:  return "Wallet"
+        case .chat:    return "Chat"
+        case .tipCard: return "You"
+        }
+    }
+```
+
+- [ ] **Step 2: Map the tab's push stack to `.you`**
+
+In `Flipcash/Core/Screens/Main/Home/HomeTabView.swift`, the `private extension HomeTab` — change the `.tipCard` arm from `nil` to `.you`:
+
+```swift
+private extension HomeTab {
+    var pushStack: AppRouter.Stack? {
+        switch self {
+        case .wallet:  return .balance
+        case .chat:    return .tips
+        case .tipCard: return .you
+        case .scan:    return nil
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Host `YouScreen` in a `.you`-bound NavigationStack**
+
+In the same file, replace the private `TipCardTab` struct so it binds `router[.you]` and registers the router destinations (so pushed settings screens render):
+
+```swift
+private struct TipCardTab: View {
+
+    @Environment(AppRouter.self) private var router
+    @Environment(SessionContainer.self) private var sessionContainer
+
+    let onSetUp: () -> Void
+
+    var body: some View {
+        @Bindable var router = router
+        NavigationStack(path: $router[.you]) {
+            Group {
+                if sessionContainer.session.profile?.isTippable == true {
+                    YouScreen()
+                } else {
+                    TipCardSetupPrompt(onSetUp: onSetUp)
+                }
+            }
+            .appRouterDestinations()
+        }
+    }
+}
+```
+
+(`TipCardSetupPrompt` and the `tabContent(for: .tipCard)` call site — `TipCardTab(onSetUp: { selection = .chat })` — are unchanged.)
+
+- [ ] **Step 4: Build**
+
+Run: `./Scripts/build.sh`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Flipcash/Core/Screens/Main/Home/HomeTab.swift Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+git commit -m "feat(you-tab): wire YouScreen into the tab and relabel to You"
+```
+
+---
+
+## Task 5: Remove the now-unused `TipcardScreen` embedded branch (cleanup)
+
+`TipcardScreen(isEmbedded: true)` had exactly one caller (the old `TipCardTab`), now replaced by `YouScreen`. The only remaining caller is `AppRouter+DestinationView.swift:142` `TipcardScreen()` (the pushed "My Tip Card"), which used the default `isEmbedded: false`. Remove the embedded-only code so no dead path lingers.
+
+**Files:**
+- Modify: `Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift`
+
+- [ ] **Step 1: Trim `TipcardScreen` to legacy-only**
+
+Remove the `isEmbedded` property, the `embeddedContent` and `settingsButton` computed views, and simplify `body`. The resulting top of the file (through `body`) reads:
+
+```swift
+struct TipcardScreen: View {
+
+    @Environment(Container.self) private var container
+    @Environment(SessionContainer.self) private var sessionContainer
+    @Environment(AppRouter.self) private var router
+
+    @State private var avatar: UIImage?
+    @State private var exportImage: Image?
+
+    /// Renders the share sheet preview image ahead of the share tap so it never
+    /// lands on the tap; keyed by user, warmed when the card is displayed.
+    @State private var previewCache = TipCodePreviewCache()
+
+    /// The card's on-screen width; the export renders the same view at @3x.
+    private static let cardWidth: CGFloat = 300
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            legacyContent
+        }
+        .navigationTitle("My Tip Card")
+        .toolbarTitleDisplayMode(.inline)
+        .task(id: profilePicture?.thumbnailBlobID) {
+            previewCache.warm(TipCode.Payload(userID: sessionContainer.session.userID))
+            await loadAvatar()
+            renderExportImage()
+        }
+    }
+```
+
+Then delete the entire `// MARK: - v2 (embedded) -` section (the `embeddedContent` and `settingsButton` computed properties) and the now-redundant `// MARK: - v1 (pushed) -` marker line above `legacyContent`. Leave `legacyContent`, `card`, `loadAvatar`, `renderExportImage`, `shareTitle`, and `shareTipCard` exactly as they are. The `router` environment is still used by nothing in the trimmed file — remove the `@Environment(AppRouter.self) private var router` line if the build warns it's unused.
+
+- [ ] **Step 2: Build**
+
+Run: `./Scripts/build.sh`
+Expected: BUILD SUCCEEDED — `AppRouter+DestinationView.swift`'s `TipcardScreen()` still compiles (no `isEmbedded` argument was passed there).
+
+- [ ] **Step 3: Run the tip-card-adjacent tests to confirm nothing regressed**
+
+Run: `./Scripts/test.sh FlipcashTests/TipCodeEncodingTests FlipcashTests/YouTabRoutingTests FlipcashTests/PresentOwnTipcardTests`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
+git commit -m "refactor(you-tab): drop the unused embedded TipcardScreen path"
+```
+
+---
+
+## Task 6: Manual verification pass
+
+No automated coverage exists for SwiftUI layout in this repo, so verify by hand on the simulator.
+
+- [ ] **Step 1: Launch and open the You tab**
+
+Run: `./Scripts/build.sh` then run the app (or use the Xcode MCP per `.claude/docs/quick-reference.md`). Sign in with a tippable profile.
+
+- [ ] **Step 2: Verify the layout** — the rightmost tab reads "You" to VoiceOver, shows the tip card near the top, a "Share as a Link" pill, and the My Account / App Settings / Advanced rows; the version string sits at the bottom.
+
+- [ ] **Step 3: Verify full-screen presentation** — tapping the card pops it full screen over the tab; the tab bar hides while it's up; dragging down dismisses it and the tab bar returns.
+
+- [ ] **Step 4: Verify share** — "Share as a Link" opens the system share sheet titled "Tip <name>" with the tipcard URL and the preview image.
+
+- [ ] **Step 5: Verify settings routing** — each row pushes its screen inside the You tab (tab bar hides on push); swipe-back returns. Confirm the v1 scanner's Settings (hamburger) still works independently — the two never interfere.
+
+- [ ] **Step 6: Verify the not-tippable state** — with a profile that has no name, the tab shows `TipCardSetupPrompt` → "Get Started" routes to Chat.
+
+- [ ] **Step 7: Verify beta gating** — 10 taps on the version string toggles `betaFlags.accessGranted`; the Beta Features / Switch Accounts rows appear/disappear accordingly.
+
+- [ ] **Step 8: iOS-version sweep** — repeat steps 2–3 on an iOS 26 simulator (native Liquid Glass tab bar) and an iOS ≤25 simulator (legacy floating pill) to confirm tab-bar hide/return behaves on both.
+
+---
+
+## Self-Review notes (spec coverage)
+
+- Tab relabel → Task 4. Tip card at top → Task 3. Tap → full screen via scanned-card presenter → Task 2 + Task 3. "Share as a Link" reusing the existing share → Task 3. Settings list (incl. beta rows + version footer) → Task 3. Dedicated `.you` routing → Task 1 + Task 4. Not-tippable `TipCardSetupPrompt` kept → Task 4. No "no funds" empty state, no Add/Withdraw on the tab → honored by omission. Cleanup of dead embedded path → Task 5. Manual + iOS-version verification → Task 6.
+- Type consistency: `presentOwnTipcard(codeData:name:avatar:)` is defined in Task 2 and called identically in Task 3; `AppRouter.Stack.you` defined in Task 1 and consumed in Tasks 1/4; `HomeTab.pushStack` returns `.you` (Task 4) matching the `router[.you]` binding (Task 4).

--- a/docs/superpowers/specs/2026-08-17-you-tab-design.md
+++ b/docs/superpowers/specs/2026-08-17-you-tab-design.md
@@ -1,0 +1,184 @@
+# Design: the "You" tab (Spec 1 of 2)
+
+**Platform:** iOS (`code-ios-app`)
+**Date:** 2026-08-17
+**Figma:** [You tab](https://www.figma.com/design/Jxf2wD9QyfKaONbhHSdU0K/Flipcash?node-id=9217-114237&m=dev)
+**Status:** approved design → ready for implementation plan
+
+## Summary
+
+Repurpose the existing `.tipCard` tab into a **"You"** landing page. Today the tab
+shows a bare centered tip card with a hamburger that presents the Settings sheet.
+The redesign turns it into a scrollable profile/settings surface:
+
+- the tip card near the top, tappable to present **full screen**,
+- a **"Share as a Link"** button,
+- the settings list rows (`My Account`, `App Settings`, `Advanced`) inlined from
+  the current Settings sheet, plus the conditional beta rows and version footer.
+
+This is **Spec 1 of 2**. A follow-up spec (Spec 2) covers the Wallet 2×2 action
+grid (Add Money / Withdraw / Discover Currencies / Create a Currency) and the
+removal of the Discover promo card. Those are explicitly **out of scope** here.
+
+## Scope decisions (confirmed)
+
+| Decision | Choice |
+|---|---|
+| Full-screen card presentation | Reuse the scanned-tipcard **bill overlay**; bare card, drag to dismiss. No Share button on the overlay, no Send-a-Tip sheet. |
+| Add Money / Withdraw on the You tab | **Absent.** They move to the Wallet grid in Spec 2. Withdraw is temporarily reachable only via Currency Info (accepted gap). |
+| "No funds" empty-state text (hidden in Figma) | **Not implemented.** Keep only the current not-tippable → `TipCardSetupPrompt` gating. Noted as future. |
+| Tab label | Relabel accessibility to **"You"**; keep the existing `NavTipCard` glyph. |
+| Settings-row routing | **Dedicated `AppRouter.Stack.you`** for the tab's `NavigationStack`. |
+
+## Current state (reference)
+
+- **Tabs:** `HomeTab` enum — `scan`, `wallet`, `chat`, `tipCard` — rendered by
+  `HomeTabView` (iOS 26 native `TabView` + Liquid Glass bar; legacy floating
+  `HomeTabBar` pill below 26). Launch tab is `.wallet`.
+  - `Flipcash/Core/Screens/Main/Home/HomeTab.swift`
+  - `Flipcash/Core/Screens/Main/Home/HomeTabView.swift`
+- **Tip card tab:** `TipCardTab` (private in `HomeTabView`) shows
+  `TipcardScreen(isEmbedded: true)` for tippable profiles, else
+  `TipCardSetupPrompt`. `TipcardScreen`'s embedded mode centers the card, taps to
+  share, and has a hamburger that calls `router.present(.settings)`.
+  - `Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift`
+  - `Flipcash/Core/Screens/Main/Tips/TipcardView.swift` (the renderable card)
+- **Settings sheet:** `SettingsScreen` — an `Add Money` / `Withdraw Money` card
+  row, then `My Account` (`settingsMyAccount`), `App Settings`
+  (`settingsAppSettings`), `Advanced` (`settingsAdvancedFeatures`), conditional
+  `Beta Features` / `Switch Accounts` behind `betaFlags.accessGranted`, and a
+  version footer whose 10th tap toggles beta access.
+  - `Flipcash/Core/Screens/Settings/SettingsScreen.swift`
+- **Bill overlay (full-screen presenter):** `BillOverlayView` renders
+  `session.billState.bill` at the app root over any tab, driven by
+  `session.presentationState`. `TipFlow.present(_:)` shows a scanned card via
+  `session.billState = BillState(bill: .tipcard(codeData:name:avatar:))` +
+  `session.presentationState = .visible(.pop)`, then (after 750ms, gated on
+  balance) raises the Send-a-Tip sheet. Drag-to-dismiss routes through
+  `BillOverlayView.dismissBill` → for `.tipcard`, `tipFlow.cancel()`.
+  - `Flipcash/Core/Screens/Main/Bill/BillOverlayView.swift`
+  - `Flipcash/Core/Screens/Main/Bill/BillState.swift`
+  - `Flipcash/Core/Screens/Main/Tips/TipFlow.swift`
+- **Routing:** `AppRouter` keeps a `NavigationPath` per `Stack`; `push` lands on
+  `topmostStack = presentedSheet?.stack ?? activeTabStack`. `HomeTabView`
+  publishes `router.activeTabStack = selection.pushStack` and hides the tab bar
+  when the active tab's stack is non-empty (`isTabBarHidden`) or while
+  `session.isShowingBill`.
+  - `Flipcash/Core/Navigation/AppRouter.swift`, `AppRouter+Stack.swift`,
+    `AppRouter+Destination*.swift`
+
+## Components to build / change
+
+### 1. `HomeTab` — relabel
+
+- `accessibilityLabel` for `.tipCard` → `"You"`. Keep `iconName = "NavTipCard"`.
+- Add `pushStack` mapping for `.tipCard` → `.you` (new stack, see §4).
+  (`HomeTabView`'s private `HomeTab.pushStack` extension currently returns `nil`
+  for `.tipCard`.)
+
+### 2. `YouScreen` (new) — replaces the embedded tip-card layout
+
+A new `YouScreen` view composing:
+
+- **Header tip card:** `TipcardView` (same payload/render as today:
+  `TipCode.Payload(userID:)`, display name, avatar). Sized per Figma (card near
+  the top rather than vertically centered). `.onTapGesture` → present full screen
+  (§3). Reuses the existing avatar load + export/preview warming currently in
+  `TipcardScreen` (move that logic into `YouScreen`, or a small shared helper).
+- **"Share as a Link" button:** invokes the existing share path — a
+  `TipCodeShareItem` (URL `.tipcard(for:)` + warmed `TipCodePreviewCache` image)
+  through `ShareSheet.present`. This is the current `shareTipCard()` behavior,
+  surfaced as an explicit button instead of a card tap.
+- **Settings list:** `SettingsRow`s for `My Account` → `settingsMyAccount`,
+  `App Settings` → `settingsAppSettings`, `Advanced` → `settingsAdvancedFeatures`;
+  conditional `Beta Features` → `settingsBetaFlags` and `Switch Accounts` →
+  `settingsAccountSelection` behind `betaFlags.accessGranted`. Pushes go on the
+  `.you` stack (§4).
+- **Version footer:** the `Version … • Build …` label with the 10-tap
+  beta-access toggle, moved from `SettingsScreen`.
+- **Not-tippable gate:** keep `TipCardSetupPrompt` (routes to Chat to add a name).
+  `TipCardTab` continues to branch on `sessionContainer.session.profile?.isTippable`.
+
+The `SettingsRow` component and the beta-toggle logic are lifted from
+`SettingsScreen`. `SettingsScreen` itself (the sheet) is left intact for now but
+is no longer presented from this tab (the hamburger is removed). Whether the
+Settings sheet is still presented from anywhere else in the v2 UI is verified
+during implementation; if nothing references it, that cleanup can be a follow-up
+rather than part of this spec.
+
+### 3. Full-screen tip card presentation
+
+Add `Session.presentOwnTipcard(codeData:name:avatar:)` (or an equivalent small
+coordinator method) that mirrors `TipFlow.present`'s card setup **without** the
+submission/sheet machinery:
+
+```swift
+session.billState = BillState(bill: .tipcard(codeData: codeData, name: name, avatar: avatar))
+session.presentationState = .visible(.pop)
+```
+
+- No `SendAmountViewModel`, no 750ms sheet scheduling, no balance gate.
+- Dismissal reuses the overlay's existing drag-to-dismiss. `dismissBill` routes
+  `.tipcard` → `tipFlow.cancel()`, which with no active submission falls through
+  to `session.dismissCashBill(style: .slide)` — a safe, correct dismiss. We
+  therefore **reuse `.tipcard`** rather than introduce a new bill case.
+- `HomeTabView` already hides the tab bar while `session.isShowingBill`, so the
+  bar clears during the presentation with no extra wiring.
+- The card's resting offset is `restingTipcardOffset` (centered) because
+  `tipFlow.isSheetPresented` is false for the own-card path.
+
+### 4. Routing — dedicated `.you` stack
+
+- Add `case you` to `AppRouter.Stack` (update the `sheet` mapping — `.you`
+  returns `nil`, it is a tab stack not a sheet — and `description`).
+- The You tab hosts `NavigationStack(path: $router[.you])` with
+  `.appRouterDestinations()` so the settings sub-destinations render on it.
+- `HomeTab.tipCard.pushStack = .you`; `HomeTabView` publishes
+  `activeTabStack = .you` when the tab is selected, so `router.push(...)` from the
+  rows lands on the You tab's stack and the tab bar hides on drill-in.
+- The still-existing Settings sheet keeps `.settings`; the two never share a path.
+
+## Data flow
+
+1. User selects the You tab → `activeTabStack = .you`.
+2. `TipCardTab` branches: tippable → `YouScreen`; else `TipCardSetupPrompt`.
+3. `YouScreen` renders the card (payload from `sessionContainer.session.userID`, avatar
+   loaded async) + Share button + settings rows + version footer.
+4. Tap card → `Session.presentOwnTipcard(...)` → bill overlay pops the card full
+   screen; drag down dismisses.
+5. Tap "Share as a Link" → `ShareSheet.present(TipCodeShareItem(...))`.
+6. Tap a settings row → `router.push(.settings*)` → pushes on `.you` → tab bar
+   hides, sub-screen renders via `.appRouterDestinations()`.
+
+## Error handling / edge cases
+
+- **Avatar load failure:** card renders without the photo (existing behavior in
+  `TipcardScreen.loadAvatar`); carry it over unchanged.
+- **Not-tippable / no display name:** show `TipCardSetupPrompt`; the card and its
+  tap/share are not shown.
+- **Rapid double-tap on the card:** presenting an own-card when a bill is already
+  showing should be guarded (no-op if `session.isShowingBill`), mirroring
+  `TipFlow.begin`'s re-entrancy guards.
+- **Beta rows / version toggle:** preserve the exact 10-tap threshold and
+  `betaFlags.setAccessGranted` behavior from `SettingsScreen`.
+
+## Testing
+
+- Unit/snapshot: `YouScreen` in tippable vs. not-tippable states; with/without
+  avatar; with/without `betaFlags.accessGranted` (beta rows shown/hidden).
+- `Session.presentOwnTipcard` sets `billState.bill == .tipcard(...)` and
+  `presentationState == .visible(.pop)`; dismissal clears `isShowingBill`.
+- Routing: pushing `settingsMyAccount` while on the You tab lands on
+  `router[.you]` and hides the tab bar; `router[.settings]` is untouched.
+- Manual: iOS 26 (native tab bar) and ≤25 (legacy pill) — verify tab-bar hide on
+  card present and on settings drill-in; verify Share sheet content (name + URL +
+  preview image).
+
+## Out of scope (Spec 2)
+
+- Wallet 2×2 action grid (Add Money / Withdraw Money / Discover Currencies /
+  Create a Currency) — Figma
+  [`9217-114318`](https://www.figma.com/design/Jxf2wD9QyfKaONbhHSdU0K/Flipcash?node-id=9217-114318&m=dev).
+- Relocating Withdraw into that grid.
+- Removing the Discover promo card; Discover Currencies list "Option B" — Figma
+  [`9217-116668`](https://www.figma.com/design/Jxf2wD9QyfKaONbhHSdU0K/Flipcash?node-id=9217-116668&m=dev).


### PR DESCRIPTION
## Summary
Repurposes the `.tipCard` tab into a **You** landing page (Figma [9217:114237](https://www.figma.com/design/Jxf2wD9QyfKaONbhHSdU0K/Flipcash?node-id=9217-114237&m=dev)):

- **Tip card** near the top; tapping it presents the card **full screen** via the app-root bill overlay — reusing the scanned-tipcard presenter (`Session.presentOwnTipcard`) minus the Send-a-Tip machinery (you cannot tip yourself). The in-page card fades out while its expanded copy is up.
- **"Share as a Link"** button — the existing tipcard share (URL + warmed preview), surfaced explicitly instead of tap-to-share.
- **Settings list** inlined from the Settings sheet — My Account / App Settings / Advanced, plus the beta rows behind `betaFlags.accessGranted` and the version footer (which scrolls with content in v2 rather than pinning).
- Tab relabeled **"You"** (keeps the `NavTipCard` glyph).
- New dedicated `AppRouter.Stack.you` hosts the tab's `NavigationStack`, so its settings pushes never collide with the v1 scanner's Settings sheet (`.settings`).
- Removes the now-dead embedded `TipcardScreen` path; the pushed "My Tip Card" screen is unchanged.

Scoped to the You tab. The Wallet 2x2 grid + Discover card move (Figma 9217:114318 / 9217:116668) are a planned follow-up (Spec 2). Design + plan under `docs/superpowers/`.

## Test Plan
- [x] `FlipcashTests/YouTabRoutingTests` — `.you` is a tab stack (no sheet); settings pushes land on `.you`, never `.settings`.
- [x] `FlipcashTests/PresentOwnTipcardTests` — presents the tipcard bill with `.pop`; guarded against double-present; dismissal clears it.
- [x] Builds clean for device + simulator; installed/run on iOS 27 sim.
- [ ] On-device manual pass: tap card → full-screen present + drag-dismiss; Share sheet contents; per-row settings navigation; beta gating; iOS 26 native bar vs <=25 pill.
