### PR TITLE
chore(previews): add #Preview states to TokenCardView

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/TokenCardView.swift
+++ b/Flipcash/Core/Screens/Main/Home/TokenCardView.swift
@@ -153,3 +153,40 @@ struct TokenCardView: View {
         }
     }
 }
+
+// MARK: - Previews -
+
+#Preview("Token cards") {
+    VStack(spacing: 16) {
+        // USDF: gold branding + the oversized "$" watermark.
+        TokenCardView(
+            name: "Dollars",
+            imageURL: nil,
+            balanceText: "$205.94",
+            appreciationText: "+$0.00",
+            colors: [],
+            isUSDF: true
+        )
+        // Bonded token: gradient painted from its bill-customization colors.
+        TokenCardView(
+            name: "Jeffy",
+            imageURL: nil,
+            balanceText: "$121.74",
+            appreciationText: "-$21.35",
+            colors: ["#F5B301", "#B06B00"],
+            isUSDF: false
+        )
+        // No customization → dark-green fallback, no appreciation pill.
+        TokenCardView(
+            name: "Testament",
+            imageURL: nil,
+            balanceText: "$10.00",
+            appreciationText: nil,
+            colors: [],
+            isUSDF: false
+        )
+    }
+    .padding(20)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.backgroundMain)
+}


### PR DESCRIPTION
Adds Xcode `#Preview` states to `TokenCardView`, starting the convention of shipping canvas previews with components.

Covers three states:
- **USDF** — gold branding + the oversized "$" watermark
- **Bonded token** — gradient from bill-customization colors
- **Fallback** — no customization (dark-green), no appreciation pill

`TokenCardView` is self-contained (plain data in, no `@Environment`), so it previews cleanly. Session-dependent views (e.g. `ActivityRow`) need a `SessionContainer.mock` first — that foundation + their previews will follow in a separate PR.

Built in Debug (`./Scripts/build.sh` / sim build) — compiles green.