### PR TITLE
fix(buy): lead the Get receipt with what you pay

### DIFF
--- a/Flipcash/Core/Screens/Main/Buy/BuyConfirmationScreen.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyConfirmationScreen.swift
@@ -33,10 +33,10 @@ struct BuyConfirmationScreen: View {
                 BorderedContainer {
                     VStack(spacing: 0) {
                         ConfirmationAmountRow(
-                            title: "You Get",
-                            currencyName: viewModel.targetName,
-                            imageURL: viewModel.targetImageURL,
-                            amount: viewModel.amountToBuy.nativeAmount.formatted()
+                            title: "You Pay",
+                            currencyName: viewModel.payment.name,
+                            imageURL: viewModel.payment.imageURL,
+                            amount: viewModel.grossDebit.nativeAmount.formatted()
                         )
                         .padding(.top, 24)
 
@@ -55,10 +55,10 @@ struct BuyConfirmationScreen: View {
                         }
 
                         ConfirmationAmountRow(
-                            title: "You Pay",
-                            currencyName: viewModel.payment.name,
-                            imageURL: viewModel.payment.imageURL,
-                            amount: viewModel.grossDebit.nativeAmount.formatted()
+                            title: "You Get",
+                            currencyName: viewModel.targetName,
+                            imageURL: viewModel.targetImageURL,
+                            amount: viewModel.amountToBuy.nativeAmount.formatted()
                         )
                         .padding(.top, viewModel.chargesFee ? 0 : 24)
                         .padding(.bottom, 24)


### PR DESCRIPTION
The Get receipt anchored on "You Get" and closed with "You Pay", so the figure that actually leaves your balance was the last thing read — and when a conversion fee applies, the breakdown sat *above* the total it decomposes rather than below it.

Swap the two anchors. Get now reads the same way as the Convert receipt: the outgoing side on top, its breakdown underneath, the incoming side last.

The padding modifiers stay with the positions rather than the content, so the card's spacing is unchanged — the top anchor keeps its 24pt top pad, and the bottom anchor keeps the `chargesFee ? 0 : 24` top pad that closes the gap when no breakdown is present.

No test changes needed: `BuyConfirmationUIScreen` matches "You Pay" by label prefix, not by position.


---

Android half: code-payments/code-android-app#1312. Both platforms swap the same two anchors; land them together so the Get receipt doesn't read differently on each.
