### PR TITLE
feat(profile): add SetUsername to the profile service

### DIFF
--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.grpc.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.grpc.swift
@@ -44,6 +44,18 @@ public enum Flipcash_Profile_V1_Profile {
                 method: "SetDisplayName"
             )
         }
+        /// Namespace for "SetUsername" metadata.
+        public enum SetUsername {
+            /// Request type for "SetUsername".
+            public typealias Input = Flipcash_Profile_V1_SetUsernameRequest
+            /// Response type for "SetUsername".
+            public typealias Output = Flipcash_Profile_V1_SetUsernameResponse
+            /// Descriptor for "SetUsername".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "flipcash.profile.v1.Profile"),
+                method: "SetUsername"
+            )
+        }
         /// Namespace for "SetProfilePicture" metadata.
         public enum SetProfilePicture {
             /// Request type for "SetProfilePicture".
@@ -96,6 +108,7 @@ public enum Flipcash_Profile_V1_Profile {
         public static let descriptors: [GRPCCore.MethodDescriptor] = [
             GetProfile.descriptor,
             SetDisplayName.descriptor,
+            SetUsername.descriptor,
             SetProfilePicture.descriptor,
             UpdateTipCard.descriptor,
             LinkSocialAccount.descriptor,
@@ -155,6 +168,30 @@ extension Flipcash_Profile_V1_Profile {
             deserializer: some GRPCCore.MessageDeserializer<Flipcash_Profile_V1_SetDisplayNameResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetDisplayNameResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "SetUsername" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > SetUsername sets the caller's username, replacing any username already
+        /// > set.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Flipcash_Profile_V1_SetUsernameRequest` message.
+        ///   - serializer: A serializer for `Flipcash_Profile_V1_SetUsernameRequest` messages.
+        ///   - deserializer: A deserializer for `Flipcash_Profile_V1_SetUsernameResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func setUsername<Result>(
+            request: GRPCCore.ClientRequest<Flipcash_Profile_V1_SetUsernameRequest>,
+            serializer: some GRPCCore.MessageSerializer<Flipcash_Profile_V1_SetUsernameRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Flipcash_Profile_V1_SetUsernameResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetUsernameResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
 
         /// Call the "SetProfilePicture" method.
@@ -326,6 +363,41 @@ extension Flipcash_Profile_V1_Profile {
             try await self.client.unary(
                 request: request,
                 descriptor: Flipcash_Profile_V1_Profile.Method.SetDisplayName.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "SetUsername" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > SetUsername sets the caller's username, replacing any username already
+        /// > set.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Flipcash_Profile_V1_SetUsernameRequest` message.
+        ///   - serializer: A serializer for `Flipcash_Profile_V1_SetUsernameRequest` messages.
+        ///   - deserializer: A deserializer for `Flipcash_Profile_V1_SetUsernameResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func setUsername<Result>(
+            request: GRPCCore.ClientRequest<Flipcash_Profile_V1_SetUsernameRequest>,
+            serializer: some GRPCCore.MessageSerializer<Flipcash_Profile_V1_SetUsernameRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Flipcash_Profile_V1_SetUsernameResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetUsernameResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Flipcash_Profile_V1_Profile.Method.SetUsername.descriptor,
                 serializer: serializer,
                 deserializer: deserializer,
                 options: options,
@@ -531,6 +603,36 @@ extension Flipcash_Profile_V1_Profile.ClientProtocol {
         )
     }
 
+    /// Call the "SetUsername" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > SetUsername sets the caller's username, replacing any username already
+    /// > set.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Flipcash_Profile_V1_SetUsernameRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func setUsername<Result>(
+        request: GRPCCore.ClientRequest<Flipcash_Profile_V1_SetUsernameRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetUsernameResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.setUsername(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Flipcash_Profile_V1_SetUsernameRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Flipcash_Profile_V1_SetUsernameResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
     /// Call the "SetProfilePicture" method.
     ///
     /// > Source IDL Documentation:
@@ -710,6 +812,40 @@ extension Flipcash_Profile_V1_Profile.ClientProtocol {
             metadata: metadata
         )
         return try await self.setDisplayName(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "SetUsername" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > SetUsername sets the caller's username, replacing any username already
+    /// > set.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func setUsername<Result>(
+        _ message: Flipcash_Profile_V1_SetUsernameRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Flipcash_Profile_V1_SetUsernameResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Flipcash_Profile_V1_SetUsernameRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.setUsername(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.pb.swift
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/Generated/profile_v1_profile_service.pb.swift
@@ -214,6 +214,109 @@ public struct Flipcash_Profile_V1_SetDisplayNameResponse: Sendable {
   public init() {}
 }
 
+public struct Flipcash_Profile_V1_SetUsernameRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Username is the new username to set.
+  public var username: Flipcash_Common_V1_Username {
+    get {return _username ?? Flipcash_Common_V1_Username()}
+    set {_username = newValue}
+  }
+  /// Returns true if `username` has been explicitly set.
+  public var hasUsername: Bool {return self._username != nil}
+  /// Clears the value of `username`. Subsequent reads from it will return its default value.
+  public mutating func clearUsername() {self._username = nil}
+
+  public var auth: Flipcash_Common_V1_Auth {
+    get {return _auth ?? Flipcash_Common_V1_Auth()}
+    set {_auth = newValue}
+  }
+  /// Returns true if `auth` has been explicitly set.
+  public var hasAuth: Bool {return self._auth != nil}
+  /// Clears the value of `auth`. Subsequent reads from it will return its default value.
+  public mutating func clearAuth() {self._auth = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _username: Flipcash_Common_V1_Username? = nil
+  fileprivate var _auth: Flipcash_Common_V1_Auth? = nil
+}
+
+public struct Flipcash_Profile_V1_SetUsernameResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var result: Flipcash_Profile_V1_SetUsernameResponse.Result = .ok
+
+  /// The best-fit category that tripped moderation, mirroring the Moderation
+  /// service's vocabulary. Set only when result == FAILED_MODERATED; NONE
+  /// otherwise.
+  public var flaggedCategory: Flipcash_Moderation_V1_FlaggedCategory = .none
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public enum Result: SwiftProtobuf.Enum, Swift.CaseIterable {
+    public typealias RawValue = Int
+    case ok // = 0
+    case invalidUsername // = 1
+    case denied // = 2
+    case alreadyTaken // = 3
+    case failedModerated // = 4
+    case insufficientBalance // = 5
+    case reservedWord // = 6
+    case UNRECOGNIZED(Int)
+
+    public init() {
+      self = .ok
+    }
+
+    public init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .ok
+      case 1: self = .invalidUsername
+      case 2: self = .denied
+      case 3: self = .alreadyTaken
+      case 4: self = .failedModerated
+      case 5: self = .insufficientBalance
+      case 6: self = .reservedWord
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    public var rawValue: Int {
+      switch self {
+      case .ok: return 0
+      case .invalidUsername: return 1
+      case .denied: return 2
+      case .alreadyTaken: return 3
+      case .failedModerated: return 4
+      case .insufficientBalance: return 5
+      case .reservedWord: return 6
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Flipcash_Profile_V1_SetUsernameResponse.Result] = [
+      .ok,
+      .invalidUsername,
+      .denied,
+      .alreadyTaken,
+      .failedModerated,
+      .insufficientBalance,
+      .reservedWord,
+    ]
+
+  }
+
+  public init() {}
+}
+
 public struct Flipcash_Profile_V1_SetProfilePictureRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -819,6 +922,84 @@ extension Flipcash_Profile_V1_SetDisplayNameResponse: SwiftProtobuf.Message, Swi
 
 extension Flipcash_Profile_V1_SetDisplayNameResponse.Result: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}INVALID_DISPLAY_NAME\0\u{1}DENIED\0\u{1}FAILED_MODERATED\0")
+}
+
+extension Flipcash_Profile_V1_SetUsernameRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SetUsernameRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}username\0\u{2}\u{9}auth\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._username) }()
+      case 10: try { try decoder.decodeSingularMessageField(value: &self._auth) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._username {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    try { if let v = self._auth {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Profile_V1_SetUsernameRequest, rhs: Flipcash_Profile_V1_SetUsernameRequest) -> Bool {
+    if lhs._username != rhs._username {return false}
+    if lhs._auth != rhs._auth {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Profile_V1_SetUsernameResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SetUsernameResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}result\0\u{3}flagged_category\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.result) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.flaggedCategory) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.result != .ok {
+      try visitor.visitSingularEnumField(value: self.result, fieldNumber: 1)
+    }
+    if self.flaggedCategory != .none {
+      try visitor.visitSingularEnumField(value: self.flaggedCategory, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Flipcash_Profile_V1_SetUsernameResponse, rhs: Flipcash_Profile_V1_SetUsernameResponse) -> Bool {
+    if lhs.result != rhs.result {return false}
+    if lhs.flaggedCategory != rhs.flaggedCategory {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Flipcash_Profile_V1_SetUsernameResponse.Result: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}INVALID_USERNAME\0\u{1}DENIED\0\u{1}ALREADY_TAKEN\0\u{1}FAILED_MODERATED\0\u{1}INSUFFICIENT_BALANCE\0\u{1}RESERVED_WORD\0")
 }
 
 extension Flipcash_Profile_V1_SetProfilePictureRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/profile_service.proto
+++ b/FlipcashAPI/Sources/FlipcashAPI/Core/proto/profile/v1/profile_service.proto
@@ -17,6 +17,10 @@ service Profile {
 
 	rpc SetDisplayName(SetDisplayNameRequest) returns (SetDisplayNameResponse);
 
+	// SetUsername sets the caller's username, replacing any username already
+	// set.
+	rpc SetUsername(SetUsernameRequest) returns (SetUsernameResponse);
+
 	// SetProfilePicture sets the caller's profile picture to a blob they have
 	// already uploaded via BlobStorage, replacing any picture already set.
 	//
@@ -88,6 +92,31 @@ message SetDisplayNameResponse {
     // service's vocabulary. Set only when result == FAILED_MODERATED; NONE
 	// otherwise.
     moderation.v1.FlaggedCategory flagged_category = 2;
+}
+
+message SetUsernameRequest {
+	// Username is the new username to set.
+	common.v1.Username username = 1 [(validate.rules).message.required = true];
+
+	common.v1.Auth auth = 10 [(validate.rules).message.required = true];
+}
+
+message SetUsernameResponse {
+	Result result = 1;
+	enum Result {
+		OK                   = 0;
+		INVALID_USERNAME     = 1;
+		DENIED               = 2;
+		ALREADY_TAKEN        = 3;
+		FAILED_MODERATED     = 4;
+		INSUFFICIENT_BALANCE = 5;
+		RESERVED_WORD        = 6;
+	}
+
+	// The best-fit category that tripped moderation, mirroring the Moderation
+	// service's vocabulary. Set only when result == FAILED_MODERATED; NONE
+	// otherwise.
+	moderation.v1.FlaggedCategory flagged_category = 2;
 }
 
 message SetProfilePictureRequest {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Profile.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Profile.swift
@@ -31,6 +31,13 @@ extension FlipClient {
         try await profileService.setDisplayName(displayName, owner: owner)
     }
 
+    /// Claims `username` for the caller, replacing any handle already set.
+    /// The server moderates it and may charge for it, so this throws on a
+    /// taken, reserved, or unaffordable handle as well as a malformed one.
+    public func setUsername(_ username: Username, owner: KeyPair) async throws {
+        try await profileService.setUsername(username, owner: owner)
+    }
+
     /// Attaches an already-finalized blob as the caller's profile picture.
     public func setProfilePicture(blobID: BlobID, owner: KeyPair) async throws {
         try await profileService.setProfilePicture(blobID: blobID, owner: owner)

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ProfileService.swift
@@ -91,6 +91,39 @@ final class ProfileService: Sendable {
         }
     }
 
+    func setUsername(_ username: Username, owner: KeyPair) async throws {
+        var request = Flipcash_Profile_V1_SetUsernameRequest()
+        request.username = username.proto
+        request.auth     = owner.authFor(message: request)
+
+        do {
+            let response = try await service.setUsername(request, options: .unaryDefault)
+
+            switch response.result {
+            case .ok:
+                logger.info("Username set")
+            case .invalidUsername:
+                throw ErrorProfile.invalidUsername
+            case .denied:
+                throw ErrorProfile.denied
+            case .alreadyTaken:
+                throw ErrorProfile.usernameTaken
+            case .failedModerated:
+                throw ErrorProfile.moderated(response.flaggedCategory)
+            case .insufficientBalance:
+                throw ErrorProfile.insufficientBalance
+            case .reservedWord:
+                throw ErrorProfile.reservedWord
+            case .UNRECOGNIZED:
+                throw ErrorProfile.unknown
+            }
+        } catch let error as ErrorProfile {
+            throw error
+        } catch {
+            throw ErrorProfile.network(error)
+        }
+    }
+
     func setProfilePicture(blobID: BlobID, owner: KeyPair) async throws {
         var request = Flipcash_Profile_V1_SetProfilePictureRequest()
         request.blobID = .with { $0.value = blobID.data }
@@ -195,6 +228,10 @@ extension ErrorUpdateTipCard: ServerError, TransportClassifiableError {
 public enum ErrorProfile: Error, Sendable {
     case denied
     case invalidDisplayName
+    case invalidUsername
+    case usernameTaken
+    case reservedWord
+    case insufficientBalance
     case moderated(Flipcash_Moderation_V1_FlaggedCategory)
     case blobNotFound
     case blobNotReady
@@ -208,6 +245,7 @@ extension ErrorProfile: ServerError {
     public var reportingLevel: ErrorReportingLevel {
         switch self {
         case .denied, .invalidDisplayName, .moderated,
+             .invalidUsername, .usernameTaken, .reservedWord, .insufficientBalance,
              .blobNotFound, .blobNotReady, .blobRejected, .invalidBlob:
             .info
         case .unknown:

--- a/FlipcashCore/Sources/FlipcashCore/Models/Username.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Username.swift
@@ -67,4 +67,9 @@ extension Username {
     init?(_ proto: Flipcash_Common_V1_Username) {
         self.init(proto.value)
     }
+
+    /// The wire form of the handle, for requests that claim or change it.
+    var proto: Flipcash_Common_V1_Username {
+        .with { $0.value = value }
+    }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
@@ -113,6 +113,10 @@ struct TransportClassificationTests {
         // Server verdicts on user input are expected outcomes, not defects.
         #expect(ErrorProfile.moderated(.nsfw).reportingLevel == .info)
         #expect(ErrorProfile.invalidDisplayName.reportingLevel == .info)
+        #expect(ErrorProfile.invalidUsername.reportingLevel == .info)
+        #expect(ErrorProfile.usernameTaken.reportingLevel == .info)
+        #expect(ErrorProfile.reservedWord.reportingLevel == .info)
+        #expect(ErrorProfile.insufficientBalance.reportingLevel == .info)
         #expect(ErrorProfile.blobRejected.reportingLevel == .info)
     }
 


### PR DESCRIPTION
Syncs the core protos, which add `Profile.SetUsername`, and wires the RPC
through `ProfileService` and `FlipClient`. Nothing else moved in the sync —
no other RPC, message, or field changed, and the OCP protos were already
current.

`SetUsername` can fail in four ways `SetDisplayName` cannot: the handle is
taken, reserved, unaffordable, or malformed. `ErrorProfile` gains a case for
each, all reporting at `.info` since they are server verdicts on user input
rather than client defects.

`Username` could only decode from the wire until now. Claiming a handle needs
the encode direction, so it gains a `proto` accessor.

There is no caller yet — no username-setting UI exists, so this leaves the RPC
reachable but unwired.

## Note for whoever builds the UI

`INSUFFICIENT_BALANCE` means claiming a handle costs money. That price will
come from user flags, alongside the USDF amounts already there —
`newCurrencyPurchaseAmount`, `newCurrencyFeeAmount`, `withdrawalFeeAmount`,
`minimumHolderValue`. Upstream has not added the field yet, so `UserFlags`
gains it in a later sync.

Until then a UI path can only react to the server refusal. Once the flag
lands, check affordability up front through `Session.hasSufficientFunds(for:)`,
the way `WithdrawViewModel` and `BuyConfirmationViewModel` already do, and
treat `INSUFFICIENT_BALANCE` as the backstop rather than the primary gate.
