### PR TITLE
feat(give): Dollars (USDF) give + give-to-bill polish

### DIFF
--- a/Flipcash/Core/Screens/Main/BalanceScreen.swift
+++ b/Flipcash/Core/Screens/Main/BalanceScreen.swift
@@ -256,7 +256,8 @@ struct ExchangedBalance: Identifiable, Hashable {
 extension Array where Element == ExchangedBalance {
 
     /// Balances eligible to send or give — every balance except USDF, the
-    /// on-Flipcash stablecoin, which is never transferred peer-to-peer.
+    /// on-Flipcash stablecoin. Dollars give is reached directly from the Dollars
+    /// card (new UI), not through this generic list.
     var giveable: [ExchangedBalance] {
         filter { $0.stored.mint != .usdf }
     }

--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoContentV2.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoContentV2.swift
@@ -286,28 +286,31 @@ struct CurrencyInfoContentV2: View {
 
     // MARK: - Actions
 
+    /// An action-tile glyph: either an SF Symbol or a bundled template asset.
+    private enum TileIcon {
+        case system(String)
+        case asset(String)
+    }
+
     @ViewBuilder private var actionTiles: some View {
         HStack(spacing: 12) {
             if isOwned {
-                // Give ships for community tokens only; USDF give comes later.
-                // Convert works from any held currency — including Dollars, which
-                // converts to a token via a reserves buy.
-                if !isUSDF {
-                    actionTile("Give", icon: "banknote", action: onGive)
-                }
-                actionTile("Convert", icon: "arrow.up.arrow.down", action: onConvert)
-                actionTile("Withdraw", icon: "arrow.up", action: onWithdraw)
+                // This layout is new-UI only, so Give (including Dollars) is
+                // inherently gated to the new UI. Convert works from any held
+                // currency — including Dollars, which converts via a reserves buy.
+                actionTile("Give", icon: .asset("IconBanknote"), action: onGive)
+                actionTile("Convert", icon: .system("arrow.up.arrow.down"), action: onConvert)
+                actionTile("Withdraw", icon: .system("arrow.up"), action: onWithdraw)
             } else {
-                actionTile("Get", icon: "arrow.down", action: onBuy)
+                actionTile("Get", icon: .system("arrow.down"), action: onBuy)
             }
         }
     }
 
-    private func actionTile(_ title: String, icon: String, action: @escaping () -> Void) -> some View {
+    private func actionTile(_ title: String, icon: TileIcon, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             VStack(spacing: 12) {
-                Image(systemName: icon)
-                    .font(.system(size: 22, weight: .regular))
+                tileIcon(icon)
                     .frame(height: 28)
                 Text(title)
                     .font(.appTextSmall)
@@ -319,6 +322,21 @@ struct CurrencyInfoContentV2: View {
             .clipShape(RoundedRectangle(cornerRadius: Metrics.buttonRadius, style: .continuous))
         }
         .buttonStyle(.plain)
+    }
+
+    @ViewBuilder private func tileIcon(_ icon: TileIcon) -> some View {
+        switch icon {
+        case .system(let name):
+            Image(systemName: name)
+                .font(.system(size: 22, weight: .regular))
+        case .asset(let name):
+            // Figma exports these glyphs at 28×28 (template-rendered, so they
+            // tint with the tile's foreground).
+            Image(name)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 28, height: 28)
+        }
     }
 
     // MARK: - Recent

--- a/Flipcash/Core/Screens/Main/GiveScreen.swift
+++ b/Flipcash/Core/Screens/Main/GiveScreen.swift
@@ -43,6 +43,11 @@ private struct GiveScreenContent: View {
     @State private var isShowingCurrencySelection: Bool = false
     @State private var isShowingTokenSelection: Bool = false
 
+    /// True when this screen was pushed (from a currency's Give tile) rather
+    /// than hosted at a tab root (the Scan tab). Only the pushed instance pops
+    /// itself when the bill appears.
+    private let isPushed: Bool
+
     private var maxLimit: ExchangedFiat {
         let rate = ratesController.rateForBalanceCurrency()
         let zero = ExchangedFiat.compute(
@@ -70,6 +75,9 @@ private struct GiveScreenContent: View {
             sessionContainer: sessionContainer,
             mint: mint
         ))
+        // The Scan tab hosts Give at its root with no mint; a currency's Give
+        // tile pushes it with the currency mint.
+        self.isPushed = mint != nil
     }
 
     // MARK: - Body -
@@ -105,6 +113,17 @@ private struct GiveScreenContent: View {
                 )
                 .id(viewModel.selectedBalance?.stored.mint)
             }
+        }
+        .onAppear {
+            // When pushed from a currency's Give tile, pop this entry screen as
+            // the bill appears so the bill sits over the currency info. The pop
+            // is un-animated so the entry doesn't visibly slide back out from
+            // under the bill. The Scan tab's root instance leaves it nil.
+            viewModel.onBillPresented = isPushed ? {
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) { router.popTopmost() }
+            } : nil
         }
         .onChange(of: viewModel.depositMint) { _, mint in
             guard let mint else { return }

--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -20,6 +20,11 @@ final class GiveViewModel {
 
     var depositMint: PublicKey?
 
+    /// Invoked right after the give bill is presented. The pushed amount-entry
+    /// screen uses this to pop itself so the bill sits over the currency info
+    /// rather than over the amount entry.
+    @ObservationIgnored var onBillPresented: (() -> Void)?
+
     var canGive: Bool {
         enteredFiat != nil && (enteredFiat?.onChainAmount.quarks ?? 0) > 0
     }
@@ -98,6 +103,10 @@ final class GiveViewModel {
                         verifiedState: pinnedState
                     )
                 )
+
+                // Pop the amount entry behind the just-presented bill so the
+                // bill sits over the currency info instead of the entry screen.
+                onBillPresented?()
             }
 
         case .insufficient(let shortfall):
@@ -125,20 +134,33 @@ final class GiveViewModel {
               let entered = amountValidator.validate(enteredAmount),
               entered > 0 else { return nil }
 
-        guard let pinnedSupply = pin.supplyFromBonding else { return nil }
-
         let nativeEntered = FiatAmount(value: entered, currency: pin.rate.currency)
         let balance = session.balance(for: mint)
 
-        guard let amount = ExchangedFiat.compute(
-            fromEntered: nativeEntered,
-            rate: pin.rate,
-            mint: mint,
-            supplyQuarks: pinnedSupply,
-            balance: balance.map(\.usdf),
-            tokenBalanceQuarks: balance?.quarks
-        ) else { return nil }
+        let computed: ExchangedFiat?
+        if mint == .usdf {
+            // Dollars has no bonding curve; value the entry 1:1 against the
+            // pinned rate, capped to the USDF balance (mirrors the buy path).
+            computed = ExchangedFiat.compute(
+                fromEntered: nativeEntered,
+                rate: pin.rate,
+                mint: .usdf,
+                supplyQuarks: 0,
+                balance: balance.map(\.usdf)
+            )
+        } else {
+            guard let pinnedSupply = pin.supplyFromBonding else { return nil }
+            computed = ExchangedFiat.compute(
+                fromEntered: nativeEntered,
+                rate: pin.rate,
+                mint: mint,
+                supplyQuarks: pinnedSupply,
+                balance: balance.map(\.usdf),
+                tokenBalanceQuarks: balance?.quarks
+            )
+        }
 
+        guard let amount = computed else { return nil }
         return (amount, pin)
     }
 

--- a/Flipcash/Core/Screens/Main/Home/TokenCardView.swift
+++ b/Flipcash/Core/Screens/Main/Home/TokenCardView.swift
@@ -68,7 +68,8 @@ struct TokenCardView: View {
 
     private static let cornerRadius: CGFloat = Metrics.boxRadius   // 12 — medium shape
     private static let fallback = Color(hex: "#06450F")!
-    private static let usdfGradient = [Color(hex: "#C4980B")!, Color(hex: "#B06B00")!]
+    // Sourced from the model so the Dollars card and its give bill can't drift.
+    private static let usdfGradient: [Color] = MintMetadata.usdf.billColors.compactMap { Color(hex: $0) }
 
     private var gradient: LinearGradient {
         let stops: [Color]

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -1274,7 +1274,11 @@ class Session {
             secondaryAction = nil
         }
 
-        let billColors = storedMintMetadata?.metadata.billColors ?? []
+        // Dollars carries no server-provided bill colors; fall back to its
+        // model-defined Dollars-card gradient so the give bill matches the card.
+        let billColors = billDescription.exchangedFiat.mint == .usdf
+            ? MintMetadata.usdf.billColors
+            : (storedMintMetadata?.metadata.billColors ?? [])
 
         sendOperation     = operation
         presentationState = .visible(billDescription.received ? .pop : .slide)

--- a/Flipcash/Supporting Files/Assets.xcassets/IconBanknote.imageset/Contents.json
+++ b/Flipcash/Supporting Files/Assets.xcassets/IconBanknote.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "IconBanknote.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Flipcash/Supporting Files/Assets.xcassets/IconBanknote.imageset/IconBanknote.svg
+++ b/Flipcash/Supporting Files/Assets.xcassets/IconBanknote.imageset/IconBanknote.svg
@@ -1,0 +1,5 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="IconBanknote1">
+<path id="Vector" d="M5.54167 9.625H6.70833M21.2917 18.375H22.4583M2.04167 21.875V6.125H25.9583V21.875H2.04167ZM16.3333 14C16.3333 15.2887 15.2887 16.3333 14 16.3333C12.7113 16.3333 11.6667 15.2887 11.6667 14C11.6667 12.7113 12.7113 11.6667 14 11.6667C15.2887 11.6667 16.3333 12.7113 16.3333 14Z" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/FlipcashCore/Sources/FlipcashCore/Models/MintMetadata.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/MintMetadata.swift
@@ -136,7 +136,12 @@ public struct MintMetadata: Equatable, Sendable {
                 )!.publicKey,
                 authority: .usdcAuthority,
                 lockDurationInDays: Int(TimelockDerivedAccounts.lockoutInDays)),
-            launchpadMetadata: nil
+            launchpadMetadata: nil,
+            // Dollars has no server-provided bill colors — carry the Dollars
+            // wallet-card gradient (leading→trailing) so the give bill matches
+            // the card. The bill renders bottom→top, so [0] is the bill's top
+            // (card's leading) and [1] its bottom (card's trailing).
+            billColors: ["#C4980B", "#B06B00"]
         )
 
     public static let usdc: MintMetadata =

--- a/FlipcashTests/GiveViewModelTests.swift
+++ b/FlipcashTests/GiveViewModelTests.swift
@@ -508,4 +508,34 @@ struct GiveViewModelTests {
         // match.
         #expect(!title.contains("$0.00"))
     }
+
+    // MARK: - USDF give
+
+    @Test("Dollars give computes a 1:1 bill amount without a bonding supply")
+    func prepareSubmission_usdf_succeedsWithoutSupply() async throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 30_000_000), // $30
+        ])
+        container.ratesController.configureTestRates(
+            balanceCurrency: .usd,
+            rates: [Rate(fx: 1, currency: .usd)]
+        )
+        await container.ratesController.verifiedProtoService.saveRates([
+            .freshRate(currencyCode: "USD", rate: 1)
+        ])
+
+        // Reaching Give with an explicit USDF mint resolves the Dollars balance
+        // directly (the Dollars-card entry point).
+        let viewModel = GiveViewModel(container: .mock, sessionContainer: container, mint: .usdf)
+        #expect(viewModel.selectedBalance?.stored.mint == .usdf)
+
+        viewModel.enteredAmount = "10"
+
+        // The bonded path's supply guard used to reject USDF outright; the
+        // Dollars branch values the entry 1:1 against the pinned rate instead.
+        let submission = try #require(await viewModel.prepareSubmission())
+        #expect(submission.amount.mint == .usdf)
+        #expect(submission.amount.onChainAmount.quarks == 10_000_000) // $10 at 6 decimals
+        #expect(submission.pinnedState.exchangeRate == 1)
+    }
 }


### PR DESCRIPTION
Adds Give support for Dollars (USDF) and refines the give→bill hand-off. New UI only.

## Give USDF
- The Give tile now shows for Dollars (the new-UI currency-info layout gates it inherently; legacy UI unchanged).
- `prepareSubmission` values a Dollars give 1:1 against the pinned rate — no bonding supply required — mirroring the buy path. The old supply guard rejected USDF outright.
- Reached directly from the Dollars card; the generic give picker/fallback stays USDF-free.

## Bill colors (from the Dollars card)
- `MintMetadata.usdf.billColors = ["#C4980B", "#B06B00"]` is the single source. The Dollars wallet card derives its gradient from it, and `showCashBill` uses it for the give bill — so the bill matches the card: top = card leading (`#C4980B`), bottom = card trailing (`#B06B00`).

## Give tile icon
- Uses the exact exported Figma outline-banknote asset (template imageset `IconBanknote`) instead of the SF Symbol `banknote`. `actionTile` now takes a system/asset `TileIcon`.

## Give → bill transition
- A pushed give pops its amount-entry as the bill appears, un-animated, so the bill sits over the currency info instead of the entry screen. The Scan-tab give is unchanged.

## Tests
- Added a give test covering the USDF 1:1 compute (`prepareSubmission_usdf_succeedsWithoutSupply`). Full give/gate suites pass.