### PR TITLE
fix(wallet): observe activity, not just balance, on the wallet tab

### DIFF
--- a/Flipcash/Core/Controllers/Database/Database+Onboarding.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Onboarding.swift
@@ -12,12 +12,25 @@ import SQLite
 /// after the user later spends the balance — mirroring Android.
 nonisolated extension Database {
 
-    /// True once a completed deposit or buy exists — the "added money" milestone.
+    /// Activity kinds that bring money *in* from outside the user's own
+    /// holdings: an on-ramp buy, an external deposit, a tip received, and a
+    /// pool distribution. `sold`/`swapped` are excluded — they move value
+    /// between tokens the user already holds rather than adding any.
+    private static let incomingKinds: [Int] = [
+        Activity.Kind.bought.rawValue,
+        Activity.Kind.deposited.rawValue,
+        Activity.Kind.received.rawValue,
+        Activity.Kind.distributed.rawValue,
+    ]
+
+    /// True once any completed incoming-money activity exists — the "added
+    /// money" milestone.
     func hasEverAddedMoney() throws -> Bool {
         let a = ActivityTable()
-        let funded = [Activity.Kind.deposited.rawValue, Activity.Kind.bought.rawValue]
         return try reader.pluck(
-            a.table.filter(funded.contains(a.kind) && a.state == Activity.State.completed.rawValue)
+            a.table.filter(
+                Self.incomingKinds.contains(a.kind) && a.state == Activity.State.completed.rawValue
+            )
         ) != nil
     }
 

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -131,8 +131,8 @@ private struct WalletScreenContent: View {
         _cards = State(initialValue: seed.cards)
         _total = State(initialValue: seed.total)
         _appreciation = State(initialValue: seed.appreciation)
-        _hasAddedMoney = State(initialValue: seed.hasAddedMoney)
-        _hasTipped = State(initialValue: seed.hasTipped)
+        _hasAddedMoney = State(initialValue: sessionContainer.session.hasEverAddedMoney())
+        _hasTipped = State(initialValue: sessionContainer.session.hasEverTipped())
         _recentActivities = State(initialValue: sessionContainer.session.recentActivities(limit: Self.recentPreviewCount))
     }
 
@@ -197,12 +197,21 @@ private struct WalletScreenContent: View {
             .toolbar(.hidden, for: .navigationBar)
             .appRouterDestinations()
             .onAppear { historyController.sync() }
-            .onChange(of: session.balances) { _, _ in refresh() }
+            .onChange(of: session.balances) { _, _ in
+                refresh()
+                // A balance that moved has an activity row on its way, so pull
+                // it now. `onAppear` cannot be the only sync: the tab stays
+                // alive behind sheets and behind the other tabs, so it fires
+                // once per launch and never again after a deposit lands.
+                historyController.sync()
+            }
             .onChange(of: rate) { _, _ in refresh() }
             // Activities land in the DB independently of a balance change (e.g.
-            // a synced history page), so reload the preview on any DB change.
+            // a synced history page), and both the recent preview and the
+            // onboarding milestones are derived from them — so reload both on
+            // any DB change rather than only when a balance moves.
             .onReceive(NotificationCenter.default.publisher(for: .databaseDidChange)) { _ in
-                recentActivities = session.recentActivities(limit: Self.recentPreviewCount)
+                reloadHistoryState()
             }
             // Popping back to the wallet restores the deck.
             // Deliberately not watching the stack depth to decide whether the
@@ -626,8 +635,28 @@ private struct WalletScreenContent: View {
             cards = snapshot.cards
             total = snapshot.total
             appreciation = snapshot.appreciation
-            hasAddedMoney = snapshot.hasAddedMoney
-            hasTipped = snapshot.hasTipped
+        }
+    }
+
+    /// Re-reads the history-derived state: the recent-activity preview and the
+    /// two onboarding milestones. All three come from the activity and message
+    /// tables, which a history sync writes without touching balances — so they
+    /// cannot ride on ``refresh()``'s balance trigger, and a deposit's activity
+    /// row routinely lands after the balance rise that preceded it.
+    private func reloadHistoryState() {
+        let activities = session.recentActivities(limit: Self.recentPreviewCount)
+        let addedMoney = session.hasEverAddedMoney()
+        let tipped = session.hasEverTipped()
+
+        guard activities != recentActivities
+                || addedMoney != hasAddedMoney
+                || tipped != hasTipped
+        else { return }
+
+        withAnimation(.default) {
+            recentActivities = activities
+            hasAddedMoney = addedMoney
+            hasTipped = tipped
         }
     }
 
@@ -637,7 +666,7 @@ private struct WalletScreenContent: View {
     private static func snapshot(
         session: Session,
         rate: Rate
-    ) -> (cards: [TokenCardData], total: ExchangedFiat, appreciation: (amount: FiatAmount, isPositive: Bool), hasAddedMoney: Bool, hasTipped: Bool) {
+    ) -> (cards: [TokenCardData], total: ExchangedFiat, appreciation: (amount: FiatAmount, isPositive: Bool)) {
         let all = session.balances(for: rate)
         let visible = all.filter { $0.stored.mint != .usdf || $0.exchangedFiat.hasDisplayableValue() }
 
@@ -670,7 +699,7 @@ private struct WalletScreenContent: View {
             isPositive: net >= 0
         )
 
-        return (cards, total, appreciation, session.hasEverAddedMoney(), session.hasEverTipped())
+        return (cards, total, appreciation)
     }
 }
 

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -170,9 +170,10 @@ class Session {
         (try? database.getRecentActivities(limit: limit)) ?? []
     }
 
-    /// Whether the caller has ever added money (a completed deposit or buy) —
-    /// the wallet onboarding "add money" milestone. Derived from durable history,
-    /// so it stays true after the balance is spent.
+    /// Whether the caller has ever received money from outside their own
+    /// holdings — a completed buy, deposit, tip received, or distribution. This
+    /// is the wallet onboarding "add money" milestone. Derived from durable
+    /// history, so it stays true after the balance is spent.
     func hasEverAddedMoney() -> Bool {
         (try? database.hasEverAddedMoney()) ?? false
     }
@@ -458,6 +459,12 @@ class Session {
     
     func didBecomeActive() {
         ratesController.ensureStreamConnected()
+        // Anything that landed while backgrounded — a tip received, a deposit
+        // that settled — is only in the local DB once history is pulled, and
+        // the balance poller does not pull it. Nothing else re-syncs on
+        // foreground, so the activity feed would stay stale until the next
+        // transaction of the user's own.
+        historyController.sync()
     }
 
     func didEnterBackground() {

--- a/FlipcashTests/Database/Database+OnboardingTests.swift
+++ b/FlipcashTests/Database/Database+OnboardingTests.swift
@@ -1,0 +1,92 @@
+//
+//  Database+OnboardingTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@Suite(.serialized)
+struct DatabaseOnboardingTests {
+
+    // MARK: - Helpers
+
+    private static func makeActivity(
+        index: Int = 0,
+        kind: Activity.Kind,
+        state: Activity.State = .completed
+    ) -> Activity {
+        Activity(
+            id: .testMint(index: index),
+            state: state,
+            kind: kind,
+            title: "Activity",
+            exchangedFiat: .mockOne,
+            date: .now,
+            metadata: nil
+        )
+    }
+
+    // MARK: - hasEverAddedMoney
+
+    @Test(
+        "hasEverAddedMoney is true for every completed incoming-money kind",
+        arguments: [Activity.Kind.bought, .deposited, .received, .distributed]
+    )
+    func hasEverAddedMoney_incomingKinds(kind: Activity.Kind) throws {
+        let (db, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+
+        #expect(try db.hasEverAddedMoney() == false)
+
+        try db.insertActivities(activities: [Self.makeActivity(kind: kind)])
+
+        #expect(try db.hasEverAddedMoney() == true)
+    }
+
+    @Test(
+        "hasEverAddedMoney ignores outgoing and same-wallet kinds",
+        arguments: [Activity.Kind.gave, .withdrew, .cashLink, .paid, .sold, .swapped]
+    )
+    func hasEverAddedMoney_nonIncomingKinds(kind: Activity.Kind) throws {
+        let (db, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+
+        try db.insertActivities(activities: [Self.makeActivity(kind: kind)])
+
+        #expect(try db.hasEverAddedMoney() == false)
+    }
+
+    @Test("hasEverAddedMoney ignores a pending deposit until it completes")
+    func hasEverAddedMoney_pendingDoesNotCount() throws {
+        let (db, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+
+        try db.insertActivities(activities: [
+            Self.makeActivity(kind: .deposited, state: .pending),
+        ])
+        #expect(try db.hasEverAddedMoney() == false)
+
+        // Same id, now settled — the upsert flips the stored state.
+        try db.insertActivities(activities: [
+            Self.makeActivity(kind: .deposited, state: .completed),
+        ])
+        #expect(try db.hasEverAddedMoney() == true)
+    }
+
+    @Test("hasEverAddedMoney sees a tip received alongside outgoing history")
+    func hasEverAddedMoney_tipAmongOutgoing() throws {
+        let (db, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+
+        try db.insertActivities(activities: [
+            Self.makeActivity(index: 1, kind: .gave),
+            Self.makeActivity(index: 2, kind: .withdrew),
+            Self.makeActivity(index: 3, kind: .received),
+        ])
+
+        #expect(try db.hasEverAddedMoney() == true)
+    }
+}


### PR DESCRIPTION
The wallet tab wasn't reacting to incoming transactions: adding money left the onboarding funnel's **Add Money** cell unchecked, and the transaction didn't show up in **Recents** right away.

## Causes

Four separate ones, all landing in the same bucket:

1. **The milestones rode the wrong trigger.** `hasAddedMoney`/`hasTipped` were computed inside `snapshot()`, so they only re-read on a `session.balances` or `rate` change. A deposit's activity row lands *after* the balance rise, so the milestone read was reliably stale and the funnel cell never checked itself off.
2. **The DB-change handler ignored them.** `.databaseDidChange` only reloaded `recentActivities`.
3. **History was barely synced.** Only on `WalletScreen.onAppear` — which under the native `TabView` fires *once per launch*, because tabs stay alive behind sheets and behind the other tabs — plus `updatePostTransaction()`. The 10s poller fetches flags/limits/balance but **not** history, so an activity arriving on its own was never pulled.
4. **The criteria were too narrow.** `hasEverAddedMoney()` matched only `.deposited` and `.bought`.

## Changes

- **`Database+Onboarding.swift`** — incoming kinds widened to `.bought`, `.deposited`, `.received`, `.distributed`. `.received` is the tip-received kind (`ActivityRow.swift:95` renders it "Tip from …"); `.distributed` is a pool payout, which `ActivityRow` already signs `+`. `.sold`/`.swapped` stay excluded — they move value between tokens the user already holds rather than adding any.
- **`WalletScreen.swift`** — history-derived state (recent preview + both milestones) moved out of `snapshot()` into `reloadHistoryState()`, driven by `.databaseDidChange` and diff-guarded before animating. `historyController.sync()` now also fires on a `session.balances` change, not just `onAppear`. Init seeds the three values from their own reads instead of the balance snapshot.
- **`Session.swift`** — `didBecomeActive()` syncs history, so a tip or a settled deposit that landed while backgrounded appears on foreground instead of waiting for the user's next transaction of their own.
- **`Database+OnboardingTests.swift`** — new Swift Testing suite: every incoming kind, every excluded kind, the pending→completed transition, and a tip buried among outgoing history.

The wallet grid tiles stay gated behind `hasAddedMoney` — unchanged.

## Cross-platform

Android's `MessageDao.hasEverAddedMoney()` currently matches only `DepositedCrypto` OR `BoughtToken`. **Android is being updated to match** this wider criteria.
