### PR TITLE
fix(tipcard): size the card from the design

### DIFF
--- a/Flipcash/Core/Screens/Main/Bill/BillCanvas.swift
+++ b/Flipcash/Core/Screens/Main/Bill/BillCanvas.swift
@@ -29,7 +29,12 @@ struct BillCanvas: UIViewControllerRepresentable {
     /// so callers positioning the card (e.g. clearing the Send a Tip sheet) size
     /// it exactly as the canvas renders it.
     static func tipcardSize(canvasWidth: CGFloat) -> CGSize {
-        let width = min(canvasWidth * 0.82, 320)
+        // 302 is the designed full-screen card (node 9277:121417 draws it 302
+        // wide on a 402 frame), and it's what Android pins. The cap binds on
+        // every regular phone — the canvas is the screen inset by 20 a side —
+        // so the fraction is only the fallback for a canvas too narrow to hold
+        // the designed card.
+        let width = min(canvasWidth * 0.86, 302)
         return CGSize(width: width, height: width * TipcardView.aspectRatio)
     }
     

--- a/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
@@ -13,8 +13,9 @@ import FlipcashUI
 struct TipcardView: View {
 
     /// The card's height-to-width proportion, shared by every surface that
-    /// sizes one.
-    static let aspectRatio: CGFloat = 1.16
+    /// sizes one. From Figma's 269 x 333 card, which holds that proportion both
+    /// on the You page (node 9276:4641) and full screen (node 9277:121417).
+    static let aspectRatio: CGFloat = 333.0 / 269.0
 
     /// Explicit because a rendered tree has no container to size against.
     let size: CGSize

--- a/Flipcash/Core/Screens/Main/You/YouScreen.swift
+++ b/Flipcash/Core/Screens/Main/You/YouScreen.swift
@@ -23,8 +23,9 @@ struct YouScreen: View {
     @State private var previewCache = TipCodePreviewCache()
     @State private var debugTapCount: Int = 0
 
-    /// The on-screen card width; tuned to the Figma placement (card near the top).
-    private static let cardWidth: CGFloat = 230
+    /// The on-screen card width, from the Figma placement: node 9276:4641 draws
+    /// the You card 241.6 wide.
+    private static let cardWidth: CGFloat = 242
     private let rowInsets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
 
     var body: some View {


### PR DESCRIPTION
The tip card was drawn at a 1.16 height-to-width proportion. The design (nodes `9276:4641` and `9277:121417`) draws it at 333/269 = 1.2379 on both the You page and full screen, which is what Android already ships — so the two platforms rendered visibly different card shapes.

Both You-page widths were off with it:

| surface | was | now | design |
|---|---|---|---|
| You resting card | 230 | 242 | 241.6 |
| You full screen | `min(canvas * 0.82, 320)` → ~290 | `min(canvas * 0.86, 302)` → 302 | 302.2 |

The full-screen card is sized off `BillCanvas`, whose canvas is the screen inset by 20 a side, so the old 320 cap never bound on a phone and the 0.82 fraction decided the width. It's now pinned to the designed 302, with the fraction left as the fallback for a canvas too narrow to hold that.

`TipcardScreen` ("My Tip Card") keeps its own 300 width and picks up the corrected proportion; it isn't part of the You page.

The card's inner metrics (code size, corner radius, name type scale) still drift from the design on both platforms — that's a separate, cross-platform fix.