### PR TITLE
fix(scan): fill the tab width so the scanner isn't pillarboxed

### DIFF
--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -101,6 +101,12 @@ private struct ScanScreenContent: View {
                     .transition(.opacity)
             }
         }
+        // Fill the tab's full width and height. The iOS 26 native `TabView` does
+        // not stretch tab content to fill, so without this the ZStack collapses to
+        // its content width (the centered `CameraPromptView` at ~340pt, or the
+        // camera viewport), leaving black bars down both sides of the scanner. The
+        // v1 full-screen root masked this; only the embedded v2 tab exposed it.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.backgroundMain)
         .animation(.easeInOut(duration: 0.15), value: showControls)
         .animation(.easeInOut(duration: 0.3), value: preferences.cameraEnabled)


### PR DESCRIPTION
## Summary
The v2 Scan tab was **pillarboxed** — the live camera (and the "Start your camera" prompt) sat in a ~340pt-wide column with black bars down both sides instead of filling the screen.

**Root cause:** `ScanScreenContent`'s `ZStack` has no fill frame. The iOS 26 native `TabView` does **not** stretch tab content to fill, so the ZStack collapsed to its content width (the centered `CameraPromptView` is `260pt text + 40pt padding×2 = 340pt`; the camera viewport fills whatever the container is). Its `.background(Color.backgroundMain)` only painted that narrow column, exposing the window's black behind it. The v1 full-screen root masked this because it was never inside a `Tab`.

**Fix:** add `.frame(maxWidth: .infinity, maxHeight: .infinity)` to the scanner's ZStack so it always fills the tab.

`videoGravity` is already `.resizeAspectFill` (fills/crops, never letterboxes), so once the container is full-width the camera fills edge-to-edge.

## Evidence (measured on iOS 26.x sim via view hierarchy; screen = 402pt)
| Scan container bounds | |
|---|---|
| Before | `[31,0][371,874]` → 340pt wide, 31pt bars each side |
| After | `[0,0][402,874]` → full width |

## Test Plan
- [x] Reproduced the pillarbox on the iOS 27 simulator (seed login), captured the narrow container via `inspect_view_hierarchy`.
- [x] After the fix, the same inspection shows the container at full `402pt`; the background fills edge-to-edge (no black bars).
- [x] Builds clean for device + simulator.
- [ ] On-device sanity: open the Scan tab with the camera running — the live preview fills the full width (no side bars). (Sim has no camera feed, so device confirms the camera path.)
