### PR TITLE
fix(wallet): cut the dead space under the wallet tiles

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/HomeTabBar.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabBar.swift
@@ -21,10 +21,16 @@ struct HomeTabBar: View {
 
     // Figma tab bar (node 8966:1557): 32pt icons in 50pt-tall items (9pt above
     // and below), inside a capsule with 4pt padding → 58pt overall.
-    private let itemVerticalPadding: CGFloat = 9
-    private let iconSize: CGFloat = 32
+    private static let itemVerticalPadding: CGFloat = 9
+    private static let iconSize: CGFloat = 32
+    private static let capsulePadding: CGFloat = 4
 
-    private var itemHeight: CGFloat { iconSize + itemVerticalPadding * 2 }
+    private static var itemHeight: CGFloat { iconSize + itemVerticalPadding * 2 }
+
+    /// The pill's overall height. It floats over the tab content instead of
+    /// sitting in the safe area, so a tab that scrolls has to leave room for it
+    /// itself — see ``HomeTabView/legacyPillClearance``.
+    static var height: CGFloat { itemHeight + capsulePadding * 2 }
 
     var body: some View {
         GeometryReader { proxy in
@@ -35,7 +41,7 @@ struct HomeTabBar: View {
                 // Selected-state pill, drawn behind the icons, sliding to the active tab.
                 Capsule()
                     .fill(Color.white.opacity(0.2))
-                    .frame(width: itemWidth, height: itemHeight)
+                    .frame(width: itemWidth, height: Self.itemHeight)
                     .offset(x: itemWidth * CGFloat(selectedIndex))
                     .animation(.spring(response: 0.35, dampingFraction: 0.8), value: selection)
 
@@ -48,7 +54,7 @@ struct HomeTabBar: View {
                                 .renderingMode(.template)
                                 .resizable()
                                 .scaledToFit()
-                                .frame(width: iconSize, height: iconSize)
+                                .frame(width: Self.iconSize, height: Self.iconSize)
                                 .foregroundStyle(Color.white)
                                 .opacity(selection == tab ? 1 : 0.5)
                                 .overlay(alignment: .topTrailing) {
@@ -66,7 +72,7 @@ struct HomeTabBar: View {
                                         .accessibilityHidden(true)
                                     }
                                 }
-                                .frame(width: itemWidth, height: itemHeight)
+                                .frame(width: itemWidth, height: Self.itemHeight)
                                 .contentShape(Capsule())
                         }
                         .buttonStyle(.plain)
@@ -77,8 +83,8 @@ struct HomeTabBar: View {
                 }
             }
         }
-        .frame(height: itemHeight)
-        .padding(4)
+        .frame(height: Self.itemHeight)
+        .padding(Self.capsulePadding)
         .capsuleGlassBackground()
     }
 }

--- a/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
@@ -148,6 +148,13 @@ struct HomeTabView: View {
         .background(TabBarSelectedIcons(tabs: HomeTab.allCases))
     }
 
+    private static let pillBottomMargin: CGFloat = 8
+
+    /// The room the legacy pill occupies above the safe area. The pill is an
+    /// overlay, so unlike the iOS 26 system bar it adds nothing to the safe
+    /// area — a tab that scrolls under it has to inset for it itself.
+    static var legacyPillClearance: CGFloat { HomeTabBar.height + pillBottomMargin }
+
     /// iOS 18–25 fallback: the home-grown floating pill hovering over the tab
     /// content, sliding out when `isTabBarHidden`.
     private var legacyTabs: some View {
@@ -162,7 +169,7 @@ struct HomeTabView: View {
                     // 402pt frame); a fixed margin keeps the floating look across
                     // device widths.
                     .padding(.horizontal, 42)
-                    .padding(.bottom, 8)
+                    .padding(.bottom, Self.pillBottomMargin)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }

--- a/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletScreen.swift
@@ -121,6 +121,19 @@ private struct WalletScreenContent: View {
     /// How far below the status bar content returns to full strength.
     private static let topFadeLength: CGFloat = 20
 
+    /// The gap the content keeps between its last tile and the tab bar.
+    private static let tabBarGap: CGFloat = 40
+
+    /// Bottom inset for the scrolling content. The iOS 26 tab bar sits in the
+    /// safe area, so the gap is the whole inset there; the legacy pill floats
+    /// over the content and has to be cleared on top of it.
+    private var bottomContentInset: CGFloat {
+        if #available(iOS 26, *) {
+            return Self.tabBarGap
+        }
+        return Self.tabBarGap + HomeTabView.legacyPillClearance
+    }
+
     init(sessionContainer: SessionContainer, onScanTipCard: @escaping () -> Void) {
         self.session = sessionContainer.session
         self.onScanTipCard = onScanTipCard
@@ -509,8 +522,8 @@ private struct WalletScreenContent: View {
                 }
                 .opacity(deckOpacity)
 
-                // Bottom inset so the last card clears the floating tab bar.
-                Color.clear.frame(height: 96)
+                // Bottom inset so the last tile clears the tab bar.
+                Color.clear.frame(height: bottomContentInset)
             }
             .padding(.horizontal, 20)
         }


### PR DESCRIPTION
Scrolled to the bottom, the wallet tab left 96pt of empty space between its last tile and the tab bar. This brings it to 40pt.

## Where the 96 came from

The inset was a flat `Color.clear.frame(height: 96)`, sized for the legacy pill. That pill is a `ZStack` overlay, so it contributes nothing to the safe area and scrolling content has to clear its 66pt (58pt capsule + 8pt float margin) on its own — leaving a ~30pt gap on iOS 18–25.

The iOS 26 system bar does sit in the safe area. A runtime probe on the wallet's container reports `safeAreaInsets.bottom = 83` on an iPhone 17: 34pt home indicator plus a 49pt bar. Content already stops at the bar's top edge there, so all 96pt landed below it as dead space.

## The fix

The inset is now the gap plus the pill's footprint, added only on the path where the pill isn't in the safe area:

```swift
private static let tabBarGap: CGFloat = 40

private var bottomContentInset: CGFloat {
    if #available(iOS 26, *) {
        return Self.tabBarGap
    }
    return Self.tabBarGap + HomeTabView.legacyPillClearance
}
```

Both paths land on 40pt. A flat 40 would have tucked the last tiles behind the pill on iOS 18–25, which is still a supported deployment target.

`HomeTabBar` now exposes its overall height (derived from the Figma metrics it already held, node 8966:1557) and `HomeTabView` the 8pt margin it floats the pill on, so the wallet reads both rather than repeating either number.
