### PR TITLE
fix(onramp): keep the pushed verification flow alive when a step covers the root

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter.swift
+++ b/Flipcash/Core/Navigation/AppRouter.swift
@@ -153,6 +153,18 @@ final class AppRouter {
             ])
             return
         }
+        pushAny(value, on: stack)
+    }
+
+    /// Pushes any Hashable value onto `stack`, named rather than inferred from
+    /// what is topmost. For multi-step sub-flows that resolve their host stack
+    /// once at the start and then measure their own depth against it (e.g. the
+    /// onramp verification steps): inferring per push would let a later step
+    /// land on a different stack from the one the flow is counting, which reads
+    /// as the flow having been unwound.
+    ///
+    /// Prefer `pushAny(_:)` for a single push onto the visible stack.
+    func pushAny<H: Hashable>(_ value: H, on stack: Stack) {
         paths[stack, default: NavigationPath()].append(value)
         logger.info("Push (sub-flow)", metadata: [
             "stack": "\(stack)",

--- a/Flipcash/Core/Screens/EmailVerification/EmailVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/EmailVerification/EmailVerificationViewModel.swift
@@ -211,12 +211,13 @@ final class EmailVerificationViewModel: EmailVerifying {
         }
     }
 
-    func applyDeeplinkVerification(_ verification: VerificationDescription) {
-        guard !isAlreadyVerified else { return }
+    @discardableResult
+    func applyDeeplinkVerification(_ verification: VerificationDescription) -> Bool {
+        guard !isAlreadyVerified else { return false }
         // Drop overlapping deeplinks while one is in flight — two concurrent
         // Tasks would fight over `confirmEmailButtonState` and could both
         // call `onVerified` / `finish`, double-finishing.
-        guard deeplinkTask == nil else { return }
+        guard deeplinkTask == nil else { return false }
 
         enteredEmail = verification.email
         // Standalone mode lands the user on the confirm screen so the API
@@ -273,6 +274,8 @@ final class EmailVerificationViewModel: EmailVerifying {
                 showGenericError()
             }
         }
+
+        return true
     }
 
     // MARK: - Dialog factories -

--- a/Flipcash/Core/Screens/EmailVerification/EmailVerifying.swift
+++ b/Flipcash/Core/Screens/EmailVerification/EmailVerifying.swift
@@ -32,5 +32,9 @@ protocol EmailVerifying: Verifying {
 
     /// Applies an out-of-flow deeplink that delivered a verification code.
     /// Idempotent: drops overlapping deeplinks while one is in flight.
-    func applyDeeplinkVerification(_ verification: VerificationDescription)
+    /// Returns `true` when the deeplink was taken — hosts navigate to their
+    /// confirm-email step only then, so a dropped deeplink can't move the user
+    /// off the step they're on.
+    @discardableResult
+    func applyDeeplinkVerification(_ verification: VerificationDescription) -> Bool
 }

--- a/Flipcash/Core/Screens/Main/AddMoney/AddMoneyStartScreen.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/AddMoneyStartScreen.swift
@@ -87,8 +87,8 @@ struct AddMoneyStartScreen: View {
         let router = self.router
 
         guard BetaFlags.shared.hasEnabled(.newUI) else {
-            if router.isAddMoneyOverBuy {
-                dismissThenPush(AddMoneyFlowStep.method(method), using: router)
+            if router.isAddMoneyOverBuy, let stack = router.addMoneyPushStack {
+                dismissThenPush(AddMoneyFlowStep.method(method), onto: stack, using: router)
             } else {
                 flowMethod = method
             }
@@ -130,23 +130,25 @@ struct AddMoneyStartScreen: View {
     /// opened over the bare scanner — it falls back to presenting the flow as
     /// its own sheet.
     private func startFlow(_ method: DepositMethod, using router: AppRouter) {
-        if router.addMoneyPushStack != nil {
-            dismissThenPush(AddMoneyFlowStep.method(method), using: router)
+        if let stack = router.addMoneyPushStack {
+            dismissThenPush(AddMoneyFlowStep.method(method), onto: stack, using: router)
         } else {
             flowMethod = method
         }
     }
 
-    /// Dismisses the picker, then pushes `value` onto the revealed stack once
-    /// the sheet's dismiss animation has cleared. Pushing while the partial
-    /// sheet is still sliding down runs the revealed stack's push animation at
-    /// the same time, which flickers the new screen's back arrow — so the push
-    /// waits for the sheet to settle (the app's dismiss-then-mutate pattern).
-    private func dismissThenPush<H: Hashable>(_ value: H, using router: AppRouter) {
+    /// Dismisses the picker, then pushes `value` onto `stack` once the sheet's
+    /// dismiss animation has cleared. Pushing while the partial sheet is still
+    /// sliding down runs the revealed stack's push animation at the same time,
+    /// which flickers the new screen's back arrow — so the push waits for the
+    /// sheet to settle (the app's dismiss-then-mutate pattern). The stack is
+    /// named rather than inferred after the wait, since anything presented in
+    /// the meantime would otherwise capture the push.
+    private func dismissThenPush<H: Hashable>(_ value: H, onto stack: AppRouter.Stack, using router: AppRouter) {
         router.dismissSheet()
         Task { @MainActor in
             try? await Task.sleep(for: AppRouter.dismissAnimationDuration)
-            router.pushAny(value)
+            router.pushAny(value, on: stack)
         }
     }
 
@@ -164,18 +166,18 @@ struct AddMoneyStartScreen: View {
                 let first = vm.initialStep()
                 vm.pushedHost = PushedVerificationHost(
                     rootStep: first,
-                    push: { router.pushAny($0) },
+                    push: { router.pushAny($0, on: stack) },
                     // Everything above the depth the stack had before the flow
                     // started is the flow's own steps.
                     liveStepCount: { router[stack].count - baseline }
                 )
-                dismissThenPush(first, using: router)
+                dismissThenPush(first, onto: stack, using: router)
             },
             perform: {
                 if case .addMoney? = router.presentedSheet {
                     // Already verified: the picker is still up. Dismiss it and
                     // push the deposit once it clears (same anti-flicker beat).
-                    dismissThenPush(AddMoneyFlowStep.method(.coinbase), using: router)
+                    dismissThenPush(AddMoneyFlowStep.method(.coinbase), onto: stack, using: router)
                 } else {
                     // Verified via the pushed steps: unwind them and push the
                     // deposit inline on the already-visible stack.
@@ -183,7 +185,7 @@ struct AddMoneyStartScreen: View {
                     if depth > baseline {
                         router.popLast(depth - baseline, on: stack)
                     }
-                    router.pushAny(AddMoneyFlowStep.method(.coinbase))
+                    router.pushAny(AddMoneyFlowStep.method(.coinbase), on: stack)
                 }
             }
         )

--- a/Flipcash/Core/Screens/Main/AddMoney/AddMoneyStartScreen.swift
+++ b/Flipcash/Core/Screens/Main/AddMoney/AddMoneyStartScreen.swift
@@ -161,9 +161,14 @@ struct AddMoneyStartScreen: View {
             for: session,
             bind: { vm in
                 guard let vm else { return }
-                vm.onAdvance = { router.pushAny($0) }
                 let first = vm.initialStep()
-                vm.rootPushedStep = first
+                vm.pushedHost = PushedVerificationHost(
+                    rootStep: first,
+                    push: { router.pushAny($0) },
+                    // Everything above the depth the stack had before the flow
+                    // started is the flow's own steps.
+                    liveStepCount: { router[stack].count - baseline }
+                )
                 dismissThenPush(first, using: router)
             },
             perform: {

--- a/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
+++ b/Flipcash/Core/Screens/Onramp/OnrampVerificationViewModel.swift
@@ -58,26 +58,32 @@ final class OnrampVerificationViewModel<P: PhoneVerifying, E: EmailVerifying>: V
 
     // MARK: - Pushed navigation -
 
-    /// When set, step advances route through this sink — used to push the flow
-    /// onto the app's navigation stack — instead of the view-model-owned
-    /// `verificationPath`. Sheet hosts (`VerifyInfoScreen`) leave it nil and let
-    /// `verificationPath` drive their own `NavigationStack`.
-    @ObservationIgnored var onAdvance: (@MainActor (OnrampVerificationPath) -> Void)?
+    /// Set when the flow runs on the app's navigation stack rather than in a
+    /// sheet: step advances push through it instead of appending to the
+    /// view-model-owned `verificationPath`. Sheet hosts (`VerifyInfoScreen`)
+    /// leave it nil and let `verificationPath` drive their own
+    /// `NavigationStack`.
+    @ObservationIgnored var pushedHost: PushedVerificationHost?
 
-    /// The first step pushed when the flow runs on the app's navigation stack.
-    /// The pushed host cancels the flow when this step is popped (the user
-    /// backed out of verification); later steps back within the flow.
-    @ObservationIgnored var rootPushedStep: OnrampVerificationPath?
-
-    /// Advances to `step` — pushing through `onAdvance` when the flow is hosted
-    /// on the app's navigation stack, otherwise appending to the sheet-owned
+    /// Advances to `step` — pushing onto the app's navigation stack when the
+    /// flow is hosted there, otherwise appending to the sheet-owned
     /// `verificationPath`.
     private func advance(to step: OnrampVerificationPath) {
-        if let onAdvance {
-            onAdvance(step)
+        if let pushedHost {
+            pushedHost.advance(to: step)
         } else {
             verificationPath.append(step)
         }
+    }
+
+    /// Called by the pushed host when `step` leaves the screen. SwiftUI reports
+    /// that both when a step is popped and when the next one covers it, so the
+    /// flow is cancelled only if the root step went away because the host stack
+    /// unwound — the user backed out of verification. A no-op once the flow has
+    /// finished, since the continuation is already cleared.
+    func cancelIfBackedOut(from step: OnrampVerificationPath) {
+        guard let pushedHost, step == pushedHost.rootStep, pushedHost.hasUnwound else { return }
+        cancel()
     }
 
     // MARK: - Init -
@@ -185,16 +191,88 @@ final class OnrampVerificationViewModel<P: PhoneVerifying, E: EmailVerifying>: V
     // MARK: - Deeplinks -
 
     /// Forwards to the inner email verifier and parks the user on the
-    /// confirm-email screen. Guards on the inner state BEFORE mutating the
-    /// shared path so a deeplink that the inner verifier would drop
-    /// (already verified, or another deeplink in flight) doesn't yank the
-    /// user off their current step.
+    /// confirm-email screen so the code check has somewhere to surface.
+    /// Navigates only if the verifier took the deeplink — one it drops
+    /// (already verified, or another deeplink in flight) must not yank the
+    /// user off the step they're on.
     func applyDeeplinkVerification(_ verification: VerificationDescription) {
-        guard !emailVerifier.isAlreadyVerified else { return }
-        if verificationPath.last != .confirmEmailCode {
+        guard emailVerifier.applyDeeplinkVerification(verification) else { return }
+        showConfirmEmailCode()
+    }
+
+    /// Moves the user to the confirm-email step unless they're already there —
+    /// pushing onto the host stack when the flow is hosted there, otherwise
+    /// replacing the sheet-owned path.
+    private func showConfirmEmailCode() {
+        if let pushedHost {
+            guard pushedHost.currentStep != .confirmEmailCode else { return }
+            pushedHost.advance(to: .confirmEmailCode)
+        } else if verificationPath.last != .confirmEmailCode {
             verificationPath = [.confirmEmailCode]
         }
-        emailVerifier.applyDeeplinkVerification(verification)
+    }
+}
+
+// MARK: - Pushed hosting -
+
+/// How a verification flow that runs on the app's navigation stack — rather
+/// than in its own sheet — reaches that stack, and the record of which of its
+/// steps that stack still holds.
+///
+/// The host stack carries other destinations below the flow and its path is
+/// type-erased, so it can only be asked how many steps it holds, never which.
+/// This type keeps the step list the count indexes into: the flow pushes
+/// through `advance(to:)`, the user pops from the top, so the live steps are
+/// always the first `liveStepCount()` of what was pushed.
+@MainActor
+final class PushedVerificationHost {
+
+    /// The first step pushed onto the host stack. Popping it backs out of
+    /// verification entirely; later steps back within the flow.
+    let rootStep: OnrampVerificationPath
+
+    private let push: @MainActor (OnrampVerificationPath) -> Void
+    private let liveStepCount: @MainActor () -> Int
+
+    private var pushedSteps: [OnrampVerificationPath]
+
+    /// - Parameters:
+    ///   - rootStep: the step the caller pushes to open the flow.
+    ///   - push: pushes a step onto the host stack.
+    ///   - liveStepCount: how many of the flow's steps the host stack holds
+    ///     right now — its depth less the depth it had before the flow began.
+    init(
+        rootStep: OnrampVerificationPath,
+        push: @MainActor @escaping (OnrampVerificationPath) -> Void,
+        liveStepCount: @MainActor @escaping () -> Int
+    ) {
+        self.rootStep = rootStep
+        self.push = push
+        self.liveStepCount = liveStepCount
+        self.pushedSteps = [rootStep]
+    }
+
+    /// The flow step the user is on, or nil once the stack has unwound past
+    /// the flow.
+    var currentStep: OnrampVerificationPath? {
+        liveSteps.last
+    }
+
+    /// `true` once the host stack no longer holds any of the flow's steps.
+    var hasUnwound: Bool {
+        liveSteps.isEmpty
+    }
+
+    /// Pushes `step` onto the host stack, dropping the record of any steps the
+    /// user has already popped.
+    func advance(to step: OnrampVerificationPath) {
+        pushedSteps = Array(liveSteps)
+        pushedSteps.append(step)
+        push(step)
+    }
+
+    private var liveSteps: ArraySlice<OnrampVerificationPath> {
+        pushedSteps.prefix(max(0, liveStepCount()))
     }
 }
 

--- a/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
+++ b/Flipcash/Core/Screens/Onramp/VerifyInfoScreen.swift
@@ -105,11 +105,8 @@ struct OnrampVerificationPushedStep: View {
                 .toolbarTitleDisplayMode(.inline)
                 .onDisappear {
                     // Popping the root step means the user abandoned
-                    // verification; cancel to release the awaiting gate. A
-                    // no-op once the flow has finished (continuation cleared).
-                    if path == viewModel.rootPushedStep {
-                        viewModel.cancel()
-                    }
+                    // verification; cancel to release the awaiting gate.
+                    viewModel.cancelIfBackedOut(from: path)
                 }
         }
     }

--- a/FlipcashTests/Navigation/AppRouterTests.swift
+++ b/FlipcashTests/Navigation/AppRouterTests.swift
@@ -242,6 +242,24 @@ struct AppRouterTests {
         #expect(router[.give].isEmpty)
     }
 
+    @Test("pushAny(on:) lands on the named stack, not the topmost one")
+    func pushAnyOnStack_landsOnNamedStack() {
+        let router = AppRouter()
+        router.present(.settings)
+        router.pushAny(WithdrawNavigationPath.enterAmount, on: .balance)
+        #expect(router[.balance].count == 1)
+        #expect(router[.settings].isEmpty)
+    }
+
+    @Test("pushAny(on:) pushes with no sheet presented")
+    func pushAnyOnStack_pushesWithNoSheet() {
+        // The stack is named, so there is nothing to infer and nothing to
+        // warn about — a sub-flow can keep pushing after its sheet closes.
+        let router = AppRouter()
+        router.pushAny(WithdrawNavigationPath.enterAmount, on: .balance)
+        #expect(router[.balance].count == 1)
+    }
+
     // MARK: - present / dismissSheet
 
     @Test("present sets the sheet")

--- a/FlipcashTests/OnrampVerificationViewModelTests.swift
+++ b/FlipcashTests/OnrampVerificationViewModelTests.swift
@@ -18,4 +18,86 @@ struct OnrampVerificationViewModelTests {
         #expect(viewModel.verificationPath == [.confirmEmailCode])
         #expect(viewModel.emailVerifier.enteredEmail == "a@b.c")
     }
+
+    // MARK: - Pushed hosting -
+
+    /// Stands in for the host `NavigationStack` a pushed flow lives on.
+    @MainActor
+    private final class HostStack {
+        var steps: [OnrampVerificationPath]
+        init(steps: [OnrampVerificationPath]) { self.steps = steps }
+    }
+
+    /// Builds a flow pushed onto `stack` with `.intro` as its root.
+    private func makePushedFlow(on stack: HostStack) -> OnrampVerification {
+        let viewModel = OnrampVerificationViewModel(session: .unverifiedMock, flipClient: .mock)
+        viewModel.pushedHost = PushedVerificationHost(
+            rootStep: .intro,
+            push: { stack.steps.append($0) },
+            liveStepCount: { stack.steps.count }
+        )
+        return viewModel
+    }
+
+    /// A pushed flow suspended in `run()`, ready to be advanced or backed out of.
+    private func makeRunningPushedFlow(on stack: HostStack) async -> (OnrampVerification, Task<Void, Error>) {
+        let viewModel = makePushedFlow(on: stack)
+        let run = Task { try await viewModel.run() }
+        while viewModel.continuation == nil { await Task.yield() }
+        return (viewModel, run)
+    }
+
+    @Test("The root step being covered by the next step leaves the flow running")
+    func pushedFlow_rootStepCovered_keepsRunning() async {
+        let stack = HostStack(steps: [.intro])
+        let (viewModel, run) = await makeRunningPushedFlow(on: stack)
+
+        viewModel.proceedFromIntro()
+        #expect(stack.steps == [.intro, .enterPhoneNumber])
+
+        // SwiftUI disappears the intro when phone entry covers it. The flow
+        // must survive that, or the pushed step renders with no view model.
+        viewModel.cancelIfBackedOut(from: .intro)
+        #expect(viewModel.continuation != nil)
+
+        viewModel.cancel()
+        _ = await run.result
+    }
+
+    @Test("Popping the root step off the host stack cancels the flow")
+    func pushedFlow_rootStepPopped_cancels() async throws {
+        let stack = HostStack(steps: [.intro])
+        let (viewModel, run) = await makeRunningPushedFlow(on: stack)
+
+        stack.steps.removeAll()
+        viewModel.cancelIfBackedOut(from: .intro)
+
+        #expect(viewModel.continuation == nil)
+        await #expect(throws: CancellationError.self) { try await run.value }
+    }
+
+    @Test("A deeplink pushes the confirm-email step onto the host stack")
+    func pushedFlow_deeplink_pushesConfirmEmail() {
+        let stack = HostStack(steps: [.intro])
+        let viewModel = makePushedFlow(on: stack)
+
+        viewModel.applyDeeplinkVerification(VerificationDescription(email: "a@b.c", code: "123456"))
+
+        #expect(stack.steps == [.intro, .confirmEmailCode])
+        #expect(viewModel.emailVerifier.enteredEmail == "a@b.c")
+        // The sheet-owned path stays out of it while the flow is pushed.
+        #expect(viewModel.verificationPath.isEmpty)
+    }
+
+    @Test("A repeat deeplink doesn't stack a second confirm-email step")
+    func pushedFlow_repeatDeeplink_doesNotPushTwice() {
+        let stack = HostStack(steps: [.intro])
+        let viewModel = makePushedFlow(on: stack)
+        let verification = VerificationDescription(email: "a@b.c", code: "123456")
+
+        viewModel.applyDeeplinkVerification(verification)
+        viewModel.applyDeeplinkVerification(verification)
+
+        #expect(stack.steps == [.intro, .confirmEmailCode])
+    }
 }


### PR DESCRIPTION
On a new account, Wallet → Add Money → Debit Card → Next showed the phone number screen for a moment and then went black, leaving only the back button.

The Coinbase verification flow runs on the app's navigation stack, and its intro step cancelled the flow as soon as phone entry pushed on top of it. SwiftUI calls `onDisappear` both when a step is popped and when the next one covers it; the old check in `OnrampVerificationPushedStep` only compared the leaving step against the flow's root, so covering the intro looked the same as backing out of it. Cancelling clears `VerificationCoordinator.currentInlineViewModel`, and `OnrampVerificationPushedStep` renders nothing without a view model. That empty render is the black screen.

Advancing and unwinding now go through a `PushedVerificationHost`, which holds the steps the flow pushed and works out which are still live from the host stack's current depth less the depth it had before the flow started. A `NavigationPath` is type-erased, so depth is the only thing the stack will report — the host keeps the step list that count indexes into. The root step cancels only once no flow step remains on the stack.

The same host covers the deeplink path. `applyDeeplinkVerification` wrote the sheet-owned `verificationPath`, which nothing observes while the flow is pushed, so an email verification link moved nothing on screen. It now pushes the confirm-email step through the host. `EmailVerifying.applyDeeplinkVerification` returns whether the inner verifier took the deeplink, so one dropped as a duplicate or as already-verified no longer moves the user off the step they're on.

`VerifyInfoScreen`'s own sheet stack is unchanged: it leaves `pushedHost` nil and keeps driving `verificationPath`.

The depth check only holds if every step lands on the stack it is measured against, so `AppRouter` gains `pushAny(_:on:)` — a push onto a named stack rather than whatever is topmost at the time. The Add Money picker passes its captured host stack through the verification pushes and the deposit push, and `dismissThenPush` now takes the stack as a parameter instead of inferring it after the dismiss-animation wait, where anything presented in the meantime would capture the push. `pushAny(_:)` is unchanged for callers doing a single push onto the visible stack; it infers the stack and then delegates.

Four tests in `OnrampVerificationViewModelTests` cover the pushed case against a stand-in host stack: the root being covered, the root being popped, a deeplink pushing confirm-email, and a repeat deeplink not stacking a second one.

Two more in `AppRouterTests` cover the new overload: it lands on the named stack while another sheet is presented, and it pushes with no sheet presented at all.
