### PR TITLE
fix(tipcard): take the keyboard down while a tip link is routed

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 import FlipcashCore
 
 private let logger = Logger(label: "flipcash.deeplink")
@@ -43,6 +44,15 @@ final class DeepLinkController {
         // error would bury genuine deep-link parse failures in expected noise.
         if let action {
             Analytics.deeplinkParsed(action: action, url: url)
+            // Every action below reroutes what's on screen, and a link can land
+            // while a text field elsewhere still holds focus — most often a chat
+            // composer the user left focused. Take the keyboard down before any
+            // of it runs. A one-shot, so a destination that focuses a field of
+            // its own on appear still gets its keyboard: that ask comes after
+            // this. It does not survive the first-responder restore that scene
+            // activation performs, which is why the tipcard path additionally bars
+            // the keyboard for a window (see `KeyboardSuppressor`).
+            KeyboardSuppressor.lower()
         }
 
         Task {

--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -38,6 +38,12 @@ final class TipFlow {
 
     @ObservationIgnored private var prepTask: Task<Void, Never>?
 
+    /// Keeps the keyboard down while a tipcard is being routed to. A tipcard
+    /// link is commonly followed from a chat the user left focused, and the
+    /// card is an overlay — it never displaces the composer that owns the
+    /// keyboard, so the keyboard has to be taken away deliberately.
+    @ObservationIgnored private let keyboard = KeyboardSuppressor()
+
     @ObservationIgnored private let session: Session
     @ObservationIgnored private let sessionContainer: SessionContainer
     @ObservationIgnored private let ratesController: RatesController
@@ -89,6 +95,7 @@ final class TipFlow {
         // the scan or tap. `showOwnTipCard()` absorbs the repeat calls the
         // per-frame scanner makes until the camera tears down.
         guard userID != session.userID else {
+            keyboard.suppress()
             router.showOwnTipCard()
             return
         }
@@ -100,10 +107,13 @@ final class TipFlow {
         guard session.profile?.isTippable == true else {
             pendingUserID = userID
             logger.info("Tip held for profile creation", metadata: ["recipient": "\(userID)"])
+            // Deliberately unsuppressed: profile creation focuses its name
+            // field on appear, and that keyboard is wanted.
             router.present(.tips)
             return
         }
 
+        keyboard.suppress()
         prepare(userID: userID)
     }
 
@@ -191,6 +201,11 @@ final class TipFlow {
         // The card is resolved and about to show, whether reached from a scan or
         // a deep link — the second step of the Scanned → Presented → Sent Tip funnel.
         Analytics.track(event: Analytics.TipCardEvent.presented)
+        // Again, because the resolve above retries: a cold-foreground `.unavailable`
+        // outlasts the window opened at `begin`, so the restore can win after it has
+        // closed. The card is a focused modal and must never share the screen with a
+        // keyboard, so it takes one down on the way up regardless.
+        keyboard.suppress()
         selection = nil
         customAmount = nil
         submission = SendAmountViewModel(

--- a/Flipcash/Utilities/KeyboardSuppressor.swift
+++ b/Flipcash/Utilities/KeyboardSuppressor.swift
@@ -1,0 +1,90 @@
+//
+//  KeyboardSuppressor.swift
+//  Flipcash
+//
+
+import UIKit
+import FlipcashCore
+
+/// Bars the keyboard for a short window.
+///
+/// A link tapped while the app is backgrounded is delivered *before* the scene
+/// finishes activating, and UIKit restores the first responder the user left
+/// focused — a chat's composer, say — as part of that activation. Lowering the
+/// keyboard once as the link is routed is therefore undone a moment later, and
+/// UIKit publishes no ordering between the two to schedule against. So rather
+/// than lowering once, this keeps lowering for as long as the window is open:
+/// the restore loses however the two land.
+@MainActor
+final class KeyboardSuppressor {
+
+    /// How long the keyboard stays barred, in milliseconds.
+    private let window: Int
+
+    /// The dismissal itself. Injected so tests can count it.
+    private let lower: () -> Void
+
+    private var observer: (any NSObjectProtocol)?
+    private var expiry: Task<Void, Never>?
+
+    /// - Parameters:
+    ///   - windowMilliseconds: must outlast the scene activation that restores
+    ///     the first responder, and close before anything the routing lands on
+    ///     can legitimately ask for a keyboard of its own.
+    ///   - lower: overridden only by tests.
+    init(windowMilliseconds: Int = 1500, lower: (() -> Void)? = nil) {
+        self.window = windowMilliseconds
+        self.lower = lower ?? { Self.lower() }
+    }
+
+    /// Takes the keyboard down once, without barring it from coming back.
+    ///
+    /// Enough on its own wherever the keyboard belongs to a screen the user is
+    /// being routed away from and nothing is racing to restore it. Resigning
+    /// first responder is what lowers the keyboard on this platform, so unlike
+    /// Compose's `hide()` there is no focused field left for the system to
+    /// raise it from again.
+    static func lower() {
+        // Targets whatever holds focus, so it needs no window reference — a
+        // link can be routed before one is key.
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+
+    isolated deinit {
+        close()
+    }
+
+    /// Lowers the keyboard now and bars it for the window. A call made while a
+    /// window is already open only re-lowers — it does not extend the bar, so
+    /// the scanner re-entering the tip flow on every decoded frame can't hold
+    /// the keyboard down indefinitely.
+    func suppress() {
+        lower()
+        guard observer == nil else { return }
+
+        // Handled on the posting thread (UIKit posts keyboard notifications on
+        // the main one) rather than hopped through a `Task`: a hop lands a
+        // runloop late, by which point the keyboard has begun animating in.
+        observer = NotificationCenter.default.addObserver(
+            forName: UIResponder.keyboardWillShowNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.lower() }
+        }
+
+        expiry = Task { [weak self, window] in
+            try? await Task.delay(milliseconds: window)
+            self?.close()
+        }
+    }
+
+    private func close() {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        observer = nil
+        expiry?.cancel()
+        expiry = nil
+    }
+}

--- a/FlipcashTests/KeyboardSuppressorTests.swift
+++ b/FlipcashTests/KeyboardSuppressorTests.swift
@@ -1,0 +1,72 @@
+//
+//  KeyboardSuppressorTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import UIKit
+@testable import Flipcash
+
+// Serialized: the suppressor observes `NotificationCenter.default`, which is
+// process-wide, so a `keyboardWillShow` posted by one test would be counted by
+// every other test's suppressor still inside its window.
+@Suite("Keyboard Suppressor", .serialized)
+@MainActor
+struct KeyboardSuppressorTests {
+
+    /// Counts dismissals in place of the real `resignFirstResponder`.
+    private final class Counter {
+        var count = 0
+    }
+
+    private static let window = 150
+
+    private func makeSuppressor() -> (KeyboardSuppressor, Counter) {
+        let counter = Counter()
+        let suppressor = KeyboardSuppressor(windowMilliseconds: Self.window) { counter.count += 1 }
+        return (suppressor, counter)
+    }
+
+    private func postKeyboardWillShow() {
+        NotificationCenter.default.post(name: UIResponder.keyboardWillShowNotification, object: nil)
+    }
+
+    @Test("Suppressing lowers the keyboard immediately")
+    func lowersOnSuppress() {
+        let (suppressor, counter) = makeSuppressor()
+        suppressor.suppress()
+        #expect(counter.count == 1)
+    }
+
+    @Test("A keyboard raised inside the window is lowered again")
+    func lowersRestoreInsideWindow() {
+        let (suppressor, counter) = makeSuppressor()
+        suppressor.suppress()
+        postKeyboardWillShow()
+        #expect(counter.count == 2)
+    }
+
+    @Test("A keyboard raised after the window is left alone")
+    func ignoresRaiseAfterWindow() async throws {
+        let (suppressor, counter) = makeSuppressor()
+        suppressor.suppress()
+        try await Task.sleep(for: .milliseconds(Self.window * 3))
+        postKeyboardWillShow()
+        #expect(counter.count == 1)
+    }
+
+    @Test("Re-entering does not extend the window")
+    func reentryDoesNotExtendWindow() async throws {
+        let (suppressor, counter) = makeSuppressor()
+        suppressor.suppress()
+        // The scanner re-enters the tip flow on every decoded frame; each
+        // re-entry lowers, but the bar still lifts on the original deadline.
+        suppressor.suppress()
+        #expect(counter.count == 2)
+
+        try await Task.sleep(for: .milliseconds(Self.window * 3))
+        postKeyboardWillShow()
+        #expect(counter.count == 2)
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -98,6 +98,7 @@ public final class ChatScreenViewController: UIViewController {
         ])
 
         barHeightConstraint = addBar(bar, controller: barController, pinnedTo: view.keyboardLayoutGuide.topAnchor)
+        lowerComposerOnResignActive()
     }
 
     /// Adds a hosted bar pinned to the view's width and the given bottom anchor; returns its height
@@ -116,6 +117,24 @@ public final class ChatScreenViewController: UIViewController {
             heightConstraint,
         ])
         return heightConstraint
+    }
+
+    /// Drops the composer's focus as the app leaves the foreground.
+    ///
+    /// UIKit otherwise restores the composer as first responder during the next activation and
+    /// raises the keyboard with it. Anything that lowers the keyboard while that restore is still
+    /// in flight — routing a deep link, say — leaves the keyboard with no owner, and SwiftUI keeps
+    /// the inset it had already reserved for it, so a sheet presented by that routing is laid out
+    /// around a keyboard that is no longer on screen. Resigning here happens while the app is
+    /// still active and nothing is animating, which leaves the restore nothing to restore.
+    private func lowerComposerOnResignActive() {
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.willResignActiveNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.bar.firstTextInputResponder?.resignFirstResponder() }
+        }
     }
 
     public override func viewWillAppear(_ animated: Bool) {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -11,15 +11,14 @@ import SwiftUI
 import FlipcashCore
 
 /// The full chat screen, entirely in UIKit: the transcript fills the view and one injected bar
-/// floats over its bottom (so content flows under it). The bar is pinned to the keyboard layout
-/// guide, which rests at the bottom safe area when the keyboard is down and rides it when shown —
-/// one bar covers both states. This screen stays agnostic about *what* the bar is and only owns
-/// layout + keyboard handling.
+/// floats over its bottom (so content flows under it). `KeyboardFloor` holds the bar at the bottom
+/// safe area when the keyboard is down and on the keyboard's top edge when it is up — one bar
+/// covers both states. This screen stays agnostic about *what* the bar is and only owns layout +
+/// keyboard handling.
 ///
-/// Keyboard handling is deliberately *not* hand-rolled. The host's safe area already grows to
-/// include the keyboard, so the bar rides the keyboard for free and the transcript only reserves
-/// the bar's own height — the safe area supplies the keyboard. Doing both ourselves was what
-/// double-counted the keyboard.
+/// The transcript reserves only the bar's own height. The system already grows the collection
+/// view's content inset by the keyboard, so counting the keyboard here too overscrolls the
+/// transcript by a whole keyboard.
 public final class ChatScreenViewController: UIViewController {
 
     private let transcript = ChatViewController()
@@ -29,6 +28,8 @@ public final class ChatScreenViewController: UIViewController {
     /// content exactly — a hosting controller's intrinsic size mis-measures multiline growth and
     /// lets the composer overflow below its frame, under the keyboard.
     private var barHeightConstraint: NSLayoutConstraint!
+    /// Keeps the bar above the keyboard. Not `view.keyboardLayoutGuide`: see `KeyboardFloor`.
+    private var keyboardFloor: KeyboardFloor!
 
     /// Raise the keyboard once the screen has finished appearing (post-tip open). Driven from
     /// UIKit rather than a SwiftUI `@FocusState`: a hosted composer's programmatic focus updates
@@ -38,7 +39,7 @@ public final class ChatScreenViewController: UIViewController {
     private var didFocusComposer = false
 
     /// - Parameters:
-    ///   - bar: pinned to the keyboard layout guide; rides the keyboard.
+    ///   - bar: pinned to the bottom of the view; rides the keyboard.
     ///   - barController: the view controller owning the bar, when hosted (e.g. a
     ///     `UIHostingController` for a SwiftUI bar). Adopted as a child so its lifecycle and
     ///     environment work. Pass `nil` for a plain `UIView` bar.
@@ -97,26 +98,33 @@ public final class ChatScreenViewController: UIViewController {
             transcript.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
 
-        barHeightConstraint = addBar(bar, controller: barController, pinnedTo: view.keyboardLayoutGuide.topAnchor)
+        let constraints = addBar(bar, controller: barController)
+        barHeightConstraint = constraints.height
+        keyboardFloor = KeyboardFloor(view: view, bottomConstraint: constraints.bottom)
         lowerComposerOnResignActive()
     }
 
-    /// Adds a hosted bar pinned to the view's width and the given bottom anchor; returns its height
-    /// constraint (driven later by the bar's measured SwiftUI content height).
-    private func addBar(_ bar: UIView, controller: UIViewController?, pinnedTo bottomAnchor: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+    /// Adds a hosted bar pinned to the view's width and bottom; returns the height constraint
+    /// (driven later by the bar's measured SwiftUI content height) and the bottom constraint
+    /// (driven by the keyboard).
+    private func addBar(
+        _ bar: UIView,
+        controller: UIViewController?
+    ) -> (height: NSLayoutConstraint, bottom: NSLayoutConstraint) {
         if let controller { addChild(controller) }
         bar.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(bar)
         controller?.didMove(toParent: self)
 
         let heightConstraint = bar.heightAnchor.constraint(equalToConstant: 80)
+        let bottomConstraint = bar.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         NSLayoutConstraint.activate([
             bar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            bar.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomConstraint,
             heightConstraint,
         ])
-        return heightConstraint
+        return (heightConstraint, bottomConstraint)
     }
 
     /// Drops the composer's focus as the app leaves the foreground.
@@ -177,10 +185,100 @@ public final class ChatScreenViewController: UIViewController {
 
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        keyboardFloor.refresh()
         // Reserve only the bar's own height. On-device the system already grows the collection
         // view's adjusted content inset by the keyboard when it's up, so adding the keyboard here
         // too (via the bar's risen position) double-counts it and overscrolls by a whole keyboard.
         transcript.setBottomInset(bar.frame.height)
+    }
+}
+
+/// Holds a bar clear of the keyboard by driving its bottom constraint from the keyboard
+/// notifications.
+///
+/// `UIView.keyboardLayoutGuide` is the shorter way to write this and is what this screen used
+/// to do, but the guide is per-view and can be torn down for good: presenting the tipcard's
+/// sheet over an open chat collapses that chat view's guide to a zero-size frame at the bottom
+/// of the screen, and it never tracks again — no layout pass, safe-area toggle, or later
+/// presentation brings it back, so the composer sits behind the keyboard for as long as the
+/// screen is up. The notifications keep reporting the right frame the whole time.
+@MainActor
+private final class KeyboardFloor {
+
+    private let bottomConstraint: NSLayoutConstraint
+    private weak var view: UIView?
+    private var observer: (any NSObjectProtocol)?
+
+    /// The keyboard's current overlap of the view, in points; zero when it is down.
+    private var overlap: CGFloat = 0
+
+    init(view: UIView, bottomConstraint: NSLayoutConstraint) {
+        self.view = view
+        self.bottomConstraint = bottomConstraint
+
+        // `willChangeFrame` alone covers showing, hiding, height changes and the interactive
+        // drag-to-dismiss, all of which post it.
+        observer = NotificationCenter.default.addObserver(
+            forName: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            let info = notification.userInfo
+            let endFrame = info?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
+            let duration = info?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval
+            let curve = info?[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt
+            MainActor.assumeIsolated {
+                // A zero end frame says nothing about where the keyboard is; UIKit posts one as
+                // the app returns to the foreground. Taken literally its top edge is the top of
+                // the screen, which would drive the bar up over the transcript.
+                guard let endFrame, !endFrame.isEmpty else { return }
+                self?.apply(endFrame: endFrame, duration: duration ?? 0, curve: curve)
+            }
+        }
+    }
+
+    isolated deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    /// Re-applies the current overlap. Called from layout so the resting inset picks up a safe
+    /// area that wasn't known yet when the bar was added.
+    func refresh() {
+        setInset(max(overlap, restingInset))
+    }
+
+    private func apply(endFrame: CGRect, duration: TimeInterval, curve: UInt?) {
+        guard let view, view.window != nil else { return }
+
+        // Keyboard frames arrive in window coordinates.
+        let frameInView = view.convert(endFrame, from: nil)
+        overlap = max(0, view.bounds.maxY - frameInView.minY)
+        guard setInset(max(overlap, restingInset)) else { return }
+
+        let options: UIView.AnimationOptions = [
+            .beginFromCurrentState,
+            curve.map { UIView.AnimationOptions(rawValue: $0 << 16) } ?? .curveEaseInOut,
+        ]
+        UIView.animate(withDuration: duration, delay: 0, options: options) {
+            view.layoutIfNeeded()
+        }
+    }
+
+    /// The keyboard-down resting inset. Zero wherever the host already ends the view at the safe
+    /// area, which is what the SwiftUI container hosting this screen does — taking the window's
+    /// inset instead counts the home indicator twice and parks the bar over the transcript.
+    private var restingInset: CGFloat {
+        view?.safeAreaInsets.bottom ?? 0
+    }
+
+    /// Returns whether the constraint actually moved, so callers can skip a no-op animation.
+    @discardableResult
+    private func setInset(_ inset: CGFloat) -> Bool {
+        guard bottomConstraint.constant != -inset else { return false }
+        bottomConstraint.constant = -inset
+        return true
     }
 }
 


### PR DESCRIPTION
Tapping a tip link while resuming from a chat presents the tip card over a live keyboard. The chat composer still holds first responder across the background, and the scene restores it as part of activating — but the URL is delivered around `willEnterForeground`, *before* that restore. Lowering the keyboard once as the link is routed is undone a moment later, and UIKit publishes no ordering between the two to schedule against.

`KeyboardSuppressor` covers both halves:

- `lower()` resigns first responder once. That's enough wherever nothing is racing to restore it — resigning is what lowers the keyboard on this platform, so no focused field is left for the system to raise it from again.
- `suppress()` keeps lowering for a bounded window, so the restore loses however the two land. Re-entry re-lowers but does not extend the window, so the scanner re-entering the tip flow on every decoded frame can't hold the keyboard down indefinitely.

`DeepLinkController` lowers once as soon as a URL parses to an action. Every action there reroutes what's on screen, and a one-shot can't swallow a keyboard the destination asks for on appear, because that request comes afterwards. Gating on a parsed action matters because `ConversationScreen` sends every tapped link through the same entry: an ordinary web URL parses to nothing, falls through to Safari, and leaves the composer alone.

`TipFlow` opens a window at `begin`, and again at `present`. The second isn't redundant — the resolve retries a cold-foreground `.unavailable` up to three times at 500ms, which outlasts the first window, so the card can go up after it has closed. The profile-creation branch stays unsuppressed deliberately: it focuses its name field on appear, and that keyboard is wanted.

## Parity

Mirrors the Android fix on `fix/tip-card-deeplink-keyboard` (`33b6a261d`), which places the same two dismissals — one at deeplink dispatch in `App.kt`, one when the bill goes up in `BillOverlay`. The class itself isn't ported: `KeyboardController.dismiss()` exists because Compose's `hide()` leaves the field focused so the platform re-raises the IME, and UIKit has no equivalent split.

## Not covered

The racy half for non-tip deeplink kinds. `.chatSendCash` presents a sheet and `.currencyInfo` expands a card; either could take a restored keyboard under it on a background resume. Each needs its own catch at its own presentation point, the way `TipFlow.present` now has one. No reported bug there.


## Follow-ups

### The sheet laid out around a keyboard that had gone

Backgrounding a chat with the composer focused and then tapping a tip link shifted the Send a Tip sheet up by the keyboard's height. Resigning first responder as the link is routed leaves the keyboard with no owner, but SwiftUI keeps the inset it had already reserved, so the sheet is laid out around a keyboard that is no longer on screen.

`ChatScreenViewController` now resigns on `willResignActive`, while the app is still active and nothing is animating, which leaves the activation restore nothing to restore. The sheet measures the same as it does with no chat behind it — chip row at 2039–2211px, knob at 2292–2442px. The cost is that the composer's keyboard no longer comes back when you foreground into a chat.

### The composer sitting behind the keyboard

Presenting the tipcard over an open chat collapses that chat view's `keyboardLayoutGuide` to `{{0, 840}, {0, 0}}` and it never tracks again, so the composer stays parked at the bottom safe area — under the keyboard — for as long as the screen is up. Nothing revives the guide: a forced layout pass, toggling `usesBottomSafeArea`, and a later presentation all leave it there. Popping and re-pushing the chat gets a healthy guide, so the teardown is confined to the one view instance. `KeyboardSuppressor`, the sheet's initial full-screen detent, and `presentationBackgroundInteraction` are each ruled out by disabling them individually, and sheets in general are not the trigger — the composer's own "$" sheet leaves the guide healthy at `{{0, 546}, {402, 328}}`.

The keyboard notifications keep reporting the right frame throughout, so `KeyboardFloor` drives the bar's bottom constraint from those instead of the guide. Two details of that constraint are worth calling out in review, because either one wrong parks the bar up over the transcript rather than merely leaving it low:

- **The resting inset comes from the view's own safe area, not the window's.** The SwiftUI container hosting this screen already ends the view at the safe area, so the chat view's `safeAreaInsets.bottom` is 0; taking the window's would count the home indicator a second time and lift the bar 34pt into the transcript.
- **An empty end frame is ignored.** Returning to the foreground posts `keyboardWillChangeFrame` with `{{0, 0}, {0, 0}}`, and read literally its top edge is the top of the screen — an overlap of the whole view height. A real hide reports `{{0, 874}, {402, 328}}`, off the bottom, for an overlap of 0.

Measured on the simulator: focusing the composer lands the bar on the keyboard's top edge at 546pt, where it used to stay at 774pt, and the composer pill sits at 488–538pt focused and 782–832pt at rest — from a fresh chat, after the tip flow, and across a background round-trip alike. The transcript's inset is unaffected: the system still grows the collection view's content inset by the keyboard, and only the bar's own height is added here.

This one predates the rest of the PR — the repro needs no backgrounding, so `willResignActive` never fires in it. It rides along because it surfaced here and lands in the same file.

## Automated coverage

None. The failure needs a tipcard presented over an open chat, and a live tip deeplink is the only route to that, which the app's own UI has none of. A test of the plain-chat focus case would guard a path that never broke.
