### PR TITLE
fix(tipcard): send your own tipcode to the You tab

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -265,6 +265,13 @@ struct DeepLinkAction {
         case .tip(let userID):
             if let container = sessionAuthenticator.loggedInContainer {
                 Analytics.deeplinkRouted(kind: kind)
+                // Tipping yourself is a payment no-op, so there's no tip flow to
+                // start from your own link — show the user their own tip card
+                // instead of swallowing the tap.
+                guard userID != container.session.userID else {
+                    container.appRouter.showOwnTipCard()
+                    return
+                }
                 container.tipFlow.begin(userID: userID)
             }
 

--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -265,13 +265,8 @@ struct DeepLinkAction {
         case .tip(let userID):
             if let container = sessionAuthenticator.loggedInContainer {
                 Analytics.deeplinkRouted(kind: kind)
-                // Tipping yourself is a payment no-op, so there's no tip flow to
-                // start from your own link — show the user their own tip card
-                // instead of swallowing the tap.
-                guard userID != container.session.userID else {
-                    container.appRouter.showOwnTipCard()
-                    return
-                }
+                // `begin` owns the own-id case: a self link lands on the user's
+                // own tip card rather than starting a tip.
                 container.tipFlow.begin(userID: userID)
             }
 

--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -507,11 +507,23 @@ final class AppRouter {
     ///
     /// Not expressible as `navigate(to:)` in the tab UI — the You tab's stack is
     /// entered by tab selection and has no destination that names the card.
+    ///
+    /// Idempotent, like `navigate(to:)`: the scanner decodes a tipcode every
+    /// frame until its camera tears down, so arriving is not allowed to re-fire
+    /// the tab request.
     func showOwnTipCard() {
         guard tabStacks.contains(.you) else {
             navigate(to: .tipcard)
             return
         }
+
+        // `requestedTabStack` covers the gap before `HomeTabView` selects the tab
+        // and publishes `activeTabStack` — until then the request is in flight,
+        // not yet arrived.
+        let alreadyThere = presentedSheets.isEmpty
+                        && activeTabStack == .you
+                        && self[.you].isEmpty
+        guard !alreadyThere, requestedTabStack != .you else { return }
 
         while !presentedSheets.isEmpty { dismissSheet() }
         setPath([], on: .you)

--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -501,4 +501,21 @@ final class AppRouter {
         present(targetSheet)
         setPath([destination], on: targetStack)
     }
+
+    /// Surfaces the user's own tip card: the You tab at its root in the tab UI,
+    /// or the "My Tip Card" screen in the tips sheet without tabs.
+    ///
+    /// Not expressible as `navigate(to:)` in the tab UI — the You tab's stack is
+    /// entered by tab selection and has no destination that names the card.
+    func showOwnTipCard() {
+        guard tabStacks.contains(.you) else {
+            navigate(to: .tipcard)
+            return
+        }
+
+        while !presentedSheets.isEmpty { dismissSheet() }
+        setPath([], on: .you)
+        requestedTabStack = .you
+        logger.info("Routed to own tip card", metadata: ["stack": "\(Stack.you)"])
+    }
 }

--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -77,13 +77,21 @@ final class TipFlow {
 
     // MARK: - Entry -
 
-    /// Handles a scanned or deeplinked tipcode. Gates in order: own-id scans
-    /// (ignored), then a tippable profile (held + profile creation presented).
+    /// Handles a scanned or deeplinked tipcode. Gates in order: own-id codes
+    /// (routed to the user's own tip card), then a tippable profile (held +
+    /// profile creation presented).
     /// The card always shows for a tippable recipient; the giveable-balance gate
     /// is deferred to ``present(_:)``, where it blocks the Send a Tip sheet
     /// (surfacing the Add Money / Discover dialog) without hiding the card.
     func begin(userID: UserID) {
-        guard userID != session.userID else { return }
+        // Tipping yourself is a payment no-op, so there's no flow to start from
+        // your own code — show the user their own tip card rather than swallow
+        // the scan or tap. `showOwnTipCard()` absorbs the repeat calls the
+        // per-frame scanner makes until the camera tears down.
+        guard userID != session.userID else {
+            router.showOwnTipCard()
+            return
+        }
         guard submission == nil, pendingUserID == nil, prepTask == nil else { return }
         // A dialog is already asking the user something (commonly this flow's
         // own balance gate) — don't churn it on every decoded camera frame.

--- a/FlipcashTests/Navigation/YouTabRoutingTests.swift
+++ b/FlipcashTests/Navigation/YouTabRoutingTests.swift
@@ -27,6 +27,32 @@ struct YouTabRoutingTests {
         #expect(router[.settings].isEmpty) // never leaks onto the Settings sheet's stack
     }
 
+    @Test("a self tipcard link brings the You tab forward at its root")
+    func showOwnTipCard_inTabUI_selectsYouTabAtRoot() {
+        let router = AppRouter()
+        router.tabStacks = [.balance, .tips, .you]
+        // Drilled into My Account behind a sheet — where a self link can land.
+        router.setPath([.settingsMyAccount], on: .you)
+        router.present(.settings)
+
+        router.showOwnTipCard()
+
+        #expect(router.requestedTabStack == .you)
+        #expect(router.presentedSheet == nil)
+        #expect(router[.you].isEmpty) // the card itself, not a pushed screen
+    }
+
+    @Test("without the tab UI, a self tipcard link opens My Tip Card in the tips sheet")
+    func showOwnTipCard_withoutTabs_navigatesToTipcard() {
+        let router = AppRouter()
+
+        router.showOwnTipCard()
+
+        #expect(router.presentedSheet == .tips)
+        #expect(router[.tips] == AppRouter.navigationPath(.tipcard))
+        #expect(router.requestedTabStack == nil)
+    }
+
     @Test("changing the display name pushes onto the You tab, and saving pops back")
     func changeDisplayName_pushesAndPopsOnYouStack() {
         let router = AppRouter()

--- a/FlipcashTests/Navigation/YouTabRoutingTests.swift
+++ b/FlipcashTests/Navigation/YouTabRoutingTests.swift
@@ -42,6 +42,35 @@ struct YouTabRoutingTests {
         #expect(router[.you].isEmpty) // the card itself, not a pushed screen
     }
 
+    @Test("a repeat self scan is absorbed once the You tab request is in flight")
+    func showOwnTipCard_whileRequestPending_doesNotRefire() {
+        let router = AppRouter()
+        router.tabStacks = [.balance, .tips, .you]
+        router.showOwnTipCard()
+        #expect(router.requestedTabStack == .you)
+
+        // What HomeTabView does on selecting the tab.
+        router.requestedTabStack = nil
+        router.activeTabStack = .you
+
+        // The scanner keeps decoding the same tipcode until the camera tears down.
+        router.showOwnTipCard()
+        #expect(router.requestedTabStack == nil, "arriving must not re-request the tab")
+    }
+
+    @Test("a self scan from a pushed You-tab screen returns to the card")
+    func showOwnTipCard_fromPushedYouScreen_popsToRoot() {
+        let router = AppRouter()
+        router.tabStacks = [.balance, .tips, .you]
+        router.activeTabStack = .you
+        router.push(.settingsMyAccount)
+
+        router.showOwnTipCard()
+
+        #expect(router[.you].isEmpty)
+        #expect(router.requestedTabStack == .you)
+    }
+
     @Test("without the tab UI, a self tipcard link opens My Tip Card in the tips sheet")
     func showOwnTipCard_withoutTabs_navigatesToTipcard() {
         let router = AppRouter()


### PR DESCRIPTION
Scanning or tapping your own tip card did nothing. `TipFlow.begin` opens with `guard userID != session.userID` — tipping yourself is a payment no-op, so the flow correctly refuses to start, but neither entry point then had anywhere to go and the scan/tap was silently swallowed.

Your own tipcode now shows you your own tip card.

## What changed

- **`TipFlow.begin`** — the own-id guard routes to the user's own tip card instead of returning. Both entry points (`ScanViewModel.didScan` and the `.tip` deep-link action) go through `begin`, so this is one rule in one place; `DeepLinkController` loses its own copy of the `userID` comparison. The QR-code scan path posts through `DeepLinkController`, so it inherits the behavior too.
- **`AppRouter.showOwnTipCard()`** — the `.you` stack is tab-only (`Stack.you.sheet` is `nil`), so it can't be reached through `navigate(to:)`; there's no destination that names the card, only a tab. The helper dismisses any presented sheets, resets `.you` to its root (so you land on the card, not a drilled-in My Account), and brings the tab forward via `requestedTabStack`. Without the tab UI it falls back to `navigate(to: .tipcard)` — the "My Tip Card" screen in the tips sheet, v1's equivalent surface.

## Idempotence

The code extractor delivers a decoded tipcode on *every* frame until the Scan tab's camera tears down, and the `.tip` branch of `didScan` has no dedup set of its own — `begin`'s in-flight guards normally serve that role, but the own-id case returns before reaching them. So `showOwnTipCard()` early-returns when it has already arrived (no sheets, `activeTabStack == .you`, empty path) or when `requestedTabStack` is already `.you`. That second clause matters: it covers the frames that land in the gap between the request and `HomeTabView` selecting the tab and publishing `activeTabStack`. The no-tab branch is already covered by `navigate(to:)`'s own `alreadyThere` check.
