### PR TITLE
fix(activity): map swap notifications and recover a dead history cursor

### DIFF
--- a/.claude/plans/2026-08-20-missing-convert-activity-rows.md
+++ b/.claude/plans/2026-08-20-missing-convert-activity-rows.md
@@ -1,0 +1,182 @@
+# Missing Convert (swap) activity rows — root cause
+
+## Symptom
+
+Swap/convert support shipped on the backend; no convert rows appear in the iOS
+activity feed. Android shows them.
+
+## Root cause
+
+`flipcash.activity.v1.Notification.payment_amount` is **not populated for
+multi-mint operations**. Upstream commit `0f97593` (flipcash2-protobuf-api #82)
+added `swapped_crypto = 14` and, in the *same* commit, added this note to
+`payment_amount`:
+
+> Note: For multi-mint operations, amounts are carried in additional_metadata
+> (eg. swapped_crypto).
+
+iOS treats `payment_amount` as mandatory:
+
+- `Activity.init(_:)` — `exchangedFiat: try ExchangedFiat(proto.paymentAmount)`
+- `ExchangedFiat.init(_ proto: Flipcash_Common_V1_CryptoPaymentAmount)` throws
+  `CurrencyCode.Error.notFound` on the empty `currency` of a proto3 default
+  message, before that `KeyError.invalidKey` on the 0-byte mint.
+
+So every `swapped_crypto` notification throws during mapping, and
+`ActivityService` drops it:
+
+```swift
+let activities = response.notifications.compactMap {
+    do { return try Activity($0) }
+    catch { logger.error("Failed to parse activity", ...); return nil }
+}
+```
+
+The row never reaches the database, so it is absent from both the per-mint
+history and the cross-mint recent list.
+
+Android is immune — it models the field as optional:
+
+```kotlin
+amount = from.paymentAmountOrNull?.let { localFiatOf(it) },   // nullable
+```
+
+## Fix
+
+Resolve the display amount from the metadata when `payment_amount` is absent,
+falling back to the swap's source (`from`) leg — which is exactly what
+`SwapMetadata.fromFiat` documents as "the amount the row displays".
+
+## Not the cause (ruled out)
+
+- **User-agent gate.** The build reports `Flipcash/iOS/2026.8.2`
+  (`CFBundleShortVersionString` 2026.8.2, build 272).
+  `UserAgentClientInterceptor` is registered on every client, and neither
+  grpc-swift-2 2.4.x nor grpc-swift-nio-transport sets a user-agent of its own,
+  so the header reaches the wire unmodified.
+- **Proto drift.** `activity/v1/model.proto` is byte-identical (modulo
+  language `option` lines) to Android's vendored copy and to upstream HEAD.
+- **Rendering.** `ActivityRow` already handles `.swapped` (overlapping from/to
+  coin avatars, `fromFiat` over a `-fee Fee` subtitle).
+- **Kind/metadata mapping.** `Activity.Kind.swapped` and
+  `Activity.SwapMetadata.init` both map `swapped_crypto` correctly — they are
+  simply never reached, because the amount is parsed first.
+
+## Why tests didn't catch it
+
+Every case in `ActivityProtoMappingTests` calls
+`proto.paymentAmount = Self.basePaymentAmount()`. No case covered an unset
+`payment_amount`.
+
+## Related defects found (not fixed here)
+
+1. `Activity.Metadata.init` returns `nil` for `.withdrewCrypto`, dropping the
+   new `WithdrewCryptoNotificationMetadata.swap_metadata`. Android maps it.
+2. `Database+Activities.getActivities(mint:)` filters `WHERE a.mint = ?` against
+   the payment-amount-derived mint, so a two-mint swap can only ever appear in
+   one token's history (the source token, after this fix).
+3. `Database+Activities.makeActivity` force-unwraps
+   `Activity.Kind(rawValue: row[a.kind])!` — a future server-side kind
+   persisted by a newer build would crash an older one.
+4. `HistoryController.syncHistory` advances its paging cursor from
+   `activities.last?.id` *after* the drop-on-parse-failure `compactMap`, so a
+   trailing unparseable notification silently rewinds/stalls the cursor.
+
+---
+
+## Second, currently-dominant cause: the server 500s on `GetPagedNotifications`
+
+Found after installing the fixed build on a logged-in simulator. The client-side
+mapping fix above is necessary but **not sufficient** — history sync is dead
+before parsing is ever reached.
+
+`ActivityService` swallowed the RPC error detail, so this was invisible. Added
+structured logging on the `RPCError` catch, which produced:
+
+```
+flipcash.activity-service Transaction history RPC failed cause=nil code=internalError message=
+flipcash.history-controller Sync failed error=unknown
+```
+
+Deterministic: 3 attempts per launch, 2 launches, always the same cursor
+(`FdBo…WVfs`), always gRPC `INTERNAL`.
+
+`cause=nil` with an empty `message` means this is a **status returned by the
+server**, not a client-side deserialization failure — grpc-swift-2 populates
+`message`/`cause` when it fails to decode a response itself.
+
+Every other RPC on the same channel and auth succeeds in the same launch
+(settings, user flags, profiles, event stream, phone linking), so this is not
+connectivity, auth, or transport.
+
+**Consequence:** no new activity of *any* kind has been ingested since that
+cursor — the local DB still holds 1427 rows, kinds `1,2,3,4,5,8,9`, zero kind 10
+(`swapped`), newest entries still the deprecated `bought`/`sold` pairs.
+
+### Root cause: the swap migration orphaned the stored paging cursor
+
+Confirmed by the user: **transactions older than today were dropped as part of
+the migration/deploy that added swap support.**
+
+That closes the chain:
+
+1. The migration deleted historical notifications server-side.
+2. iOS persists a paging cursor that *is* a notification id —
+   `HistoryController.syncDeltaHistory` reads `database.getLatestActivityID()`
+   and passes it as `query_options.paging_token`.
+3. That id now names a deleted notification. The server cannot resolve the
+   token and fails the request with `INTERNAL` rather than ignoring it.
+4. `syncDeltaHistory` had **no recovery** — it always started from the stored
+   cursor, so every subsequent sync failed identically and *no* activity of any
+   kind was ever ingested again, the new convert rows included.
+
+This is why the mapping fix alone changed nothing: the swap notifications never
+reached the parser.
+
+### Why Android is immune
+
+Android never depends on a stored id staying resolvable:
+
+- `FeedRemoteMediator` uses `loadKey = null` for `LoadType.REFRESH` and calls
+  `dataSource.clear()` on that path — a refresh re-seeds from the top.
+- `ActivityFeedCoordinator.fetchSinceLatest` falls back to
+  `descending = latest == null`, i.e. it re-seeds when there is no local latest.
+
+So a dropped cursor costs Android one refresh; on iOS it was terminal.
+
+### Fix
+
+`ErrorFetchTransactionHistory.warrantsFullResync` classifies server-side
+failures (`.unknown`, `.rejected`) as recoverable-by-restart, and
+`HistoryController.syncDeltaHistory` catches those and retries the whole sync
+with no cursor. Transport failures and cancellation deliberately do *not*
+trigger a full refetch — those are transient and refetching all of history
+would be wasteful.
+
+### Stale local rows: `SQLiteVersion` bumped 32 → 33
+
+The activity table is upsert-only — `Database+Activities.insertActivity` writes
+with `onConflictOf: table.id`, and the table has no delete path at all (unlike
+conversations, blocklist, and contact sync). Sync can add and update rows by id
+but can never learn that a row was removed server-side.
+
+So a resync alone would insert the server's current history *alongside* the
+~1427 pre-migration rows already stored, and those would linger forever as
+rows for transactions the backend no longer has — an upgraded install showing a
+longer history than a fresh install of the same account.
+
+Bumping `SQLiteVersion` is the codebase's existing remedy for exactly this:
+`SessionAuthenticator.initializeDatabase` deletes the store and rebuilds from
+the server whenever the plist value exceeds the stored user version ("Currently
+we don't do migrations so every time the user version is outdated, we'll
+rebuild the database during sync"). Cost is a full re-sync on first launch
+after upgrade.
+
+### Also ruled out this session
+
+- **User-agent version gate.** Both platforms send `2026.8.2`
+  (Android `Packaging.kt`: `majorVersion = 2026, minorVersion = 8,
+  patchVersion = 2`). Only the platform token differs (`iOS` vs `Android`).
+- **Request shape.** Android's `asQueryOptions()` builds the same
+  order + pageSize + pagingToken triple. Page size differs (iOS 1024 vs
+  Android ≤100) but that was not the explanation.

--- a/Flipcash/Core/Controllers/HistoryController.swift
+++ b/Flipcash/Core/Controllers/HistoryController.swift
@@ -117,9 +117,26 @@ class HistoryController {
         return true
     }
 
+    /// Syncs everything newer than the latest locally-stored activity.
+    ///
+    /// The stored cursor is a server notification id, and the server can drop
+    /// the notification it names — a history migration does exactly that. It
+    /// then fails the request rather than ignoring the dead token, which would
+    /// wedge every later sync on the same cursor, so a server-side failure
+    /// falls back to a full resync.
     private func syncDeltaHistory() async throws -> Bool {
-        let latestID = try database.getLatestActivityID()
-        return try await syncHistory(since: latestID)
+        guard let latestID = try database.getLatestActivityID() else {
+            return try await syncHistory()
+        }
+        do {
+            return try await syncHistory(since: latestID)
+        } catch let error as ErrorFetchTransactionHistory where error.warrantsFullResync {
+            logger.warning("Delta sync failed, resyncing full history", metadata: [
+                "cursor": "\(latestID.base58)",
+                "error": "\(error)",
+            ])
+            return try await syncHistory()
+        }
     }
 
     private func syncHistory(since id: PublicKey? = nil) async throws -> Bool {

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 		<string>com.flipcash.app.openChat</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>32</integer>
+	<integer>33</integer>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ActivityService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ActivityService.swift
@@ -58,8 +58,14 @@ final class ActivityService: Sendable {
                 logger.info("Fetched activities", metadata: ["count": "\(activities.count)"])
                 await MainActor.run { completion(.success(activities)) }
             } catch let error as RPCError {
+                logger.error("Transaction history RPC failed", metadata: [
+                    "code": "\(error.code)",
+                    "message": "\(error.message)",
+                    "cause": "\(String(describing: error.cause))",
+                ])
                 await MainActor.run { completion(.failure(.from(transportError: error))) }
             } catch {
+                logger.error("Transaction history call threw", metadata: ["error": "\(error)"])
                 await MainActor.run { completion(.failure(.unknown)) }
             }
         }
@@ -93,8 +99,14 @@ final class ActivityService: Sendable {
                 logger.info("Fetched activities by ID", metadata: ["count": "\(activities.count)"])
                 await MainActor.run { completion(.success(activities)) }
             } catch let error as RPCError {
+                logger.error("Transaction history batch RPC failed", metadata: [
+                    "code": "\(error.code)",
+                    "message": "\(error.message)",
+                    "cause": "\(String(describing: error.cause))",
+                ])
                 await MainActor.run { completion(.failure(.from(transportError: error))) }
             } catch {
+                logger.error("Transaction history batch call threw", metadata: ["error": "\(error)"])
                 await MainActor.run { completion(.failure(.unknown)) }
             }
         }
@@ -120,6 +132,22 @@ public enum ErrorFetchTransactionHistoryItemsByID: Int, Error {
     case transportFailure = -2
     case cancelled = -3
     case rejected = -4
+}
+
+extension ErrorFetchTransactionHistory {
+    /// Whether a failed paged fetch should be retried from the start of
+    /// history. A stored paging cursor names a notification the server can
+    /// later drop, and it rejects the dead token with a server-side failure
+    /// rather than ignoring it — leaving a delta sync permanently stuck
+    /// unless it starts over with no cursor.
+    public var warrantsFullResync: Bool {
+        switch self {
+        case .unknown, .rejected:
+            true
+        case .ok, .denied, .transportFailure, .cancelled:
+            false
+        }
+    }
 }
 
 extension ErrorFetchTransactionHistory: ServerError, TransportClassifiableError {

--- a/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Activity.swift
@@ -213,12 +213,31 @@ extension Activity {
                 template: proto.localizedText,
                 resolutions: substitutions.map(\.fallback)
             ),
-            exchangedFiat: try ExchangedFiat(proto.paymentAmount),
+            exchangedFiat: try ExchangedFiat(Self.displayAmount(of: proto)),
             date: proto.ts.date,
             metadata: .init(proto.additionalMetadata),
             textSubstitutions: substitutions,
             counterparty: .init(proto.additionalMetadata)
         )
+    }
+
+    /// The amount the activity renders. `payment_amount` is unset for multi-mint
+    /// operations — the contract carries those amounts in `additional_metadata`
+    /// instead — so a swap falls back to its source leg.
+    private static func displayAmount(
+        of proto: Flipcash_Activity_V1_Notification
+    ) -> Flipcash_Common_V1_CryptoPaymentAmount {
+        guard !proto.hasPaymentAmount else { return proto.paymentAmount }
+
+        switch proto.additionalMetadata {
+        case .swappedCrypto(let metadata):
+            return metadata.from
+        case .withdrewCrypto(let metadata) where metadata.hasSwapMetadata:
+            return metadata.swapMetadata.from
+        case .directlySentCrypto, .receivedCrypto, .withdrewCrypto, .indirectlySentCrypto,
+             .depositedCrypto, .boughtCrypto, .soldCrypto, .none:
+            return proto.paymentAmount
+        }
     }
 }
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/ActivityHistoryResyncTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ActivityHistoryResyncTests.swift
@@ -1,0 +1,44 @@
+//
+//  ActivityHistoryResyncTests.swift
+//  FlipcashCoreTests
+//
+
+import Testing
+import GRPCCore
+@testable import FlipcashCore
+
+@Suite("Paged history resync classification")
+struct ActivityHistoryResyncTests {
+
+    // A stored paging cursor names a notification the server may later drop
+    // (a history migration does exactly that). The server rejects the dead
+    // token with a server-side failure rather than ignoring it, so the only
+    // way a delta sync recovers is to start over with no cursor.
+
+    @Test("A server-side failure warrants restarting history from the beginning")
+    func serverFailureWarrantsResync() {
+        #expect(ErrorFetchTransactionHistory.unknown.warrantsFullResync)
+        #expect(ErrorFetchTransactionHistory.rejected.warrantsFullResync)
+    }
+
+    @Test("The INTERNAL a dead paging token produces classifies as resyncable")
+    func serverInternalWarrantsResync() {
+        // The observed failure: the swap migration dropped the notification the
+        // stored cursor named, and the server answered the token with INTERNAL.
+        let error = ErrorFetchTransactionHistory.from(
+            transportError: RPCError(code: .internalError, message: "")
+        )
+        #expect(error == .unknown)
+        #expect(error.warrantsFullResync)
+    }
+
+    @Test("Transient and terminal outcomes do not warrant a full resync")
+    func otherOutcomesDoNotResync() {
+        // Refetching all of history would be wasteful for a dropped
+        // connection or a cancelled task, and pointless when denied.
+        #expect(!ErrorFetchTransactionHistory.transportFailure.warrantsFullResync)
+        #expect(!ErrorFetchTransactionHistory.cancelled.warrantsFullResync)
+        #expect(!ErrorFetchTransactionHistory.denied.warrantsFullResync)
+        #expect(!ErrorFetchTransactionHistory.ok.warrantsFullResync)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ActivityProtoMappingTests.swift
@@ -263,4 +263,74 @@ struct ActivityProtoMappingTests {
             _ = try Activity(proto)
         }
     }
+
+    // MARK: Swap notifications without a top-level payment amount
+
+    // The contract documents `payment_amount` as absent for multi-mint
+    // operations — those amounts are carried in `additional_metadata` instead.
+    // A swap notification must therefore still map with no top-level amount.
+
+    @Test("swappedCrypto without a top-level paymentAmount still maps, deriving the amount from the From leg")
+    func swappedWithoutPaymentAmount() throws {
+        let fromMintBytes = Data(repeating: 7, count: 32)
+        let toMintBytes   = Data(repeating: 9, count: 32)
+
+        var swapped = Flipcash_Activity_V1_SwappedCryptoNotificationMetadata()
+        swapped.from.mint.value   = fromMintBytes
+        swapped.from.quarks       = 5_000_000
+        swapped.from.nativeAmount = 5.0
+        swapped.from.currency     = "usd"
+
+        var toAmount = Flipcash_Common_V1_CryptoPaymentAmount()
+        toAmount.mint.value   = toMintBytes
+        toAmount.quarks       = 100_000_000
+        toAmount.nativeAmount = 4.95
+        toAmount.currency     = "usd"
+        swapped.to = .toAmount(toAmount)
+
+        swapped.fee.nativeAmount = 0.05
+        swapped.fee.currency     = "usd"
+        swapped.swapState        = .succeeded
+
+        var proto = Flipcash_Activity_V1_Notification()
+        proto.id.value      = Self.notificationId
+        proto.localizedText = "Converted"
+        proto.state         = .completed
+        proto.additionalMetadata = .swappedCrypto(swapped)
+        // Deliberately no `proto.paymentAmount`.
+
+        let activity = try Activity(proto)
+
+        #expect(activity.kind == .swapped)
+        #expect(activity.exchangedFiat.mint == (try PublicKey(fromMintBytes)))
+        #expect(activity.exchangedFiat.onChainAmount.quarks == 5_000_000)
+        #expect(activity.exchangedFiat.nativeAmount.value == Decimal(5.0))
+        #expect(activity.swapMetadata?.toQuarks == 100_000_000)
+    }
+
+    @Test("A pending swap without a top-level paymentAmount still maps")
+    func pendingSwapWithoutPaymentAmount() throws {
+        var swapped = Flipcash_Activity_V1_SwappedCryptoNotificationMetadata()
+        swapped.from.mint.value   = Self.mintBytes
+        swapped.from.quarks       = 1_000_000
+        swapped.from.nativeAmount = 1.0
+        swapped.from.currency     = "usd"
+        swapped.toMint.value      = Self.vaultBytes
+        swapped.fee.nativeAmount  = 0.01
+        swapped.fee.currency      = "usd"
+        swapped.swapState         = .pending
+
+        var proto = Flipcash_Activity_V1_Notification()
+        proto.id.value      = Self.notificationId
+        proto.localizedText = "Converting"
+        proto.state         = .pending
+        proto.additionalMetadata = .swappedCrypto(swapped)
+
+        let activity = try Activity(proto)
+
+        #expect(activity.kind == .swapped)
+        #expect(activity.state == .pending)
+        #expect(activity.exchangedFiat.mint == (try PublicKey(Self.mintBytes)))
+        #expect(activity.swapMetadata?.state == .pending)
+    }
 }


### PR DESCRIPTION
Convert rows never showed up in the activity feed after swap support shipped on the backend. There were two independent causes.

## 1. Swap notifications were dropped during mapping

`payment_amount` is **unset for multi-mint operations** — the contract carries those amounts in `additional_metadata` instead. Upstream `0f97593` added `swapped_crypto` and, in the same commit, this note on `payment_amount`:

> Note: For multi-mint operations, amounts are carried in additional_metadata (eg. swapped_crypto).

iOS treated the field as mandatory. `ExchangedFiat.init` threw `CurrencyCode.Error.notFound` on the empty `currency` of a proto3 default message, and the `compactMap` in `ActivityService` silently swallowed it — so no swap notification ever reached the database.

`Activity.displayAmount(of:)` now resolves the amount from the metadata, falling back to the swap's `from` leg (which `SwapMetadata.fromFiat` already documents as "the amount the row displays").

Android was never affected — it models the field as optional (`paymentAmountOrNull`).

## 2. History sync was wedged on a dead paging cursor

The swap migration dropped transactions older than today. iOS persists a paging cursor that *is* a notification id (`database.getLatestActivityID()`), so that cursor came to name a deleted notification. The server fails the dead token with `INTERNAL` rather than ignoring it, and `syncDeltaHistory` always restarted from the stored cursor — so every sync failed identically and **no activity of any kind was ingested again**, the new convert rows included.

This is why fix #1 alone changed nothing: the swap notifications never reached the parser.

`ErrorFetchTransactionHistory.warrantsFullResync` classifies server-side failures (`.unknown`, `.rejected`) as recoverable-by-restart, and `syncDeltaHistory` falls back to a full sync with no cursor. Transport failures and cancellation deliberately do not trigger a full refetch — those are transient, and refetching all of history would be wasteful.

Android is immune structurally: `FeedRemoteMediator` refreshes with `loadKey = null` plus `dataSource.clear()`, and `fetchSinceLatest` falls back to `descending = latest == null`. A dropped cursor costs Android one refresh; on iOS it was terminal.

## 3. SQLiteVersion 32 to 33

The activity table is upsert-only (`onConflictOf: table.id`) and has no delete path at all, unlike conversations, blocklist, and contact sync. Sync can add and update rows by id but can never learn that a row was removed server-side.

Without a rebuild, a resync would insert the server's current history *alongside* the pre-migration rows already stored (~1427 on the account I inspected), leaving rows for transactions the backend no longer has — an upgraded install showing a longer history than a fresh install of the same account. Bumping the version makes `SessionAuthenticator.initializeDatabase` delete the store and rebuild from the server, which is the codebase's existing remedy for exactly this.

Cost: a full re-sync on first launch after upgrade.

## Also

`ActivityService` now logs RPC failure detail. Cause #2 was invisible precisely because the error was swallowed — the structured log is what made it diagnosable, and it stays.

Full analysis, including four related defects found but deliberately left alone, is recorded in `.claude/plans/2026-08-20-missing-convert-activity-rows.md`.
