### PR TITLE
feat(wallet): add the $ watermark to the Dollars card

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/TokenCardView.swift
+++ b/Flipcash/Core/Screens/Main/Home/TokenCardView.swift
@@ -88,13 +88,32 @@ struct TokenCardView: View {
     var body: some View {
         RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
             .fill(gradient)
+            .overlay(alignment: .trailing) {
+                if isUSDF { dollarWatermark }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: height)
+            .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
                     .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
             )
-            .frame(maxWidth: .infinity)
-            .frame(height: height)
             .overlay(alignment: .top) { header.padding(16) }
+    }
+
+    /// The Dollars bill's oversized "$", vertically centred and tucked toward the
+    /// right edge — taller than the card so it clips top and bottom. White at 30%
+    /// over an overlay blend, matching the Figma watermark (node 9223:23556).
+    private var dollarWatermark: some View {
+        Text("$")
+            .font(.default(size: 213, weight: .bold))
+            .foregroundStyle(.white)
+            .opacity(0.30)
+            .blendMode(.overlay)
+            .fixedSize()
+            .padding(.trailing, 10)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
     }
 
     private var header: some View {


### PR DESCRIPTION
Adds the oversized "$" watermark to the Dollars (USDF) bill card, per the v2 wallet design (Figma node `9223:23556`).

## Details
- The USDF card now renders a large "$" behind the header: Avenir bold, size 213, **white at 30% opacity over an `overlay` blend**, vertically centred and tucked to the right edge so it clips top and bottom — matching the design's fill/position.
- Gated on `isUSDF`; other token cards are unchanged. Clipped to the card's rounded rect; non-interactive and hidden from accessibility.

## Font note
The design specifies Avenir Next LT Pro **Bold**, but the app bundles only **Demi/Medium/Regular** (`.default(.bold)` → Demi). Per decision, we keep Demi (a touch lighter than the design) rather than add the licensed Bold face — consistent with how the rest of the app treats "bold" as Demi.

## Testing
Built + launched on the iPhone 17 (iOS 27.0) simulator; verified on the expanded Dollars card.