### PR TITLE
feat(chat): backfill transcripts after a feed sync

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -129,6 +129,10 @@ final class ConversationController {
     /// Debounced live-gap catch-ups, one per conversation: a detected gap waits briefly (a late
     /// out-of-order event may close it) before spending a `GetDelta`.
     @ObservationIgnored private var gapCatchUpTasks: [ConversationID: Task<Void, Never>] = [:]
+    /// Conversations with a newest-page `GetMessages` in flight. Read by the backfill so it doesn't
+    /// re-fetch a page the open chat is already loading; `loadMessages` itself never short-circuits,
+    /// because the screen awaits it before marking read.
+    @ObservationIgnored private var messageLoadsInFlight: Set<ConversationID> = []
     @ObservationIgnored private let receiptSettle = ReceiptSettleGate()
 
     /// The typing-indicator concern, both directions (outgoing driver + incoming typist
@@ -466,28 +470,120 @@ final class ConversationController {
     // MARK: - Feed
 
     func loadFeed() async {
+        let loaded = await loadFeeds()
+        // Outside the loading flag: the feed itself is on screen the moment the
+        // conversations apply, and the transcripts fill behind it.
+        await backfillMessages(for: loaded)
+    }
+
+    private func loadFeeds() async -> [Conversation] {
         isLoadingFeed = true
         defer { isLoadingFeed = false }
         // Both DM feeds load concurrently and apply independently, so one
         // type's failure doesn't drop the other's conversations.
-        async let contact: Void = loadFeed(type: .contactDm)
-        async let tip: Void = loadFeed(type: .tipDm)
-        _ = await (contact, tip)
+        async let contact = loadFeed(type: .contactDm)
+        async let tip = loadFeed(type: .tipDm)
+        return await contact + tip
     }
 
-    func loadFeed(type: ConversationType) async {
+    /// Loads one DM feed type and returns the conversations the server reported,
+    /// empty if the load failed.
+    @discardableResult
+    func loadFeed(type: ConversationType) async -> [Conversation] {
         do {
             let conversations = try await fetching.getDmChatFeed(owner: owner, type: type)
             store.setFeed(conversations, type: type)
             reconcileHidden()
             persist(operation: "replace-feed") { try database.replaceConversationFeed(conversations, type: type) }
+            return conversations
         } catch {
             logger.error("Failed to load conversation feed", metadata: [
                 "type": "\(type)",
                 "error": "\(error)",
             ])
             ErrorReporting.captureError(error, reason: "Failed to load conversation feed")
+            return []
         }
+    }
+
+    // MARK: - Backfill
+
+    /// How many conversations backfill at once. The transcripts are wanted soon, not instantly — a
+    /// login with a large feed must not open a round trip per chat at the same moment as the balance,
+    /// rates, and history syncs it shares the launch with.
+    private static let backfillConcurrency = 4
+
+    /// What a conversation needs to bring its local transcript level with the server.
+    private enum Backfill: Equatable {
+        /// The local cursor lags the server's head: stream the missed window from it.
+        case delta
+        /// Nothing is cached at all: fetch the newest page, which also seats the cursor to head.
+        case newestPage
+    }
+
+    /// One conversation's backfill, queued.
+    private struct BackfillTask: Sendable {
+        let conversationID: ConversationID
+        let kind: Backfill
+    }
+
+    /// Brings every conversation in a freshly-loaded feed up to the server's head, so a transcript is
+    /// there when the chat is opened rather than fetched on arrival.
+    ///
+    /// Without this, chat history is only ever fetched by opening a chat, and each fresh login —
+    /// switching accounts included — starts from a per-owner database with no messages in it at all.
+    /// Ported from Android's `FeedSyncDelegate`, branch order included: a cursor that lags is streamed
+    /// forward from where it sits, and only a conversation holding nothing falls back to the newest
+    /// page. Reversing that would spend a `GetDelta(after: 0)` re-pulling whole histories.
+    private func backfillMessages(for conversations: [Conversation]) async {
+        // Deduped by id: the feed loads by type, and a conversation reported under more than one type
+        // must not queue its transcript twice.
+        var seen: Set<ConversationID> = []
+        let work = conversations.compactMap { conversation -> BackfillTask? in
+            guard seen.insert(conversation.id).inserted else { return nil }
+            return backfill(for: conversation).map { BackfillTask(conversationID: conversation.id, kind: $0) }
+        }
+        guard !work.isEmpty else { return }
+        logger.info("Backfilling chat history", metadata: [
+            "conversations": "\(work.count)",
+            "delta": "\(work.filter { $0.kind == .delta }.count)",
+        ])
+
+        await withTaskGroup(of: Void.self) { group in
+            var next = 0
+            // Start a window of tasks, then replace each as it finishes, so the queue drains at a
+            // steady width instead of in lock-stepped batches.
+            while next < min(Self.backfillConcurrency, work.count) {
+                group.addTask { [task = work[next]] in await self.perform(task) }
+                next += 1
+            }
+            while await group.next() != nil, next < work.count {
+                group.addTask { [task = work[next]] in await self.perform(task) }
+                next += 1
+            }
+        }
+    }
+
+    private func perform(_ task: BackfillTask) async {
+        switch task.kind {
+        case .delta:      await catchUp(conversationID: task.conversationID)
+        case .newestPage: await loadMessages(for: task.conversationID)
+        }
+    }
+
+    /// The work one conversation needs, or `nil` when its transcript is already current — or is
+    /// already being fetched by the open chat, whose own load lands the same page.
+    private func backfill(for conversation: Conversation) -> Backfill? {
+        let conversationID = conversation.id
+        guard !messageLoadsInFlight.contains(conversationID) else { return nil }
+
+        // A zero head means the server reported no sequence for this chat, and a zero cursor means the
+        // client has never applied one — neither is a lag that `GetDelta` can resume from.
+        let cursor = store.appliedCursor(for: conversationID)
+        if conversation.latestEventSequence > 0, cursor > 0, cursor < conversation.latestEventSequence {
+            return .delta
+        }
+        return hasMessages(for: conversationID) ? nil : .newestPage
     }
 
     // MARK: - Persistence
@@ -766,6 +862,8 @@ final class ConversationController {
     }
 
     func loadMessages(for conversationID: ConversationID) async {
+        messageLoadsInFlight.insert(conversationID)
+        defer { messageLoadsInFlight.remove(conversationID) }
         do {
             let messages = try await messaging.getMessages(owner: owner, conversationID: conversationID, before: nil)
             logger.info("Loaded conversation messages", metadata: [

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -577,13 +577,14 @@ final class ConversationController {
         let conversationID = conversation.id
         guard !messageLoadsInFlight.contains(conversationID) else { return nil }
 
-        // A zero head means the server reported no sequence for this chat, and a zero cursor means the
-        // client has never applied one — neither is a lag that `GetDelta` can resume from.
+        // The cursor, not the presence of messages, is what says whether a transcript was ever pulled:
+        // the feed persists each conversation's last-message preview as a message row before this runs,
+        // so "holds a message" is true for nearly every chat in a feed the client has otherwise never
+        // fetched. Only a newest page or an applied delta seats a cursor.
         let cursor = store.appliedCursor(for: conversationID)
-        if conversation.latestEventSequence > 0, cursor > 0, cursor < conversation.latestEventSequence {
-            return .delta
-        }
-        return hasMessages(for: conversationID) ? nil : .newestPage
+        guard cursor > 0 else { return .newestPage }
+        // A zero head means the server reported no sequence for this chat — nothing to compare against.
+        return conversation.latestEventSequence > cursor ? .delta : nil
     }
 
     // MARK: - Persistence

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Conversation.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/Conversation.swift
@@ -24,7 +24,16 @@ public struct Conversation: Identifiable, Hashable, Sendable {
     /// where the counterpart's name is used instead.
     public var title: String?
 
-    public init(id: ConversationID, members: [ConversationMember], lastMessage: ConversationMessage?, lastActivity: Date, type: ConversationType = .contactDm, isHidden: Bool = false, title: String? = nil) {
+    /// The newest event-log sequence the server holds for this chat, as reported
+    /// by the feed. Compared against the locally-applied catch-up cursor to tell
+    /// a transcript that lags the server from one that is current.
+    ///
+    /// Server truth valid only at fetch time, so it is deliberately not cached:
+    /// a conversation restored from the local database reports `0`, meaning
+    /// "unknown", not "empty".
+    public var latestEventSequence: UInt64
+
+    public init(id: ConversationID, members: [ConversationMember], lastMessage: ConversationMessage?, lastActivity: Date, type: ConversationType = .contactDm, isHidden: Bool = false, title: String? = nil, latestEventSequence: UInt64 = 0) {
         self.id = id
         self.members = members
         self.lastMessage = lastMessage
@@ -32,6 +41,7 @@ public struct Conversation: Identifiable, Hashable, Sendable {
         self.type = type
         self.isHidden = isHidden
         self.title = title
+        self.latestEventSequence = latestEventSequence
     }
 }
 
@@ -77,6 +87,7 @@ extension Conversation {
         // Proto represents an unset title as an empty string; normalize to nil so
         // DMs (which never carry a title) and untitled groups behave the same.
         self.title = proto.title.isEmpty ? nil : proto.title
+        self.latestEventSequence = proto.latestEventSequence
     }
 
     /// The member that isn't the signed-in user, used to title the conversation.

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -711,6 +711,26 @@ struct ConversationControllerTests {
         #expect(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [9])
     }
 
+    @Test("a chat holding only the feed's last-message preview still has its transcript fetched")
+    func loadFeedBackfillsConversationWithOnlyAPreviewRow() async {
+        let mock = MockConversations()
+        // The feed persists this preview as a message row before the backfill plans, so a check for
+        // "holds any message" would call this transcript cached and never fetch it — which is every
+        // conversation on a fresh login.
+        let preview = ConversationMessage(id: MessageID(value: 4), senderID: nil, content: .text("preview"), date: Date(timeIntervalSince1970: 40), unreadSeq: 4, eventSequence: 4)
+        mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: preview, lastActivity: Date(timeIntervalSince1970: 100))]
+        mock.messages = [
+            ConversationMessage(id: MessageID(value: 3), senderID: nil, content: .text("older"), date: Date(timeIntervalSince1970: 30), unreadSeq: 3, eventSequence: 3),
+            preview,
+        ]
+        let controller = makeController(mock)
+
+        await controller.loadFeed()
+
+        #expect(mock.latestPageQueries == [ConversationID.test(1)])
+        #expect(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [3, 4])
+    }
+
     @Test("a second feed load leaves an already-cached transcript alone")
     func loadFeedSkipsCachedConversation() async {
         let mock = MockConversations()

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -618,6 +618,11 @@ struct ConversationControllerTests {
         try await waitUntil { !controller.conversations.isEmpty }
         controller.visibleConversationID = ConversationID.test(1)
 
+        // start()'s feed load backfilled the (then-empty) transcript already; this test is about the
+        // page the reset path fetches, so wait that one out and forget it.
+        try await waitUntil { !mock.latestPageQueries.isEmpty }
+        mock.clearLatestPageQueries()
+
         // The cursor is too far behind: GetDelta returns RESET_REQUIRED, so catch-up falls back to the
         // newest page and re-establishes the cursor from that page's floor.
         mock.deltaError = ErrorGetDelta.resetRequired
@@ -669,8 +674,8 @@ struct ConversationControllerTests {
         controller.stop()
     }
 
-    @Test("a reconnect with no conversation open refreshes the feed but fetches no transcript")
-    func reconnectWithoutVisibleConversationSkipsMessages() async throws {
+    @Test("a reconnect backfills a chat it surfaces, without a catch-up it has no cursor for")
+    func reconnectBackfillsSurfacedConversation() async throws {
         let mock = MockConversations()
         let controller = makeController(mock)
 
@@ -678,16 +683,72 @@ struct ConversationControllerTests {
         try await waitUntil { mock.connectionStateStreamOpened }
         mock.emitConnectionState(.live)   // initial connection — baseline
 
-        // No conversation is visible. The feed refresh proves the refetch ran;
-        // the transcript page must not be fetched.
+        // A conversation the client has never held anything for appears on the refreshed feed. Its
+        // transcript is fetched even though nothing is on screen — that is the backfill — but as a
+        // newest page, since a zero cursor is nothing GetDelta could resume from.
         mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
         mock.emitConnectionState(.disconnected)
-        mock.emitConnectionState(.live)   // reconnect → loadFeed only
+        mock.emitConnectionState(.live)   // reconnect → refetch
 
-        try await waitUntil { controller.conversations.map(\.id) == [ConversationID.test(1)] }
-        #expect(mock.latestPageQueries.isEmpty)
-        #expect(mock.deltaAfterSequences.isEmpty) // no visible chat → no catch-up
+        try await waitUntil { mock.latestPageQueries == [ConversationID.test(1)] }
+        #expect(controller.conversations.map(\.id) == [ConversationID.test(1)])
+        #expect(mock.deltaAfterSequences.isEmpty)
         controller.stop()
+    }
+
+    // MARK: - Backfill -
+
+    @Test("a feed load fetches the transcript of a conversation the client holds nothing for")
+    func loadFeedBackfillsEmptyConversation() async {
+        let mock = MockConversations()
+        mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
+        mock.messages = [ConversationMessage(id: MessageID(value: 9), senderID: nil, content: .text("hi"), date: Date(timeIntervalSince1970: 90), unreadSeq: 9, eventSequence: 9)]
+        let controller = makeController(mock)
+
+        await controller.loadFeed()
+
+        #expect(mock.latestPageQueries == [ConversationID.test(1)])
+        #expect(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [9])
+    }
+
+    @Test("a second feed load leaves an already-cached transcript alone")
+    func loadFeedSkipsCachedConversation() async {
+        let mock = MockConversations()
+        mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
+        mock.messages = [ConversationMessage(id: MessageID(value: 9), senderID: nil, content: .text("hi"), date: Date(timeIntervalSince1970: 90), unreadSeq: 9, eventSequence: 9)]
+        let controller = makeController(mock)
+
+        await controller.loadFeed()
+        await controller.loadFeed()
+
+        #expect(mock.latestPageQueries == [ConversationID.test(1)])
+    }
+
+    @Test("a feed load streams the missed window when the local cursor lags the server's head")
+    func loadFeedBackfillsLaggingConversationViaDelta() async {
+        let mock = MockConversations()
+        mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 100))]
+        mock.messages = [ConversationMessage(id: MessageID(value: 2), senderID: nil, content: .text("old"), date: Date(timeIntervalSince1970: 20), unreadSeq: 2, eventSequence: 2)]
+        let controller = makeController(mock)
+
+        // Seed the cache: the newest page lands and seats the cursor at 2.
+        await controller.loadFeed()
+
+        // The server has moved past that cursor. The lag is streamed forward from where the cursor
+        // sits — not re-pulled as a newest page, which would spend a GetDelta(after: 0)'s worth of
+        // history and prepend it.
+        mock.feed = [Conversation(id: ConversationID.test(1), members: [], lastMessage: nil, lastActivity: Date(timeIntervalSince1970: 200), latestEventSequence: 5)]
+        mock.deltaHead = 5
+        mock.deltaBatches = [MockConversations.DeltaBatch(
+            messages: [ConversationMessage(id: MessageID(value: 3), senderID: nil, content: .text("new"), date: Date(timeIntervalSince1970: 30), unreadSeq: 3, eventSequence: 5)],
+            checkpoint: 5
+        )]
+
+        await controller.loadFeed()
+
+        #expect(mock.deltaAfterSequences == [2])
+        #expect(mock.latestPageQueries == [ConversationID.test(1)]) // no second newest-page fetch
+        #expect(controller.messages(for: ConversationID.test(1)).map(\.id.value) == [2, 3])
     }
 
     // MARK: - Pagination -

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -57,6 +57,9 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
     var olderQueries: [MessageID] { lock.withLock { _olderQueries } }
     /// The conversations `getMessages` was asked for the newest page of (`before == nil`).
     var latestPageQueries: [ConversationID] { lock.withLock { _latestPageQueries } }
+    /// Forget the recorded newest-page fetches, so a test can assert on the ones its own exercise
+    /// makes rather than the post-feed backfill that already ran during `start()`.
+    func clearLatestPageQueries() { lock.withLock { _latestPageQueries.removeAll() } }
     var sendResult: ConversationMessage? {
         get { lock.withLock { _sendResult } }
         set { lock.withLock { _sendResult = newValue } }


### PR DESCRIPTION
Chat history was only ever fetched by opening a chat: `loadMessages(for:)` had exactly one caller (`ConversationScreen`, on open) and `catchUp` fired only for the visible chat or a detected live gap. A fresh login — switching accounts included — starts from a per-owner database with no messages in it, so every conversation in the feed sat empty until it was opened by hand.

## What changed

- `ConversationController.loadFeed()` now backfills the conversations the feed reported, four at a time, outside the loading flag — the feed is on screen the moment the conversations apply and the transcripts fill behind it.
- The branch is chosen from the **catch-up cursor**, which is the only thing that says whether a transcript was ever pulled: a zero cursor takes the newest page, and a seated cursor behind the feed's `latest_event_sequence` resumes with `GetDelta` from where it sits. Choosing on "does this chat hold any message" does not work — the feed persists each conversation's last-message preview as a message row before the backfill plans, so that test is true for nearly every chat in a feed the client has otherwise never fetched. Order matters too: a `GetDelta(after: 0)` would re-pull whole histories and prepend them, knocking an open transcript off the bottom, so delta only runs on a cursor that is already seated.
- Work is deduped by conversation id (the feed loads per type) and skips any chat whose newest page the open screen is already fetching.
- `Conversation` carries the server's `latestEventSequence` from the feed payload. It is server truth valid only at fetch time, so it is deliberately not cached — a conversation restored from the local database reports `0`, meaning "unknown", not "empty". No schema change: the local cursor is already persisted as `ConversationTable.catchupCursor`.

## Tests

Four new cases in `ConversationControllerTests` cover the empty-conversation backfill, the cached no-op, the lagging-cursor delta path, and the regression above — a chat holding only the feed's preview row still gets its transcript fetched. Two existing cases were updated for the new premise: `RESET_REQUIRED…` now forgets the page `start()`'s backfill fetched, and the old "a reconnect with no conversation open fetches no transcript" is now "a reconnect backfills a chat it surfaces" — that behavior is the point of the change.
