### PR TITLE
fix: keep name-less accounts usable and count held balance as the add-money milestone

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
@@ -187,7 +187,7 @@ struct HomeTabView: View {
         case .chat:
             ChatTab()
         case .tipCard:
-            TipCardTab(onSetUp: { selection = .chat })
+            TipCardTab()
                 .environment(tipCardPresentation)
         }
     }
@@ -230,52 +230,23 @@ private struct ChatTab: View {
 
 // MARK: - Tip Card tab -
 
-/// The Tip Card tab — the user's own shareable tip card. Only tippable profiles
-/// have a card; before then it prompts the user over to the Chat tab, where the
-/// add-your-name flow lives (avoiding a duplicate profile-creation push here).
+/// The Tip Card tab — the user's own shareable tip card, plus the settings list
+/// that is the tab-bar entry into My Account.
+///
+/// `YouScreen` renders whether or not the profile is tippable: without a display
+/// name it draws the add-your-name invitation where the card would be and drops
+/// the share affordances, keeping the settings rows reachable. Swapping the
+/// whole screen out for a bare prompt (as this once did) stranded name-less
+/// accounts with no way to reach Settings, and so no way to log out.
 private struct TipCardTab: View {
 
     @Environment(AppRouter.self) private var router
-    @Environment(SessionContainer.self) private var sessionContainer
-
-    let onSetUp: () -> Void
 
     var body: some View {
         @Bindable var router = router
         NavigationStack(path: $router[.you]) {
-            Group {
-                if sessionContainer.session.profile?.isTippable == true {
-                    YouScreen()
-                } else {
-                    TipCardSetupPrompt(onSetUp: onSetUp)
-                }
-            }
-            .appRouterDestinations()
-        }
-    }
-}
-
-/// Shown on the Tip Card tab before the user has a tippable profile.
-private struct TipCardSetupPrompt: View {
-
-    let onSetUp: () -> Void
-
-    var body: some View {
-        Background(color: .backgroundMain) {
-            VStack(spacing: 12) {
-                Text("Set Up Your Tip Card")
-                    .font(.appTextLarge)
-                    .foregroundStyle(Color.textMain)
-
-                Text("Add your name to get a tip card you can share and receive tips.")
-                    .font(.appTextMedium)
-                    .foregroundStyle(Color.textSecondary)
-                    .multilineTextAlignment(.center)
-
-                BubbleButton(text: "Get Started") { onSetUp() }
-                    .padding(.top, 8)
-            }
-            .padding(.horizontal, 40)
+            YouScreen()
+                .appRouterDestinations()
         }
     }
 }

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -202,6 +202,11 @@ private struct WalletScreenContent: View {
             .onAppear { historyController.sync() }
             .onChange(of: session.balances) { _, _ in
                 refresh()
+                // The "add money" milestone is met by a balance as well as by
+                // history, so a balance that moved can settle it on its own —
+                // without this it would wait on an activity row that may never
+                // come.
+                reloadHistoryState()
                 // A balance that moved has an activity row on its way, so pull
                 // it now. `onAppear` cannot be the only sync: the tab stays
                 // alive behind sheets and behind the other tabs, so it fires

--- a/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
@@ -19,7 +19,13 @@ struct TipsScreen: View {
     var isEmbedded: Bool = false
 
     var body: some View {
-        if sessionContainer.session.profile?.isTippable == true {
+        // v2's Chats tab is chats, whatever the profile says. A name-less
+        // account can still send tips, so it can still hold conversations —
+        // swapping the tab out for a setup prompt hid them, and hid the "No
+        // Chats Yet" empty state behind a second copy of the tip-card
+        // invitation the tip-card tab already makes. v1's sheet keeps the
+        // intro: it is that flow's only door into profile creation.
+        if isEmbedded || sessionContainer.session.profile?.isTippable == true {
             TipConversationsScreen(isEmbedded: isEmbedded)
         } else {
             TipsIntroScreen(isEmbedded: isEmbedded)

--- a/Flipcash/Core/Screens/Main/You/YouScreen.swift
+++ b/Flipcash/Core/Screens/Main/You/YouScreen.swift
@@ -18,6 +18,11 @@ import FlipcashUI
 /// nothing is pushed or presented — so the card never leaves this screen.
 /// Settings rows push onto the tab's `.you` stack, so they never touch the v1
 /// scanner's Settings sheet.
+///
+/// A profile with no display name has no card: the page then shows the
+/// add-your-name invitation in the card's place and drops the link and share
+/// affordances, but still renders — the settings rows are this account's only
+/// way to reach My Account, and with it Log Out.
 struct YouScreen: View {
 
     @Environment(SessionContainer.self) private var sessionContainer
@@ -87,6 +92,9 @@ struct YouScreen: View {
             )
         }
         .task(id: profilePicture?.thumbnailBlobID) {
+            // There is no card to share, and so no preview worth rendering, until
+            // the profile has a name.
+            guard displayName != nil else { return }
             previewCache.warm(TipCode.Payload(userID: sessionContainer.session.userID))
         }
     }
@@ -95,6 +103,10 @@ struct YouScreen: View {
 
     /// The card plus its "Full Screen" caption. Tapping either expands the card;
     /// tapping the expanded card puts it back.
+    ///
+    /// A profile without a display name has no card to draw, so the slot carries
+    /// the invitation to add one instead. The rest of the page stays where it is
+    /// either way — settings included, which is the only route to logging out.
     @ViewBuilder
     private var cardSection: some View {
         if let name = displayName {
@@ -133,8 +145,84 @@ struct YouScreen: View {
             .accessibilityAddTraits(.isButton)
             .accessibilityLabel(isExpanded ? "Close tip card" : "View tip card full screen")
             .accessibilityIdentifier("you-fullscreen-button")
+        } else {
+            setupPrompt
         }
     }
+
+    /// Stands in for the card until the profile has a display name: the card the
+    /// user is about to get, blurred out behind the invitation to claim it, so
+    /// the slot shows what is on offer rather than sitting empty.
+    ///
+    /// "Get Started" opens the name editor, which pops back here on save — by
+    /// which point the profile is tippable and the real card has taken this slot.
+    private var setupPrompt: some View {
+        ZStack {
+            // A stand-in name, never read: it only has to give the blur a card
+            // shaped like the one the user gets.
+            TipcardView(
+                size: Self.collapsedCardSize,
+                name: Self.placeholderName,
+                avatar: nil,
+                codeData: codeData,
+                // The card's own tint is black over a frosted backdrop, which
+                // on this black page paints black on black — it can only take
+                // brightness away from the base below, so it takes none.
+                tintOpacity: 0
+            )
+            // The base the card is missing: without it the stand-in has no
+            // surface, just a code glowing in the dark.
+            .background(Self.placeholderShape.fill(Color.white.opacity(0.08)))
+            .blur(radius: 12)
+            // Blur bleeds past the card's edge and, on a black page, a card
+            // whose edge has dissolved is just a smudge — so clip the softened
+            // content back to the card's own outline and draw that outline.
+            .clipShape(Self.placeholderShape)
+            .overlay {
+                Self.placeholderShape.strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+            }
+            .accessibilityHidden(true)
+
+            // Word for word the Chats tab's own name-less state
+            // (`TipsScreen.TipsIntroScreen`): the same account hits both, and
+            // two different asks for the one thing read as two different jobs.
+            VStack(spacing: 0) {
+                Text("Receive Tips From Everyone")
+                    .font(.appTextLarge)
+                    .foregroundStyle(Color.textMain)
+                    .multilineTextAlignment(.center)
+
+                // Full strength where the Chats tab uses secondary grey: this
+                // copy sits over the blurred code's brightest patch, and grey
+                // on that glow is the one line you can't read.
+                Text("Add your name to receive tips")
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textMain)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 8)
+
+                BubbleButton(text: "Start Receiving Tips") {
+                    router.push(.changeDisplayName)
+                }
+                .padding(.top, 20)
+                .accessibilityIdentifier("you-start-receiving-tips-button")
+            }
+            // Held inside the card it sits on, so the copy reads as part of the
+            // card rather than spilling past its edges.
+            .frame(maxWidth: Self.collapsedCardSize.width - 16)
+        }
+    }
+
+    /// Fills the blurred placeholder card's name line. Long enough to occupy the
+    /// line the real name will, short enough not to wrap.
+    private static let placeholderName = "Your Name"
+
+    /// The placeholder card's outline, matching `TipcardView`'s own corner
+    /// rounding — which it derives from the card's width.
+    private static let placeholderShape = RoundedRectangle(
+        cornerRadius: collapsedCardSize.width * 0.08,
+        style: .continuous
+    )
 
     /// The expanded card's collapse control (Figma node 9276:4601): the same
     /// caption as "Full Screen", chevron flipped, sitting at the bottom of the
@@ -174,24 +262,30 @@ struct YouScreen: View {
     // MARK: - Page -
 
     /// Everything below the card — the part that clears out when the card expands.
+    ///
+    /// The link and the Share/Download pair all address a card that a name-less
+    /// profile does not have, so they sit out until it does; the settings rows
+    /// take up the slack.
     private var pageContent: some View {
         VStack(spacing: 0) {
-            TipCardLinkRow(url: url)
-                .padding(.top, 70)
+            if displayName != nil {
+                TipCardLinkRow(url: url)
+                    .padding(.top, 70)
 
-            HStack(spacing: 10) {
-                TipCardActionButton(asset: .shareOS, title: "Share", action: shareTipCard)
-                    .accessibilityIdentifier("you-share-button")
+                HStack(spacing: 10) {
+                    TipCardActionButton(asset: .shareOS, title: "Share", action: shareTipCard)
+                        .accessibilityIdentifier("you-share-button")
 
-                TipCardActionButton(asset: .fileDownload, title: "Download") {
-                    isShowingDownloadOptions = true
+                    TipCardActionButton(asset: .fileDownload, title: "Download") {
+                        isShowingDownloadOptions = true
+                    }
+                    .accessibilityIdentifier("you-download-button")
                 }
-                .accessibilityIdentifier("you-download-button")
+                .padding(.top, 11)
             }
-            .padding(.top, 11)
 
             settingsList
-                .padding(.top, 19)
+                .padding(.top, displayName == nil ? 48 : 19)
 
             // v2 scrolls the version string with the content rather than
             // pinning it above the tab bar (the v1 Settings sheet pinned it).

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -172,10 +172,24 @@ class Session {
 
     /// Whether the caller has ever received money from outside their own
     /// holdings — a completed buy, deposit, tip received, or distribution. This
-    /// is the wallet onboarding "add money" milestone. Derived from durable
-    /// history, so it stays true after the balance is spent.
+    /// is the wallet onboarding "add money" milestone.
+    ///
+    /// Money in hand settles it before history is consulted: a balance cannot
+    /// exist without having arrived, and the history feed does not always carry
+    /// the arrival that put it there — an account holding a balance against an
+    /// empty activity table was being told to go add money. History still
+    /// answers for the spent case, where the balance is gone but the milestone
+    /// must stay met.
     func hasEverAddedMoney() -> Bool {
-        (try? database.hasEverAddedMoney()) ?? false
+        if holdsBalance { return true }
+        return (try? database.hasEverAddedMoney()) ?? false
+    }
+
+    /// Whether any token balance is non-zero. Unlike ``hasGiveableBalance(for:includingDollars:)``
+    /// this asks only whether money is held, not whether it can be spent — dust
+    /// too small to give away still proves money arrived.
+    private var holdsBalance: Bool {
+        updateableBalances.value.contains { $0.quarks > 0 }
     }
 
     /// Whether the caller has ever sent a tip — the "scan a tip card" milestone.


### PR DESCRIPTION
Three fixes that shipped in the 2026.8.3 rebuild, brought back to `main` so they aren't stranded on the release branch.

### `fix(you)` — keep the You tab usable without a display name

`TipCardTab` swapped `YouScreen` out entirely for a bare setup prompt, so an account with no display name could not reach Settings — and therefore could not log out. `YouScreen` now always renders; only the card slot changes. Where the card would be, a blurred stand-in card carries the invitation, and the share affordances drop out until there is a name.

The card's own fill is black over a frosted backdrop, so on the black page it can only subtract brightness — the stand-in gets a pale base underneath instead, clipped back to the card's outline so the blur reads as a card rather than a smudge.

The CTA routes to `.changeDisplayName`, not `.profileName`: the latter's submit path guards on the sheet being on the `.tips` stack, so pushing it from `.you` saves the name and strands the user.

### `fix(chats)` — stop gating the Chats tab on a tip card

`TipsScreen` swapped the whole Chats tab for the tip-card intro when the profile wasn't tippable. That hid existing conversations, and put a second copy of the invitation behind a tab that already has one next door. A name-less account can still send tips, so it can still hold conversations — the embedded tab now always renders `TipConversationsScreen` with its own "No Chats Yet" empty state.

The v1 sheet keeps the intro: it is that flow's only door into profile creation.

The You tab's copy is now word-for-word the Chats tab's, since the same account hits both and two different asks for one thing read as two different jobs.

### `fix(wallet)` — count money in hand as the add-money milestone

`hasEverAddedMoney()` read only the activity table. On the affected account that table had 0 rows against a balance of 17452 quarks, so an account visibly holding $0.02 was being told to go add money. A balance cannot exist without having arrived, and the history feed does not always carry the arrival that put it there — so money in hand now settles the milestone before history is consulted. History still answers the spent case, where the balance is gone but the milestone must stay met.

Dust counts: the check is `quarks > 0`, not the giveable-balance check — too-small-to-spend still proves money arrived.

The second half is re-evaluation. The check was one-shot, so `WalletScreen` now recomputes the milestone and pulls history when the balance moves; `onAppear` alone fires once per launch and never again after a deposit lands.
