### PR TITLE
feat(give): give Dollars in tips, chat, and the Cash tab on the new UI

### DIFF
--- a/.claude/reflections/2026-02-06-give-flow-currency-selection.md
+++ b/.claude/reflections/2026-02-06-give-flow-currency-selection.md
@@ -41,3 +41,20 @@ Added back a fallback to `availableBalances.first` but forgot to sync the fallba
 4. **The smallest fix is usually the best fix.** One new method + one call site vs. restructuring the entire presentation flow.
 5. **When setting local state, check if shared state needs to sync too.** `selectedBalance` (local) and `ratesController.selectedTokenMint` (shared) must agree, or different UI components will show inconsistent state (toolbar vs. selection sheet).
 6. **"Trust the existing system" doesn't mean "assume it handles your specific case."** `ensureValidTokenSelection` is correct for its purpose, but the Give flow has additional constraints (no USDF) that the global selector doesn't know about.
+
+## Update (2026-08-20)
+
+Give/send/tip excludes USDF only on the old UI now. Dollars give ships with
+`BetaFlags.newUI` — its entry point is the Give tile on the Dollars card, which
+only the new currency-info layout draws — so the filter is a parameter rather
+than a constant: `giveable(includingDollars:)`,
+`Session.hasGiveableBalance(for:includingDollars:)`,
+`giveCashGate(session:rate:includingDollars:)`, and
+`RatesController.resolveInitialBalance(mint:session:includingDollars:)` all take
+it, and every call site passes `BetaFlags.shared.allowsDollarsGive`.
+
+The trap this reflection records still stands either way: `ensureValidTokenSelection`
+parks the global selection on the highest balance, which is routinely USDF, so
+`resolveInitialBalance` still declines to read a USDF selection as an intentional
+choice and prefers a community currency, falling back to Dollars only when there
+is nothing else and Dollars is giveable.

--- a/Flipcash/Core/Controllers/BetaFlags.swift
+++ b/Flipcash/Core/Controllers/BetaFlags.swift
@@ -41,6 +41,15 @@ class BetaFlags {
         options.contains(option)
     }
     
+    /// Whether Dollars (USDF) can be given, sent, or tipped like a community
+    /// currency. Dollars give ships with the new UI: its only entry point is the
+    /// Give tile on the Dollars card, which the new currency-info layout alone
+    /// draws, so on the old UI a Dollars row in a give picker would offer a
+    /// currency the rest of that UI never gives.
+    var allowsDollarsGive: Bool {
+        hasEnabled(.newUI)
+    }
+
     /// Enables or disables a beta flag and persists the change to disk.
     func set(_ option: Option, enabled: Bool) {
         if enabled {

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -273,7 +273,7 @@ struct DeepLinkAction {
                 Analytics.deeplinkRouted(kind: kind)
                 if sheet == .give {
                     let rate = container.ratesController.rateForBalanceCurrency()
-                    let gate = giveCashGate(session: container.session, rate: rate)
+                    let gate = giveCashGate(session: container.session, rate: rate, includingDollars: BetaFlags.shared.allowsDollarsGive)
                     if let dialog = gate.blockingDialog(router: container.appRouter, addMoneySource: .giveShortfall) {
                         container.session.dialogItem = dialog
                         return

--- a/Flipcash/Core/Controllers/RatesController.swift
+++ b/Flipcash/Core/Controllers/RatesController.swift
@@ -351,25 +351,34 @@ class RatesController {
         selectedTokenMint == mint
     }
 
-    /// The balance an amount-entry flow (Send, Give) should open with. An
+    /// The balance an amount-entry flow (Send, Give, Tip) should open with. An
     /// explicit `mint` wins; otherwise the current selection when it's giveable,
-    /// else the highest-value giveable balance — the fallback covers a stale or
-    /// USDF selection.
-    func resolveInitialBalance(mint: PublicKey?, session: Session) -> ExchangedBalance? {
+    /// else the highest-value giveable balance — the fallback covers a stale
+    /// selection.
+    ///
+    /// The auto-pick prefers a community currency and only lands on Dollars when
+    /// there's nothing else: `Session.ensureValidTokenSelection` parks the global
+    /// selection on the highest balance, which is routinely USDF, so treating it
+    /// as an intentional Dollars choice would open every flow in Dollars. Where
+    /// Dollars isn't giveable at all it can't be auto-picked either, so a
+    /// Dollars-only account resolves to nothing.
+    ///
+    /// - Parameter includingDollars: `BetaFlags.allowsDollarsGive`.
+    func resolveInitialBalance(mint: PublicKey?, session: Session, includingDollars: Bool) -> ExchangedBalance? {
         let rate = rateForBalanceCurrency()
 
         if let mint, let stored = session.balance(for: mint) {
             return stored.exchanged(with: rate)
         }
 
-        let giveable = session.balances(for: rate).giveable
+        let giveable = session.balances(for: rate).giveable(includingDollars: includingDollars)
 
-        if let stored = selectedTokenMint,
+        if let stored = selectedTokenMint, stored != .usdf,
            let match = giveable.first(where: { $0.stored.mint == stored }) {
             return match
         }
 
-        return giveable.first
+        return giveable.first { $0.stored.mint != .usdf } ?? giveable.first
     }
 
     /// Prepare for logout of current user

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -318,7 +318,7 @@ struct ConversationScreen: View {
         case .contact: .giveCash
         }
         let rate = ratesController.rateForBalanceCurrency()
-        if let dialog = giveCashGate(session: session, rate: rate).blockingDialog(router: router, addMoneySource: .chat, context: context) {
+        if let dialog = giveCashGate(session: session, rate: rate, includingDollars: BetaFlags.shared.allowsDollarsGive).blockingDialog(router: router, addMoneySource: .chat, context: context) {
             session.dialogItem = dialog
             return
         }

--- a/Flipcash/Core/Screens/Main/AddMoney/AddMoneyGate.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/AddMoneyGate.swift
@@ -44,30 +44,37 @@ func shouldAddMoneyBeforeLaunch(session: some LaunchBalanceReading, launchCost: 
 }
 
 /// The balance inputs the give/send cash gate needs — `USDFReserveReading`
-/// plus the community-currency predicate.
+/// plus the giveable-balance predicate.
 @MainActor
 protocol GiveBalanceReading: USDFReserveReading {
-    func hasGiveableBalance(for rate: Rate) -> Bool
+    func hasGiveableBalance(for rate: Rate, includingDollars: Bool) -> Bool
 }
 
 extension Session: GiveBalanceReading {}
 
-/// Where a "give cash" entry (Cash tab, in-chat Send, give deeplink) routes.
+/// Where a "give cash" entry (Cash tab, in-chat Send, tip sheet, give deeplink)
+/// routes.
 enum GiveCashGate: Equatable {
-    /// Community currency on hand.
+    /// Something spendable on hand — a community currency, or Dollars when the
+    /// new UI has them giveable.
     case proceed
-    /// USDF but no community currency.
+    /// Dollars on hand but nothing this UI can give (old UI only).
     case discoverCurrencies
     /// No balance at all.
     case addMoney
 }
 
-/// Returns where a give-cash entry routes given the user's balances. USDF
+/// Returns where a give-cash entry routes given the user's balances. Every mint
 /// counts only at displayable value, so the prompt agrees with the balance the
-/// wallet renders.
+/// wallet renders. `includingDollars` is `BetaFlags.allowsDollarsGive`.
 @MainActor
-func giveCashGate(session: some GiveBalanceReading, rate: Rate) -> GiveCashGate {
-    if session.hasGiveableBalance(for: rate) { return .proceed }
+func giveCashGate(session: some GiveBalanceReading, rate: Rate, includingDollars: Bool) -> GiveCashGate {
+    if session.hasGiveableBalance(for: rate, includingDollars: includingDollars) { return .proceed }
+
+    // Old UI only: Dollars is on hand but isn't giveable there, so point at
+    // Discover — the user has money, just nothing this UI can give. Once
+    // Dollars is giveable the branch is unreachable, since a displayable
+    // Dollars balance has already proceeded above.
     let hasUSDF = session.balance(for: .usdf)?
         .computeExchangedValue(with: rate)
         .hasDisplayableValue() ?? false

--- a/Flipcash/Core/Screens/Main/BalanceScreen.swift
+++ b/Flipcash/Core/Screens/Main/BalanceScreen.swift
@@ -255,11 +255,16 @@ struct ExchangedBalance: Identifiable, Hashable {
 
 extension Array where Element == ExchangedBalance {
 
-    /// Balances eligible to send or give — every balance except USDF, the
-    /// on-Flipcash stablecoin. Dollars give is reached directly from the Dollars
-    /// card (new UI), not through this generic list.
-    var giveable: [ExchangedBalance] {
-        filter { $0.stored.mint != .usdf }
+    /// Balances eligible to give, send, or tip. Dollars appears only when
+    /// `includingDollars` — see `BetaFlags.allowsDollarsGive` — and only when it
+    /// carries a displayable value: `balances(for:)` keeps USDF at any value so
+    /// the wallet can render a zero Dollars card, and an amount-entry picker has
+    /// no use for a balance that can't fund anything.
+    func giveable(includingDollars: Bool) -> [ExchangedBalance] {
+        filter { balance in
+            guard balance.stored.mint == .usdf else { return true }
+            return includingDollars && balance.exchangedFiat.hasDisplayableValue()
+        }
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
@@ -26,6 +26,7 @@ final class BuyConfirmationViewModel {
     private(set) var targetImageURL: URL?
 
     @ObservationIgnored private var hasCheckedFundsOnAppear = false
+    @ObservationIgnored private let collectsUSDFFee: Bool
 
     var isUSDF: Bool { payment.mint == .usdf }
 
@@ -37,7 +38,7 @@ final class BuyConfirmationViewModel {
 
     /// New-UI USDF reserves buys collect a 1% fee (split off on-chain via the
     /// server's fee destination). Old UI leaves the reserves buy fee-free.
-    private var chargesUSDFFee: Bool { isUSDF && BetaFlags.shared.hasEnabled(.newUI) }
+    private var chargesUSDFFee: Bool { isUSDF && collectsUSDFFee }
 
     /// Whether a fee row is shown and collected. Token-funded buys always carry
     /// the implicit sell fee; USDF buys only in the new UI.
@@ -72,12 +73,22 @@ final class BuyConfirmationViewModel {
         return isUSDF ? paymentAmount.adding(fee) : paymentAmount
     }
 
-    init(targetMint: PublicKey, targetName: String, payment: StoredBalance, paymentAmount: ExchangedFiat, pinnedState: VerifiedState) {
+    /// Injected rather than read from `BetaFlags.shared` at each use so both fee
+    /// branches stay testable without mutating the persisted flag.
+    init(
+        targetMint: PublicKey,
+        targetName: String,
+        payment: StoredBalance,
+        paymentAmount: ExchangedFiat,
+        pinnedState: VerifiedState,
+        collectsUSDFFee: Bool = BetaFlags.shared.hasEnabled(.newUI)
+    ) {
         self.targetMint = targetMint
         self.targetName = targetName
         self.payment = payment
         self.paymentAmount = paymentAmount
         self.pinnedState = pinnedState
+        self.collectsUSDFFee = collectsUSDFFee
     }
 
     // MARK: - Actions

--- a/Flipcash/Core/Screens/Main/GiveViewModel.swift
+++ b/Flipcash/Core/Screens/Main/GiveViewModel.swift
@@ -53,7 +53,7 @@ final class GiveViewModel {
     init(container: Container, sessionContainer: SessionContainer, mint: PublicKey?) {
         let session          = sessionContainer.session
         let ratesController  = sessionContainer.ratesController
-        let resolved         = ratesController.resolveInitialBalance(mint: mint, session: session)
+        let resolved         = ratesController.resolveInitialBalance(mint: mint, session: session, includingDollars: BetaFlags.shared.allowsDollarsGive)
 
         self.container        = container
         self.sessionContainer = sessionContainer

--- a/Flipcash/Core/Screens/Main/ScanScreen.swift
+++ b/Flipcash/Core/Screens/Main/ScanScreen.swift
@@ -192,7 +192,7 @@ private struct ScanScreenContent: View {
 
     private func presentGive() {
         let rate = sessionContainer.ratesController.rateForBalanceCurrency()
-        if let dialog = giveCashGate(session: session, rate: rate).blockingDialog(router: router, addMoneySource: .scanner) {
+        if let dialog = giveCashGate(session: session, rate: rate, includingDollars: BetaFlags.shared.allowsDollarsGive).blockingDialog(router: router, addMoneySource: .scanner) {
             session.dialogItem = dialog
             return
         }

--- a/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
+++ b/Flipcash/Core/Screens/Main/SelectCurrencyScreen.swift
@@ -21,7 +21,7 @@ struct SelectCurrencyScreen: View {
 
     private var balances: [ExchangedBalance] {
         session.balances(for: ratesController.rateForBalanceCurrency())
-            .giveable
+            .giveable(includingDollars: BetaFlags.shared.allowsDollarsGive)
     }
 
     init(

--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -214,7 +214,7 @@ final class TipFlow {
             try? await Task.delay(milliseconds: 750)
             guard let self, submission != nil else { return }
             let rate = ratesController.rateForBalanceCurrency()
-            if let dialog = giveCashGate(session: session, rate: rate)
+            if let dialog = giveCashGate(session: session, rate: rate, includingDollars: BetaFlags.shared.allowsDollarsGive)
                 .blockingDialog(router: router, addMoneySource: .scanner, context: .sendTips)?
                 .onDismiss(perform: { [weak self] in self?.cancel() }) {
                 session.dialogItem = dialog

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -78,7 +78,7 @@ final class SendAmountViewModel {
     ) {
         let session          = sessionContainer.session
         let ratesController  = sessionContainer.ratesController
-        let resolved         = ratesController.resolveInitialBalance(mint: mint, session: session)
+        let resolved         = ratesController.resolveInitialBalance(mint: mint, session: session, includingDollars: BetaFlags.shared.allowsDollarsGive)
 
         self.session         = session
         self.ratesController = ratesController

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -197,12 +197,15 @@ class Session {
         return colors
     }
 
-    /// True when the user has at least one non-USDF balance with a displayable
-    /// fiat value. Skips the sort + allocate that `balances(for:)` does, so
-    /// callers gating a presentation pay only the early-exit predicate cost.
-    func hasGiveableBalance(for rate: Rate) -> Bool {
+    /// True when the user has at least one balance with a displayable fiat
+    /// value that a give, send, or tip can spend. Dollars counts only when
+    /// `includingDollars` — see `BetaFlags.allowsDollarsGive`. Skips the sort +
+    /// allocate that `balances(for:)` does, so callers gating a presentation pay
+    /// only the early-exit predicate cost.
+    func hasGiveableBalance(for rate: Rate, includingDollars: Bool) -> Bool {
         updateableBalances.value.contains { stored in
-            stored.mint != .usdf && stored.computeExchangedValue(with: rate).hasDisplayableValue()
+            guard stored.mint != .usdf || includingDollars else { return false }
+            return stored.computeExchangedValue(with: rate).hasDisplayableValue()
         }
     }
     

--- a/FlipcashTests/AddMoneyGateTests.swift
+++ b/FlipcashTests/AddMoneyGateTests.swift
@@ -124,30 +124,40 @@ struct AddMoneyGateTests {
 
     // MARK: - Give / send cash
 
-    @Test("Give gate proceeds when a community currency is on hand")
-    func give_communityCurrency_proceeds() {
+    // `includingDollars` is `BetaFlags.allowsDollarsGive` at every call site:
+    // false on the old UI, which has no Dollars give affordance, true on the new.
+
+    @Test("Give gate proceeds when a community currency is on hand", arguments: [false, true])
+    func give_communityCurrency_proceeds(includingDollars: Bool) {
         let session = MockSession()
         session.giveableBalanceExists = true
-        #expect(giveCashGate(session: session, rate: .oneToOne) == .proceed)
+        #expect(giveCashGate(session: session, rate: .oneToOne, includingDollars: includingDollars) == .proceed)
     }
 
-    @Test("Give gate routes to Discover when only USDF is on hand")
-    func give_usdfOnly_discovers() throws {
+    @Test("Give gate routes to Discover when only Dollars is on hand and Dollars can't be given")
+    func give_usdfOnly_oldUI_discovers() throws {
         let session = MockSession()
         session.usdfReserveBalance = try makeUSDFBalance(quarks: 1_000_000)
-        #expect(giveCashGate(session: session, rate: .oneToOne) == .discoverCurrencies)
+        #expect(giveCashGate(session: session, rate: .oneToOne, includingDollars: false) == .discoverCurrencies)
     }
 
-    @Test("Give gate routes to Add Money when there is no balance at all")
-    func give_noBalance_addsMoney() {
+    @Test("Give gate proceeds on Dollars alone once Dollars can be given")
+    func give_usdfOnly_newUI_proceeds() throws {
         let session = MockSession()
-        #expect(giveCashGate(session: session, rate: .oneToOne) == .addMoney)
+        session.usdfReserveBalance = try makeUSDFBalance(quarks: 1_000_000)
+        #expect(giveCashGate(session: session, rate: .oneToOne, includingDollars: true) == .proceed)
     }
 
-    @Test("Give gate treats USDF that displays as $0.00 as no balance")
-    func give_dustUSDF_addsMoney() throws {
+    @Test("Give gate routes to Add Money when there is no balance at all", arguments: [false, true])
+    func give_noBalance_addsMoney(includingDollars: Bool) {
+        let session = MockSession()
+        #expect(giveCashGate(session: session, rate: .oneToOne, includingDollars: includingDollars) == .addMoney)
+    }
+
+    @Test("Give gate treats Dollars that displays as $0.00 as no balance", arguments: [false, true])
+    func give_dustUSDF_addsMoney(includingDollars: Bool) throws {
         let session = MockSession()
         session.usdfReserveBalance = try makeUSDFBalance(quarks: 1_000) // $0.001
-        #expect(giveCashGate(session: session, rate: .oneToOne) == .addMoney)
+        #expect(giveCashGate(session: session, rate: .oneToOne, includingDollars: includingDollars) == .addMoney)
     }
 }

--- a/FlipcashTests/Buy/BuyAmountViewModelTests.swift
+++ b/FlipcashTests/Buy/BuyAmountViewModelTests.swift
@@ -63,15 +63,17 @@ struct BuyAmountViewModelTests {
         )
     }
 
-    @Test("Cap is the highest eligible balance")
-    func cap_isHighestBalance() async throws {
-        // USDF $30 dwarfs the small launchpad holding.
+    @Test("Cap follows the default Dollars payment source")
+    func cap_defaultsToDollars() async throws {
+        // Dollars is the default source whenever it's spendable, whatever the
+        // other holdings are worth.
         let container = try await Self.makeContainer(holdings: [
             .init(mint: .usdf, quarks: 30_000_000),
             .init(mint: .makeLaunchpad(address: .jeffy), quarks: 10_000_000_000), // 1 token ≈ $0.01
         ])
         let viewModel = Self.makeViewModel(mint: .usdcAuthority, container: container)
 
+        #expect(viewModel.paymentMint == .usdf)
         #expect(viewModel.maxPossibleAmount.nativeAmount.formatted() == "$30.00")
         #expect(!viewModel.isBalanceEmpty)
         #expect(viewModel.actionTitle == "Next")
@@ -91,19 +93,34 @@ struct BuyAmountViewModelTests {
         #expect(viewModel.maxPossibleAmount.nativeAmount.formatted() == "$5.00")
     }
 
-    @Test("A launchpad balance above USDF drives the cap when it isn't the target")
-    func cap_launchpadCanExceedUSDF() async throws {
-        let jeffyQuarks: UInt64 = 2_000 * 10_000_000_000
+    @Test("Selecting a launchpad source lifts the cap above the Dollars balance")
+    func cap_followsSelectedPaymentSource() async throws {
+        let jeffyQuarks: UInt64 = 2_000 * 10_000_000_000 // ≈ $20 of curve value
         let container = try await Self.makeContainer(holdings: [
             .init(mint: .usdf, quarks: 5_000_000),
             .init(mint: .makeLaunchpad(address: .jeffy), quarks: jeffyQuarks),
         ])
         let viewModel = Self.makeViewModel(mint: .usdcAuthority, container: container)
 
+        #expect(viewModel.maxPossibleAmount.nativeAmount.formatted() == "$5.00")
+
+        viewModel.paymentMint = .jeffy
+
         let jeffyValue = try #require(container.session.balance(for: .jeffy))
             .computeExchangedValue(with: container.ratesController.rateForBalanceCurrency())
         #expect(viewModel.maxPossibleAmount.nativeAmount == jeffyValue.nativeAmount)
         #expect(viewModel.maxPossibleAmount.nativeAmount.value > 5)
+    }
+
+    @Test("Without Dollars the largest eligible balance becomes the source")
+    func defaultSource_fallsBackToLargestBalance() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .makeLaunchpad(address: .jeffy), quarks: 2_000 * 10_000_000_000),
+            .init(mint: .makeLaunchpad(address: .testMint(index: 1)), quarks: 10_000_000_000),
+        ])
+        let viewModel = Self.makeViewModel(mint: .usdcAuthority, container: container)
+
+        #expect(viewModel.paymentMint == .jeffy)
     }
 
     @Test("Zero eligible balance flips the button to Add Money")
@@ -142,8 +159,8 @@ struct BuyAmountViewModelTests {
         #expect(router.presentedSheets.contains(.addMoney(.buyCurrency)))
     }
 
-    @Test("Next pushes the payment-currency step with the validated amount")
-    func next_pushesSelectPaymentCurrency() async throws {
+    @Test("Next pushes the payment confirmation with the validated amount")
+    func next_pushesPaymentConfirmation() async throws {
         let container = try await Self.makeContainer(holdings: [
             .init(mint: .usdf, quarks: 30_000_000),
         ])
@@ -155,7 +172,9 @@ struct BuyAmountViewModelTests {
         viewModel.enteredAmount = "10"
         viewModel.primaryAction(router: router)
 
-        #expect(router[.buy].count == 1)
+        // The push lands after the async pin fetch, not on the calling turn.
+        try await waitUntil(router) { $0[.buy].count == 1 }
+        #expect(viewModel.dialogItem == nil)
     }
 
     @Test("An invalid entered amount does not push")

--- a/FlipcashTests/Buy/BuyConfirmationViewModelTests.swift
+++ b/FlipcashTests/Buy/BuyConfirmationViewModelTests.swift
@@ -71,17 +71,22 @@ struct BuyConfirmationViewModelTests {
         ))
     }
 
+    /// `collectsUSDFFee` is pinned rather than left to `BetaFlags.shared`, whose
+    /// persisted value varies by simulator — every case here states the fee
+    /// branch it means to exercise.
     private static func makeViewModel(
         payment: StoredBalance,
         paymentAmount: ExchangedFiat,
-        pin: VerifiedState
+        pin: VerifiedState,
+        collectsUSDFFee: Bool = false
     ) -> BuyConfirmationViewModel {
         BuyConfirmationViewModel(
             targetMint: .usdcAuthority,
             targetName: "Moony",
             payment: payment,
             paymentAmount: paymentAmount,
-            pinnedState: pin
+            pinnedState: pin,
+            collectsUSDFFee: collectsUSDFFee
         )
     }
 
@@ -190,7 +195,7 @@ struct BuyConfirmationViewModelTests {
 
     // MARK: - USDF variant
 
-    @Test("USDF payments show no fee and amountToBuy equals the payment")
+    @Test("Fee-free USDF payments show no fee and amountToBuy equals the payment")
     func usdfVariant_noFee() async throws {
         let container = try await Self.makeContainer(holdings: [
             .init(mint: .usdf, quarks: 30_000_000),
@@ -202,11 +207,15 @@ struct BuyConfirmationViewModelTests {
         let viewModel = Self.makeViewModel(payment: usdfBalance, paymentAmount: paymentAmount, pin: pin)
 
         #expect(viewModel.isUSDF)
+        #expect(!viewModel.chargesFee)
         #expect(viewModel.amountToBuy == viewModel.paymentAmount)
     }
 
-    @Test("An underfunded USDF payment surfaces the insufficient sheet, without the fee wording")
-    func usdfUnderfunded_showsSheet() async throws {
+    @Test(
+        "An underfunded USDF payment surfaces the insufficient sheet, without the fee wording",
+        arguments: [false, true]
+    )
+    func usdfUnderfunded_showsSheet(collectsUSDFFee: Bool) async throws {
         let container = try await Self.makeContainer(holdings: [
             .init(mint: .usdf, quarks: 630_000), // $0.63
         ])
@@ -214,7 +223,12 @@ struct BuyConfirmationViewModelTests {
         let pin = try #require(await container.ratesController.currentPinnedState(for: .usd, mint: .usdf))
         let paymentAmount = try Self.makePaymentAmount(entered: Decimal(string: "0.74")!, balance: usdfBalance, pin: pin, container: container)
 
-        let viewModel = Self.makeViewModel(payment: usdfBalance, paymentAmount: paymentAmount, pin: pin)
+        let viewModel = Self.makeViewModel(
+            payment: usdfBalance,
+            paymentAmount: paymentAmount,
+            pin: pin,
+            collectsUSDFFee: collectsUSDFFee
+        )
         let router = AppRouter()
         router.present(.balance)
         router.presentNested(.buy(.usdcAuthority))
@@ -224,9 +238,18 @@ struct BuyConfirmationViewModelTests {
         #expect(viewModel.dialogItem?.title == "Insufficient Balance")
         #expect(router[.buy].isEmpty)
 
-        // Buy Maximum recomputes to the full USDF balance (no reserve supply needed).
+        // Buy Maximum spends the whole USDF balance (no reserve supply needed):
+        // the debit lands on the balance, within a rounding quark of it.
         viewModel.buyMaximum(session: container.session)
-        #expect(viewModel.paymentAmount.onChainAmount.quarks == usdfBalance.quarks)
+        #expect(viewModel.grossDebit.onChainAmount.quarks <= usdfBalance.quarks)
+        #expect(viewModel.grossDebit.onChainAmount.quarks >= usdfBalance.quarks - usdfBalance.quarks / 1_000)
+
+        if collectsUSDFFee {
+            // The net purchase shrinks to leave room for the 1% on-top fee.
+            #expect(viewModel.paymentAmount.onChainAmount.quarks < usdfBalance.quarks)
+        } else {
+            #expect(viewModel.paymentAmount.onChainAmount.quarks == usdfBalance.quarks)
+        }
     }
 
     /// Regression: the funds gate must value the balance at the REQUESTED

--- a/FlipcashTests/GiveViewModelTests.swift
+++ b/FlipcashTests/GiveViewModelTests.swift
@@ -435,7 +435,7 @@ struct GiveViewModelTests {
         #expect(container.ratesController.selectedTokenMint == .jeffy)
     }
 
-    @Test("Init with no mint and no prior selection skips USDF and auto-selects a giveable currency")
+    @Test("Init with no mint and no prior selection prefers a community currency over USDF")
     func testInit_NoMint_NoSelection_SkipsUSDF() throws {
         let container = try SessionContainer.makeTest(holdings: [
             .init(mint: .usdf, quarks: 100_000_000_000), // $100k USDF — sorts first
@@ -452,7 +452,7 @@ struct GiveViewModelTests {
         #expect(container.ratesController.selectedTokenMint == .jeffy)
     }
 
-    @Test("Init with a stale USDF global selection still resolves to a giveable currency")
+    @Test("Init with a stale USDF global selection still resolves to a community currency")
     func testInit_NoMint_StaleUSDFSelection_SkipsUSDF() throws {
         let container = try SessionContainer.makeTest(holdings: [
             .init(mint: .usdf, quarks: 100_000_000_000),

--- a/FlipcashTests/ResolveInitialBalanceTests.swift
+++ b/FlipcashTests/ResolveInitialBalanceTests.swift
@@ -1,0 +1,125 @@
+//
+//  ResolveInitialBalanceTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+/// `includingDollars` is `BetaFlags.allowsDollarsGive` at every call site: false
+/// on the old UI, which has no Dollars give affordance anywhere, true on the new.
+@MainActor
+@Suite("RatesController.resolveInitialBalance")
+struct ResolveInitialBalanceTests {
+
+    @Test("A Dollars-only account resolves to Dollars once Dollars can be given")
+    func dollarsOnly_withDollars_resolvesToUSDF() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 25_000_000), // $25
+        ])
+        container.ratesController.selectedTokenMint = nil
+
+        let resolved = container.ratesController.resolveInitialBalance(
+            mint: nil,
+            session: container.session,
+            includingDollars: true
+        )
+
+        #expect(resolved?.stored.mint == .usdf)
+    }
+
+    @Test("A Dollars-only account resolves to nothing while Dollars can't be given")
+    func dollarsOnly_withoutDollars_resolvesToNil() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 25_000_000),
+        ])
+        container.ratesController.selectedTokenMint = nil
+
+        let resolved = container.ratesController.resolveInitialBalance(
+            mint: nil,
+            session: container.session,
+            includingDollars: false
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test("Dollars that displays as $0.00 can't fund anything, so it resolves to nothing")
+    func dollarsDust_resolvesToNil() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 1_000), // $0.001
+        ])
+        container.ratesController.selectedTokenMint = nil
+
+        let resolved = container.ratesController.resolveInitialBalance(
+            mint: nil,
+            session: container.session,
+            includingDollars: true
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test("The auto-pick prefers a community currency over a larger Dollars balance")
+    func autoPick_prefersCommunityCurrency() throws {
+        let container = try makeMixedContainer()
+        container.ratesController.selectedTokenMint = nil
+
+        let resolved = container.ratesController.resolveInitialBalance(
+            mint: nil,
+            session: container.session,
+            includingDollars: true
+        )
+
+        #expect(resolved?.stored.mint == .jeffy)
+    }
+
+    @Test("A parked USDF selection isn't read as an intentional Dollars choice")
+    func staleUSDFSelection_prefersCommunityCurrency() throws {
+        // `Session.ensureValidTokenSelection` parks the global selection on the
+        // highest balance, which is routinely USDF — honoring it would open every
+        // flow in Dollars.
+        let container = try makeMixedContainer()
+        container.ratesController.selectedTokenMint = .usdf
+
+        let resolved = container.ratesController.resolveInitialBalance(
+            mint: nil,
+            session: container.session,
+            includingDollars: true
+        )
+
+        #expect(resolved?.stored.mint == .jeffy)
+    }
+
+    @Test("An explicit mint wins over the auto-pick")
+    func explicitMint_wins() throws {
+        let container = try makeMixedContainer()
+        container.ratesController.selectedTokenMint = nil
+
+        let resolved = container.ratesController.resolveInitialBalance(
+            mint: .usdf,
+            session: container.session,
+            includingDollars: true
+        )
+
+        #expect(resolved?.stored.mint == .usdf)
+    }
+
+    // MARK: - Helpers
+
+    /// $100k of Dollars — which sorts first — alongside a funded community currency.
+    private func makeMixedContainer() throws -> SessionContainer {
+        try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 100_000_000_000),
+            .init(
+                mint: .makeLaunchpad(
+                    address: .jeffy,
+                    supplyFromBonding: 1_000_000 * 10_000_000_000
+                ),
+                quarks: 10 * 10_000_000_000
+            ),
+        ])
+    }
+}

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -78,10 +78,11 @@ struct SendAmountViewModelTests {
 
     // MARK: - Init resolution
 
-    @Test("Init with no mint and no prior selection skips USDF and auto-selects a giveable currency")
+    @Test("Init with no mint and no prior selection prefers a community currency over USDF")
     func testInit_NoMint_NoSelection_SkipsUSDF() throws {
-        // USDF holds the highest value, so the pre-fix resolver auto-selected it;
-        // the giveable filter must skip it and land on the launchpad currency.
+        // USDF is sendable, but it holds the highest value on nearly every
+        // account — auto-picking it would open every send in Dollars, so the
+        // resolver prefers the launchpad currency and keeps Dollars as a fallback.
         let container = try SessionContainer.makeTest(holdings: [
             .init(mint: .usdf, quarks: 100_000_000_000), // $100k USDF — sorts first
             .init(
@@ -97,8 +98,10 @@ struct SendAmountViewModelTests {
         #expect(container.ratesController.selectedTokenMint == .jeffy)
     }
 
-    @Test("Init with a stale USDF global selection still resolves to a giveable currency")
+    @Test("Init with a stale USDF global selection still resolves to a community currency")
     func testInit_NoMint_StaleUSDFSelection_SkipsUSDF() throws {
+        // `ensureValidTokenSelection` parks the global selection on the highest
+        // balance, which is routinely USDF — that isn't an intentional Dollars pick.
         let container = try SessionContainer.makeTest(holdings: [
             .init(mint: .usdf, quarks: 100_000_000_000),
             .init(

--- a/FlipcashTests/SessionTests.swift
+++ b/FlipcashTests/SessionTests.swift
@@ -710,24 +710,36 @@ struct SessionOfflineCacheTests {
 @Suite("Session.hasGiveableBalance")
 struct SessionHasGiveableBalanceTests {
 
-    @Test("Fresh account (USDF at zero) has no giveable balance")
-    func freshAccount_hasNone() throws {
+    // `includingDollars` is `BetaFlags.allowsDollarsGive`: false on the old UI,
+    // which has no Dollars give affordance, true on the new.
+
+    @Test("Fresh account (USDF at zero) has no giveable balance", arguments: [false, true])
+    func freshAccount_hasNone(includingDollars: Bool) throws {
         let container = try SessionContainer.makeTest(holdings: [
             .init(mint: .usdf, quarks: 0),
         ])
-        #expect(container.session.hasGiveableBalance(for: .oneToOne) == false)
+        #expect(container.session.hasGiveableBalance(for: .oneToOne, includingDollars: includingDollars) == false)
     }
 
-    @Test("USDF balance alone is not giveable — USDF is never sent peer-to-peer")
-    func usdfOnly_isNotGiveable() throws {
+    @Test("USDF balance alone is giveable only once Dollars can be given")
+    func usdfOnly_isGiveableWithDollars() throws {
         let container = try SessionContainer.makeTest(holdings: [
             .init(mint: .usdf, quarks: 5 * 10_000_000_000),
         ])
-        #expect(container.session.hasGiveableBalance(for: .oneToOne) == false)
+        #expect(container.session.hasGiveableBalance(for: .oneToOne, includingDollars: true) == true)
+        #expect(container.session.hasGiveableBalance(for: .oneToOne, includingDollars: false) == false)
     }
 
-    @Test("A funded non-USDF balance is giveable")
-    func fundedNonUSDF_isGiveable() throws {
+    @Test("USDF dust that displays as $0.00 is not giveable", arguments: [false, true])
+    func usdfDust_isNotGiveable(includingDollars: Bool) throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 1_000), // $0.001
+        ])
+        #expect(container.session.hasGiveableBalance(for: .oneToOne, includingDollars: includingDollars) == false)
+    }
+
+    @Test("A funded non-USDF balance is giveable", arguments: [false, true])
+    func fundedNonUSDF_isGiveable(includingDollars: Bool) throws {
         let container = try SessionContainer.makeTest(holdings: [
             .init(mint: .usdf, quarks: 0),
             .init(
@@ -738,6 +750,6 @@ struct SessionHasGiveableBalanceTests {
                 quarks: 10 * 10_000_000_000
             ),
         ])
-        #expect(container.session.hasGiveableBalance(for: .oneToOne) == true)
+        #expect(container.session.hasGiveableBalance(for: .oneToOne, includingDollars: includingDollars) == true)
     }
 }

--- a/FlipcashTests/SwapProcessingViewModelTests.swift
+++ b/FlipcashTests/SwapProcessingViewModelTests.swift
@@ -12,12 +12,13 @@ import FlipcashCore
 @MainActor
 struct SwapProcessingViewModelTests {
 
-    @Test("SwapType exposes the reserves, currency-paid, and sell cases")
+    @Test("SwapType exposes the reserves, currency-paid, sell, and convert cases")
     func swapType_exposesExpectedCases() {
-        #expect(SwapType.allCases.count == 3)
+        #expect(SwapType.allCases.count == 4)
         #expect(SwapType.allCases.contains(.buyWithReserves))
         #expect(SwapType.allCases.contains(.buyWithCurrency))
         #expect(SwapType.allCases.contains(.sell))
+        #expect(SwapType.allCases.contains(.convert))
     }
 
     @Test("Processing navigation title reads the trimmed switch for every remaining case")
@@ -30,8 +31,10 @@ struct SwapProcessingViewModelTests {
                 amount: .mockOne
             )
         }
-        #expect(makeViewModel(.buyWithReserves).navigationTitle == "Purchasing TestCoin")
-        #expect(makeViewModel(.buyWithCurrency).navigationTitle == "Purchasing TestCoin")
+        #expect(makeViewModel(.buyWithReserves).navigationTitle == "Buying TestCoin")
+        #expect(makeViewModel(.buyWithCurrency).navigationTitle == "Buying TestCoin")
         #expect(makeViewModel(.sell).navigationTitle == "Selling TestCoin")
+        // Convert spans two currencies, so the title names neither.
+        #expect(makeViewModel(.convert).navigationTitle == "Converting")
     }
 }

--- a/FlipcashTests/TestSupport/MockSession.swift
+++ b/FlipcashTests/TestSupport/MockSession.swift
@@ -188,10 +188,14 @@ final class MockSession:
     /// set, is included automatically in `balances`.
     var extraBalances: [StoredBalance] = []
 
+    /// Whether a non-Dollars balance is on hand. Dollars is weighed separately,
+    /// from `usdfReserveBalance`, so the gate's Dollars routing can be exercised.
     var giveableBalanceExists = false
 
-    func hasGiveableBalance(for rate: Rate) -> Bool {
-        giveableBalanceExists
+    func hasGiveableBalance(for rate: Rate, includingDollars: Bool) -> Bool {
+        if giveableBalanceExists { return true }
+        guard includingDollars else { return false }
+        return usdfReserveBalance?.computeExchangedValue(with: rate).hasDisplayableValue() ?? false
     }
 
     func balance(for mint: PublicKey) -> StoredBalance? {


### PR DESCRIPTION
Dollars give was reachable only from the Dollars card, so the tip sheet, in-chat Send Cash, the Cash-tab give, and the give deeplink all filtered USDF out of the picker — and a Dollars-only account was blocked behind the "No Community Currencies Yet" Discover nudge.

Dollars now counts as a giveable balance in every one of those entries, **but only where the new UI is on**: the old currency-info screen offers Deposit/Withdraw for Dollars and has no give affordance for it at all, so surfacing a Dollars row in an old-UI picker would offer a currency the rest of that UI never gives.

## The gate has one name

```swift
// BetaFlags.swift
var allowsDollarsGive: Bool {
    hasEnabled(.newUI)
}
```

Rather than reading that singleton inside the filters, it's threaded as a parameter — the singleton is off by default in the test host, so a direct read would leave the new-UI path untestable without mutating persisted `UserDefaults` across parallel tests. Four signatures take it, and all six call sites pass `BetaFlags.shared.allowsDollarsGive`:

- `giveable(includingDollars:)` — `BalanceScreen.swift`
- `Session.hasGiveableBalance(for:includingDollars:)`
- `giveCashGate(session:rate:includingDollars:)` — `AddMoneyGate.swift`
- `RatesController.resolveInitialBalance(mint:session:includingDollars:)`

Because `SelectCurrencyScreen` reads `giveable` and all four entry points read `giveCashGate`, that covers the Send a Tip sheet, in-chat Send Cash, the Cash-tab give, and the give deeplink in one stroke.

## Notes

- **Dollars counts only at displayable value.** `Session.balances(for:)` deliberately keeps USDF at *any* value so the wallet can render a zero Dollars card; an amount-entry picker has no use for a balance that can't fund anything, so dust is excluded and a dust-only account still routes to Add Money.
- **The auto-pick still prefers a community currency**, landing on Dollars only when there's nothing else. `ensureValidTokenSelection` parks the global selection on the highest balance, which is routinely USDF — treating that as an intentional Dollars choice would open every flow in Dollars.
- **`GiveCashGate.discoverCurrencies` stays** as the old-UI path. It's structurally unreachable once Dollars is giveable, since a displayable Dollars balance returns `.proceed` before the fallback runs.
- **The payment path needed no work.** `ExchangedBalance+EnteredFiat`, `SendAmountViewModel`, and `Session.send(amount:verifiedState:to:chat:)` were already mint-agnostic with an explicit USDF 1:1 branch.

## Tests

`FlipcashTests` goes from 182 tests / 30 suites to 210 / 33.

- `ResolveInitialBalanceTests` (new) — Dollars-only resolves to Dollars with the flag and to nothing without it; dust resolves to nothing; the auto-pick still prefers a community currency over a larger Dollars balance; a parked USDF selection still isn't read as intentional; an explicit mint still wins.
- `AddMoneyGateTests` — Dollars-only routes to `.discoverCurrencies` at `includingDollars: false` and `.proceed` at `true`; the community-currency, no-balance, and dust cases are parameterized over both.
- `SessionTests` — `hasGiveableBalance` asserted in both directions.
- `MockSession` weighs Dollars from `usdfReserveBalance` instead of stubbing a single `Bool`, so the gate's Dollars routing is actually exercised.

---

## Also here: the Buy/Swap suites, realigned with #604

Five assertions had been failing on `main` since #604 reshaped the Get flow. They're unrelated to Dollars give but were blocking a green run, so they ride along in `33a9d7c`.

- **`SwapProcessingViewModel`** — `SwapType` gained a `convert` case and the buy copy moved from "Purchasing" to "Buying". The surface test still expected three cases and the old wording; it now covers `.convert` → "Converting".
- **`BuyAmountViewModel`** — payment-source selection moved inline, so `maxPossibleAmount` is the *selected* source's balance rather than the largest eligible one, and Next pushes `BuyFlowPath.paymentConfirmation` from an async `Task` instead of a payment-currency step. The cap test drives `paymentMint` directly, the push test waits for the async push, and a new case covers the largest-balance fallback when Dollars isn't held.
- **`BuyConfirmationViewModel`** — this one was environment-dependent rather than stale. `chargesUSDFFee` read `BetaFlags.shared.hasEnabled(.newUI)`, whose persisted value varies by simulator because `applyLaunchArgumentOverrides()` only runs under UI tests; with `.newUI` on, Buy Maximum shrinks the net purchase to leave room for the 1% on-top fee and the full-balance assertion failed. The flag is now injected at `init` (defaulting to the same read, so `BuyConfirmationScreen` is unchanged) and the test is parameterized over both fee branches.
