### PR TITLE
fix(scanner): read the luminance plane at its own row stride

### DIFF
--- a/CodeScanner/CodeScanner/Code.mm
+++ b/CodeScanner/CodeScanner/Code.mm
@@ -56,7 +56,7 @@
 }
 
 + (nullable NSData *)scan:(nonnull NSData *)data width:(NSInteger)width height:(NSInteger)height {
-    [self scan:data width:width height:height quality:KikCodesScanQualityHigh];
+    return [self scan:data width:width height:height quality:KikCodesScanQualityHigh];
 }
 
 + (nullable NSData *)scan:(nonnull NSData *)data width:(NSInteger)width height:(NSInteger)height quality:(KikCodesScanQuality)quality {

--- a/Flipcash/Core/Screens/Main/Bill/Extraction/CodeExtractor.swift
+++ b/Flipcash/Core/Screens/Main/Bill/Extraction/CodeExtractor.swift
@@ -17,19 +17,15 @@ class CodeExtractor: CameraSessionExtractor {
     required init() {}
 
     func extract(output: AVCaptureOutput, sampleBuffer: CMSampleBuffer, connection: AVCaptureConnection) -> ScannedCode? {
-        let sample = extractSample(from: sampleBuffer)
-        
-        guard let sample = sample else {
-            return nil
+        // The scan runs inside withLuminanceSample so the sample's zero-copy view of the plane
+        // stays valid -- the base address is only guaranteed while the pixel buffer is locked.
+        withLuminanceSample(from: sampleBuffer) { sample in
+            Self.processSample(
+                sample: sample,
+                quality: .best,
+                container: &container
+            )
         }
-        
-        let payload = Self.processSample(
-            sample: sample,
-            quality: .best,
-            container: &container
-        )
-        
-        return payload
     }
     
     private static func processSample(sample: Sample, quality: KikCodesScanQuality) -> (Data, ScannedCode)? {
@@ -61,31 +57,86 @@ class CodeExtractor: CameraSessionExtractor {
         return nil
     }
     
-    private func extractSample(from sampleBuffer: CMSampleBuffer) -> Sample? {
+    /// Vends the frame's luminance (Y) plane as a `Sample`, tightly packed the way `kikCodeScan`
+    /// expects, and calls `body` with it.
+    ///
+    /// Internal rather than private so `CodeScanSweepTests` can drive it with synthesized frames.
+    ///
+    /// The sample is only valid for the duration of `body`: when the plane is already tightly
+    /// packed its `data` is a no-copy view of the locked pixel buffer, which CoreVideo only
+    /// guarantees between lock and unlock.
+    func withLuminanceSample<T>(
+        from sampleBuffer: CMSampleBuffer,
+        _ body: (Sample) -> T?
+    ) -> T? {
         guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
             return nil
         }
-        
-        CVPixelBufferLockBaseAddress(buffer, CVPixelBufferLockFlags(rawValue: 0))
+
+        CVPixelBufferLockBaseAddress(buffer, .readOnly)
         defer {
-            CVPixelBufferUnlockBaseAddress(buffer, CVPixelBufferLockFlags(rawValue: 0))
+            CVPixelBufferUnlockBaseAddress(buffer, .readOnly)
         }
-        
+
         guard let base = CVPixelBufferGetBaseAddressOfPlane(buffer, 0) else {
             return nil
         }
-        
-        let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
-        let width = CVPixelBufferGetWidth(buffer)
-        let height = CVPixelBufferGetHeight(buffer)
-        
+
+        // The capture format is planar 420, so these must be read per-plane.
+        // CVPixelBufferGetBytesPerRow reports a whole-buffer value for planar formats -- at
+        // 1920x1080 it returns 2884 rather than the plane's actual 1920 -- which both over-claims
+        // the buffer's length and hides the row padding below.
+        let width = CVPixelBufferGetWidthOfPlane(buffer, 0)
+        let height = CVPixelBufferGetHeightOfPlane(buffer, 0)
+        let rowStride = CVPixelBufferGetBytesPerRowOfPlane(buffer, 0)
+
         let sample = Sample(
             width: width,
             height: height,
-            data: Data(bytesNoCopy: base, count: bytesPerRow * height, deallocator: .none)
+            data: Self.luminanceData(base: base, width: width, height: height, rowStride: rowStride)
         )
-        
-        return sample
+
+        return body(sample)
+    }
+
+    /// Produces the tightly packed `width * height` buffer `kikCodeScan` reads.
+    ///
+    /// CoreVideo aligns plane rows to 64 bytes, so a capture width that is not a multiple of 64
+    /// arrives padded -- 1440 wide comes back with a 1472-byte stride. Handing that straight to the
+    /// scanner shears the image by a growing offset per row. Widths that are already 64-aligned
+    /// (1920 among them, which is why `.hd1920x1080` has always worked) need no copy at all.
+    ///
+    /// This mirrors `LuminancePlane` in the shared Kotlin module, which Android applies to the same
+    /// decision; there is no pixel-stride term because plane 0 of a 420 buffer is always one byte
+    /// per pixel.
+    static func luminanceData(
+        base: UnsafeRawPointer,
+        width: Int,
+        height: Int,
+        rowStride: Int
+    ) -> Data {
+        let scannedByteCount = width * height
+
+        guard rowStride != width else {
+            return Data(
+                bytesNoCopy: UnsafeMutableRawPointer(mutating: base),
+                count: scannedByteCount,
+                deallocator: .none
+            )
+        }
+
+        var data = Data(count: scannedByteCount)
+        data.withUnsafeMutableBytes { destination in
+            guard let destination = destination.baseAddress else { return }
+            for row in 0..<height {
+                memcpy(
+                    destination.advanced(by: row * width),
+                    base.advanced(by: row * rowStride),
+                    width
+                )
+            }
+        }
+        return data
     }
 }
 

--- a/FlipcashTests/CodeScanSweepTests.swift
+++ b/FlipcashTests/CodeScanSweepTests.swift
@@ -1,0 +1,308 @@
+//
+//  CodeScanSweepTests.swift
+//  FlipcashTests
+//
+
+import AVFoundation
+import CoreVideo
+import SwiftUI
+import Testing
+import UIKit
+
+import CodeScanner
+@testable import Flipcash
+@testable import FlipcashUI
+
+/// The iOS half of the scanner harness, mirroring `KikCodeScanTest` in the Android repo
+/// (`vendor/kik/scanner/src/androidTest/.../KikCodeScanTest.kt`).
+///
+/// Both platforms feed the same C++ scanner — the eight files under `CodeScanner/src` are
+/// byte-identical to Android's `vendor/kik/scanner/src/main/cpp` — so the only place the two can
+/// disagree is the ~20 lines of pixel-buffer glue each one wraps it in. That glue is what this
+/// exercises: a code is rendered, written into a real `CVPixelBuffer`, and pulled back out through
+/// `CodeExtractor` exactly the way a capture frame would be.
+///
+/// The interesting axis is capture width. CoreVideo aligns plane rows to 64 bytes, so 1920 comes
+/// back tightly packed (stride 1920) while 1440 comes back padded (stride 1472). `CodeExtractor`
+/// used to read its stride from `CVPixelBufferGetBytesPerRow`, which reports a whole-buffer value
+/// for planar formats, and never unpadded — so the padded widths below are the cases that were
+/// silently sheared.
+@MainActor
+@Suite("Code Scan Sweep")
+struct CodeScanSweepTests {
+
+    /// Chosen so the sweep covers both sides of CoreVideo's 64-byte row alignment.
+    static let resolutions: [(width: Int, height: Int)] = [
+        (1920, 1080), // 64-aligned -> tightly packed
+        (1440, 1080), // padded to a 1472-byte stride
+        (1000, 750),  // padded to a 1024-byte stride
+    ]
+
+    static let codeScales: [CGFloat] = [0.5, 0.7, 0.9]
+
+    /// `kikCodeEncodeRemote` takes a 20-byte payload.
+    static let payload = Data((0..<20).map { UInt8(($0 &* 7 &+ 11) % 251) })
+
+    // MARK: - Sweep -
+
+    @Test("rendered codes decode at every resolution and code scale")
+    func sweepRenderedCodesAcrossResolutionsAndScales() throws {
+        var decoded = 0
+        var attempted = 0
+
+        for resolution in Self.resolutions {
+            for scale in Self.codeScales {
+                attempted += 1
+
+                let buffer = try Self.makeFrame(
+                    width: resolution.width,
+                    height: resolution.height,
+                    codeScale: scale
+                )
+
+                if let payload = Self.scan(buffer) {
+                    #expect(payload == Self.payload)
+                    decoded += 1
+                } else {
+                    Issue.record(
+                        """
+                        no decode at \(resolution.width)x\(resolution.height) scale=\(scale) \
+                        stride=\(CVPixelBufferGetBytesPerRowOfPlane(buffer, 0))
+                        """
+                    )
+                }
+            }
+        }
+
+        #expect(decoded == attempted, "sweep: \(decoded)/\(attempted) decoded")
+    }
+
+    /// The regression that matters: a padded capture width must decode to the same payload as a
+    /// packed one. Before the stride fix the padded frames sheared by 32-64 bytes per row and
+    /// decoded to nothing.
+    @Test("padded and packed capture widths decode identically")
+    func paddedAndPackedWidthsDecodeIdentically() throws {
+        let packed = try Self.makeFrame(width: 1920, height: 1080, codeScale: 0.7)
+        let padded = try Self.makeFrame(width: 1440, height: 1080, codeScale: 0.7)
+
+        #expect(CVPixelBufferGetBytesPerRowOfPlane(packed, 0) == 1920, "expected a packed plane")
+        #expect(CVPixelBufferGetBytesPerRowOfPlane(padded, 0) > 1440, "expected a padded plane")
+
+        #expect(Self.scan(packed) == Self.payload)
+        #expect(Self.scan(padded) == Self.payload)
+    }
+
+    // MARK: - Packing rule -
+
+    /// Mirrors `LuminancePlaneTest` in `:libs:codes:kikcode` commonTest. The two implementations
+    /// have to agree byte for byte, so they are checked against the same geometries and the same
+    /// `(i % 251)` fill.
+    @Test("packing rule matches the shared Kotlin rule")
+    func packingRuleMatchesSharedRule() {
+        let geometries: [(width: Int, height: Int, rowStride: Int)] = [
+            (640, 480, 640),
+            (640, 480, 768),
+            (1280, 720, 1280),
+            (1280, 720, 1408),
+            (1920, 1080, 1920),
+            (1920, 1080, 2048),
+        ]
+
+        for geometry in geometries {
+            let plane = [UInt8]((0..<(geometry.rowStride * geometry.height)).map { UInt8($0 % 251) })
+
+            let packed = plane.withUnsafeBytes { raw in
+                CodeExtractor.luminanceData(
+                    base: raw.baseAddress!,
+                    width: geometry.width,
+                    height: geometry.height,
+                    rowStride: geometry.rowStride
+                )
+            }
+
+            #expect(
+                packed.count == geometry.width * geometry.height,
+                "wrong length at \(geometry.width)x\(geometry.height)/\(geometry.rowStride)"
+            )
+
+            for row in 0..<geometry.height {
+                for column in 0..<geometry.width {
+                    let expected = plane[row * geometry.rowStride + column]
+                    let actual = packed[row * geometry.width + column]
+                    guard expected == actual else {
+                        Issue.record(
+                            """
+                            mismatch at (\(column),\(row)) for \
+                            \(geometry.width)x\(geometry.height)/\(geometry.rowStride): \
+                            expected \(expected), got \(actual)
+                            """
+                        )
+                        return
+                    }
+                }
+            }
+        }
+    }
+
+    /// The fast path exists to avoid copying ~2MB per frame, so assert it really is a view onto the
+    /// plane rather than a copy of it.
+    @Test("tightly packed planes are handed over without copying")
+    func tightlyPackedPlanesAreNotCopied() {
+        let width = 1920
+        let height = 1080
+        var plane = [UInt8](repeating: 0, count: width * height)
+
+        plane.withUnsafeMutableBytes { raw in
+            let base = raw.baseAddress!
+            let data = CodeExtractor.luminanceData(
+                base: base,
+                width: width,
+                height: height,
+                rowStride: width
+            )
+
+            // Mutating the plane must be visible through `data` if nothing was copied.
+            base.assumingMemoryBound(to: UInt8.self)[42] = 0xAB
+            #expect(data[42] == 0xAB, "packed plane should be a no-copy view of the buffer")
+        }
+    }
+
+    // MARK: - Helpers -
+
+    /// Runs a frame through the real extraction path and returns the decoded payload.
+    private static func scan(_ buffer: CVPixelBuffer) -> Data? {
+        let extractor = CodeExtractor()
+        return extractor.withLuminanceSample(from: makeSampleBuffer(buffer)) { sample in
+            guard
+                let scanned = KikCodes.scan(
+                    sample.data,
+                    width: sample.width,
+                    height: sample.height,
+                    quality: .best
+                )
+            else {
+                return nil
+            }
+            return KikCodes.decode(scanned)
+        }
+    }
+
+    /// Renders a code into the luminance plane of a real 420 pixel buffer, letting CoreVideo pick
+    /// the row stride so the padded cases are the ones the camera would actually hand us.
+    private static func makeFrame(width: Int, height: Int, codeScale: CGFloat) throws -> CVPixelBuffer {
+        let image = try renderCode(side: CGFloat(min(width, height)) * codeScale)
+
+        var buffer: CVPixelBuffer?
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            width,
+            height,
+            kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+            [kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary] as CFDictionary,
+            &buffer
+        )
+
+        guard status == kCVReturnSuccess, let buffer else {
+            throw ScanHarnessError.pixelBufferCreationFailed(status)
+        }
+
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+
+        guard let base = CVPixelBufferGetBaseAddressOfPlane(buffer, 0) else {
+            throw ScanHarnessError.missingPlane
+        }
+
+        let rowStride = CVPixelBufferGetBytesPerRowOfPlane(buffer, 0)
+
+        // Drawing straight into the plane at its own stride is what makes the padded cases real:
+        // CoreGraphics writes the padding bytes the camera would have left there.
+        guard let context = CGContext(
+            data: base,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: rowStride,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        ) else {
+            throw ScanHarnessError.contextCreationFailed
+        }
+
+        context.setFillColor(gray: 1.0, alpha: 1.0)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        if let cgImage = image.cgImage {
+            let side = image.size.width
+            context.draw(
+                cgImage,
+                in: CGRect(
+                    x: (CGFloat(width) - side) / 2,
+                    y: (CGFloat(height) - side) / 2,
+                    width: side,
+                    height: side
+                )
+            )
+        }
+
+        // Neutral chroma, so the frame is a plausible greyscale image end to end.
+        if CVPixelBufferGetPlaneCount(buffer) > 1, let chroma = CVPixelBufferGetBaseAddressOfPlane(buffer, 1) {
+            memset(chroma, 128, CVPixelBufferGetBytesPerRowOfPlane(buffer, 1) * CVPixelBufferGetHeightOfPlane(buffer, 1))
+        }
+
+        return buffer
+    }
+
+    /// Renders `CodeView`, which draws the code together with the centre badge. The badge matters:
+    /// the native detector finds a code by its centre ellipse, so a code rendered with an empty
+    /// well is undetectable.
+    private static func renderCode(side: CGFloat) throws -> UIImage {
+        let encoded = KikCodes.encode(payload)
+
+        let renderer = ImageRenderer(
+            content: CodeView(data: encoded)
+                .foregroundStyle(.black)
+                .frame(width: side, height: side)
+                .background(Color.white)
+        )
+        renderer.scale = 1.0
+
+        guard let image = renderer.uiImage else {
+            throw ScanHarnessError.renderFailed
+        }
+        return image
+    }
+
+    private static func makeSampleBuffer(_ pixelBuffer: CVPixelBuffer) -> CMSampleBuffer {
+        var formatDescription: CMFormatDescription?
+        CMVideoFormatDescriptionCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescriptionOut: &formatDescription
+        )
+
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: 30),
+            presentationTimeStamp: .zero,
+            decodeTimeStamp: .invalid
+        )
+
+        var sampleBuffer: CMSampleBuffer?
+        CMSampleBufferCreateReadyWithImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescription: formatDescription!,
+            sampleTiming: &timing,
+            sampleBufferOut: &sampleBuffer
+        )
+
+        return sampleBuffer!
+    }
+
+    enum ScanHarnessError: Error {
+        case pixelBufferCreationFailed(CVReturn)
+        case missingPlane
+        case contextCreationFailed
+        case renderFailed
+    }
+}

--- a/FlipcashTests/CodeScanSweepTests.swift
+++ b/FlipcashTests/CodeScanSweepTests.swift
@@ -229,7 +229,8 @@ struct CodeScanSweepTests {
             throw ScanHarnessError.contextCreationFailed
         }
 
-        context.setFillColor(gray: 1.0, alpha: 1.0)
+        // Dark field, matching the rendered code's polarity and Android's harness.
+        context.setFillColor(gray: 0.0, alpha: 1.0)
         context.fill(CGRect(x: 0, y: 0, width: width, height: height))
 
         if let cgImage = image.cgImage {
@@ -253,17 +254,22 @@ struct CodeScanSweepTests {
         return buffer
     }
 
-    /// Renders `CodeView`, which draws the code together with the centre badge. The badge matters:
-    /// the native detector finds a code by its centre ellipse, so a code rendered with an empty
-    /// well is undetectable.
+    /// Renders `CodeView`, which draws the code together with the centre badge.
+    ///
+    /// Polarity is not cosmetic. The detector finds a candidate code by thresholding for *bright*
+    /// blobs and fitting an ellipse to the centre badge, and only then looks at the ring around it
+    /// to decide whether the marks are inverted. So the badge has to be the bright part: light
+    /// marks and a light badge on a dark field, which is also what the bill draws and what
+    /// Android's harness renders. Black-on-white leaves the badge as a dark hole and nothing is
+    /// ever detected.
     private static func renderCode(side: CGFloat) throws -> UIImage {
         let encoded = KikCodes.encode(payload)
 
         let renderer = ImageRenderer(
             content: CodeView(data: encoded)
-                .foregroundStyle(.black)
+                .foregroundStyle(.white)
                 .frame(width: side, height: side)
-                .background(Color.white)
+                .background(Color.black)
         )
         renderer.scale = 1.0
 


### PR DESCRIPTION
`CodeExtractor` built the scanner's input from `CVPixelBufferGetBytesPerRow`, which reports the **buffer-level** stride rather than plane 0's. On a planar `420YpCbCr8` buffer that is roughly 1.5x the luma row -- 2884 for a 1920-wide frame -- so the pointer handed to the scanner did not describe the bytes behind it.

`kikCodeScan` does `memcpy(greyscale.data, image, height * width)`: it reads exactly `width * height` bytes from the front of whatever it is given and assumes they are a tightly packed greyscale image. CoreVideo aligns plane 0 to 64 bytes, so any width that is not a multiple of 64 arrives padded (1440 -> 1472, 1000 -> 1024), and those frames were being fed skewed rows.

This reads the plane-level geometry instead -- `CVPixelBufferGetWidthOfPlane` / `GetHeightOfPlane` / `GetBytesPerRowOfPlane(buffer, 0)` -- and strips row padding when the plane is padded. When `rowStride == width` the plane is already what the scanner wants, so it passes through with `bytesNoCopy` and no per-frame allocation.

Two related fixes fall out of the same path:

- The zero-copy `Data` escaped its `CVPixelBufferLockBaseAddress` scope. The base address is only guaranteed while the buffer is locked, so this was a latent use-after-unlock. The scan now runs inside the lock via `withLuminanceSample`.
- `KikCodes.scan(data:width:height:)` dropped the result of the quality overload it delegates to -- a missing `return` in `Code.mm` -- so the three-argument entry point always returned nil.

## Cross-platform

Android had the same class of bug in the other direction: it guarded its unpadding with `pixelStride != -1`, which is vacuously true for a `YUV_420_888` Y plane, so it ran a per-pixel copy on every frame. Two independent implementations of "is this plane packed?" produced two independent bugs.

The rule now lives once, in `:libs:codes:kikcode` as `LuminancePlane`, which `SharedCoreKit` already exports: code-payments/code-android-app#1303.

That version is not published yet, so this PR still carries a Swift-side implementation. `CodeScanSweepTests.packingRuleMatchesSharedRule` pins it to the Kotlin one byte-for-byte over the same geometries and the same fill until the pin moves to SharedCore 0.3.2, at which point the Swift copy is deleted and the test becomes a straight regression test.

## Tests

`CodeScanSweepTests` is the iOS half of the harness mirroring Android's `KikCodeScanTest`. Both platforms feed the same C++ scanner -- the eight sources under `CodeScanner/src` are byte-identical to Android's `vendor/kik/scanner/src/main/cpp` -- so the pixel-buffer glue is the only place the two can disagree, and that glue is what these cover. It renders real codes, pushes them through real `CVPixelBuffer`s at packed and padded widths, and checks that packed planes are genuinely not copied.
