### PR TITLE
feat(api): build the contract packages from local checkouts

### DIFF
--- a/FlipcashAPI/Package.swift
+++ b/FlipcashAPI/Package.swift
@@ -2,6 +2,41 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import Foundation
+
+// The contract packages are normally consumed at a pinned version, which means trying a
+// proto change would mean publishing one. Set FLIPCASH_PROTO_LOCAL to the directory that
+// holds ocp-client-protocol/ and flipcash2-client-protocol/ to build against those
+// checkouts instead:
+//
+//     export FLIPCASH_PROTO_LOCAL=~/dev/bmcreations/code
+//     xed .
+//
+// Xcode inherits the environment of whatever launched it, so it has to be started from a
+// shell that exported the variable rather than from the Dock. SwiftPM re-evaluates this
+// manifest when the variable changes, so switching back needs no clean.
+//
+// Local mode drops the two contract entries from the tracked workspace Package.resolved.
+// That is noise rather than a version change, since the pins below are exact, but restore it
+// before committing:
+//
+//     git checkout -- Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+//
+// Unset is the committed state, and CI never sets it, so release builds always resolve the
+// pinned version below.
+let protoLocalRoot = ProcessInfo.processInfo.environment["FLIPCASH_PROTO_LOCAL"]
+    .map { ($0 as NSString).expandingTildeInPath }
+    .flatMap { $0.isEmpty ? nil : $0 }
+
+let contractDependencies: [Package.Dependency] = protoLocalRoot.map { root in
+    [
+        .package(path: "\(root)/ocp-client-protocol"),
+        .package(path: "\(root)/flipcash2-client-protocol"),
+    ]
+} ?? [
+    .package(url: "https://github.com/code-payments/ocp-client-protocol", exact: "0.1.0"),
+    .package(url: "https://github.com/code-payments/flipcash2-client-protocol", exact: "0.1.0"),
+]
 
 let package = Package(
     name: "FlipcashAPI",
@@ -14,10 +49,7 @@ let package = Package(
             targets: ["FlipcashAPI"]
         ),
     ],
-    dependencies: [
-        .package(url: "https://github.com/code-payments/ocp-client-protocol", exact: "0.1.0"),
-        .package(url: "https://github.com/code-payments/flipcash2-client-protocol", exact: "0.1.0"),
-    ],
+    dependencies: contractDependencies,
     targets: [
         .target(
             name: "FlipcashAPI",


### PR DESCRIPTION
`FlipcashAPI/Package.swift` pins both contract packages with `.package(url:, exact:)`, so trying a
contract change meant tagging a release of the client repos first.

The manifest now reads `FLIPCASH_PROTO_LOCAL`. When it names a directory holding
`ocp-client-protocol` and `flipcash2-client-protocol` checkouts, both dependencies become
`.package(path:)`; unset, the manifest resolves the same pinned versions as before. Product
references and the re-export are untouched, so `import FlipcashAPI` behaves identically either way.
Xcode inherits the environment of whatever launched it, so it has to be started from a shell that
exported the variable.

Nothing is edited to enter local mode, so there is nothing to commit by accident. It does drop the
two contract entries from the workspace `Package.resolved` while active. That is noise rather than a
version change, since the manifest pins are `exact`, but the file should be restored before
committing.

Checked with `swift package dump-package` in both states, and with `swift build` of `FlipcashAPI`
against local client checkouts carrying an uncommitted proto change: the added message reached
`Ocp_Common_V1_LocalDevProbe` in the generated Swift and the build succeeded.

Pairs with the client-repo change that lets the contract itself be synced from a local checkout:
code-payments/ocp-client-protocol#3 and code-payments/flipcash2-client-protocol#3.
