### PR TITLE
feat(discovery): rank the leaderboard by market cap via MarketCapMetrics

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryList.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryList.swift
@@ -14,6 +14,11 @@ struct CurrencyDiscoveryList: View {
     @State private var mints: [MintMetadata]?
     @State private var isFailed: Bool = false
 
+    /// v2 ranks the leaderboard by market cap; the legacy UI stays on holders.
+    private var rankingSystem: RankingSystem {
+        BetaFlags.shared.hasEnabled(.newUI) ? .marketCap : .holders
+    }
+
     private enum LoadState {
         case loading
         case failed
@@ -37,7 +42,7 @@ struct CurrencyDiscoveryList: View {
                     Button {
                         onSelectMint(item.element.address)
                     } label: {
-                        CurrencyDiscoveryRow(rank: item.index + 1, mint: item.element)
+                        CurrencyDiscoveryRow(rank: item.index + 1, mint: item.element, rankingSystem: rankingSystem)
                     }
                     .buttonStyle(.plain)
                     // Stable handle for UI tests — the visible label is

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
@@ -11,8 +11,8 @@ struct CurrencyDiscoveryRow: View {
     let rank: Int
     let mint: MintMetadata
     /// Drives which metric is prominent (trailing value + delta) and which is the
-    /// secondary line under the name. Holders for now — see ``RankingSystem``.
-    var rankingSystem: RankingSystem = .holders
+    /// secondary line under the name. Market cap for v2 — see ``RankingSystem``.
+    var rankingSystem: RankingSystem = .marketCap
 
     var body: some View {
         HStack(spacing: 12) {
@@ -88,8 +88,13 @@ struct CurrencyDiscoveryRow: View {
                     .contentTransition(.numericText())
             }
         case .marketCap:
-            // Needs a market-cap weekly delta from the Discover API; not yet available.
-            EmptyView()
+            if let metrics = mint.marketCapMetrics,
+               let weekly = metrics.marketCapDeltas.first(where: { $0.range == .lastWeek }) {
+                Text(Self.formatMarketCapDelta(weekly.delta))
+                    .font(.appTextSmall)
+                    .foregroundStyle(weekly.delta > 0 ? Color.Sentiment.positive : Color.Sentiment.neutral)
+                    .contentTransition(.numericText())
+            }
         }
     }
 
@@ -100,9 +105,18 @@ struct CurrencyDiscoveryRow: View {
     }
 
     @ViewBuilder private var marketCapText: some View {
-        if let marketCap = mint.launchpadMetadata?.marketCap, marketCap > 0 {
+        if let marketCap = marketCapValue, marketCap > 0 {
             Text(marketCap, format: .compactCurrency(code: .usd))
         }
+    }
+
+    /// Prefer the Discover market-cap metric; fall back to the bonding-curve
+    /// estimate on `launchpadMetadata` when the metric isn't populated.
+    private var marketCapValue: Double? {
+        if let current = mint.marketCapMetrics?.currentMarketCap, current > 0 {
+            return current
+        }
+        return mint.launchpadMetadata?.marketCap
     }
 }
 
@@ -112,6 +126,12 @@ private extension CurrencyDiscoveryRow {
     static func formatHolderDelta(_ delta: Int64) -> String {
         let sign = delta >= 0 ? "+" : ""
         let compact = delta.formatted(.number.notation(.compactName))
+        return "\(sign)\(compact) this week"
+    }
+
+    static func formatMarketCapDelta(_ delta: Double) -> String {
+        let sign = delta >= 0 ? "+" : ""
+        let compact = delta.formatted(.compactCurrency(code: .usd))
         return "\(sign)\(compact) this week"
     }
 }

--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
@@ -11,8 +11,9 @@ struct CurrencyDiscoveryRow: View {
     let rank: Int
     let mint: MintMetadata
     /// Drives which metric is prominent (trailing value + delta) and which is the
-    /// secondary line under the name. Market cap for v2 — see ``RankingSystem``.
-    var rankingSystem: RankingSystem = .marketCap
+    /// secondary line under the name. Callers pass `.marketCap` under v2; the
+    /// default stays on holders for the legacy UI. See ``RankingSystem``.
+    var rankingSystem: RankingSystem = .holders
 
     var body: some View {
         HStack(spacing: 12) {

--- a/Flipcash/Core/Screens/Main/Currency Discovery/RankingSystem.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/RankingSystem.swift
@@ -8,10 +8,10 @@ import Foundation
 /// The metric the discovery leaderboard ranks by, which also drives what each
 /// row's prominent value and weekly delta represent.
 ///
-/// Market-cap ranking is the intended direction for the new UI, but the Discover
-/// API only returns a *holder* weekly delta (`HolderMetrics.holderDeltas`) and a
-/// point-in-time market cap — there is no market-cap delta yet. Until that lands
-/// we rank by holders in both UIs.
+/// v2 ranks by market cap: the Discover RPC now returns `MarketCapMetrics`
+/// (`current_market_cap` + per-range deltas), so a row shows the current market
+/// cap and its weekly change. Holder metrics remain available as the secondary
+/// line and an alternate ranking.
 enum RankingSystem {
     /// Rank by holder count; the weekly delta is the change in holders.
     case holders

--- a/FlipcashCore/Sources/FlipcashCore/Models/MintMetadata.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/MintMetadata.swift
@@ -69,6 +69,9 @@ public struct MintMetadata: Equatable, Sendable {
     /// Holder metrics (only populated by the Discover RPC)
     public let holderMetrics: HolderMetrics?
 
+    /// Market-cap metrics (only populated by the Discover RPC)
+    public let marketCapMetrics: MarketCapMetrics?
+
     public init(
         address: PublicKey,
         decimals: Int,
@@ -81,7 +84,8 @@ public struct MintMetadata: Equatable, Sendable {
         socialLinks: [SocialLink] = [],
         billColors: [String] = [],
         createdAt: Date? = nil,
-        holderMetrics: HolderMetrics? = nil
+        holderMetrics: HolderMetrics? = nil,
+        marketCapMetrics: MarketCapMetrics? = nil
     ) {
         self.address = address
         self.decimals = decimals
@@ -95,6 +99,7 @@ public struct MintMetadata: Equatable, Sendable {
         self.billColors = billColors
         self.createdAt = createdAt
         self.holderMetrics = holderMetrics
+        self.marketCapMetrics = marketCapMetrics
     }
 
     /// A bare-bones `MintMetadata` for a freshly-launched currency mint. Used
@@ -264,6 +269,31 @@ public struct HolderMetrics: Equatable, Sendable {
     }
 }
 
+// MARK: - MarketCapMetrics -
+
+public struct MarketCapMetrics: Equatable, Sendable {
+    /// Current market capitalization in USD
+    public let currentMarketCap: Double
+
+    /// Net market-cap changes (USD) for various time ranges
+    public let marketCapDeltas: [MarketCapDelta]
+
+    public struct MarketCapDelta: Equatable, Sendable {
+        public let range: Ocp_Currency_V1_PredefinedRange
+        public let delta: Double
+
+        public init(range: Ocp_Currency_V1_PredefinedRange, delta: Double) {
+            self.range = range
+            self.delta = delta
+        }
+    }
+
+    public init(currentMarketCap: Double, marketCapDeltas: [MarketCapDelta]) {
+        self.currentMarketCap = currentMarketCap
+        self.marketCapDeltas = marketCapDeltas
+    }
+}
+
 // MARK: - Errors -
 
 enum MintMetadataError: Swift.Error {
@@ -310,7 +340,8 @@ extension MintMetadata {
             socialLinks: socialLinks,
             billColors: billColors,
             createdAt: proto.hasCreatedAt ? proto.createdAt.date : nil,
-            holderMetrics: proto.hasHolderMetrics ? HolderMetrics(proto.holderMetrics) : nil
+            holderMetrics: proto.hasHolderMetrics ? HolderMetrics(proto.holderMetrics) : nil,
+            marketCapMetrics: proto.hasMarketCapMetrics ? MarketCapMetrics(proto.marketCapMetrics) : nil
         )
     }
     
@@ -366,6 +397,17 @@ extension HolderMetrics {
             currentHolders: proto.currentHolders,
             holderDeltas: proto.holderDeltas.map {
                 HolderDelta(range: $0.range, delta: $0.delta)
+            }
+        )
+    }
+}
+
+extension MarketCapMetrics {
+    init(_ proto: Ocp_Currency_V1_MarketCapMetrics) {
+        self.init(
+            currentMarketCap: proto.currentMarketCap,
+            marketCapDeltas: proto.marketCapDeltas.map {
+                MarketCapDelta(range: $0.range, delta: $0.delta)
             }
         )
     }


### PR DESCRIPTION
Wires up the new `MarketCapMetrics` from the synced Discover proto and moves the discovery/leaderboard to market-cap ranking (v2).

## Background
The proto sync (#599) added `MarketCapMetrics` (`current_market_cap` + up to 4 per-range `DeltaMarketCap`s) on `Mint`, but it was only regenerated — never modeled or consumed. `RankingSystem` was explicitly stuck on holders: "there is no market-cap delta yet. Until that lands we rank by holders." This lands it.

## Changes
- **Model** `MarketCapMetrics` on `MintMetadata` (mirrors `HolderMetrics`): `currentMarketCap` + `[MarketCapDelta { range, delta }]`, mapped from `proto.market_cap_metrics` (gated on `hasMarketCapMetrics`).
- **Leaderboard** (`CurrencyDiscoveryRow`): default ranking is now `.marketCap`; the prominent value uses `currentMarketCap` (falling back to the `launchpadMetadata` bonding-curve estimate when the metric isn't populated), and the weekly delta now renders from `marketCapDeltas[.lastWeek]` — replacing the old "not yet available" `EmptyView`.
- **Docs**: refreshed `RankingSystem`.
