### PR TITLE
fix(chat): open Send Cash from tab-hosted chats

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -362,6 +362,18 @@ final class AppRouter {
         }
     }
 
+    /// Presents the Send Cash amount sheet — as the root sheet when nothing is
+    /// presented (the chat lives inside a tab's nav stack), stacked on top of
+    /// the current sheet otherwise (the chat was itself opened as a sheet, e.g.
+    /// from the scanner's tips flow). Either way, dismissing it reveals the chat.
+    func presentSendAmount(_ target: SendTarget) {
+        if presentedSheets.isEmpty {
+            present(.sendAmount(target))
+        } else {
+            presentNested(.sendAmount(target))
+        }
+    }
+
     /// Whether the Add Money sheet is stacked directly over the buy sheet.
     var isAddMoneyOverBuy: Bool {
         guard presentedSheets.count >= 2 else { return false }

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -322,7 +322,7 @@ struct ConversationScreen: View {
             session.dialogItem = dialog
             return
         }
-        router.presentNested(.sendAmount(sendTarget))
+        router.presentSendAmount(sendTarget)
     }
 
     /// Re-send a failed message tapped in the transcript. The id is the row's stable id, which for a

--- a/FlipcashTests/Navigation/SendCashRoutingTests.swift
+++ b/FlipcashTests/Navigation/SendCashRoutingTests.swift
@@ -1,0 +1,45 @@
+//
+//  SendCashRoutingTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@Suite("Send Cash routing")
+@MainActor
+struct SendCashRoutingTests {
+
+    private static let target: SendTarget = .tip(
+        TipRecipient(userID: UUID(), displayName: "Fred", origin: .chat)
+    )
+
+    @Test("The sendAmount sheet maps to the sendAmount stack")
+    func sendAmountSheet_mapsToSendAmountStack() {
+        #expect(AppRouter.SheetPresentation.sendAmount(Self.target).stack == .sendAmount)
+    }
+
+    // Regression: a chat opened from the Chat tab lives inside the tab's nav
+    // stack with no sheet presented. Send Cash must still open — presenting the
+    // amount sheet at root — rather than no-op the way a bare `presentNested`
+    // does on an empty stack.
+    @Test("With no sheet presented, Send Cash presents at root")
+    func fromTabChat_presentsAtRoot() {
+        let router = AppRouter()
+        router.activeTabStack = .tips
+        router.presentSendAmount(Self.target)
+        #expect(router.presentedSheets == [.sendAmount(Self.target)])
+    }
+
+    // A chat opened as a sheet (the scanner's tips flow) keeps the old
+    // behaviour: the amount sheet stacks on top so dismissing reveals the chat.
+    @Test("Over a presented chat sheet, Send Cash stacks nested")
+    func overChatSheet_stacksNested() {
+        let router = AppRouter()
+        router.present(.tips)
+        router.presentSendAmount(Self.target)
+        #expect(router.presentedSheets == [.tips, .sendAmount(Self.target)])
+    }
+}


### PR DESCRIPTION
## Problem

The **Send Cash** button in a chat — rendered as the balance currency's single-character symbol, so it reads as an "S" for currencies like SOS/SRD/SHP — stopped doing anything.

`sendCash()` called `router.presentNested(.sendAmount(...))`, but `presentNested` **no-ops (with a warning) when no sheet is presented** (`AppRouter.swift:318`). Since the Chat tab landed, chats live *inside* the tab's `.tips` `NavigationStack` rather than as a presented sheet — so there's nothing to stack onto and every tap silently did nothing. It worked before the tab redesign because the chat was itself a presented sheet.

## Fix

Add `AppRouter.presentSendAmount(_:)`, mirroring the existing `presentAddMoney` present-or-nest pattern, and point `sendCash()` at it:

- **No sheet presented** (chat opened from the Chat tab) → present `.sendAmount` at root.
- **A sheet is presented** (chat opened as a sheet from the scanner's tips flow) → nest on top, unchanged.

Either way, dismissing reveals the chat. `.sendAmount` has its own dedicated stack, so presenting it at root doesn't collide with the tab's `.tips` stack.

## Testing

- New `SendCashRoutingTests` covering both paths: root-present from a tab-hosted chat (the regression) and nesting over a presented chat sheet.
- Builds and runs on the iOS 27 simulator (iPhone 17); the app launches with the fix in place.
