### PR TITLE
chore(ui): drop the unreachable sell branch from swap processing

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Swap/SwapProcessingViewModel.swift
@@ -29,8 +29,6 @@ class SwapProcessingViewModel {
                     // Convert names its destination via `currencyName`, so the
                     // same "X of <currency>" reads correctly there too.
                     return "\(exchangedFiat.nativeAmount.formatted()) of \(currencyName)"
-                case .sell:
-                    return "\(exchangedFiat.nativeAmount.formatted()) of USDF"
                 }
             }
             return "Transaction Complete"
@@ -45,7 +43,7 @@ class SwapProcessingViewModel {
             return "This transaction typically takes about a minute. You may leave the app while it completes"
         case .success:
             switch swapType {
-            case .buyWithReserves, .buyWithCurrency, .sell, .convert:
+            case .buyWithReserves, .buyWithCurrency, .convert:
                 return "was just added to your Flipcash wallet"
             }
         case .failed:
@@ -70,8 +68,6 @@ class SwapProcessingViewModel {
             switch swapType {
             case .buyWithReserves, .buyWithCurrency:
                 "Buying \(currencyName)"
-            case .sell:
-                "Selling \(currencyName)"
             case .convert:
                 "Converting"
             }
@@ -94,8 +90,7 @@ class SwapProcessingViewModel {
 
     private let swapId: SwapId
     private let swapType: SwapType
-    /// The token being bought — analytics-only; nil on the sell path, where
-    /// `amount.mint` already names the subject token.
+    /// The token being bought, or a convert's destination — analytics-only.
     private let targetMint: PublicKey?
     private let currencyName: String
     private let amount: ExchangedFiat
@@ -191,8 +186,6 @@ class SwapProcessingViewModel {
             Analytics.tokenPurchase(method: .purchaseWithReserves, targetMint: targetMint, exchangedFiat: amount, successful: successful)
         case .buyWithCurrency:
             Analytics.tokenPurchase(method: .purchaseWithCurrency, targetMint: targetMint, exchangedFiat: amount, successful: successful)
-        case .sell:
-            Analytics.tokenSell(exchangedFiat: amount, successful: successful)
         case .convert:
             // A convert always disposes of the source token; record it as a
             // sell of the amount that left the wallet.
@@ -222,7 +215,6 @@ enum SwapError: Error {
 nonisolated enum SwapType: CaseIterable {
     case buyWithReserves
     case buyWithCurrency
-    case sell
     /// Selling one currency straight into another (source → USDF, or source →
     /// another launchpad token). Drives the "Converting" copy.
     case convert

--- a/FlipcashTests/SwapProcessingViewModelTests.swift
+++ b/FlipcashTests/SwapProcessingViewModelTests.swift
@@ -12,12 +12,11 @@ import FlipcashCore
 @MainActor
 struct SwapProcessingViewModelTests {
 
-    @Test("SwapType exposes the reserves, currency-paid, sell, and convert cases")
+    @Test("SwapType exposes the reserves, currency-paid, and convert cases")
     func swapType_exposesExpectedCases() {
-        #expect(SwapType.allCases.count == 4)
+        #expect(SwapType.allCases.count == 3)
         #expect(SwapType.allCases.contains(.buyWithReserves))
         #expect(SwapType.allCases.contains(.buyWithCurrency))
-        #expect(SwapType.allCases.contains(.sell))
         #expect(SwapType.allCases.contains(.convert))
     }
 
@@ -33,7 +32,6 @@ struct SwapProcessingViewModelTests {
         }
         #expect(makeViewModel(.buyWithReserves).navigationTitle == "Buying TestCoin")
         #expect(makeViewModel(.buyWithCurrency).navigationTitle == "Buying TestCoin")
-        #expect(makeViewModel(.sell).navigationTitle == "Selling TestCoin")
         // Convert spans two currencies, so the title names neither.
         #expect(makeViewModel(.convert).navigationTitle == "Converting")
     }


### PR DESCRIPTION
Stacked on #619 — base it there, not `main`. Merge that first.

#619 deletes the Currency Sell flow outright (`CurrencySellAmountScreen`, `CurrencySellViewModel`, `CurrencySellConfirmationScreen`, `CurrencySellConfirmationViewModel`, and their tests), along with the v1 `LoadedContent` branch of `CurrencyInfoScreen` where `onSell` lived. That was the only `swapType: .sell` call site — Convert replaces it and carries its own case — so nothing constructs a sell any more.

`SwapProcessingViewModel` still branched on it in four places. This drops `case sell` from `SwapType` and the arms it fed in `title`, `subtitle`, `navigationTitle`, and `trackTransaction`, and updates the two tests that asserted a fourth case and the "Selling TestCoin" title.

Convert keeps reporting through `Analytics.tokenSell` — it still disposes of the source token — so only the unreachable UI path goes. `Session.sell` is untouched; Convert calls the same machinery.

### Conflict note

`feat/usdc-to-dollars-conversion-graphic` (commit `f3f580a8`) touches this same `title` switch to suppress the "of <currency>" suffix when a convert lands in the reserve, and rewrites the `targetMint` doc comment. Preserve that branch's `case .convert where targetMint == .usdf` arm and its comment, minus the now-stale "nil on the sell path" clause.
