### PR TITLE
fix(tipcard): scale the name with the card width

### DIFF
--- a/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
@@ -17,6 +17,13 @@ struct TipcardView: View {
     /// on the You page (node 9276:4641) and full screen (node 9277:121417).
     static let aspectRatio: CGFloat = 333.0 / 269.0
 
+    /// The name's size as a fraction of the card's width. Figma draws the name
+    /// at 17 on the 269-wide card and scales it with the card, so the 302-wide
+    /// full-screen card gets 19.1 (node 9277:121421) and the 242-wide You-page
+    /// card 15.3 (node 9276:4645). A fixed size instead left the name looking
+    /// oversized on the small card and undersized on the big one.
+    static let nameFraction: CGFloat = 17.0 / 269.0
+
     /// Explicit because a rendered tree has no container to size against.
     let size: CGSize
     let name: String
@@ -66,7 +73,7 @@ struct TipcardView: View {
             .truncationMode(.tail)
             .multilineTextAlignment(.center)
             .padding(.horizontal, size.width * 0.08)
-            .font(.appDisplayXS)
+            .font(.default(size: nameFontSize, weight: .bold))
             .foregroundStyle(Color.textMain)
             .padding(.top, size.height * 0.06)
         }
@@ -83,6 +90,10 @@ struct TipcardView: View {
         } else {
             Image(systemName: "person.crop.circle.fill")
         }
+    }
+
+    private var nameFontSize: CGFloat {
+        size.width * Self.nameFraction
     }
 
     private var codeDimension: CGFloat {

--- a/Flipcash/Core/Screens/Main/You/YouScreen.swift
+++ b/Flipcash/Core/Screens/Main/You/YouScreen.swift
@@ -113,12 +113,13 @@ struct YouScreen: View {
                     .frame(width: Self.collapsedCardSize.width, height: Self.collapsedCardSize.height)
                     .overlay {
                         TipcardView(
-                            size: cardSize,
+                            size: Self.drawnCardSize,
                             name: name,
                             avatar: nil,
                             codeData: codeData,
                             tintOpacity: 0.36
                         )
+                        .scaleEffect(cardScale)
                         .offset(y: cardOffset)
                     }
                     .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { cardSlotFrame = $0 }
@@ -256,9 +257,21 @@ struct YouScreen: View {
         height: cardWidth * TipcardView.aspectRatio
     )
 
-    private var cardSize: CGSize {
-        let width = isExpanded ? expandedCardWidth : Self.cardWidth
-        return CGSize(width: width, height: width * TipcardView.aspectRatio)
+    /// The size the card is always drawn at, whatever it currently measures on
+    /// screen — the widest it ever gets, so scaling it to size only ever
+    /// samples the drawing down.
+    private static let drawnCardSize = CGSize(
+        width: maxExpandedCardWidth,
+        height: maxExpandedCardWidth * TipcardView.aspectRatio
+    )
+
+    /// The expansion runs as one scale on the drawn card rather than a new size
+    /// for it to lay itself out at. Laid out, each of the card's metrics is a
+    /// separate animatable value — and the name's font size is not animatable
+    /// at all — so the parts arrived at their new sizes at different moments
+    /// and overlapped mid-flight. Scaled, the card travels as one figure.
+    private var cardScale: CGFloat {
+        (isExpanded ? expandedCardWidth : Self.cardWidth) / Self.drawnCardSize.width
     }
 
     /// The expanded width: the design's 302, narrowed only if the screen can't


### PR DESCRIPTION
The tip card derives every metric from its width — the code, the avatar, the corner radius, the name's padding — except the name itself, which was pinned at `appDisplayXS`'s 20. So it read oversized on the 242-wide You-page card and undersized on the 302-wide full-screen one.

Figma scales the name with the rest of the card. Both instances land on the same ratio:

| Card | Width | Name |
|---|---|---|
| Full screen (node 9277:121421) | 302.2 | 19.10 |
| You page (node 9276:4645) | 241.6 | 15.27 |

Both are `width × 17/269` — the 269-wide base card draws it at 17.

Derive the name size from the same width the other metrics come from, keeping `appDisplayXS`'s family and weight. You page 242 → 15.3, expanded and bill canvas 302 → 19.1, tips-flow screen 300 → 19.0.

Also closes a cross-platform divergence: iOS drew the name at 20 and Android at 16 on cards of near-identical width. Mirrors code-payments/code-android-app#1313.


---

**Also: expand the card as one figure.**

Making the name width-derived surfaced a latent problem in the You-tab expansion. The card was laid out at a different size on each side of the transition, so every metric it derives from that size animated as an independent value — and font size isn't animatable at all, so the name snapped. The parts arrived at different moments and overlapped mid-flight.

The card is now drawn once at the widest size it ever reaches (302) and the expansion runs as a single `scaleEffect`. The whole figure travels together, and since the scale only ever goes down from the drawn size, the card is never sampled up. Layout is unchanged — the fixed slot still governs the page.

Android needs no equivalent change: it animates one `cardWidth` and derives every metric from it in the same composition, so nothing can drift.
