### PR TITLE
feat: swap activity row + proto sync

### DIFF
--- a/Flipcash/Core/Controllers/Database/Database+Activities.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Activities.swift
@@ -168,7 +168,7 @@ nonisolated extension Database {
 
     private func metadata(for kind: Activity.Kind, row: RowIterator.Element) -> Activity.Metadata? {
         switch kind {
-        case .gave, .received, .withdrew, .deposited, .paid, .distributed, .bought, .sold, .unknown:
+        case .gave, .received, .withdrew, .deposited, .paid, .distributed, .bought, .sold, .swapped, .unknown:
             return nil
         case .cashLink:
             let table = CashLinkMetadataTable()
@@ -210,7 +210,7 @@ nonisolated extension Database {
         )
         
         switch activity.kind {
-        case .gave, .received, .withdrew, .deposited, .paid, .distributed, .bought, .sold, .unknown:
+        case .gave, .received, .withdrew, .deposited, .paid, .distributed, .bought, .sold, .swapped, .unknown:
             break
         case .cashLink:
             if case .cashLink(let metadata) = activity.metadata {

--- a/Flipcash/Core/Controllers/Database/Database+Activities.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Activities.swift
@@ -84,11 +84,24 @@ nonisolated extension Database {
             a.counterpartyPhone,
 
             c.vault,
-            c.canCancel
+            c.canCancel,
+
+            s.fromMint,
+            s.fromQuarks,
+            s.fromNativeAmount,
+            s.fromCurrency,
+            s.toMint,
+            s.toQuarks,
+            s.toNativeAmount,
+            s.toCurrency,
+            s.feeNativeAmount,
+            s.feeCurrency,
+            s.state AS swapState
 
         FROM activity a
 
         LEFT JOIN cashLinkMetadata c ON c.id = a.id
+        LEFT JOIN swapMetadata s ON s.id = a.id
 
         WHERE a.mint = ?
 
@@ -118,11 +131,24 @@ nonisolated extension Database {
             a.counterpartyPhone,
 
             c.vault,
-            c.canCancel
+            c.canCancel,
+
+            s.fromMint,
+            s.fromQuarks,
+            s.fromNativeAmount,
+            s.fromCurrency,
+            s.toMint,
+            s.toQuarks,
+            s.toNativeAmount,
+            s.toCurrency,
+            s.feeNativeAmount,
+            s.feeCurrency,
+            s.state AS swapState
 
         FROM activity a
 
         LEFT JOIN cashLinkMetadata c ON c.id = a.id
+        LEFT JOIN swapMetadata s ON s.id = a.id
 
         ORDER BY a.date DESC
         LIMIT ?;
@@ -168,7 +194,7 @@ nonisolated extension Database {
 
     private func metadata(for kind: Activity.Kind, row: RowIterator.Element) -> Activity.Metadata? {
         switch kind {
-        case .gave, .received, .withdrew, .deposited, .paid, .distributed, .bought, .sold, .swapped, .unknown:
+        case .gave, .received, .withdrew, .deposited, .paid, .distributed, .bought, .sold, .unknown:
             return nil
         case .cashLink:
             let table = CashLinkMetadataTable()
@@ -178,7 +204,48 @@ nonisolated extension Database {
                     canCancel: row[table.canCancel]
                 )
             )
+        case .swapped:
+            return swapMetadata(from: row)
         }
+    }
+
+    /// Reads the joined `swapMetadata` columns. A `.swapped` row should always
+    /// have a match, but the reads are optional so a legacy/un-persisted swap
+    /// degrades to no metadata instead of trapping on a NULL column. `s.state` is
+    /// aliased to `swapState` in the SELECT to avoid colliding with `a.state`.
+    private func swapMetadata(from row: RowIterator.Element) -> Activity.Metadata? {
+        guard
+            let fromMint   = row[Expression<PublicKey?>("fromMint")],
+            let fromQuarks = row[Expression<UInt64?>("fromQuarks")],
+            let fromNative = row[Expression<Double?>("fromNativeAmount")],
+            let fromCurr   = row[Expression<CurrencyCode?>("fromCurrency")],
+            let toMint     = row[Expression<PublicKey?>("toMint")],
+            let feeNative  = row[Expression<Double?>("feeNativeAmount")],
+            let feeCurr    = row[Expression<CurrencyCode?>("feeCurrency")]
+        else {
+            return nil
+        }
+
+        let toFiat: FiatAmount?
+        if let toNative = row[Expression<Double?>("toNativeAmount")],
+           let toCurr = row[Expression<CurrencyCode?>("toCurrency")] {
+            toFiat = FiatAmount(value: Decimal(toNative), currency: toCurr)
+        } else {
+            toFiat = nil
+        }
+
+        return .swap(
+            Activity.SwapMetadata(
+                fromMint: fromMint,
+                fromQuarks: fromQuarks,
+                fromFiat: FiatAmount(value: Decimal(fromNative), currency: fromCurr),
+                toMint: toMint,
+                toQuarks: row[Expression<UInt64?>("toQuarks")],
+                toFiat: toFiat,
+                fee: FiatAmount(value: Decimal(feeNative), currency: feeCurr),
+                state: Activity.SwapMetadata.State(rawValue: row[Expression<Int?>("swapState")] ?? 0) ?? .unknown
+            )
+        )
     }
     
     // MARK: - Insert -
@@ -210,15 +277,19 @@ nonisolated extension Database {
         )
         
         switch activity.kind {
-        case .gave, .received, .withdrew, .deposited, .paid, .distributed, .bought, .sold, .swapped, .unknown:
+        case .gave, .received, .withdrew, .deposited, .paid, .distributed, .bought, .sold, .unknown:
             break
         case .cashLink:
             if case .cashLink(let metadata) = activity.metadata {
                 try insertCashLinkMetaData(id: activity.id, metadata: metadata)
             }
+        case .swapped:
+            if case .swap(let metadata) = activity.metadata {
+                try insertSwapMetadata(id: activity.id, metadata: metadata)
+            }
         }
     }
-    
+
     private func insertCashLinkMetaData(id: PublicKey, metadata: Activity.CashLinkMetadata) throws {
         let table = CashLinkMetadataTable()
         try writer.run(
@@ -226,7 +297,29 @@ nonisolated extension Database {
                 table.id        <- id,
                 table.vault     <- metadata.vault,
                 table.canCancel <- metadata.canCancel,
-                
+
+                onConflictOf: table.id,
+            )
+        )
+    }
+
+    private func insertSwapMetadata(id: PublicKey, metadata: Activity.SwapMetadata) throws {
+        let table = SwapMetadataTable()
+        try writer.run(
+            table.table.upsert(
+                table.id               <- id,
+                table.fromMint         <- metadata.fromMint,
+                table.fromQuarks       <- metadata.fromQuarks,
+                table.fromNativeAmount <- metadata.fromFiat.doubleValue,
+                table.fromCurrency     <- metadata.fromFiat.currency,
+                table.toMint           <- metadata.toMint,
+                table.toQuarks         <- metadata.toQuarks,
+                table.toNativeAmount   <- metadata.toFiat?.doubleValue,
+                table.toCurrency       <- metadata.toFiat?.currency,
+                table.feeNativeAmount  <- metadata.fee.doubleValue,
+                table.feeCurrency      <- metadata.fee.currency,
+                table.state            <- metadata.state.rawValue,
+
                 onConflictOf: table.id,
             )
         )

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -82,6 +82,27 @@ nonisolated struct CashLinkMetadataTable: Sendable {
     let canCancel    = Expression <Bool>      ("canCancel")
 }
 
+// Side table for `.swapped` activities: the two swap legs + fee. Joined 1:1 to
+// `activity` by id. The destination amount columns are nullable — a swap that
+// hasn't executed yet carries only its destination mint.
+nonisolated struct SwapMetadataTable: Sendable {
+    static let name = "swapMetadata"
+
+    let table            = Table(Self.name)
+    let id               = Expression <PublicKey>     ("id")
+    let fromMint         = Expression <PublicKey>     ("fromMint")
+    let fromQuarks       = Expression <UInt64>        ("fromQuarks")
+    let fromNativeAmount = Expression <Double>        ("fromNativeAmount")
+    let fromCurrency     = Expression <CurrencyCode>  ("fromCurrency")
+    let toMint           = Expression <PublicKey>     ("toMint")
+    let toQuarks         = Expression <UInt64?>       ("toQuarks")
+    let toNativeAmount   = Expression <Double?>       ("toNativeAmount")
+    let toCurrency       = Expression <CurrencyCode?> ("toCurrency")
+    let feeNativeAmount  = Expression <Double>        ("feeNativeAmount")
+    let feeCurrency      = Expression <CurrencyCode>  ("feeCurrency")
+    let state            = Expression <Int>           ("state")
+}
+
 nonisolated struct LimitsTable: Sendable {
     static let name = "limits"
 
@@ -325,6 +346,27 @@ nonisolated extension Database {
                 t.column(cashLinkMetadataTable.canCancel)
 
                 t.foreignKey(cashLinkMetadataTable.id, references: activityTable.table, activityTable.id, delete: .cascade)
+            })
+        }
+
+        let swapMetadataTable = SwapMetadataTable()
+
+        try writer.transaction {
+            try writer.run(swapMetadataTable.table.create(ifNotExists: true, withoutRowid: true) { t in
+                t.column(swapMetadataTable.id, primaryKey: true)
+                t.column(swapMetadataTable.fromMint)
+                t.column(swapMetadataTable.fromQuarks)
+                t.column(swapMetadataTable.fromNativeAmount)
+                t.column(swapMetadataTable.fromCurrency)
+                t.column(swapMetadataTable.toMint)
+                t.column(swapMetadataTable.toQuarks)
+                t.column(swapMetadataTable.toNativeAmount)
+                t.column(swapMetadataTable.toCurrency)
+                t.column(swapMetadataTable.feeNativeAmount)
+                t.column(swapMetadataTable.feeCurrency)
+                t.column(swapMetadataTable.state)
+
+                t.foreignKey(swapMetadataTable.id, references: activityTable.table, activityTable.id, delete: .cascade)
             })
         }
 

--- a/Flipcash/Core/Screens/Main/Home/ActivityHistoryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/ActivityHistoryScreen.swift
@@ -51,7 +51,7 @@ private struct ActivityHistoryContent: View {
                 ScrollView(.vertical, showsIndicators: false) {
                     LazyVStack(spacing: 0) {
                         ForEach(activities) { activity in
-                            WalletActivityRow(activity: activity)
+                            ActivityRow(activity: activity)
                         }
                     }
                     .padding(.horizontal, 20)

--- a/Flipcash/Core/Screens/Main/Home/ActivityRow.swift
+++ b/Flipcash/Core/Screens/Main/Home/ActivityRow.swift
@@ -27,11 +27,14 @@ struct ActivityRow: View {
     @State private var avatarData: Data?
     @State private var avatarBlurhash: String?
 
+    /// Swap coin logos resolved beyond the held-balance cache (local mint store,
+    /// then a server fetch) so a swapped-away token still shows its real logo.
+    @State private var swapFromImageURL: URL?
+    @State private var swapToImageURL: URL?
+
     var body: some View {
         HStack(spacing: 12) {
             avatar
-                .frame(width: 40, height: 40)
-                .clipShape(Circle())
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(displayTitle)
@@ -45,13 +48,39 @@ struct ActivityRow: View {
 
             Spacer(minLength: 8)
 
+            amount
+        }
+        .padding(.vertical, 12)
+        .task(id: activity.id) {
+            await resolveCounterparty()
+            if let swap = activity.swapMetadata {
+                await resolveSwapLogos(swap)
+            }
+        }
+    }
+
+    // MARK: - Amount
+
+    /// A swap shows the converted (From) fiat amount over its fee; every other
+    /// row shows the single signed amount.
+    @ViewBuilder private var amount: some View {
+        if let swap = activity.swapMetadata {
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(swap.fromFiat.formatted())
+                    .font(.appTextMedium)
+                    .foregroundStyle(Color.textMain)
+                    .lineLimit(1)
+                Text("-\(swap.fee.formatted()) Fee")
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(1)
+            }
+        } else {
             Text(signedAmount)
                 .font(.appTextMedium)
                 .foregroundStyle(Color.textMain)
                 .lineLimit(1)
         }
-        .padding(.vertical, 12)
-        .task(id: activity.id) { await resolveCounterparty() }
     }
 
     // MARK: - Title
@@ -73,6 +102,16 @@ struct ActivityRow: View {
     // MARK: - Avatar
 
     @ViewBuilder private var avatar: some View {
+        if let swap = activity.swapMetadata {
+            swapAvatar(swap)
+        } else {
+            singleAvatar
+                .frame(width: 40, height: 40)
+                .clipShape(Circle())
+        }
+    }
+
+    @ViewBuilder private var singleAvatar: some View {
         switch activity.counterparty {
         case .user(let userID):
             ContactAvatarView(
@@ -100,6 +139,51 @@ struct ActivityRow: View {
         } else {
             ContactAvatarView(id: activity.id.base58, displayName: "", size: 40)
         }
+    }
+
+    /// The two swapped tokens as overlapping coins — the destination (To) sits on
+    /// top of the source (From), per the Recent design. Each coin shows its mint
+    /// logo (held balance first, then the async-resolved fallback).
+    private func swapAvatar(_ swap: Activity.SwapMetadata) -> some View {
+        ZStack {
+            tokenCoin(url: coinURL(for: swap.fromMint, fallback: swapFromImageURL), monogramID: swap.fromMint.base58, size: 26)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            tokenCoin(url: coinURL(for: swap.toMint, fallback: swapToImageURL), monogramID: swap.toMint.base58, size: 26)
+                .overlay(Circle().stroke(Color.backgroundMain, lineWidth: 2))
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        }
+        .frame(width: 40, height: 40)
+    }
+
+    /// The held-balance logo (instant, from cache) or the async-resolved fallback.
+    private func coinURL(for mint: PublicKey, fallback: URL?) -> URL? {
+        session.balance(for: mint)?.imageURL ?? fallback
+    }
+
+    @ViewBuilder private func tokenCoin(url: URL?, monogramID: String, size: CGFloat) -> some View {
+        Group {
+            if let url {
+                RemoteImage(url: url)
+            } else {
+                ContactAvatarView(id: monogramID, displayName: "", size: size)
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+    }
+
+    /// Resolves both coins' logos beyond the held-balance cache: the local mint
+    /// store, then a server fetch, so a swapped-away token still shows its logo.
+    private func resolveSwapLogos(_ swap: Activity.SwapMetadata) async {
+        swapFromImageURL = await resolveMintImageURL(swap.fromMint)
+        swapToImageURL   = await resolveMintImageURL(swap.toMint)
+    }
+
+    private func resolveMintImageURL(_ mint: PublicKey) async -> URL? {
+        if let url = session.storedMintMetadata(for: mint)?.imageURL {
+            return url
+        }
+        return try? await session.fetchMintMetadata(mint: mint).imageURL
     }
 
     // MARK: - Amount

--- a/Flipcash/Core/Screens/Main/Home/ActivityRow.swift
+++ b/Flipcash/Core/Screens/Main/Home/ActivityRow.swift
@@ -1,5 +1,5 @@
 //
-//  WalletActivityRow.swift
+//  ActivityRow.swift
 //  Flipcash
 //
 
@@ -7,13 +7,14 @@ import SwiftUI
 import FlipcashUI
 import FlipcashCore
 
-/// A single row in the v2 Wallet's "Recent" activity preview (Figma 8966:1910,
-/// ported from Android's `ActivityFeedRow`): a 40pt avatar, the title + relative
-/// time, and a signed amount. The avatar is the counterparty's profile photo for
-/// peer activity (tips/sends), the token image for token activity (deposits,
-/// buys), or a monogram fallback. A sent tip reads "Tipped <name>" once the
-/// counterparty resolves.
-struct WalletActivityRow: View {
+/// The single activity row used across every surface — the Wallet and Currency
+/// Info "Recent" previews, the cross-token Activity history, and the per-token
+/// Transaction history (Figma 8966:1910, ported from Android's `ActivityFeedRow`):
+/// a 40pt avatar, the title + relative time, and a signed amount. The avatar is
+/// the counterparty's profile photo for peer activity (tips/sends), the token
+/// image for token activity (deposits, buys), or a monogram fallback. A sent tip
+/// reads "Tipped <name>" once the counterparty resolves.
+struct ActivityRow: View {
 
     let activity: Activity
 

--- a/Flipcash/Core/Screens/Main/Home/RecentActivitySection.swift
+++ b/Flipcash/Core/Screens/Main/Home/RecentActivitySection.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import FlipcashCore
 
 /// The "Recent" activity preview: a tappable header that opens the full history,
-/// over a short list of ``WalletActivityRow``s. Shared by the wallet (all tokens)
+/// over a short list of ``ActivityRow``s. Shared by the wallet (all tokens)
 /// and the currency info screen (a single token), which differ only in what the
 /// header opens.
 struct RecentActivitySection: View {
@@ -36,7 +36,7 @@ struct RecentActivitySection: View {
             .padding(.bottom, 4)
 
             ForEach(activities) { activity in
-                WalletActivityRow(activity: activity)
+                ActivityRow(activity: activity)
             }
         }
     }

--- a/Flipcash/Core/Screens/Main/Home/WalletActivityRow.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletActivityRow.swift
@@ -110,7 +110,9 @@ struct WalletActivityRow: View {
             return "+\(formatted)"
         case .gave, .withdrew, .cashLink, .paid:
             return "-\(formatted)"
-        case .unknown:
+        case .swapped, .unknown:
+            // A swap's net effect on the wallet isn't inherently in or out, so it
+            // renders unsigned until the swap notification is modelled richly.
             return formatted
         }
     }

--- a/Flipcash/Core/Screens/Main/TransactionHistoryScreen.swift
+++ b/Flipcash/Core/Screens/Main/TransactionHistoryScreen.swift
@@ -33,9 +33,14 @@ struct TransactionHistoryScreen: View {
                     switch historyController.loadingState {
                     case .loaded(let activities):
                         ForEach(activities) { activity in
-                            ActivityRow(activity: activity) {
+                            Button {
                                 rowAction(activity: activity)
+                            } label: {
+                                ActivityRow(activity: activity)
+                                    .padding(.horizontal, 20)
                             }
+                            .buttonStyle(.plain)
+                            .listRowBackground(Color.clear)
                         }
                     case .loading:
                         ProgressView()
@@ -94,42 +99,5 @@ struct TransactionHistoryScreen: View {
                 )
             }
         }
-    }
-}
-
-// MARK: - Activity Row -
-
-private struct ActivityRow: View {
-    let activity: Activity
-    let onTap: () -> Void
-
-    var body: some View {
-        Button(action: onTap) {
-            VStack {
-                HStack {
-                    Text(activity.title)
-                        .font(.appTextMedium)
-                        .foregroundStyle(Color.textMain)
-                    Spacer()
-                    AmountText(
-                        flagStyle: activity.exchangedFiat.nativeAmount.currency.flagStyle,
-                        flagSize: .small,
-                        content: activity.exchangedFiat.nativeAmount.formatted()
-                    )
-                    .font(.appTextMedium)
-                    .foregroundStyle(Color.textMain)
-                }
-
-                HStack {
-                    Text(activity.date.formattedRelatively(useTimeForToday: true))
-                        .font(.appTextSmall)
-                        .foregroundStyle(Color.textSecondary)
-                    Spacer()
-                }
-            }
-        }
-        .listRowBackground(Color.clear)
-        .padding(.horizontal, 20)
-        .padding(.vertical, 20)
     }
 }

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -158,6 +158,12 @@ class Session {
         updateableBalances.value.first { $0.mint == mint }
     }
 
+    /// Locally-cached metadata for any known mint, held or not. Nil when the mint
+    /// has never been synced — a swap's counterpart currency may not be a balance.
+    func storedMintMetadata(for mint: PublicKey) -> StoredMintMetadata? {
+        try? database.getMintMetadata(mint: mint)
+    }
+
     /// The newest `limit` activities across all tokens — the unified feed shown
     /// as the wallet's "Recent Activity" preview.
     func recentActivities(limit: Int) -> [Activity] {

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 		<string>com.flipcash.app.openChat</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>31</integer>
+	<integer>32</integer>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/activity_v1_model.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/activity_v1_model.pb.swift
@@ -163,108 +163,133 @@ public struct Flipcash_Activity_V1_NotificationId: Sendable {
 }
 
 /// Notification is a message that is displayed in an activity feed
-public struct Flipcash_Activity_V1_Notification: Sendable {
+public struct Flipcash_Activity_V1_Notification: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The ID of this notification
   public var id: Flipcash_Activity_V1_NotificationId {
-    get {return _id ?? Flipcash_Activity_V1_NotificationId()}
-    set {_id = newValue}
+    get {return _storage._id ?? Flipcash_Activity_V1_NotificationId()}
+    set {_uniqueStorage()._id = newValue}
   }
   /// Returns true if `id` has been explicitly set.
-  public var hasID: Bool {return self._id != nil}
+  public var hasID: Bool {return _storage._id != nil}
   /// Clears the value of `id`. Subsequent reads from it will return its default value.
-  public mutating func clearID() {self._id = nil}
+  public mutating func clearID() {_uniqueStorage()._id = nil}
 
   /// The localized title text for the notification
-  public var localizedText: String = String()
+  public var localizedText: String {
+    get {return _storage._localizedText}
+    set {_uniqueStorage()._localizedText = newValue}
+  }
 
   /// If a payment applies, the amount that was paid
+  ///
+  /// Note: For multi-mint operations, amounts are carried in additional_metadata
+  ///       (eg. swapped_crypto).
   public var paymentAmount: Flipcash_Common_V1_CryptoPaymentAmount {
-    get {return _paymentAmount ?? Flipcash_Common_V1_CryptoPaymentAmount()}
-    set {_paymentAmount = newValue}
+    get {return _storage._paymentAmount ?? Flipcash_Common_V1_CryptoPaymentAmount()}
+    set {_uniqueStorage()._paymentAmount = newValue}
   }
   /// Returns true if `paymentAmount` has been explicitly set.
-  public var hasPaymentAmount: Bool {return self._paymentAmount != nil}
+  public var hasPaymentAmount: Bool {return _storage._paymentAmount != nil}
   /// Clears the value of `paymentAmount`. Subsequent reads from it will return its default value.
-  public mutating func clearPaymentAmount() {self._paymentAmount = nil}
+  public mutating func clearPaymentAmount() {_uniqueStorage()._paymentAmount = nil}
 
   /// The timestamp of this notification
   public var ts: SwiftProtobuf.Google_Protobuf_Timestamp {
-    get {return _ts ?? SwiftProtobuf.Google_Protobuf_Timestamp()}
-    set {_ts = newValue}
+    get {return _storage._ts ?? SwiftProtobuf.Google_Protobuf_Timestamp()}
+    set {_uniqueStorage()._ts = newValue}
   }
   /// Returns true if `ts` has been explicitly set.
-  public var hasTs: Bool {return self._ts != nil}
+  public var hasTs: Bool {return _storage._ts != nil}
   /// Clears the value of `ts`. Subsequent reads from it will return its default value.
-  public mutating func clearTs() {self._ts = nil}
+  public mutating func clearTs() {_uniqueStorage()._ts = nil}
 
   /// The state of this notification
-  public var state: Flipcash_Activity_V1_NotificationState = .unknown
+  public var state: Flipcash_Activity_V1_NotificationState {
+    get {return _storage._state}
+    set {_uniqueStorage()._state = newValue}
+  }
 
   /// Additional metadata for this notification specific to the notification
-  public var additionalMetadata: Flipcash_Activity_V1_Notification.OneOf_AdditionalMetadata? = nil
+  public var additionalMetadata: OneOf_AdditionalMetadata? {
+    get {return _storage._additionalMetadata}
+    set {_uniqueStorage()._additionalMetadata = newValue}
+  }
 
   public var directlySentCrypto: Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata {
     get {
-      if case .directlySentCrypto(let v)? = additionalMetadata {return v}
+      if case .directlySentCrypto(let v)? = _storage._additionalMetadata {return v}
       return Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata()
     }
-    set {additionalMetadata = .directlySentCrypto(newValue)}
+    set {_uniqueStorage()._additionalMetadata = .directlySentCrypto(newValue)}
   }
 
   public var receivedCrypto: Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata {
     get {
-      if case .receivedCrypto(let v)? = additionalMetadata {return v}
+      if case .receivedCrypto(let v)? = _storage._additionalMetadata {return v}
       return Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata()
     }
-    set {additionalMetadata = .receivedCrypto(newValue)}
+    set {_uniqueStorage()._additionalMetadata = .receivedCrypto(newValue)}
   }
 
   public var withdrewCrypto: Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata {
     get {
-      if case .withdrewCrypto(let v)? = additionalMetadata {return v}
+      if case .withdrewCrypto(let v)? = _storage._additionalMetadata {return v}
       return Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata()
     }
-    set {additionalMetadata = .withdrewCrypto(newValue)}
+    set {_uniqueStorage()._additionalMetadata = .withdrewCrypto(newValue)}
   }
 
   public var indirectlySentCrypto: Flipcash_Activity_V1_IndirectlySentCryptoNotificationMetadata {
     get {
-      if case .indirectlySentCrypto(let v)? = additionalMetadata {return v}
+      if case .indirectlySentCrypto(let v)? = _storage._additionalMetadata {return v}
       return Flipcash_Activity_V1_IndirectlySentCryptoNotificationMetadata()
     }
-    set {additionalMetadata = .indirectlySentCrypto(newValue)}
+    set {_uniqueStorage()._additionalMetadata = .indirectlySentCrypto(newValue)}
   }
 
   public var depositedCrypto: Flipcash_Activity_V1_DepositedCryptoNotificationMetadata {
     get {
-      if case .depositedCrypto(let v)? = additionalMetadata {return v}
+      if case .depositedCrypto(let v)? = _storage._additionalMetadata {return v}
       return Flipcash_Activity_V1_DepositedCryptoNotificationMetadata()
     }
-    set {additionalMetadata = .depositedCrypto(newValue)}
+    set {_uniqueStorage()._additionalMetadata = .depositedCrypto(newValue)}
   }
 
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var boughtCrypto: Flipcash_Activity_V1_BoughtCryptoNotificationMetadata {
     get {
-      if case .boughtCrypto(let v)? = additionalMetadata {return v}
+      if case .boughtCrypto(let v)? = _storage._additionalMetadata {return v}
       return Flipcash_Activity_V1_BoughtCryptoNotificationMetadata()
     }
-    set {additionalMetadata = .boughtCrypto(newValue)}
+    set {_uniqueStorage()._additionalMetadata = .boughtCrypto(newValue)}
   }
 
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var soldCrypto: Flipcash_Activity_V1_SoldCryptoNotificationMetadata {
     get {
-      if case .soldCrypto(let v)? = additionalMetadata {return v}
+      if case .soldCrypto(let v)? = _storage._additionalMetadata {return v}
       return Flipcash_Activity_V1_SoldCryptoNotificationMetadata()
     }
-    set {additionalMetadata = .soldCrypto(newValue)}
+    set {_uniqueStorage()._additionalMetadata = .soldCrypto(newValue)}
+  }
+
+  public var swappedCrypto: Flipcash_Activity_V1_SwappedCryptoNotificationMetadata {
+    get {
+      if case .swappedCrypto(let v)? = _storage._additionalMetadata {return v}
+      return Flipcash_Activity_V1_SwappedCryptoNotificationMetadata()
+    }
+    set {_uniqueStorage()._additionalMetadata = .swappedCrypto(newValue)}
   }
 
   /// Ordered substitutions to apply to localized_text
-  public var textSubstitutions: [Flipcash_Common_V1_Substitution] = []
+  public var textSubstitutions: [Flipcash_Common_V1_Substitution] {
+    get {return _storage._textSubstitutions}
+    set {_uniqueStorage()._textSubstitutions = newValue}
+  }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -275,16 +300,17 @@ public struct Flipcash_Activity_V1_Notification: Sendable {
     case withdrewCrypto(Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata)
     case indirectlySentCrypto(Flipcash_Activity_V1_IndirectlySentCryptoNotificationMetadata)
     case depositedCrypto(Flipcash_Activity_V1_DepositedCryptoNotificationMetadata)
+    /// NOTE: This field was marked as deprecated in the .proto file.
     case boughtCrypto(Flipcash_Activity_V1_BoughtCryptoNotificationMetadata)
+    /// NOTE: This field was marked as deprecated in the .proto file.
     case soldCrypto(Flipcash_Activity_V1_SoldCryptoNotificationMetadata)
+    case swappedCrypto(Flipcash_Activity_V1_SwappedCryptoNotificationMetadata)
 
   }
 
   public init() {}
 
-  fileprivate var _id: Flipcash_Activity_V1_NotificationId? = nil
-  fileprivate var _paymentAmount: Flipcash_Common_V1_CryptoPaymentAmount? = nil
-  fileprivate var _ts: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata: Sendable {
@@ -360,11 +386,24 @@ public struct Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata: Sendable 
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  /// Deprecated in favour of swap_metadata
   public var swapState: Flipcash_Activity_V1_SwapState = .unknown
+
+  /// When a withdraw is a swap, the metadata for that swap
+  public var swapMetadata: Flipcash_Activity_V1_SwappedCryptoNotificationMetadata {
+    get {return _swapMetadata ?? Flipcash_Activity_V1_SwappedCryptoNotificationMetadata()}
+    set {_swapMetadata = newValue}
+  }
+  /// Returns true if `swapMetadata` has been explicitly set.
+  public var hasSwapMetadata: Bool {return self._swapMetadata != nil}
+  /// Clears the value of `swapMetadata`. Subsequent reads from it will return its default value.
+  public mutating func clearSwapMetadata() {self._swapMetadata = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _swapMetadata: Flipcash_Activity_V1_SwappedCryptoNotificationMetadata? = nil
 }
 
 public struct Flipcash_Activity_V1_IndirectlySentCryptoNotificationMetadata: Sendable {
@@ -402,6 +441,8 @@ public struct Flipcash_Activity_V1_DepositedCryptoNotificationMetadata: Sendable
   public init() {}
 }
 
+/// Deprecated: Use SwappedCryptoNotificationMetadata, which models both halves
+///             of the swap in a single notification.
 public struct Flipcash_Activity_V1_BoughtCryptoNotificationMetadata: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -414,6 +455,8 @@ public struct Flipcash_Activity_V1_BoughtCryptoNotificationMetadata: Sendable {
   public init() {}
 }
 
+/// Deprecated: Use SwappedCryptoNotificationMetadata, which models both halves
+///             of the swap in a single notification.
 public struct Flipcash_Activity_V1_SoldCryptoNotificationMetadata: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -424,6 +467,79 @@ public struct Flipcash_Activity_V1_SoldCryptoNotificationMetadata: Sendable {
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+}
+
+/// SwappedCryptoNotificationMetadata represents a swap between two mints as a
+/// single notification. It supersedes BoughtCryptoNotificationMetadata and
+/// SoldCryptoNotificationMetadata, which modelled the two halves of a swap as
+/// separate notifications.
+public struct Flipcash_Activity_V1_SwappedCryptoNotificationMetadata: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The amount the user gave up in the source mint
+  public var from: Flipcash_Common_V1_CryptoPaymentAmount {
+    get {return _from ?? Flipcash_Common_V1_CryptoPaymentAmount()}
+    set {_from = newValue}
+  }
+  /// Returns true if `from` has been explicitly set.
+  public var hasFrom: Bool {return self._from != nil}
+  /// Clears the value of `from`. Subsequent reads from it will return its default value.
+  public mutating func clearFrom() {self._from = nil}
+
+  /// What the user received in the destination mint. The mint is always known,
+  /// but the amount is only known once the swap has executed.
+  public var to: Flipcash_Activity_V1_SwappedCryptoNotificationMetadata.OneOf_To? = nil
+
+  /// The destination mint, when the amount isn't yet known
+  public var toMint: Flipcash_Common_V1_PublicKey {
+    get {
+      if case .toMint(let v)? = to {return v}
+      return Flipcash_Common_V1_PublicKey()
+    }
+    set {to = .toMint(newValue)}
+  }
+
+  /// The amount the user received in the destination mint
+  public var toAmount: Flipcash_Common_V1_CryptoPaymentAmount {
+    get {
+      if case .toAmount(let v)? = to {return v}
+      return Flipcash_Common_V1_CryptoPaymentAmount()
+    }
+    set {to = .toAmount(newValue)}
+  }
+
+  /// The fee charged for the swap, which is known upfront and is set regardless
+  /// of the state of the swap
+  public var fee: Flipcash_Common_V1_FiatPaymentAmount {
+    get {return _fee ?? Flipcash_Common_V1_FiatPaymentAmount()}
+    set {_fee = newValue}
+  }
+  /// Returns true if `fee` has been explicitly set.
+  public var hasFee: Bool {return self._fee != nil}
+  /// Clears the value of `fee`. Subsequent reads from it will return its default value.
+  public mutating func clearFee() {self._fee = nil}
+
+  /// The state of the swap as a whole
+  public var swapState: Flipcash_Activity_V1_SwapState = .unknown
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  /// What the user received in the destination mint. The mint is always known,
+  /// but the amount is only known once the swap has executed.
+  public enum OneOf_To: Equatable, Sendable {
+    /// The destination mint, when the amount isn't yet known
+    case toMint(Flipcash_Common_V1_PublicKey)
+    /// The amount the user received in the destination mint
+    case toAmount(Flipcash_Common_V1_CryptoPaymentAmount)
+
+  }
+
+  public init() {}
+
+  fileprivate var _from: Flipcash_Common_V1_CryptoPaymentAmount? = nil
+  fileprivate var _fee: Flipcash_Common_V1_FiatPaymentAmount? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -474,181 +590,246 @@ extension Flipcash_Activity_V1_NotificationId: SwiftProtobuf.Message, SwiftProto
 
 extension Flipcash_Activity_V1_Notification: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Notification"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}localized_text\0\u{3}payment_amount\0\u{1}ts\0\u{1}state\0\u{4}\u{2}directly_sent_crypto\0\u{3}received_crypto\0\u{3}withdrew_crypto\0\u{3}indirectly_sent_crypto\0\u{3}deposited_crypto\0\u{3}bought_crypto\0\u{3}sold_crypto\0\u{4}W\u{1}text_substitutions\0\u{c}\u{6}\u{1}")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}localized_text\0\u{3}payment_amount\0\u{1}ts\0\u{1}state\0\u{4}\u{2}directly_sent_crypto\0\u{3}received_crypto\0\u{3}withdrew_crypto\0\u{3}indirectly_sent_crypto\0\u{3}deposited_crypto\0\u{3}bought_crypto\0\u{3}sold_crypto\0\u{3}swapped_crypto\0\u{4}V\u{1}text_substitutions\0\u{c}\u{6}\u{1}")
+
+  fileprivate class _StorageClass {
+    var _id: Flipcash_Activity_V1_NotificationId? = nil
+    var _localizedText: String = String()
+    var _paymentAmount: Flipcash_Common_V1_CryptoPaymentAmount? = nil
+    var _ts: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
+    var _state: Flipcash_Activity_V1_NotificationState = .unknown
+    var _additionalMetadata: Flipcash_Activity_V1_Notification.OneOf_AdditionalMetadata?
+    var _textSubstitutions: [Flipcash_Common_V1_Substitution] = []
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _id = source._id
+      _localizedText = source._localizedText
+      _paymentAmount = source._paymentAmount
+      _ts = source._ts
+      _state = source._state
+      _additionalMetadata = source._additionalMetadata
+      _textSubstitutions = source._textSubstitutions
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularMessageField(value: &self._id) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self.localizedText) }()
-      case 3: try { try decoder.decodeSingularMessageField(value: &self._paymentAmount) }()
-      case 4: try { try decoder.decodeSingularMessageField(value: &self._ts) }()
-      case 5: try { try decoder.decodeSingularEnumField(value: &self.state) }()
-      case 7: try {
-        var v: Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata?
-        var hadOneofValue = false
-        if let current = self.additionalMetadata {
-          hadOneofValue = true
-          if case .directlySentCrypto(let m) = current {v = m}
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularMessageField(value: &_storage._id) }()
+        case 2: try { try decoder.decodeSingularStringField(value: &_storage._localizedText) }()
+        case 3: try { try decoder.decodeSingularMessageField(value: &_storage._paymentAmount) }()
+        case 4: try { try decoder.decodeSingularMessageField(value: &_storage._ts) }()
+        case 5: try { try decoder.decodeSingularEnumField(value: &_storage._state) }()
+        case 7: try {
+          var v: Flipcash_Activity_V1_DirectlySentCryptoNotificationMetadata?
+          var hadOneofValue = false
+          if let current = _storage._additionalMetadata {
+            hadOneofValue = true
+            if case .directlySentCrypto(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._additionalMetadata = .directlySentCrypto(v)
+          }
+        }()
+        case 8: try {
+          var v: Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata?
+          var hadOneofValue = false
+          if let current = _storage._additionalMetadata {
+            hadOneofValue = true
+            if case .receivedCrypto(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._additionalMetadata = .receivedCrypto(v)
+          }
+        }()
+        case 9: try {
+          var v: Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata?
+          var hadOneofValue = false
+          if let current = _storage._additionalMetadata {
+            hadOneofValue = true
+            if case .withdrewCrypto(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._additionalMetadata = .withdrewCrypto(v)
+          }
+        }()
+        case 10: try {
+          var v: Flipcash_Activity_V1_IndirectlySentCryptoNotificationMetadata?
+          var hadOneofValue = false
+          if let current = _storage._additionalMetadata {
+            hadOneofValue = true
+            if case .indirectlySentCrypto(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._additionalMetadata = .indirectlySentCrypto(v)
+          }
+        }()
+        case 11: try {
+          var v: Flipcash_Activity_V1_DepositedCryptoNotificationMetadata?
+          var hadOneofValue = false
+          if let current = _storage._additionalMetadata {
+            hadOneofValue = true
+            if case .depositedCrypto(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._additionalMetadata = .depositedCrypto(v)
+          }
+        }()
+        case 12: try {
+          var v: Flipcash_Activity_V1_BoughtCryptoNotificationMetadata?
+          var hadOneofValue = false
+          if let current = _storage._additionalMetadata {
+            hadOneofValue = true
+            if case .boughtCrypto(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._additionalMetadata = .boughtCrypto(v)
+          }
+        }()
+        case 13: try {
+          var v: Flipcash_Activity_V1_SoldCryptoNotificationMetadata?
+          var hadOneofValue = false
+          if let current = _storage._additionalMetadata {
+            hadOneofValue = true
+            if case .soldCrypto(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._additionalMetadata = .soldCrypto(v)
+          }
+        }()
+        case 14: try {
+          var v: Flipcash_Activity_V1_SwappedCryptoNotificationMetadata?
+          var hadOneofValue = false
+          if let current = _storage._additionalMetadata {
+            hadOneofValue = true
+            if case .swappedCrypto(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._additionalMetadata = .swappedCrypto(v)
+          }
+        }()
+        case 100: try { try decoder.decodeRepeatedMessageField(value: &_storage._textSubstitutions) }()
+        default: break
         }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.additionalMetadata = .directlySentCrypto(v)
-        }
-      }()
-      case 8: try {
-        var v: Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata?
-        var hadOneofValue = false
-        if let current = self.additionalMetadata {
-          hadOneofValue = true
-          if case .receivedCrypto(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.additionalMetadata = .receivedCrypto(v)
-        }
-      }()
-      case 9: try {
-        var v: Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata?
-        var hadOneofValue = false
-        if let current = self.additionalMetadata {
-          hadOneofValue = true
-          if case .withdrewCrypto(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.additionalMetadata = .withdrewCrypto(v)
-        }
-      }()
-      case 10: try {
-        var v: Flipcash_Activity_V1_IndirectlySentCryptoNotificationMetadata?
-        var hadOneofValue = false
-        if let current = self.additionalMetadata {
-          hadOneofValue = true
-          if case .indirectlySentCrypto(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.additionalMetadata = .indirectlySentCrypto(v)
-        }
-      }()
-      case 11: try {
-        var v: Flipcash_Activity_V1_DepositedCryptoNotificationMetadata?
-        var hadOneofValue = false
-        if let current = self.additionalMetadata {
-          hadOneofValue = true
-          if case .depositedCrypto(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.additionalMetadata = .depositedCrypto(v)
-        }
-      }()
-      case 12: try {
-        var v: Flipcash_Activity_V1_BoughtCryptoNotificationMetadata?
-        var hadOneofValue = false
-        if let current = self.additionalMetadata {
-          hadOneofValue = true
-          if case .boughtCrypto(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.additionalMetadata = .boughtCrypto(v)
-        }
-      }()
-      case 13: try {
-        var v: Flipcash_Activity_V1_SoldCryptoNotificationMetadata?
-        var hadOneofValue = false
-        if let current = self.additionalMetadata {
-          hadOneofValue = true
-          if case .soldCrypto(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.additionalMetadata = .soldCrypto(v)
-        }
-      }()
-      case 100: try { try decoder.decodeRepeatedMessageField(value: &self.textSubstitutions) }()
-      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    try { if let v = self._id {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    } }()
-    if !self.localizedText.isEmpty {
-      try visitor.visitSingularStringField(value: self.localizedText, fieldNumber: 2)
-    }
-    try { if let v = self._paymentAmount {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    } }()
-    try { if let v = self._ts {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-    } }()
-    if self.state != .unknown {
-      try visitor.visitSingularEnumField(value: self.state, fieldNumber: 5)
-    }
-    switch self.additionalMetadata {
-    case .directlySentCrypto?: try {
-      guard case .directlySentCrypto(let v)? = self.additionalMetadata else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }()
-    case .receivedCrypto?: try {
-      guard case .receivedCrypto(let v)? = self.additionalMetadata else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-    }()
-    case .withdrewCrypto?: try {
-      guard case .withdrewCrypto(let v)? = self.additionalMetadata else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-    }()
-    case .indirectlySentCrypto?: try {
-      guard case .indirectlySentCrypto(let v)? = self.additionalMetadata else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-    }()
-    case .depositedCrypto?: try {
-      guard case .depositedCrypto(let v)? = self.additionalMetadata else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-    }()
-    case .boughtCrypto?: try {
-      guard case .boughtCrypto(let v)? = self.additionalMetadata else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-    }()
-    case .soldCrypto?: try {
-      guard case .soldCrypto(let v)? = self.additionalMetadata else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-    }()
-    case nil: break
-    }
-    if !self.textSubstitutions.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.textSubstitutions, fieldNumber: 100)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      try { if let v = _storage._id {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      } }()
+      if !_storage._localizedText.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._localizedText, fieldNumber: 2)
+      }
+      try { if let v = _storage._paymentAmount {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      } }()
+      try { if let v = _storage._ts {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      } }()
+      if _storage._state != .unknown {
+        try visitor.visitSingularEnumField(value: _storage._state, fieldNumber: 5)
+      }
+      switch _storage._additionalMetadata {
+      case .directlySentCrypto?: try {
+        guard case .directlySentCrypto(let v)? = _storage._additionalMetadata else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      }()
+      case .receivedCrypto?: try {
+        guard case .receivedCrypto(let v)? = _storage._additionalMetadata else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      }()
+      case .withdrewCrypto?: try {
+        guard case .withdrewCrypto(let v)? = _storage._additionalMetadata else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+      }()
+      case .indirectlySentCrypto?: try {
+        guard case .indirectlySentCrypto(let v)? = _storage._additionalMetadata else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+      }()
+      case .depositedCrypto?: try {
+        guard case .depositedCrypto(let v)? = _storage._additionalMetadata else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      }()
+      case .boughtCrypto?: try {
+        guard case .boughtCrypto(let v)? = _storage._additionalMetadata else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+      }()
+      case .soldCrypto?: try {
+        guard case .soldCrypto(let v)? = _storage._additionalMetadata else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+      }()
+      case .swappedCrypto?: try {
+        guard case .swappedCrypto(let v)? = _storage._additionalMetadata else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+      }()
+      case nil: break
+      }
+      if !_storage._textSubstitutions.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._textSubstitutions, fieldNumber: 100)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Flipcash_Activity_V1_Notification, rhs: Flipcash_Activity_V1_Notification) -> Bool {
-    if lhs._id != rhs._id {return false}
-    if lhs.localizedText != rhs.localizedText {return false}
-    if lhs._paymentAmount != rhs._paymentAmount {return false}
-    if lhs._ts != rhs._ts {return false}
-    if lhs.state != rhs.state {return false}
-    if lhs.additionalMetadata != rhs.additionalMetadata {return false}
-    if lhs.textSubstitutions != rhs.textSubstitutions {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._id != rhs_storage._id {return false}
+        if _storage._localizedText != rhs_storage._localizedText {return false}
+        if _storage._paymentAmount != rhs_storage._paymentAmount {return false}
+        if _storage._ts != rhs_storage._ts {return false}
+        if _storage._state != rhs_storage._state {return false}
+        if _storage._additionalMetadata != rhs_storage._additionalMetadata {return false}
+        if _storage._textSubstitutions != rhs_storage._textSubstitutions {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -790,7 +971,7 @@ extension Flipcash_Activity_V1_ReceivedCryptoNotificationMetadata: SwiftProtobuf
 
 extension Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WithdrewCryptoNotificationMetadata"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}swap_state\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}swap_state\0\u{3}swap_metadata\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -799,20 +980,29 @@ extension Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata: SwiftProtobuf
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularEnumField(value: &self.swapState) }()
+      case 2: try { try decoder.decodeSingularMessageField(value: &self._swapMetadata) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.swapState != .unknown {
       try visitor.visitSingularEnumField(value: self.swapState, fieldNumber: 1)
     }
+    try { if let v = self._swapMetadata {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata, rhs: Flipcash_Activity_V1_WithdrewCryptoNotificationMetadata) -> Bool {
     if lhs.swapState != rhs.swapState {return false}
+    if lhs._swapMetadata != rhs._swapMetadata {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -930,6 +1120,88 @@ extension Flipcash_Activity_V1_SoldCryptoNotificationMetadata: SwiftProtobuf.Mes
   }
 
   public static func ==(lhs: Flipcash_Activity_V1_SoldCryptoNotificationMetadata, rhs: Flipcash_Activity_V1_SoldCryptoNotificationMetadata) -> Bool {
+    if lhs.swapState != rhs.swapState {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Activity_V1_SwappedCryptoNotificationMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SwappedCryptoNotificationMetadata"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}from\0\u{3}to_mint\0\u{3}to_amount\0\u{1}fee\0\u{3}swap_state\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._from) }()
+      case 2: try {
+        var v: Flipcash_Common_V1_PublicKey?
+        var hadOneofValue = false
+        if let current = self.to {
+          hadOneofValue = true
+          if case .toMint(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.to = .toMint(v)
+        }
+      }()
+      case 3: try {
+        var v: Flipcash_Common_V1_CryptoPaymentAmount?
+        var hadOneofValue = false
+        if let current = self.to {
+          hadOneofValue = true
+          if case .toAmount(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.to = .toAmount(v)
+        }
+      }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._fee) }()
+      case 5: try { try decoder.decodeSingularEnumField(value: &self.swapState) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._from {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    switch self.to {
+    case .toMint?: try {
+      guard case .toMint(let v)? = self.to else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case .toAmount?: try {
+      guard case .toAmount(let v)? = self.to else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }()
+    case nil: break
+    }
+    try { if let v = self._fee {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    } }()
+    if self.swapState != .unknown {
+      try visitor.visitSingularEnumField(value: self.swapState, fieldNumber: 5)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Activity_V1_SwappedCryptoNotificationMetadata, rhs: Flipcash_Activity_V1_SwappedCryptoNotificationMetadata) -> Bool {
+    if lhs._from != rhs._from {return false}
+    if lhs.to != rhs.to {return false}
+    if lhs._fee != rhs._fee {return false}
     if lhs.swapState != rhs.swapState {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/activity/v1/model.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/activity/v1/model.proto
@@ -30,6 +30,9 @@ message Notification {
     }];
 
     // If a payment applies, the amount that was paid
+    //
+    // Note: For multi-mint operations, amounts are carried in additional_metadata
+    //       (eg. swapped_crypto).
     common.v1.CryptoPaymentAmount payment_amount = 3;
 
     // The timestamp of this notification
@@ -45,8 +48,9 @@ message Notification {
         WithdrewCryptoNotificationMetadata       withdrew_crypto        = 9;
         IndirectlySentCryptoNotificationMetadata indirectly_sent_crypto = 10;
         DepositedCryptoNotificationMetadata      deposited_crypto       = 11;
-        BoughtCryptoNotificationMetadata         bought_crypto          = 12;
-        SoldCryptoNotificationMetadata           sold_crypto            = 13;
+        BoughtCryptoNotificationMetadata         bought_crypto          = 12 [deprecated = true];
+        SoldCryptoNotificationMetadata           sold_crypto            = 13 [deprecated = true];
+        SwappedCryptoNotificationMetadata        swapped_crypto         = 14;
     }
 
     reserved 6; // Deprecated WelcomeBonusNotificationMetadata
@@ -70,7 +74,11 @@ message ReceivedCryptoNotificationMetadata {
 }
 
 message WithdrewCryptoNotificationMetadata {
+    // Deprecated in favour of swap_metadata
     SwapState swap_state = 1 [(validate.rules).enum.not_in = 0];
+
+    // When a withdraw is a swap, the metadata for that swap
+    SwappedCryptoNotificationMetadata swap_metadata = 2;
 }
 
 message IndirectlySentCryptoNotificationMetadata {
@@ -84,12 +92,44 @@ message IndirectlySentCryptoNotificationMetadata {
 message DepositedCryptoNotificationMetadata {
 }
 
+// Deprecated: Use SwappedCryptoNotificationMetadata, which models both halves
+//             of the swap in a single notification.
 message BoughtCryptoNotificationMetadata {
     SwapState swap_state = 1 [(validate.rules).enum.not_in = 0];
 }
 
+// Deprecated: Use SwappedCryptoNotificationMetadata, which models both halves
+//             of the swap in a single notification.
 message SoldCryptoNotificationMetadata {
     SwapState swap_state = 1 [(validate.rules).enum.not_in = 0];
+}
+
+// SwappedCryptoNotificationMetadata represents a swap between two mints as a
+// single notification. It supersedes BoughtCryptoNotificationMetadata and
+// SoldCryptoNotificationMetadata, which modelled the two halves of a swap as
+// separate notifications.
+message SwappedCryptoNotificationMetadata {
+    // The amount the user gave up in the source mint
+    common.v1.CryptoPaymentAmount from = 1 [(validate.rules).message.required = true];
+
+    // What the user received in the destination mint. The mint is always known,
+    // but the amount is only known once the swap has executed.
+    oneof to {
+        option (validate.required) = true;
+
+        // The destination mint, when the amount isn't yet known
+        common.v1.PublicKey           to_mint   = 2;
+
+        // The amount the user received in the destination mint
+        common.v1.CryptoPaymentAmount to_amount = 3;
+    }
+
+    // The fee charged for the swap, which is known upfront and is set regardless
+    // of the state of the swap
+    common.v1.FiatPaymentAmount fee = 4 [(validate.rules).message.required = true];
+
+    // The state of the swap as a whole
+    SwapState swap_state = 5 [(validate.rules).enum.not_in = 0];
 }
 
 // ActivityFeedType enables multiple activity feeds, where notifications may be

--- a/FlipcashAPI/Sources/FlipcashAPI/Payments/Generated/currency_v1_ocp_currency_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Payments/Generated/currency_v1_ocp_currency_service.pb.swift
@@ -445,6 +445,16 @@ public struct Ocp_Currency_V1_Mint: @unchecked Sendable {
   /// Clears the value of `holderMetrics`. Subsequent reads from it will return its default value.
   public mutating func clearHolderMetrics() {_uniqueStorage()._holderMetrics = nil}
 
+  /// Market cap metrics. This is surfaced where needed (e.g. only in the Discover RPC)
+  public var marketCapMetrics: Ocp_Currency_V1_MarketCapMetrics {
+    get {return _storage._marketCapMetrics ?? Ocp_Currency_V1_MarketCapMetrics()}
+    set {_uniqueStorage()._marketCapMetrics = newValue}
+  }
+  /// Returns true if `marketCapMetrics` has been explicitly set.
+  public var hasMarketCapMetrics: Bool {return _storage._marketCapMetrics != nil}
+  /// Clears the value of `marketCapMetrics`. Subsequent reads from it will return its default value.
+  public mutating func clearMarketCapMetrics() {_uniqueStorage()._marketCapMetrics = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -916,6 +926,37 @@ public struct Ocp_Currency_V1_HolderMetrics: Sendable {
 
     /// Net holders within the time range
     public var delta: Int64 = 0
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  public init() {}
+}
+
+public struct Ocp_Currency_V1_MarketCapMetrics: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The current market capitalization in USD for a currency
+  public var currentMarketCap: Double = 0
+
+  public var marketCapDeltas: [Ocp_Currency_V1_MarketCapMetrics.DeltaMarketCap] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public struct DeltaMarketCap: Sendable {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    /// Predefined range where delta is calculated from
+    public var range: Ocp_Currency_V1_PredefinedRange = .allTime
+
+    /// Net change in market capitalization in USD within the time range
+    public var delta: Double = 0
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1967,7 +2008,7 @@ extension Ocp_Currency_V1_StreamLiveMintDataResponse.LiveData: SwiftProtobuf.Mes
 
 extension Ocp_Currency_V1_Mint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Mint"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}address\0\u{1}decimals\0\u{1}name\0\u{1}symbol\0\u{1}description\0\u{3}image_url\0\u{3}vm_metadata\0\u{3}launchpad_metadata\0\u{3}created_at\0\u{3}social_links\0\u{3}bill_customization\0\u{3}holder_metrics\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}address\0\u{1}decimals\0\u{1}name\0\u{1}symbol\0\u{1}description\0\u{3}image_url\0\u{3}vm_metadata\0\u{3}launchpad_metadata\0\u{3}created_at\0\u{3}social_links\0\u{3}bill_customization\0\u{3}holder_metrics\0\u{3}market_cap_metrics\0")
 
   fileprivate class _StorageClass {
     var _address: Ocp_Common_V1_SolanaAccountId? = nil
@@ -1982,6 +2023,7 @@ extension Ocp_Currency_V1_Mint: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
     var _socialLinks: [Ocp_Currency_V1_SocialLink] = []
     var _billCustomization: Ocp_Currency_V1_BillCustomization? = nil
     var _holderMetrics: Ocp_Currency_V1_HolderMetrics? = nil
+    var _marketCapMetrics: Ocp_Currency_V1_MarketCapMetrics? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -2004,6 +2046,7 @@ extension Ocp_Currency_V1_Mint: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
       _socialLinks = source._socialLinks
       _billCustomization = source._billCustomization
       _holderMetrics = source._holderMetrics
+      _marketCapMetrics = source._marketCapMetrics
     }
   }
 
@@ -2034,6 +2077,7 @@ extension Ocp_Currency_V1_Mint: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
         case 10: try { try decoder.decodeRepeatedMessageField(value: &_storage._socialLinks) }()
         case 11: try { try decoder.decodeSingularMessageField(value: &_storage._billCustomization) }()
         case 12: try { try decoder.decodeSingularMessageField(value: &_storage._holderMetrics) }()
+        case 13: try { try decoder.decodeSingularMessageField(value: &_storage._marketCapMetrics) }()
         default: break
         }
       }
@@ -2082,6 +2126,9 @@ extension Ocp_Currency_V1_Mint: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
       try { if let v = _storage._holderMetrics {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
       } }()
+      try { if let v = _storage._marketCapMetrics {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -2103,6 +2150,7 @@ extension Ocp_Currency_V1_Mint: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
         if _storage._socialLinks != rhs_storage._socialLinks {return false}
         if _storage._billCustomization != rhs_storage._billCustomization {return false}
         if _storage._holderMetrics != rhs_storage._holderMetrics {return false}
+        if _storage._marketCapMetrics != rhs_storage._marketCapMetrics {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -2849,6 +2897,76 @@ extension Ocp_Currency_V1_HolderMetrics.DeltaHolders: SwiftProtobuf.Message, Swi
   }
 
   public static func ==(lhs: Ocp_Currency_V1_HolderMetrics.DeltaHolders, rhs: Ocp_Currency_V1_HolderMetrics.DeltaHolders) -> Bool {
+    if lhs.range != rhs.range {return false}
+    if lhs.delta != rhs.delta {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Ocp_Currency_V1_MarketCapMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".MarketCapMetrics"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}current_market_cap\0\u{3}market_cap_deltas\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularDoubleField(value: &self.currentMarketCap) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.marketCapDeltas) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.currentMarketCap.bitPattern != 0 {
+      try visitor.visitSingularDoubleField(value: self.currentMarketCap, fieldNumber: 1)
+    }
+    if !self.marketCapDeltas.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.marketCapDeltas, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Ocp_Currency_V1_MarketCapMetrics, rhs: Ocp_Currency_V1_MarketCapMetrics) -> Bool {
+    if lhs.currentMarketCap != rhs.currentMarketCap {return false}
+    if lhs.marketCapDeltas != rhs.marketCapDeltas {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Ocp_Currency_V1_MarketCapMetrics.DeltaMarketCap: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Ocp_Currency_V1_MarketCapMetrics.protoMessageName + ".DeltaMarketCap"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}range\0\u{1}delta\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.range) }()
+      case 2: try { try decoder.decodeSingularDoubleField(value: &self.delta) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.range != .allTime {
+      try visitor.visitSingularEnumField(value: self.range, fieldNumber: 1)
+    }
+    if self.delta.bitPattern != 0 {
+      try visitor.visitSingularDoubleField(value: self.delta, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Ocp_Currency_V1_MarketCapMetrics.DeltaMarketCap, rhs: Ocp_Currency_V1_MarketCapMetrics.DeltaMarketCap) -> Bool {
     if lhs.range != rhs.range {return false}
     if lhs.delta != rhs.delta {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}

--- a/FlipcashAPI/Sources/FlipcashAPI/Payments/Generated/transaction_v1_ocp_transaction_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Payments/Generated/transaction_v1_ocp_transaction_service.pb.swift
@@ -1161,7 +1161,7 @@ public struct Ocp_Transaction_V1_StatefulSwapResponse: Sendable {
     ///
     /// Instruction formats:
     ///
-    /// Buy Tokens (Core Mint -> Launchpad Currency Mint):
+    /// Buy Tokens (Core Mint -> Launchpad Currency Mint) without a buy fee:
     ///  1. System::AdvanceNonce
     ///  2. [Optional] ComputeBudget::SetComputeUnitLimit
     ///  3. [Optional] ComputeBudget::SetComputeUnitPrice
@@ -1169,6 +1169,18 @@ public struct Ocp_Transaction_V1_StatefulSwapResponse: Sendable {
     ///  5. AssociatedTokenAccount::CreateIdempotent (open Core Mint temporary account)
     ///  6. VM::TransferForSwap (Core Mint VM swap ATA -> Core Mint temporary account)
     ///  7. Reserve::BuyAndDepositIntoVm (bounded buy depositing to_mint tokens into the to_mint VM)
+    ///  8. Token::CloseAccount (closes Core Mint temporary account)
+    ///  9. VM::CloseSwapAccountIfEmpty (closes Core Mint VM swap ATA if empty)
+    ///
+    /// Buy Tokens (Core Mint -> Launchpad Currency Mint) with a buy fee, which
+    /// is used when fee_amount is non-zero:
+    ///  1. System::AdvanceNonce
+    ///  2. [Optional] ComputeBudget::SetComputeUnitLimit
+    ///  3. [Optional] ComputeBudget::SetComputeUnitPrice
+    ///  4. [Optional] Memo::Memo
+    ///  5. AssociatedTokenAccount::CreateIdempotent (open Core Mint temporary account)
+    ///  6. VM::TransferForSwapWithFee (Core Mint VM swap ATA -> Core Mint temporary account (swap amount) and fee destination (fee amount))
+    ///  7. Reserve::BuyAndDepositIntoVm (bounded buy of the swap amount depositing to_mint tokens into the to_mint VM)
     ///  8. Token::CloseAccount (closes Core Mint temporary account)
     ///  9. VM::CloseSwapAccountIfEmpty (closes Core Mint VM swap ATA if empty)
     ///
@@ -1259,6 +1271,17 @@ public struct Ocp_Transaction_V1_StatefulSwapResponse: Sendable {
       /// The memory index where the destination virtual Timelock account lives
       public var memoryIndex: UInt32 = 0
 
+      /// Destination account where the buy fee should be paid. Only set when
+      /// a non-zero fee_amount was provided in the client parameters.
+      public var feeDestination: Ocp_Common_V1_SolanaAccountId {
+        get {return _feeDestination ?? Ocp_Common_V1_SolanaAccountId()}
+        set {_feeDestination = newValue}
+      }
+      /// Returns true if `feeDestination` has been explicitly set.
+      public var hasFeeDestination: Bool {return self._feeDestination != nil}
+      /// Clears the value of `feeDestination`. Subsequent reads from it will return its default value.
+      public mutating func clearFeeDestination() {self._feeDestination = nil}
+
       public var unknownFields = SwiftProtobuf.UnknownStorage()
 
       public init() {}
@@ -1267,6 +1290,7 @@ public struct Ocp_Transaction_V1_StatefulSwapResponse: Sendable {
       fileprivate var _nonce: Ocp_Common_V1_SolanaAccountId? = nil
       fileprivate var _blockhash: Ocp_Common_V1_Blockhash? = nil
       fileprivate var _memoryAccount: Ocp_Common_V1_SolanaAccountId? = nil
+      fileprivate var _feeDestination: Ocp_Common_V1_SolanaAccountId? = nil
     }
 
     /// Server parameters when executing stateful buy flows against the
@@ -4865,7 +4889,7 @@ extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters: SwiftProtobu
 
 extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveExistingCurrencyServerParameters: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.protoMessageName + ".ReserveExistingCurrencyServerParameters"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payer\0\u{1}nonce\0\u{1}blockhash\0\u{1}alts\0\u{3}compute_unit_limit\0\u{3}compute_unit_price\0\u{3}memo_value\0\u{3}memory_account\0\u{3}memory_index\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payer\0\u{1}nonce\0\u{1}blockhash\0\u{1}alts\0\u{3}compute_unit_limit\0\u{3}compute_unit_price\0\u{3}memo_value\0\u{3}memory_account\0\u{3}memory_index\0\u{3}fee_destination\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4882,6 +4906,7 @@ extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveExisti
       case 7: try { try decoder.decodeSingularStringField(value: &self.memoValue) }()
       case 8: try { try decoder.decodeSingularMessageField(value: &self._memoryAccount) }()
       case 9: try { try decoder.decodeSingularUInt32Field(value: &self.memoryIndex) }()
+      case 10: try { try decoder.decodeSingularMessageField(value: &self._feeDestination) }()
       default: break
       }
     }
@@ -4919,6 +4944,9 @@ extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveExisti
     if self.memoryIndex != 0 {
       try visitor.visitSingularUInt32Field(value: self.memoryIndex, fieldNumber: 9)
     }
+    try { if let v = self._feeDestination {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -4932,6 +4960,7 @@ extension Ocp_Transaction_V1_StatefulSwapResponse.ServerParameters.ReserveExisti
     if lhs.memoValue != rhs.memoValue {return false}
     if lhs._memoryAccount != rhs._memoryAccount {return false}
     if lhs.memoryIndex != rhs.memoryIndex {return false}
+    if lhs._feeDestination != rhs._feeDestination {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/FlipcashAPI/Sources/FlipcashAPI/Payments/proto/currency/v1/ocp_currency_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Payments/proto/currency/v1/ocp_currency_service.proto
@@ -176,6 +176,9 @@ message Mint {
 
     // Holder metrics. This is surfaced where needed (e.g. only in the Discover RPC)
     HolderMetrics holder_metrics = 12;
+
+    // Market cap metrics. This is surfaced where needed (e.g. only in the Discover RPC)
+    MarketCapMetrics market_cap_metrics = 13;
 }
 
 message VmMetadata {
@@ -359,6 +362,24 @@ message HolderMetrics {
 
         // Net holders within the time range
         int64 delta = 2;
+    }
+}
+
+message MarketCapMetrics {
+    // The current market capitalization in USD for a currency
+    double current_market_cap = 1;
+
+    repeated DeltaMarketCap market_cap_deltas = 2 [(validate.rules).repeated = {
+        min_items: 0
+        max_items: 4
+    }];
+
+    message DeltaMarketCap {
+        // Predefined range where delta is calculated from
+        PredefinedRange range = 1;
+
+        // Net change in market capitalization in USD within the time range
+        double delta = 2;
     }
 }
 

--- a/FlipcashAPI/Sources/FlipcashAPI/Payments/proto/transaction/v1/ocp_transaction_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Payments/proto/transaction/v1/ocp_transaction_service.proto
@@ -462,7 +462,7 @@ message StatefulSwapResponse {
         //
         // Instruction formats:
         //
-        // Buy Tokens (Core Mint -> Launchpad Currency Mint):
+        // Buy Tokens (Core Mint -> Launchpad Currency Mint) without a buy fee:
         //  1. System::AdvanceNonce
         //  2. [Optional] ComputeBudget::SetComputeUnitLimit
         //  3. [Optional] ComputeBudget::SetComputeUnitPrice
@@ -470,6 +470,18 @@ message StatefulSwapResponse {
         //  5. AssociatedTokenAccount::CreateIdempotent (open Core Mint temporary account)
         //  6. VM::TransferForSwap (Core Mint VM swap ATA -> Core Mint temporary account)
         //  7. Reserve::BuyAndDepositIntoVm (bounded buy depositing to_mint tokens into the to_mint VM)
+        //  8. Token::CloseAccount (closes Core Mint temporary account)
+        //  9. VM::CloseSwapAccountIfEmpty (closes Core Mint VM swap ATA if empty)
+        //
+        // Buy Tokens (Core Mint -> Launchpad Currency Mint) with a buy fee, which
+        // is used when fee_amount is non-zero:
+        //  1. System::AdvanceNonce
+        //  2. [Optional] ComputeBudget::SetComputeUnitLimit
+        //  3. [Optional] ComputeBudget::SetComputeUnitPrice
+        //  4. [Optional] Memo::Memo
+        //  5. AssociatedTokenAccount::CreateIdempotent (open Core Mint temporary account)
+        //  6. VM::TransferForSwapWithFee (Core Mint VM swap ATA -> Core Mint temporary account (swap amount) and fee destination (fee amount))
+        //  7. Reserve::BuyAndDepositIntoVm (bounded buy of the swap amount depositing to_mint tokens into the to_mint VM)
         //  8. Token::CloseAccount (closes Core Mint temporary account)
         //  9. VM::CloseSwapAccountIfEmpty (closes Core Mint VM swap ATA if empty)
         //
@@ -527,6 +539,10 @@ message StatefulSwapResponse {
 
             // The memory index where the destination virtual Timelock account lives
             uint32 memory_index = 9;
+
+            // Destination account where the buy fee should be paid. Only set when
+            // a non-zero fee_amount was provided in the client parameters.
+            common.v1.SolanaAccountId fee_destination = 10;
         }
 
         // Server parameters when executing stateful buy flows against the

--- a/FlipcashCore/Sources/FlipcashCore/Models/Activity+Metadata.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Activity+Metadata.swift
@@ -28,3 +28,113 @@ extension Activity.CashLinkMetadata {
         )
     }
 }
+
+extension Activity {
+    /// The two legs of a swap plus its fee, carried on a `.swapped` activity so a
+    /// row can render "<from> → <to>" and the fee without a second lookup. The
+    /// destination amount is only known once the swap executes; until then only
+    /// `toMint` is set (`toQuarks`/`toFiat` are `nil`).
+    public struct SwapMetadata: Sendable, Equatable, Hashable {
+
+        /// The whole-swap lifecycle state as reported by the server.
+        public enum State: Int, Sendable {
+            case unknown   = 0
+            case pending   = 1
+            case succeeded = 2
+            case failed    = 3
+            case none      = 4
+        }
+
+        /// Source mint the user converted away from.
+        public let fromMint: PublicKey
+        /// On-chain quantity given up, in the source mint's quarks.
+        public let fromQuarks: UInt64
+        /// Fiat value of the source leg — the amount the row displays.
+        public let fromFiat: FiatAmount
+
+        /// Destination mint the user received.
+        public let toMint: PublicKey
+        /// On-chain quantity received, once the swap has executed.
+        public let toQuarks: UInt64?
+        /// Fiat value of the destination leg, once the swap has executed.
+        public let toFiat: FiatAmount?
+
+        /// Swap fee, known upfront regardless of swap state.
+        public let fee: FiatAmount
+        public let state: State
+
+        public init(
+            fromMint: PublicKey,
+            fromQuarks: UInt64,
+            fromFiat: FiatAmount,
+            toMint: PublicKey,
+            toQuarks: UInt64?,
+            toFiat: FiatAmount?,
+            fee: FiatAmount,
+            state: State,
+        ) {
+            self.fromMint   = fromMint
+            self.fromQuarks = fromQuarks
+            self.fromFiat   = fromFiat
+            self.toMint     = toMint
+            self.toQuarks   = toQuarks
+            self.toFiat     = toFiat
+            self.fee        = fee
+            self.state      = state
+        }
+    }
+}
+
+extension Activity.SwapMetadata.State {
+    init(_ proto: Flipcash_Activity_V1_SwapState) {
+        self = Activity.SwapMetadata.State(rawValue: proto.rawValue) ?? .unknown
+    }
+}
+
+extension Activity.SwapMetadata {
+    /// Missing `to` oneof — an invalid swap notification the client can't render.
+    enum ParseError: Error {
+        case missingDestination
+    }
+
+    init(_ proto: Flipcash_Activity_V1_SwappedCryptoNotificationMetadata) throws {
+        let fromFiat = FiatAmount(
+            value: Decimal(proto.from.nativeAmount),
+            currency: try CurrencyCode(currencyCode: proto.from.currency)
+        )
+
+        let toMint: PublicKey
+        let toQuarks: UInt64?
+        let toFiat: FiatAmount?
+
+        switch proto.to {
+        case .toAmount(let amount):
+            toMint   = try PublicKey(amount.mint.value)
+            toQuarks = amount.quarks
+            toFiat   = FiatAmount(
+                value: Decimal(amount.nativeAmount),
+                currency: try CurrencyCode(currencyCode: amount.currency)
+            )
+        case .toMint(let mint):
+            toMint   = try PublicKey(mint.value)
+            toQuarks = nil
+            toFiat   = nil
+        case .none:
+            throw ParseError.missingDestination
+        }
+
+        self.init(
+            fromMint: try PublicKey(proto.from.mint.value),
+            fromQuarks: proto.from.quarks,
+            fromFiat: fromFiat,
+            toMint: toMint,
+            toQuarks: toQuarks,
+            toFiat: toFiat,
+            fee: FiatAmount(
+                value: Decimal(proto.fee.nativeAmount),
+                currency: try CurrencyCode(currencyCode: proto.fee.currency)
+            ),
+            state: .init(proto.swapState)
+        )
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
@@ -92,7 +92,7 @@ extension Activity.Counterparty {
             case .phone(let phone): self = .phone(phone.value)
             case .none:             return nil
             }
-        case .withdrewCrypto, .indirectlySentCrypto, .depositedCrypto, .boughtCrypto, .soldCrypto, .none:
+        case .withdrewCrypto, .indirectlySentCrypto, .depositedCrypto, .boughtCrypto, .soldCrypto, .swappedCrypto, .none:
             return nil
         }
     }
@@ -111,6 +111,10 @@ extension Activity {
         case distributed  = 7
         case bought       = 8
         case sold         = 9
+        /// A swap between two mints, modelled as a single notification. Supersedes
+        /// the deprecated `bought`/`sold` pair; also backs a withdraw that executes
+        /// as a swap (e.g. USDF withdrawn as USDC).
+        case swapped      = 10
         case unknown
     }
 }
@@ -229,6 +233,8 @@ extension Activity.Kind {
                 self = .bought
             case .soldCrypto:
                 self = .sold
+            case .swappedCrypto:
+                self = .swapped
             }
             
         } else {
@@ -242,7 +248,7 @@ extension Activity.Metadata {
         guard let proto else { return nil }
 
         switch proto {
-        case .directlySentCrypto, .receivedCrypto, .withdrewCrypto, .depositedCrypto, .boughtCrypto, .soldCrypto:
+        case .directlySentCrypto, .receivedCrypto, .withdrewCrypto, .depositedCrypto, .boughtCrypto, .soldCrypto, .swappedCrypto:
             return nil
         case .indirectlySentCrypto(let metadata):
             do {

--- a/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
@@ -42,6 +42,12 @@ public struct Activity: Identifiable, Sendable, Equatable, Hashable {
         return nil
     }
 
+    /// The swap legs + fee when this is a swap activity, else `nil`.
+    public var swapMetadata: SwapMetadata? {
+        if case .swap(let swapMetadata) = metadata { return swapMetadata }
+        return nil
+    }
+
     public init(id: PublicKey, state: State, kind: Kind, title: String, exchangedFiat: ExchangedFiat, date: Date, metadata: Metadata?, textSubstitutions: [TextSubstitution] = [], counterparty: Counterparty? = nil) {
         self.id = id
         self.state = state
@@ -144,6 +150,7 @@ extension Activity {
 extension Activity {
     public enum Metadata: Sendable, Equatable, Hashable {
         case cashLink(CashLinkMetadata)
+        case swap(SwapMetadata)
     }
 }
 
@@ -248,11 +255,17 @@ extension Activity.Metadata {
         guard let proto else { return nil }
 
         switch proto {
-        case .directlySentCrypto, .receivedCrypto, .withdrewCrypto, .depositedCrypto, .boughtCrypto, .soldCrypto, .swappedCrypto:
+        case .directlySentCrypto, .receivedCrypto, .withdrewCrypto, .depositedCrypto, .boughtCrypto, .soldCrypto:
             return nil
         case .indirectlySentCrypto(let metadata):
             do {
                 self = try .cashLink(.init(metadata))
+            } catch {
+                return nil
+            }
+        case .swappedCrypto(let metadata):
+            do {
+                self = try .swap(.init(metadata))
             } catch {
                 return nil
             }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
@@ -136,6 +136,69 @@ struct ActivityProtoMappingTests {
         #expect(activity.metadata == .cashLink(.init(vault: expectedVault, canCancel: true)))
     }
 
+    @Test("swappedCrypto maps to Kind.swapped AND populates SwapMetadata")
+    func kindSwapped() throws {
+        let fromMintBytes = Data(repeating: 7, count: 32)
+        let toMintBytes   = Data(repeating: 9, count: 32)
+
+        var swapped = Flipcash_Activity_V1_SwappedCryptoNotificationMetadata()
+        swapped.from.mint.value   = fromMintBytes
+        swapped.from.quarks       = 5_000_000
+        swapped.from.nativeAmount = 5.0
+        swapped.from.currency     = "usd"
+
+        var toAmount = Flipcash_Common_V1_CryptoPaymentAmount()
+        toAmount.mint.value   = toMintBytes
+        toAmount.quarks       = 100_000_000
+        toAmount.nativeAmount = 4.95
+        toAmount.currency     = "usd"
+        swapped.to = .toAmount(toAmount)
+
+        swapped.fee.nativeAmount = 0.05
+        swapped.fee.currency     = "usd"
+        swapped.swapState        = .succeeded
+
+        let activity = try Activity(baseNotification(metadata: .swappedCrypto(swapped)))
+
+        #expect(activity.kind == .swapped)
+        guard case .swap(let meta)? = activity.metadata else {
+            Issue.record("expected .swap metadata")
+            return
+        }
+        #expect(meta.fromMint == (try PublicKey(fromMintBytes)))
+        #expect(meta.fromQuarks == 5_000_000)
+        #expect(meta.fromFiat.doubleValue == 5.0)
+        #expect(meta.toMint == (try PublicKey(toMintBytes)))
+        #expect(meta.toQuarks == 100_000_000)
+        #expect(meta.toFiat?.doubleValue == 4.95)
+        #expect(meta.fee.doubleValue == 0.05)
+        #expect(meta.state == .succeeded)
+    }
+
+    @Test("swappedCrypto with only a destination mint leaves the To amount nil")
+    func kindSwappedPendingDestination() throws {
+        var swapped = Flipcash_Activity_V1_SwappedCryptoNotificationMetadata()
+        swapped.from.mint.value   = Self.mintBytes
+        swapped.from.quarks       = 1
+        swapped.from.nativeAmount = 1.0
+        swapped.from.currency     = "usd"
+        swapped.toMint.value      = Self.vaultBytes
+        swapped.fee.nativeAmount  = 0.01
+        swapped.fee.currency      = "usd"
+        swapped.swapState         = .pending
+
+        let activity = try Activity(baseNotification(metadata: .swappedCrypto(swapped)))
+
+        #expect(activity.kind == .swapped)
+        guard case .swap(let meta)? = activity.metadata else {
+            Issue.record("expected .swap metadata")
+            return
+        }
+        #expect(meta.toQuarks == nil)
+        #expect(meta.toFiat == nil)
+        #expect(meta.state == .pending)
+    }
+
     @Test("Missing additionalMetadata maps to Kind.unknown with no Metadata")
     func kindUnknownWhenAbsent() throws {
         let activity = try Activity(baseNotification(metadata: nil))

--- a/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
@@ -109,6 +109,10 @@ struct ActivityProtoMappingTests {
             .soldCrypto(Flipcash_Activity_V1_SoldCryptoNotificationMetadata()),
             .sold,
         ),
+        (
+            .swappedCrypto(Flipcash_Activity_V1_SwappedCryptoNotificationMetadata()),
+            .swapped,
+        ),
     ] as [(Flipcash_Activity_V1_Notification.OneOf_AdditionalMetadata, Activity.Kind)])
     func kindMappingWithoutPayload(
         metadata: Flipcash_Activity_V1_Notification.OneOf_AdditionalMetadata,


### PR DESCRIPTION
## Summary

Syncs the backend contracts and adds first-class **swap** support to the activity feed, so a currency→currency swap (and a withdraw that executes as a swap) renders as `<from> → <to>` on every surface.

Context: the two withdraw flows from the Figma (token → Solana address, Dollars → USDC) are already implemented and wired; the proto sync surfaced a new unified swap notification that these screens produce, and the activity row didn't yet understand it.

## What's in here

**Proto sync** (`chore: sync core + payments protos`)
- Re-vendored + regenerated core + payments. Notable: swap buy-fee (`fee_destination`/`fee_amount`) on `StatefulSwapResponse`, `MarketCapMetrics` on `Mint`, and `SwappedCryptoNotificationMetadata` (supersedes bought/sold); `WithdrewCrypto` now carries `swap_metadata`.

**Swap kind** (`feat: map swapped-crypto notifications to Activity.Kind.swapped`)
- New `Activity.Kind.swapped`, wired through every exhaustive switch (kind/metadata/counterparty mapping, DB persistence, row sign display) + a proto-mapping test.

**Row consolidation** (`refactor: consolidate activity rows into a single ActivityRow`)
- Transaction history had its own bespoke row; wallet/currency-info recents and activity history shared a richer one. Renamed `WalletActivityRow` → `ActivityRow` and reused it everywhere (wrapped in a `Button` in transaction history to keep the cancel-cash-link tap). One row on every surface — and one place for the swap UI.

**Swap rendering** (`feat: render swaps in the activity row with swap metadata`)
- `Activity.SwapMetadata` (from/to legs + fee + state) mapped from the proto (handles the pending-destination oneof).
- New `swapMetadata` table (1:1 FK to activity, nullable destination columns for pending swaps); both feed queries `LEFT JOIN` it; `SQLiteVersion` 31 → 32.
- Row: dual coin avatar with the **destination on top of the source**, the converted (From) fiat amount over a `-$x Fee` line. Coin logos resolve held-balance → local mint store → server fetch, so a swapped-away token still shows its logo.

## Testing

- `./Scripts/build.sh` green.
- Added proto-mapping tests (executed swap + pending destination). Note: `build.sh` uses the `build` action, which does not compile the test targets, and the `FlipcashCore` package can't build on host (a dependency needs macOS 13.3), so the new tests were **not** executed on a simulator in this branch — worth a sim test run in CI/review.

## Notes for review

- The fee line uses `Color.textSecondary`; swap if the spec wants the mock's reddish tone.
- `SwappedCryptoNotificationMetadata` also backs `WithdrewCrypto.swap_metadata` (withdraw-as-USDC); this PR maps the standalone `.swappedCrypto` case. Wiring the withdraw-as-swap notification onto the same row is a natural follow-up.