### PR TITLE
fix(amount): correct the entry to the fee-affordable maximum

### DIFF
--- a/.claude/plans/2026-08-21-conversion-max-fee-handling.md
+++ b/.claude/plans/2026-08-21-conversion-max-fee-handling.md
@@ -1,0 +1,65 @@
+# Auto-correct the entry to the fee-affordable maximum (iOS mirror of Android #1302)
+
+## Problem
+Amount entry is capped at the RAW balance, but the fee comes out of that same balance:
+- **fee on top** (funding side is Dollars — no launchpad sale to skim): debit = entered × (1 + f)
+- **fee grossed up** (every other currency): debit = entered / (1 − f)
+
+So entering the maximum always overruns by exactly the fee, never more. Today that surfaces as
+a "Buy Maximum Amount" modal (Buy) or a hard failure at submit (Convert-from-Dollars).
+
+## Findings (iOS specifics)
+- `ConvertAmountViewModel.canPerformAction` gates on the raw balance only; from-Dollars charges
+  1% on top (`ConvertConfirmationViewModel.totalDebited = amount + fee`), so converting the FULL
+  Dollars balance passes the gate and hard-fails at submit. **Confirmed.**
+- Convert *from a token* has the fee taken out of the entry (`totalDebited == amount`) — it
+  cannot overrun, so no correction there.
+- iOS entry state is a plain `String` bound straight into `EnterAmountView`/`KeyPadView`; there is
+  **no** "prefill types on top" trap like Android's `AmountEntryDelegate`. Assigning the string
+  replaces the entry. It does need rendering back into the keypad's locale-separator form.
+- The Buy confirmation is a *separate pushed VM*; it cannot reach back to the entry. So the
+  correction belongs in the **amount** view models, before pricing/pushing.
+
+## Layers
+1. `FiatAmount.flooredToSmallestUnit()` — truncate to `currency.maximumFractionDigits` via the
+   existing `Decimal.roundedDown(to:)`. Floors, never rounds: $10.11/1.01 = $10.0099 → rounding up
+   to $10.01 puts the debit ($10.1101) back over the balance.
+2. Inverses beside the existing helpers in `ExchangedFiat+LaunchpadSellFee.swift`:
+   - `FiatAmount.spendableUnderGrossedUpSellFee(bps:)` = balance × (1 − f)
+   - `FiatAmount.spendableUnderSellFeeOnTop(bps:)`     = balance / (1 + f)
+   Left **unrounded**, like `grossingUpLaunchpadSellFee` — the floor is an *entry-precision*
+   concern, not the fiat→quark boundary, so it is applied by the entry helper instead.
+3. `entryAffordableAfterFee(entered:balance:feeBps:feeChargedOnTop:) -> FiatAmount?` — pure, in
+   FlipcashCore; returns nil when the entry already fits.
+4. `AmountValidator.string(from:fractionDigits:)` — inverse of `validate`, so the corrected value
+   is written back in the keypad's own separator convention.
+
+## Call sites
+- `BuyAmountViewModel.primaryAction` — correct before `computePaymentAmount`. Needs the
+  `collectsUSDFFee` beta flag (fee-on-top only applies to the new-UI USDF buy).
+- `ConvertAmountViewModel.showConfirmation` — correct when `sourceBalance.mint == .usdf`.
+- Delete `BuyConfirmationViewModel.buyMaximum` + `showInsufficientBalance`'s Buy Maximum action
+  and the appear-time auto-prompt (`presentInsufficientBalanceIfNeeded` + the screen's 0.35s task);
+  the submit-time gate stays, as a plain error dialog.
+
+## Parity
+Fee math is a cross-platform hotspot: the correction, including the flooring, must agree exactly
+with Android's `entryAffordableAfterFee` / `Fiat.flooredToSmallestUnit`.
+
+## Outcome (shipped)
+All four layers landed as planned, TDD throughout (six red→green cycles, 29 new tests):
+
+| Suite | New |
+|---|---|
+| `FlipcashCoreTests/FeeAffordableEntryTests` | 8 (mirrors Android's cases 1:1) |
+| `FlipcashCoreTests/LaunchpadSellFeeTests` | 4 inverse/round-trip |
+| `FlipcashCoreTests/FiatAmountTests` | 3 flooring (incl. zero-decimal JPY) |
+| `FlipcashCoreTests/AmountValidatorTests` | 4 `string(from:)` round-trip |
+| `FlipcashTests/BuyAmountViewModelTests` | 4 correction (both fee branches) |
+| `FlipcashTests/ConvertAmountViewModelTests` | 4 correction (new file) |
+
+Removed with the modal: `BuyConfirmationViewModel.buyMaximum`,
+`presentInsufficientBalanceIfNeeded`, the screen's 0.35s auto-prompt task and the
+`paymentAmount` animation (nothing mutates it in place any more — it is now a `let`).
+The submit-time gate remains as a plain "Insufficient Balance" error, reachable only when the
+balance moves under a quote.

--- a/Flipcash/Core/Screens/Main/Buy/BuyAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyAmountViewModel.swift
@@ -60,14 +60,25 @@ final class BuyAmountViewModel {
     @ObservationIgnored private let session: Session
     @ObservationIgnored private let ratesController: RatesController
     @ObservationIgnored private let amountValidator = AmountValidator()
+    @ObservationIgnored private let collectsUSDFFee: Bool
     /// Double-tap guard around the async pin fetch.
     private var isSubmitting = false
 
-    init(mint: PublicKey, currencyName: String, session: Session, ratesController: RatesController) {
+    /// `collectsUSDFFee` is injected rather than read from `BetaFlags.shared` at
+    /// each use so both fee branches stay testable without mutating the
+    /// persisted flag — same convention as `BuyConfirmationViewModel`.
+    init(
+        mint: PublicKey,
+        currencyName: String,
+        session: Session,
+        ratesController: RatesController,
+        collectsUSDFFee: Bool = BetaFlags.shared.hasEnabled(.newUI)
+    ) {
         self.mint = mint
         self.currencyName = currencyName
         self.session = session
         self.ratesController = ratesController
+        self.collectsUSDFFee = collectsUSDFFee
 
         // Default the payment source to Dollars when it's spendable, otherwise
         // the largest eligible balance — so Next is never dead on arrival.
@@ -103,6 +114,7 @@ final class BuyAmountViewModel {
             router.presentAddMoney(.buyCurrency, source: .buyShortfall)
             return
         }
+        correctEntryToAffordable()
         guard let entered = amountValidator.validate(enteredAmount) else { return }
         guard !isSubmitting else { return }
         isSubmitting = true
@@ -137,6 +149,46 @@ final class BuyAmountViewModel {
         }
     }
 
+    /// The fee the selected payment source charges, and whether it lands *on
+    /// top* of the entry rather than being skimmed out of it.
+    ///
+    /// A token-funded buy pays the pool's sell fee out of the sale, so the debit
+    /// is the entry grossed up; a new-UI Dollars buy adds a flat 1% on top. The
+    /// old-UI reserves buy is fee-free.
+    private var paymentFee: (bps: UInt64, chargedOnTop: Bool) {
+        guard let selected = session.balance(for: paymentMint) else { return (0, false) }
+        guard selected.mint == .usdf else {
+            return (UInt64(max(0, selected.sellFeeBps ?? 100)), false)
+        }
+        return collectsUSDFFee ? (100, true) : (0, false)
+    }
+
+    /// Drops the entry to the most the payment balance can fund once its fee is
+    /// applied, when the entry as typed would overrun it.
+    ///
+    /// Entry is capped at the raw balance while the fee comes out of that same
+    /// balance, so entering the maximum always overruns — by the fee, and never
+    /// by more. That band is narrow enough to correct silently, and correcting
+    /// here rather than on the confirmation keeps the entry and the receipt
+    /// showing the same figure.
+    func correctEntryToAffordable() {
+        guard let entered = amountValidator.validate(enteredAmount) else { return }
+
+        let balance = maxPossibleAmount.nativeAmount
+        let fee = paymentFee
+        guard let corrected = entryAffordableAfterFee(
+            entered: entered,
+            balance: balance,
+            feeBps: fee.bps,
+            feeChargedOnTop: fee.chargedOnTop
+        ) else { return }
+
+        enteredAmount = amountValidator.string(
+            from: corrected.value,
+            fractionDigits: balance.currency.maximumFractionDigits
+        )
+    }
+
     /// Converts the entered (net) target fiat into the payment token's gross
     /// debit against the pinned rate + supply. Moved here from the old
     /// payment-currency step now that selection is inline.
@@ -151,9 +203,9 @@ final class BuyAmountViewModel {
             // to collect, so the debit equals the entered target — grossing it up
             // would just make the user over-buy. Within the displayed balance the
             // compute is balance-capped so FX display rounding can't push the
-            // quarks past the spendable reserves; past it it's deliberately
-            // uncapped so the confirmation's gate can offer Buy Maximum instead of
-            // silently shrinking the entry.
+            // quarks past the spendable reserves; past it it stays uncapped so
+            // the summary shows what was actually entered and the confirmation's
+            // gate can surface the shortfall.
             let displayedBalance = balance.usdf.converting(to: pin.rate).value
                 .rounded(to: entered.currency.maximumFractionDigits)
             let isWithinDisplayedBalance = entered.value <= displayedBalance
@@ -168,9 +220,9 @@ final class BuyAmountViewModel {
 
         guard let supply = pin.supplyFromBonding else { return nil }
 
-        // Deliberately uncapped: when the fee doesn't fit, the gross must exceed
-        // the balance so the confirmation's gate can offer Buy Maximum explicitly
-        // instead of silently clamping.
+        // Deliberately uncapped: the entry has already been corrected to what the
+        // balance can fund, so any remaining overrun is a real shortfall the
+        // confirmation's gate must surface rather than something to clamp away.
         let gross = entered.grossingUpLaunchpadSellFee(bps: UInt64(max(0, balance.sellFeeBps ?? 100)))
         return ExchangedFiat.compute(
             fromEntered: gross,

--- a/Flipcash/Core/Screens/Main/Buy/BuyConfirmationScreen.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyConfirmationScreen.swift
@@ -64,9 +64,6 @@ struct BuyConfirmationScreen: View {
                         .padding(.bottom, 24)
                     }
                 }
-                // Buy Maximum rewrites every figure in place — roll the
-                // digits instead of snapping them.
-                .animation(.default, value: viewModel.paymentAmount)
 
                 Spacer()
 
@@ -96,13 +93,6 @@ struct BuyConfirmationScreen: View {
         .navigationBarBackButtonHidden(viewModel.actionButtonState == .loading)
         .dialog(item: $viewModel.dialogItem)
         .task { await viewModel.loadTargetImage(session: session) }
-        .task {
-            // A sheet presented mid-push is swallowed by the transition — let
-            // the push land before offering Buy Maximum.
-            try? await Task.sleep(for: .seconds(0.35))
-            guard !Task.isCancelled else { return }
-            viewModel.presentInsufficientBalanceIfNeeded(session: session)
-        }
     }
 
     // MARK: - Actions -

--- a/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyConfirmationViewModel.swift
@@ -20,12 +20,11 @@ final class BuyConfirmationViewModel {
 
     var dialogItem: DialogItem?
     private(set) var actionButtonState: ButtonState = .normal
-    /// Gross debit in the payment token. Mutated in place by Buy Maximum.
-    private(set) var paymentAmount: ExchangedFiat
+    /// Gross debit in the payment token, priced on the amount screen.
+    @ObservationIgnored let paymentAmount: ExchangedFiat
     /// Icon for the You Receive row, resolved from cached mint metadata.
     private(set) var targetImageURL: URL?
 
-    @ObservationIgnored private var hasCheckedFundsOnAppear = false
     @ObservationIgnored private let collectsUSDFFee: Bool
 
     var isUSDF: Bool { payment.mint == .usdf }
@@ -97,25 +96,6 @@ final class BuyConfirmationViewModel {
         targetImageURL = try? await session.fetchMintMetadata(mint: targetMint).imageURL
     }
 
-    /// Surfaces the insufficient-balance sheet when the amount pushed onto this
-    /// screen already exceeds the payment balance, at most once per screen.
-    func presentInsufficientBalanceIfNeeded(session: Session) {
-        guard !hasCheckedFundsOnAppear else { return }
-        hasCheckedFundsOnAppear = true
-
-        switch session.hasSufficientFunds(for: grossDebit) {
-        case .sufficient:
-            break
-        case .insufficient:
-            logger.info("Buy gated on appear: insufficient balance", metadata: [
-                "paymentMint": "\(payment.mint.base58)",
-                "amountQuarks": "\(grossDebit.onChainAmount.quarks)",
-                "balanceQuarks": "\(session.balance(for: payment.mint)?.quarks ?? 0)",
-            ])
-            showInsufficientBalance(session: session)
-        }
-    }
-
     func buyAction(session: Session, router: AppRouter) async {
         // Re-entrancy guard: don't rely on the button disabling itself.
         guard actionButtonState == .normal else { return }
@@ -148,42 +128,8 @@ final class BuyConfirmationViewModel {
                 "amountQuarks": "\(paymentAmount.onChainAmount.quarks)",
                 "balanceQuarks": "\(session.balance(for: payment.mint)?.quarks ?? 0)",
             ])
-            showInsufficientBalance(session: session)
+            showInsufficientBalance()
         }
-    }
-
-    /// Recomputes the summary in place to spend the entire payment balance —
-    /// the user still confirms with Buy.
-    func buyMaximum(session: Session) {
-        guard let live = session.balance(for: payment.mint) else { return }
-        // USDF needs no reserve supply; bonded mints do (a nil supply would
-        // value the balance as zero).
-        let supply = pinnedState.supplyFromBonding
-        guard isUSDF || supply != nil else { return }
-
-        // With an on-top USDF fee the debit is `net + net·bps/10⁴`, so the net
-        // purchase must be shrunk to keep the whole debit within the balance:
-        // net = ⌊balance · 10⁴ / (10⁴ + bps)⌋. Split-divide to avoid overflow.
-        let maxQuarks: UInt64
-        if chargesUSDFFee {
-            let denom = 10_000 + feeBps
-            maxQuarks = live.quarks / denom * 10_000 + (live.quarks % denom) * 10_000 / denom
-        } else {
-            maxQuarks = live.quarks
-        }
-
-        logger.info("Buy maximum selected", metadata: [
-            "paymentMint": "\(payment.mint.base58)",
-            "previousQuarks": "\(paymentAmount.onChainAmount.quarks)",
-            "balanceQuarks": "\(live.quarks)",
-            "maxQuarks": "\(maxQuarks)",
-        ])
-
-        paymentAmount = ExchangedFiat.compute(
-            onChainAmount: TokenAmount(quarks: maxQuarks, mint: payment.mint),
-            rate: pinnedState.rate,
-            supplyQuarks: supply
-        )
     }
 
     private func submit(session: Session, router: AppRouter) async {
@@ -253,15 +199,12 @@ final class BuyConfirmationViewModel {
 
     // MARK: - Dialogs
 
-    private func showInsufficientBalance(session: Session) {
-        dialogItem = .info(
-            title: isUSDF ? "Insufficient Balance" : "Insufficient Balance After Fees",
-            subtitle: "Switch to maximum amount, or go back and enter a smaller amount"
-        ) {
-            .standard("Buy Maximum Amount") { [weak self] in
-                self?.buyMaximum(session: session)
-            };
-            .dismiss(kind: .subtle)
-        }
+    /// The amount screen already trims an entry to what the fee leaves, so
+    /// reaching this is a genuine shortfall — the balance moved under the quote.
+    private func showInsufficientBalance() {
+        dialogItem = .error(
+            title: "Insufficient Balance",
+            subtitle: "Please go back and enter a smaller amount"
+        )
     }
 }

--- a/Flipcash/Core/Screens/Main/Currency Convert/ConvertAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Main/Currency Convert/ConvertAmountViewModel.swift
@@ -100,6 +100,7 @@ final class ConvertAmountViewModel {
     // MARK: - Actions -
 
     func showConfirmation(router: AppRouter) {
+        correctEntryToAffordable()
         guard enteredFiat != nil else { return }
 
         Task {
@@ -116,6 +117,32 @@ final class ConvertAmountViewModel {
                 pinnedState: pin
             ))
         }
+    }
+
+    /// Drops the entry to the most the source balance can fund once the fee is
+    /// applied, when the entry as typed would overrun it.
+    ///
+    /// Only converting *out of Dollars* can overrun: that leg charges its 1% on
+    /// top of the entry, while a token source has the pool fee taken out of the
+    /// sale, so the debit never exceeds what was entered. Amount entry is capped
+    /// at the raw balance, so the overrun is at most the fee — small and bounded
+    /// enough to correct silently rather than put to the user.
+    func correctEntryToAffordable() {
+        guard sourceBalance.mint == .usdf else { return }
+        guard let entered = amountValidator.validate(enteredAmount) else { return }
+
+        let balance = maxPossibleAmount.nativeAmount
+        guard let corrected = entryAffordableAfterFee(
+            entered: entered,
+            balance: balance,
+            feeBps: 100,
+            feeChargedOnTop: true
+        ) else { return }
+
+        enteredAmount = amountValidator.string(
+            from: corrected.value,
+            fractionDigits: balance.currency.maximumFractionDigits
+        )
     }
 
     /// Resolves the pin against the source mint and computes the source amount

--- a/FlipcashCore/Sources/FlipcashCore/Models/ExchangedFiat+LaunchpadSellFee.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/ExchangedFiat+LaunchpadSellFee.swift
@@ -45,4 +45,26 @@ public extension FiatAmount {
         let feeFraction = Decimal(bps) / Decimal(10_000)
         return FiatAmount(value: value / (1 - feeFraction), currency: currency)
     }
+
+    /// The most of this balance that can be spent when the pool's sell fee is
+    /// *grossed up* out of the spend: `balance × (1 − bps/10⁴)`, the inverse of
+    /// `grossingUpLaunchpadSellFee(bps:)`.
+    ///
+    /// Grossing the result back up lands exactly on this balance, which makes it
+    /// the largest entry the balance can fund. Unrounded, like its inverse —
+    /// callers that need an entry-precision value floor it themselves.
+    func spendableUnderGrossedUpSellFee(bps: UInt64) -> FiatAmount {
+        let feeFraction = Decimal(min(bps, 10_000)) / Decimal(10_000)
+        return FiatAmount(value: value * (1 - feeFraction), currency: currency)
+    }
+
+    /// The most of this balance that can be spent when the fee is charged *on
+    /// top* of the spend rather than skimmed out of it: `balance / (1 + bps/10⁴)`.
+    ///
+    /// Adding that entry's own fee back lands exactly on this balance. Unrounded,
+    /// for the same reason as `spendableUnderGrossedUpSellFee(bps:)`.
+    func spendableUnderSellFeeOnTop(bps: UInt64) -> FiatAmount {
+        let feeFraction = Decimal(min(bps, 10_000)) / Decimal(10_000)
+        return FiatAmount(value: value / (1 + feeFraction), currency: currency)
+    }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/FeeAffordableEntry.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/FeeAffordableEntry.swift
@@ -1,0 +1,44 @@
+//
+//  FeeAffordableEntry.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+/// Trims an entered amount down to what its funding `balance` can actually cover
+/// once the fee is applied.
+///
+/// Amount entry is capped at the raw balance, so the only thing that can push the
+/// debit past it is the fee: charged on top, the debit is `entered × (1 + f)`;
+/// grossed up out of a launchpad sale, it is `entered / (1 − f)`. Entering the
+/// maximum therefore always overruns — by the fee, and never by more — which is
+/// why the correction is applied silently instead of being put to the user.
+///
+/// Returns the corrected entry, floored to the currency's smallest unit so
+/// re-deriving the debit from it never lands back over the balance, or `nil` when
+/// the entry already fits and should stay exactly as typed. `entered` is
+/// interpreted in `balance`'s currency.
+public func entryAffordableAfterFee(
+    entered: Decimal,
+    balance: FiatAmount,
+    feeBps: UInt64,
+    feeChargedOnTop: Bool
+) -> FiatAmount? {
+    guard feeBps > 0 else { return nil }
+
+    let entry = FiatAmount(value: entered, currency: balance.currency)
+    let feeFraction = Decimal(min(feeBps, 10_000)) / Decimal(10_000)
+
+    // The fee has no fiat-only helper of its own — on `ExchangedFiat` it is
+    // scaled by the on-chain quark ratio, which an entry-level check must not
+    // depend on — so the on-top debit is spelled out here.
+    let debit = feeChargedOnTop
+        ? FiatAmount(value: entry.value * (1 + feeFraction), currency: balance.currency)
+        : entry.grossingUpLaunchpadSellFee(bps: feeBps)
+    guard debit > balance else { return nil }
+
+    let spendable = feeChargedOnTop
+        ? balance.spendableUnderSellFeeOnTop(bps: feeBps)
+        : balance.spendableUnderGrossedUpSellFee(bps: feeBps)
+    return spendable.flooredToSmallestUnit()
+}

--- a/FlipcashCore/Sources/FlipcashCore/Models/FiatAmount.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/FiatAmount.swift
@@ -108,6 +108,16 @@ extension FiatAmount {
 
     /// Non-zero but too small to display (would format as the currency's zero).
     public var isApproximatelyZero: Bool { value > 0 && !hasDisplayableValue }
+
+    /// This value truncated down to its currency's smallest displayable unit
+    /// (e.g. $9.90099 → $9.90). For values whose defining invariant rounding up
+    /// would break, such as a spend ceiling derived from a balance.
+    public func flooredToSmallestUnit() -> FiatAmount {
+        FiatAmount(
+            value: value.roundedDown(to: currency.maximumFractionDigits),
+            currency: currency
+        )
+    }
 }
 
 // MARK: - Description -

--- a/FlipcashCore/Sources/FlipcashCore/Validation/AmountValidator.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Validation/AmountValidator.swift
@@ -23,4 +23,23 @@ public struct AmountValidator: Validator {
         let separator = self.separator ?? Self.localizedDecimalSeparator
         return Decimal(string: input.replacingOccurrences(of: separator, with: "."))
     }
+
+    /// Renders `value` back into the string the keypad itself would have
+    /// produced — the inverse of `validate(_:)`. For the rare correction a flow
+    /// makes on the user's behalf, such as dropping an entry to the maximum its
+    /// balance can fund; ordinary display goes through `FiatAmount.formatted()`.
+    ///
+    /// Truncates rather than rounds, so a correction derived as a ceiling can't
+    /// be nudged back above it.
+    public func string(from value: Decimal, fractionDigits: Int) -> String {
+        let separator = self.separator ?? Self.localizedDecimalSeparator
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = false
+        formatter.decimalSeparator = separator
+        formatter.minimumFractionDigits = fractionDigits
+        formatter.maximumFractionDigits = fractionDigits
+        formatter.roundingMode = .down
+        return formatter.string(from: value as NSDecimalNumber) ?? ""
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/AmountValidatorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/AmountValidatorTests.swift
@@ -35,4 +35,36 @@ struct AmountValidatorTests {
         let entered = "2\(AmountValidator.localizedDecimalSeparator)25"
         #expect(AmountValidator().validate(entered) == Decimal(string: "2.25"))
     }
+
+    // MARK: - Rendering back into the keypad's own form
+
+    @Test("A rendered amount parses back to the same value")
+    func string_roundTripsThroughValidate() {
+        let validator = AmountValidator(separator: ".")
+
+        let rendered = validator.string(from: Decimal(string: "9.9")!, fractionDigits: 2)
+
+        #expect(rendered == "9.90")
+        #expect(validator.validate(rendered) == Decimal(string: "9.9"))
+    }
+
+    @Test("Rendering uses the keypad's own decimal separator")
+    func string_usesConfiguredSeparator() {
+        let validator = AmountValidator(separator: ",")
+
+        let rendered = validator.string(from: Decimal(string: "9.9")!, fractionDigits: 2)
+
+        #expect(rendered == "9,90")
+        #expect(validator.validate(rendered) == Decimal(string: "9.9"))
+    }
+
+    @Test("A zero-decimal currency renders without a separator")
+    func string_zeroFractionDigits_hasNoSeparator() {
+        #expect(AmountValidator(separator: ".").string(from: 990, fractionDigits: 0) == "990")
+    }
+
+    @Test("Rendering never groups digits — the keypad emits none")
+    func string_doesNotGroupDigits() {
+        #expect(AmountValidator(separator: ".").string(from: Decimal(string: "12345.67")!, fractionDigits: 2) == "12345.67")
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/FeeAffordableEntryTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/FeeAffordableEntryTests.swift
@@ -1,0 +1,126 @@
+//
+//  FeeAffordableEntryTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("Fee-affordable entry")
+struct FeeAffordableEntryTests {
+
+    private func usd(_ value: String) -> FiatAmount {
+        FiatAmount.usd(Decimal(string: value)!)
+    }
+
+    // MARK: - Entries that already fit
+
+    @Test("An entry with room for its fee is left exactly as typed")
+    func entryWithRoom_isLeftAlone() {
+        #expect(entryAffordableAfterFee(
+            entered: 5,
+            balance: usd("10.00"),
+            feeBps: 100,
+            feeChargedOnTop: true
+        ) == nil)
+    }
+
+    @Test("A free conversion never corrects the entry")
+    func zeroFee_neverCorrects() {
+        #expect(entryAffordableAfterFee(
+            entered: 10,
+            balance: usd("10.00"),
+            feeBps: 0,
+            feeChargedOnTop: true
+        ) == nil)
+    }
+
+    // MARK: - Entering the maximum
+
+    @Test("The whole balance drops to what a fee charged on top leaves")
+    func wholeBalance_feeOnTop() throws {
+        let corrected = try #require(entryAffordableAfterFee(
+            entered: 10,
+            balance: usd("10.00"),
+            feeBps: 100,
+            feeChargedOnTop: true
+        ))
+
+        #expect(corrected.formatted() == "$9.90")
+        // The entry plus its own on-top fee stays inside the balance.
+        #expect(corrected.value * Decimal(string: "1.01")! <= Decimal(10))
+    }
+
+    @Test("The whole balance drops to what a grossed-up fee leaves")
+    func wholeBalance_feeGrossedUp() throws {
+        let corrected = try #require(entryAffordableAfterFee(
+            entered: 10,
+            balance: usd("10.00"),
+            feeBps: 100,
+            feeChargedOnTop: false
+        ))
+
+        #expect(corrected.formatted() == "$9.90")
+        #expect(corrected.grossingUpLaunchpadSellFee(bps: 100).value <= Decimal(10))
+    }
+
+    @Test("The correction is floored so the fee still fits when rounding would not")
+    func correction_isFlooredNotRounded() throws {
+        // $10.11 / 1.01 = $10.0099, which rounds up to $10.01 — and $10.01 plus
+        // its own 1% fee is $10.1101, back over the balance. Flooring to $10.00
+        // keeps the debit inside it.
+        let corrected = try #require(entryAffordableAfterFee(
+            entered: Decimal(string: "10.11")!,
+            balance: usd("10.11"),
+            feeBps: 100,
+            feeChargedOnTop: true
+        ))
+
+        #expect(corrected.formatted() == "$10.00")
+        #expect(corrected.value * Decimal(string: "1.01")! <= Decimal(string: "10.11")!)
+    }
+
+    @Test("Re-entering the corrected amount does not correct it again")
+    func correction_isIdempotent() throws {
+        let corrected = try #require(entryAffordableAfterFee(
+            entered: 10,
+            balance: usd("10.00"),
+            feeBps: 100,
+            feeChargedOnTop: true
+        ))
+
+        #expect(entryAffordableAfterFee(
+            entered: corrected.value,
+            balance: usd("10.00"),
+            feeBps: 100,
+            feeChargedOnTop: true
+        ) == nil)
+    }
+
+    @Test("An entry beyond the balance is corrected down to the maximum too")
+    func entryOverBalance_correctsToMaximum() throws {
+        let corrected = try #require(entryAffordableAfterFee(
+            entered: 50,
+            balance: usd("10.00"),
+            feeBps: 100,
+            feeChargedOnTop: true
+        ))
+
+        #expect(corrected.formatted() == "$9.90")
+    }
+
+    @Test("The correction is denominated in the balance's currency")
+    func correction_usesBalanceCurrency() throws {
+        let corrected = try #require(entryAffordableAfterFee(
+            entered: 1_000,
+            balance: FiatAmount(value: 1_000, currency: .jpy),
+            feeBps: 100,
+            feeChargedOnTop: true
+        ))
+
+        // ¥ has no fractional unit, so the correction floors to whole yen.
+        #expect(corrected.currency == .jpy)
+        #expect(corrected.value == 990)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/FiatAmountTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/FiatAmountTests.swift
@@ -1,0 +1,37 @@
+//
+//  FiatAmountTests.swift
+//  FlipcashCoreTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+
+@Suite("FiatAmount")
+struct FiatAmountTests {
+
+    // MARK: - Flooring to the smallest unit
+
+    @Test("Flooring truncates sub-unit precision instead of rounding it up")
+    func flooring_truncatesRatherThanRounds() {
+        // Leaving 1% headroom on a $10.00 balance gives $9.90099 — rounding up
+        // would put the entry right back over budget.
+        let floored = FiatAmount.usd(Decimal(string: "9.90099")!).flooredToSmallestUnit()
+
+        #expect(floored.value == Decimal(string: "9.90")!)
+    }
+
+    @Test("Flooring leaves a value already on the smallest unit untouched")
+    func flooring_exactValue_unchanged() {
+        let exact = FiatAmount.usd(Decimal(string: "9.90")!)
+
+        #expect(exact.flooredToSmallestUnit() == exact)
+    }
+
+    @Test("Flooring a zero-decimal currency truncates to whole units")
+    func flooring_zeroDecimalCurrency_truncatesToWholeUnits() {
+        let yen = FiatAmount(value: Decimal(string: "1234.9")!, currency: .jpy)
+
+        #expect(yen.flooredToSmallestUnit().value == 1234)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/LaunchpadSellFeeTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/LaunchpadSellFeeTests.swift
@@ -50,8 +50,8 @@ struct LaunchpadSellFeeTests {
         #expect(netted.nativeAmount.value.rounded(to: 2) == net.rounded(to: 2))
     }
 
-    @Test("Buy Maximum shape: full balance nets to balance × (1 − f)")
-    func buyMaximum_netting() {
+    @Test("Selling the whole balance nets to balance × (1 − f)")
+    func wholeBalance_netting() {
         let balance = ExchangedFiat(nativeAmount: FiatAmount.usd(20), rate: .oneToOne)
 
         let fee = balance.launchpadSellFee(bps: 100)
@@ -81,5 +81,45 @@ struct LaunchpadSellFeeTests {
         let net = FiatAmount.usd(20)
 
         #expect(net.grossingUpLaunchpadSellFee(bps: 10_000) == net)
+    }
+
+    // MARK: - Inverses: the most a balance can fund
+
+    @Test("Spendable under a grossed-up fee grosses back up to exactly the balance")
+    func spendableUnderGrossedUp_roundTrips() {
+        let balance = FiatAmount.usd(20)
+
+        let spendable = balance.spendableUnderGrossedUpSellFee(bps: 100)
+
+        #expect(spendable.formatted() == "$19.80")
+        #expect(spendable.grossingUpLaunchpadSellFee(bps: 100).value.rounded(to: 2) == balance.value)
+    }
+
+    @Test("Spendable under a fee charged on top leaves exactly enough for that fee")
+    func spendableUnderOnTop_leavesRoomForTheFee() {
+        let balance = FiatAmount.usd(Decimal(string: "10.10")!)
+
+        let spendable = balance.spendableUnderSellFeeOnTop(bps: 100)
+
+        #expect(spendable.formatted() == "$10.00")
+        // entry + its own fee lands back on the balance.
+        let debit = ExchangedFiat(nativeAmount: spendable, rate: .oneToOne)
+        #expect((spendable + debit.launchpadSellFee(bps: 100).nativeAmount).value.rounded(to: 2) == balance.value)
+    }
+
+    @Test("Spending the whole balance is only possible with a zero fee")
+    func spendable_zeroBps_isTheWholeBalance() {
+        let balance = FiatAmount.usd(20)
+
+        #expect(balance.spendableUnderSellFeeOnTop(bps: 0) == balance)
+        #expect(balance.spendableUnderGrossedUpSellFee(bps: 0) == balance)
+    }
+
+    @Test("An on-top fee above 100% is clamped rather than over-shrinking the entry")
+    func spendableUnderOnTop_bpsAboveMax_isClamped() {
+        let balance = FiatAmount.usd(20)
+
+        // Clamped to 10_000 (100%): half the balance covers a fee equal to the entry.
+        #expect(balance.spendableUnderSellFeeOnTop(bps: 12_000).formatted() == "$10.00")
     }
 }

--- a/FlipcashTests/Buy/BuyAmountViewModelTests.swift
+++ b/FlipcashTests/Buy/BuyAmountViewModelTests.swift
@@ -53,13 +53,15 @@ struct BuyAmountViewModelTests {
     private static func makeViewModel(
         mint: PublicKey = .jeffy,
         currencyName: String = "Jeffy",
-        container: SessionContainer
+        container: SessionContainer,
+        collectsUSDFFee: Bool = false
     ) -> BuyAmountViewModel {
         BuyAmountViewModel(
             mint: mint,
             currencyName: currencyName,
             session: container.session,
-            ratesController: container.ratesController
+            ratesController: container.ratesController,
+            collectsUSDFFee: collectsUSDFFee
         )
     }
 
@@ -202,5 +204,66 @@ struct BuyAmountViewModelTests {
 
         #expect(viewModel.actionEnabled("30") == true)
         #expect(viewModel.actionEnabled("31") == false)
+    }
+
+    // MARK: - Fee-affordable entry
+
+    @Test("Paying the whole Dollars balance drops the entry to what the on-top fee leaves")
+    func wholeDollarsBalance_isCorrected() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .usdf, quarks: 10_000_000), // $10.00
+        ])
+        let viewModel = Self.makeViewModel(mint: .usdcAuthority, container: container, collectsUSDFFee: true)
+        viewModel.enteredAmount = "10"
+
+        viewModel.correctEntryToAffordable()
+
+        // $10.00 / 1.01 = $9.90099, floored to the cent so the debit fits.
+        #expect(viewModel.enteredAmount == "9.90")
+    }
+
+    @Test("A Dollars entry with room for its fee is left exactly as typed")
+    func dollarsEntryWithRoom_isLeftAlone() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .usdf, quarks: 10_000_000), // $10.00
+        ])
+        let viewModel = Self.makeViewModel(mint: .usdcAuthority, container: container, collectsUSDFFee: true)
+        viewModel.enteredAmount = "5"
+
+        viewModel.correctEntryToAffordable()
+
+        #expect(viewModel.enteredAmount == "5")
+    }
+
+    @Test("Without the USDF fee the whole Dollars balance stays spendable")
+    func wholeDollarsBalance_feeFreeUI_isLeftAlone() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .usdf, quarks: 10_000_000), // $10.00
+        ])
+        let viewModel = Self.makeViewModel(mint: .usdcAuthority, container: container, collectsUSDFFee: false)
+        viewModel.enteredAmount = "10"
+
+        viewModel.correctEntryToAffordable()
+
+        #expect(viewModel.enteredAmount == "10")
+    }
+
+    @Test("Paying the whole token balance drops the entry to what the pool fee leaves")
+    func wholeTokenBalance_isCorrected() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .makeLaunchpad(address: .jeffy), quarks: 2_000 * 10_000_000_000), // ≈ $20
+        ])
+        let viewModel = Self.makeViewModel(mint: .usdcAuthority, container: container)
+        let balance = viewModel.maxPossibleAmount.nativeAmount
+        let displayed = balance.value.rounded(to: CurrencyCode.usd.maximumFractionDigits)
+        viewModel.enteredAmount = "\(displayed)"
+
+        viewModel.correctEntryToAffordable()
+
+        let corrected = try #require(AmountValidator().validate(viewModel.enteredAmount))
+        #expect(corrected < displayed)
+        // The entry is grossed up by the pool fee to form the debit — it must fit.
+        let debit = FiatAmount(value: corrected, currency: .usd).grossingUpLaunchpadSellFee(bps: 100)
+        #expect(debit.value <= balance.value)
     }
 }

--- a/FlipcashTests/Buy/BuyConfirmationViewModelTests.swift
+++ b/FlipcashTests/Buy/BuyConfirmationViewModelTests.swift
@@ -92,7 +92,10 @@ struct BuyConfirmationViewModelTests {
 
     // MARK: - Boundary gate
 
-    @Test("Entering the full token balance surfaces the insufficient-after-fees sheet, not a submit")
+    /// The amount screen trims an entry to what the fee leaves, so an amount
+    /// this short only reaches here when the balance moved under the quote.
+    /// The gate must still catch it rather than submit.
+    @Test("An amount the balance can no longer cover surfaces the insufficient sheet, not a submit")
     func boundary_showsSheet() async throws {
         let container = try await Self.makeContainer(holdings: [
             .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: Self.jeffyQuarks),
@@ -111,86 +114,9 @@ struct BuyConfirmationViewModelTests {
 
         await viewModel.buyAction(session: container.session, router: router)
 
-        #expect(viewModel.dialogItem?.title == "Insufficient Balance After Fees")
+        #expect(viewModel.dialogItem?.title == "Insufficient Balance")
         #expect(viewModel.actionButtonState == .normal)
         #expect(router[.buy].isEmpty, "A short buy must never reach the processing push")
-    }
-
-    @Test("Buy Maximum recomputes the summary from the full balance and passes the gate")
-    func buyMaximum_recomputesAndPasses() async throws {
-        let container = try await Self.makeContainer(holdings: [
-            .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: Self.jeffyQuarks),
-        ])
-        let rate = container.ratesController.rateForBalanceCurrency()
-        let jeffyBalance = try #require(container.session.balance(for: .jeffy))
-        let displayed = jeffyBalance.computeExchangedValue(with: rate)
-            .nativeAmount.value.rounded(to: CurrencyCode.usd.maximumFractionDigits)
-        let pin = try #require(await container.ratesController.currentPinnedState(for: .usd, mint: .jeffy))
-        let paymentAmount = try Self.makePaymentAmount(entered: displayed, balance: jeffyBalance, pin: pin, container: container)
-
-        let viewModel = Self.makeViewModel(payment: jeffyBalance, paymentAmount: paymentAmount, pin: pin)
-
-        viewModel.buyMaximum(session: container.session)
-
-        #expect(viewModel.paymentAmount.onChainAmount.quarks == jeffyBalance.quarks)
-
-        // The recomputed summary must be internally consistent at display
-        // precision: amount to buy + fee == you pay.
-        let pay = viewModel.paymentAmount.nativeAmount.value
-        let net = viewModel.amountToBuy.nativeAmount.value.rounded(to: 2)
-        let fee = viewModel.fee.nativeAmount.value.rounded(to: 2)
-        #expect((net + fee).rounded(to: 2) == pay.rounded(to: 2))
-
-        // And the canonical gate must now pass.
-        switch container.session.hasSufficientFunds(for: viewModel.paymentAmount) {
-        case .sufficient:
-            break
-        case .insufficient:
-            Issue.record("Buy Maximum must satisfy the funds gate")
-        }
-    }
-
-    // MARK: - Appear-time gate
-
-    @Test("Landing on the confirmation with an underfunded amount surfaces the sheet without a Buy tap")
-    func appearGate_underfunded_showsSheet() async throws {
-        let container = try await Self.makeContainer(holdings: [
-            .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: Self.jeffyQuarks),
-        ])
-        let rate = container.ratesController.rateForBalanceCurrency()
-        let jeffyBalance = try #require(container.session.balance(for: .jeffy))
-        let displayed = jeffyBalance.computeExchangedValue(with: rate)
-            .nativeAmount.value.rounded(to: CurrencyCode.usd.maximumFractionDigits)
-        let pin = try #require(await container.ratesController.currentPinnedState(for: .usd, mint: .jeffy))
-        let paymentAmount = try Self.makePaymentAmount(entered: displayed, balance: jeffyBalance, pin: pin, container: container)
-
-        let viewModel = Self.makeViewModel(payment: jeffyBalance, paymentAmount: paymentAmount, pin: pin)
-
-        viewModel.presentInsufficientBalanceIfNeeded(session: container.session)
-
-        #expect(viewModel.dialogItem?.title == "Insufficient Balance After Fees")
-
-        // Dismissing must not let the next appear re-present it — the Buy tap
-        // is the only thing that fires the gate again.
-        viewModel.dialogItem = nil
-        viewModel.presentInsufficientBalanceIfNeeded(session: container.session)
-        #expect(viewModel.dialogItem == nil)
-    }
-
-    @Test("Landing on the confirmation with a covered amount surfaces nothing")
-    func appearGate_funded_staysSilent() async throws {
-        let container = try await Self.makeContainer(holdings: [
-            .init(mint: .usdf, quarks: 30_000_000),
-        ])
-        let usdfBalance = try #require(container.session.balance(for: .usdf))
-        let pin = try #require(await container.ratesController.currentPinnedState(for: .usd, mint: .usdf))
-        let paymentAmount = try Self.makePaymentAmount(entered: 10, balance: usdfBalance, pin: pin, container: container)
-
-        let viewModel = Self.makeViewModel(payment: usdfBalance, paymentAmount: paymentAmount, pin: pin)
-
-        viewModel.presentInsufficientBalanceIfNeeded(session: container.session)
-
-        #expect(viewModel.dialogItem == nil)
     }
 
     // MARK: - USDF variant
@@ -212,7 +138,7 @@ struct BuyConfirmationViewModelTests {
     }
 
     @Test(
-        "An underfunded USDF payment surfaces the insufficient sheet, without the fee wording",
+        "An underfunded USDF payment surfaces the insufficient sheet under either fee branch",
         arguments: [false, true]
     )
     func usdfUnderfunded_showsSheet(collectsUSDFFee: Bool) async throws {
@@ -237,19 +163,7 @@ struct BuyConfirmationViewModelTests {
 
         #expect(viewModel.dialogItem?.title == "Insufficient Balance")
         #expect(router[.buy].isEmpty)
-
-        // Buy Maximum spends the whole USDF balance (no reserve supply needed):
-        // the debit lands on the balance, within a rounding quark of it.
-        viewModel.buyMaximum(session: container.session)
-        #expect(viewModel.grossDebit.onChainAmount.quarks <= usdfBalance.quarks)
-        #expect(viewModel.grossDebit.onChainAmount.quarks >= usdfBalance.quarks - usdfBalance.quarks / 1_000)
-
-        if collectsUSDFFee {
-            // The net purchase shrinks to leave room for the 1% on-top fee.
-            #expect(viewModel.paymentAmount.onChainAmount.quarks < usdfBalance.quarks)
-        } else {
-            #expect(viewModel.paymentAmount.onChainAmount.quarks == usdfBalance.quarks)
-        }
+        #expect(viewModel.grossDebit.onChainAmount.quarks > usdfBalance.quarks)
     }
 
     /// Regression: the funds gate must value the balance at the REQUESTED
@@ -288,7 +202,7 @@ struct BuyConfirmationViewModelTests {
 
         await viewModel.buyAction(session: container.session, router: router)
 
-        #expect(viewModel.dialogItem?.title == "Insufficient Balance After Fees")
+        #expect(viewModel.dialogItem?.title == "Insufficient Balance")
         #expect(router[.buy].isEmpty)
     }
 

--- a/FlipcashTests/Buy/BuyPaymentCurrencyViewModelTests.swift
+++ b/FlipcashTests/Buy/BuyPaymentCurrencyViewModelTests.swift
@@ -76,7 +76,8 @@ struct BuyPaymentCurrencyViewModelTests {
     @Test("An underfunded balance stays listed and selectable")
     func underfunded_staysListed() async throws {
         // Even a balance worth far less than any plausible entry stays in the
-        // list so the confirmation's Buy can offer Buy Maximum Amount.
+        // list — selecting it re-caps the entry, and the amount screen trims
+        // anything the fee can't cover.
         let container = try await Self.makeContainer(holdings: [
             .init(mint: .usdf, quarks: 30_000_000),
             .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: Self.jeffyQuarks),
@@ -116,7 +117,7 @@ struct BuyPaymentCurrencyViewModelTests {
         #expect(amount.mint == .usdf)
     }
 
-    @Test("USDF entered above the displayed balance is deliberately uncapped so the gate can offer Buy Maximum")
+    @Test("USDF entered above the displayed balance is deliberately uncapped so the gate can surface the shortfall")
     func usdfCompute_aboveDisplayedBalance_uncapped() async throws {
         let container = try await Self.makeContainer(holdings: [
             .init(mint: .usdf, quarks: 630_000), // $0.63
@@ -128,7 +129,8 @@ struct BuyPaymentCurrencyViewModelTests {
         let amount = try #require(viewModel.computePaymentAmount(for: usdfBalance, entered: FiatAmount(value: Decimal(string: "0.74")!, currency: .usd), pin: pin))
 
         // The summary must show the true entered amount, not a silently
-        // shrunken one — the confirmation's gate then surfaces the sheet.
+        // shrunken one — the confirmation's gate then surfaces the sheet. (The
+        // entry itself is trimmed upstream by `correctEntryToAffordable`.)
         #expect(amount.onChainAmount.quarks == 740_000)
         #expect(amount.onChainAmount.quarks > usdfBalance.quarks)
     }
@@ -178,7 +180,8 @@ struct BuyPaymentCurrencyViewModelTests {
         let amount = try #require(viewModel.computePaymentAmount(for: jeffyBalance, entered: FiatAmount(value: jeffyDisplayed, currency: .usd), pin: pin))
 
         // Entering the full displayed balance must overshoot it by the fee —
-        // that overshoot is what drives the insufficient-after-fees sheet.
+        // that overshoot is exactly what `correctEntryToAffordable` trims away
+        // before this compute ever runs in production.
         #expect(amount.onChainAmount.quarks > jeffyBalance.quarks)
         #expect(amount.mint == .jeffy)
     }

--- a/FlipcashTests/Convert/ConvertAmountViewModelTests.swift
+++ b/FlipcashTests/Convert/ConvertAmountViewModelTests.swift
@@ -1,0 +1,124 @@
+//
+//  ConvertAmountViewModelTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+@testable import FlipcashCore
+@testable import Flipcash
+
+@Suite("ConvertAmountViewModel — fee-affordable entry")
+@MainActor
+struct ConvertAmountViewModelTests {
+
+    private static let jeffySupply: UInt64 = 50_000 * 10_000_000_000
+    private static let jeffyQuarks: UInt64 = 2_000 * 10_000_000_000 // ≈ $20 of curve value
+
+    private static func makeContainer(
+        holdings: [SessionContainer.Holding],
+        currency: CurrencyCode = .usd,
+        fx: Double = 1.0
+    ) async throws -> SessionContainer {
+        let container = try SessionContainer.makeTest(holdings: holdings)
+
+        container.ratesController.configureTestRates(
+            balanceCurrency: currency,
+            rates: [Rate(fx: Decimal(fx), currency: currency)]
+        )
+        await container.ratesController.verifiedProtoService.saveRates([
+            .freshRate(currencyCode: currency.rawValue.uppercased(), rate: fx)
+        ])
+        await container.ratesController.verifiedProtoService.saveReserveStates([
+            .freshReserve(mint: .jeffy, supplyFromBonding: jeffySupply)
+        ])
+
+        return container
+    }
+
+    private static func makeViewModel(
+        source: StoredBalance,
+        container: SessionContainer
+    ) -> ConvertAmountViewModel {
+        ConvertAmountViewModel(
+            sourceBalance: source,
+            session: container.session,
+            ratesController: container.ratesController
+        )
+    }
+
+    // MARK: - Converting out of Dollars (fee charged on top)
+
+    @Test("Converting the whole Dollars balance drops the entry to what the on-top fee leaves")
+    func wholeDollarsBalance_isCorrected() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .usdf, quarks: 10_000_000), // $10.00
+            .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: Self.jeffyQuarks),
+        ])
+        let usdf = try #require(container.session.balance(for: .usdf))
+        let viewModel = Self.makeViewModel(source: usdf, container: container)
+        viewModel.enteredAmount = "10"
+
+        viewModel.correctEntryToAffordable()
+
+        // $10.00 / 1.01 = $9.90099, floored to the cent so the debit fits.
+        #expect(viewModel.enteredAmount == "9.90")
+    }
+
+    @Test("A Dollars entry with room for its fee is left exactly as typed")
+    func dollarsEntryWithRoom_isLeftAlone() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .usdf, quarks: 10_000_000), // $10.00
+            .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: Self.jeffyQuarks),
+        ])
+        let usdf = try #require(container.session.balance(for: .usdf))
+        let viewModel = Self.makeViewModel(source: usdf, container: container)
+        viewModel.enteredAmount = "5"
+
+        viewModel.correctEntryToAffordable()
+
+        #expect(viewModel.enteredAmount == "5")
+    }
+
+    @Test("The corrected entry clears the gate that the uncorrected one failed")
+    func correctedEntry_passesTheAffordabilityGate() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .usdf, quarks: 10_000_000), // $10.00
+            .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: Self.jeffyQuarks),
+        ])
+        let usdf = try #require(container.session.balance(for: .usdf))
+        let viewModel = Self.makeViewModel(source: usdf, container: container)
+        viewModel.enteredAmount = "10"
+        viewModel.correctEntryToAffordable()
+
+        // The debit is the entry plus its own 1% — it must now fit the balance.
+        let entered = try #require(viewModel.enteredFiat)
+        let debit = entered.adding(entered.launchpadSellFee(bps: 100))
+        switch container.session.hasSufficientFunds(for: debit) {
+        case .sufficient:
+            break
+        case .insufficient:
+            Issue.record("The corrected entry must cover its own fee")
+        }
+    }
+
+    // MARK: - Converting out of a token (fee skimmed from the entry)
+
+    @Test("Converting a whole token balance is left alone — its fee comes out of the entry")
+    func wholeTokenBalance_isLeftAlone() async throws {
+        let container = try await Self.makeContainer(holdings: [
+            .init(mint: .makeLaunchpad(address: .jeffy, supplyFromBonding: Self.jeffySupply), quarks: Self.jeffyQuarks),
+            .init(mint: .usdf, quarks: 10_000_000),
+        ])
+        let jeffy = try #require(container.session.balance(for: .jeffy))
+        let rate = container.ratesController.rateForBalanceCurrency()
+        let displayed = jeffy.computeExchangedValue(with: rate)
+            .nativeAmount.value.rounded(to: CurrencyCode.usd.maximumFractionDigits)
+        let viewModel = Self.makeViewModel(source: jeffy, container: container)
+        viewModel.enteredAmount = "\(displayed)"
+
+        viewModel.correctEntryToAffordable()
+
+        #expect(viewModel.enteredAmount == "\(displayed)")
+    }
+}

--- a/FlipcashUITests/Regression/BuyWithCurrencyRegressionTests.swift
+++ b/FlipcashUITests/Regression/BuyWithCurrencyRegressionTests.swift
@@ -8,9 +8,9 @@ import XCTest
 /// Regression test for buying a currency paying with another launchpad
 /// currency: the multi-step flow (amount → Select Payment Currency → summary
 /// with fee breakdown → processing) with a real $0.01 swap. The insufficient
-/// sheet and Buy Maximum math are covered deterministically by
-/// `BuyConfirmationViewModelTests` — a UI rendition proved too balance-
-/// dependent to keep stable.
+/// sheet and the fee-affordable entry correction are covered deterministically
+/// by `BuyConfirmationViewModelTests` and `BuyAmountViewModelTests` — a UI
+/// rendition proved too balance-dependent to keep stable.
 ///
 /// **Prerequisites:**
 /// - A valid `FLIPCASH_UI_TEST_ACCESS_KEY` set in `secrets.local.xcconfig`

--- a/FlipcashUITests/Support/Screens/PaymentCurrencyUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/PaymentCurrencyUIScreen.swift
@@ -22,8 +22,8 @@ struct PaymentCurrencyUIScreen {
     var usdfRow: XCUIElement { app.buttons["payment-currency-row-usdf"] }
 
     /// First non-USDF payment row. The buy target never appears in the list,
-    /// and underfunded rows stay tappable (their Buy surfaces the Buy Maximum
-    /// sheet).
+    /// and underfunded rows stay tappable (the amount screen trims the entry to
+    /// what the row's balance can fund).
     var firstTokenRow: XCUIElement { app.buttons.matching(identifier: "payment-currency-row").firstMatch }
 
     // MARK: - Assertions


### PR DESCRIPTION
iOS mirror of the Android change in `code-payments/code-android-app#1302`.

## Why it always happens at the max

Amount entry is capped at the **raw** balance, but the fee comes out of that same balance. Two conventions apply:

| Funding side | Convention | Debit |
|---|---|---|
| Dollars (no launchpad sale to skim) | fee **on top** | `entered × (1 + f)` |
| every other currency | fee **grossed up** out of the sale | `entered / (1 − f)` |

So entering the maximum always overruns by exactly the fee, and never by more. That band is narrow and bounded, which is what makes correcting it silently safe rather than surprising.

Buy surfaced the overrun as a "Buy Maximum Amount" modal. Convert-from-Dollars didn't surface it at all: `ConvertAmountViewModel.canPerformAction` gates on the raw balance while `ConvertConfirmationViewModel.totalDebited` is `amount + 1%`, so converting the **whole** Dollars balance passed the gate and hard-failed at submit with `insufficientBalance`. Converting *from a token* takes its fee out of the entry, so it can't overrun and is left alone.

## What changed

Trim the entry to what the balance can actually fund, **before** anything is priced — so the amount screen and the receipt agree, and navigating back shows the corrected figure rather than a stale one.

**FlipcashCore**
- `FiatAmount.spendableUnderGrossedUpSellFee(bps:)` / `spendableUnderSellFeeOnTop(bps:)` — inverses of `grossingUpLaunchpadSellFee(bps:)`, sitting beside it and unrounded like it.
- `FiatAmount.flooredToSmallestUnit()` — the derived max must **floor**, never round. $10.11 at 1% corrects to $10.00: $10.01 plus its own fee is $10.1101, straight back over the balance. The floor is an entry-precision concern, so it lives here rather than at the fiat→quark boundary.
- `entryAffordableAfterFee(entered:balance:feeBps:feeChargedOnTop:)` — pure and unit-tested; returns `nil` when the entry already fits.
- `AmountValidator.string(from:fractionDigits:)` — the inverse of `validate(_:)`, so the corrected value is written back in the keypad's own separator convention instead of an ad-hoc format.

**Call sites**
- `BuyAmountViewModel.primaryAction` corrects before `computePaymentAmount`. It now takes the same injectable `collectsUSDFFee` flag as the confirmation, since fee-on-top applies only to the new-UI Dollars buy.
- `ConvertAmountViewModel.showConfirmation` corrects when the source is Dollars.
- Deleted with the modal: `BuyConfirmationViewModel.buyMaximum`, the appear-time auto-prompt, and the screen's 0.35s `.task`. `paymentAmount` is a `let` now that nothing mutates it in place. The submit-time gate stays as a plain "Insufficient Balance" error — reachable only when the balance moves under a quote.

## Parity

Fee math is a cross-platform hotspot, so the helper deliberately mirrors Android's structure rather than an algebraically-equivalent rearrangement: it builds the debit and compares `debit > balance` (not `entered > spendable`), so neither platform can drift at the boundary. The flooring matches `Fiat.flooredToSmallestUnit` on Android.

## Tests

29 new tests, TDD throughout — Android's cases mirrored 1:1 in `FeeAffordableEntryTests` (entries with room, zero fee, the whole balance under each convention, $10.11 → $10.00 flooring, idempotence, over-balance entries, and a JPY case proving the correction is denominated in the balance's currency and floors to whole yen), plus inverse round-trips in `LaunchpadSellFeeTests`, flooring in `FiatAmountTests`, the validator round-trip in `AmountValidatorTests`, and correction coverage on both amount view models.
