### PR TITLE
feat(username): claim a handle, show it on the tip card, and open its link

### DIFF
--- a/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
+++ b/Flipcash/Core/Controllers/Deep Links/DeepLinkController.swift
@@ -148,6 +148,9 @@ final class DeepLinkController {
         case .tip(let userID):
             return action(.tip(userID))
 
+        case .username(let username):
+            return action(.username(username))
+
         case .give:
             return action(.openSheet(.give))
 
@@ -280,6 +283,14 @@ struct DeepLinkAction {
                 container.tipFlow.begin(userID: userID)
             }
 
+        case .username(let username):
+            if let container = sessionAuthenticator.loggedInContainer {
+                Analytics.deeplinkRouted(kind: kind)
+                // Same destination as `.tip`, reached by handle — including the
+                // own-handle case, which `begin` routes to the user's own card.
+                container.tipFlow.begin(username: username)
+            }
+
         case .openSheet(let sheet):
             if let container = sessionAuthenticator.loggedInContainer {
                 Analytics.deeplinkRouted(kind: kind)
@@ -326,6 +337,7 @@ extension DeepLinkAction {
         case chat(ConversationID)
         case chatSendCash(ConversationID)
         case tip(UserID)
+        case username(Username)
         case openSheet(AppRouter.SheetPresentation)
     }
 }
@@ -340,6 +352,7 @@ extension DeepLinkAction.Kind {
         case .chat:                 "Chat"
         case .chatSendCash:         "ChatSendCash"
         case .tip:                  "Tip"
+        case .username:             "Username"
         case .openSheet(let sheet): "Sheet:\(sheet)"
         }
     }

--- a/Flipcash/Core/Controllers/Deep Links/Route.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Route.swift
@@ -24,7 +24,7 @@ nonisolated struct Route {
         // - Deep Links: flipcash://token/ABC → host = "token", path = "/ABC"
         //   Need to combine as "/token/ABC"
         let normalizedPath: String
-        if components.scheme == "flipcash", let host = components.host {
+        if components.scheme == Path.customScheme, let host = components.host {
             // Deep link: combine host + path
             normalizedPath = "/\(host)\(components.path)"
         } else {
@@ -32,7 +32,7 @@ nonisolated struct Route {
             normalizedPath = components.path
         }
 
-        guard let path = Path.parse(path: normalizedPath) else {
+        guard let path = Path.parse(path: normalizedPath, scheme: components.scheme) else {
             return nil
         }
         
@@ -92,8 +92,15 @@ nonisolated extension Route {
         case balance
         case discover
         case unknown(String)
-        
-        static func parse(path: String) -> Path? {
+
+        /// The app's custom URL scheme, registered in `Info.plist`.
+        static let customScheme = "flipcash"
+
+        /// `scheme` separates a home-screen quick action (`flipcash://give`)
+        /// from a web link (`app.flipcash.com/give`). Only the custom scheme
+        /// carries the quick-action routes; on the web those names are ordinary
+        /// path segments, and Phase 2 reads an unmatched one as a handle.
+        static func parse(path: String, scheme: String?) -> Path? {
             guard let url = URL(string: path.trimmingCharacters(in: .init(charactersIn: "/"))) else {
                 return nil
             }
@@ -135,16 +142,16 @@ nonisolated extension Route {
                     return nil
                 }
                 return .tip(userID)
-            case "give":
+            case "give" where scheme == customScheme:
                 return .give
-            case "balance":
+            case "balance" where scheme == customScheme:
                 return .balance
             case "wallet":
                 // Reserved for Phantom callbacks (consumed by
                 // `WalletConnection.didReceiveURL`). Home-screen
                 // "Wallet" quick action uses `/balance` instead.
                 return .unknown(url.lastPathComponent)
-            case "discover":
+            case "discover" where scheme == customScheme:
                 return .discover
             default:
                 return .unknown(url.lastPathComponent)

--- a/Flipcash/Core/Controllers/Deep Links/Route.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Route.swift
@@ -88,7 +88,7 @@ nonisolated extension Route {
         case chat(ConversationID)
         case chatSendCash(ConversationID)
         case tip(UserID)
-        /// A vanity tipcard link — `app.flipcash.com/<handle>`, no `/tip/`
+        /// A vanity tipcard link — `flipcash.com/<handle>`, no `/tip/`
         /// segment and no `@`. The same destination as ``tip(_:)``, reached by
         /// the handle its owner claimed rather than by their user id.
         case username(Username)

--- a/Flipcash/Core/Controllers/Deep Links/Route.swift
+++ b/Flipcash/Core/Controllers/Deep Links/Route.swift
@@ -88,6 +88,10 @@ nonisolated extension Route {
         case chat(ConversationID)
         case chatSendCash(ConversationID)
         case tip(UserID)
+        /// A vanity tipcard link — `app.flipcash.com/<handle>`, no `/tip/`
+        /// segment and no `@`. The same destination as ``tip(_:)``, reached by
+        /// the handle its owner claimed rather than by their user id.
+        case username(Username)
         case give
         case balance
         case discover
@@ -99,7 +103,12 @@ nonisolated extension Route {
         /// `scheme` separates a home-screen quick action (`flipcash://give`)
         /// from a web link (`app.flipcash.com/give`). Only the custom scheme
         /// carries the quick-action routes; on the web those names are ordinary
-        /// path segments, and Phase 2 reads an unmatched one as a handle.
+        /// path segments, and an unmatched one reads as a handle.
+        ///
+        /// Host-agnostic by design: `app.flipcash.com/<handle>` and
+        /// `flipcash.com/<handle>` are the same link, and which hosts reach the
+        /// app at all is the associated-domains entitlement's decision, not
+        /// this parser's.
         static func parse(path: String, scheme: String?) -> Path? {
             guard let url = URL(string: path.trimmingCharacters(in: .init(charactersIn: "/"))) else {
                 return nil
@@ -154,6 +163,15 @@ nonisolated extension Route {
             case "discover" where scheme == customScheme:
                 return .discover
             default:
+                // A single unmatched segment is a claimed handle. Lowercased
+                // first: handles are stored lowercase, and a link a messaging
+                // app auto-capitalized is still the same link. Whether the
+                // handle *can* be claimed — the reserved list — is the server's
+                // to say, so nothing is filtered out here beyond the routes
+                // above.
+                if components.count == 1, let username = Username(components[0].lowercased()) {
+                    return .username(username)
+                }
                 return .unknown(url.lastPathComponent)
             }
         }

--- a/Flipcash/Core/Navigation/AppRouter+Destination.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Destination.swift
@@ -54,6 +54,10 @@ extension AppRouter {
         /// profile-setup flow starts on the same screen but carries on to the
         /// tip card; this one returns to the settings list.
         case changeDisplayName
+        /// The public handle, claimed from the You page or changed from My
+        /// Account. One destination for both: the screen seeds itself from the
+        /// handle already on the profile, so there is nothing to distinguish.
+        case username(Username?)
         case settingsAdvancedFeatures
         case settingsAdvancedBetaFeatures
         case settingsAppSettings
@@ -89,7 +93,7 @@ extension AppRouter {
                  .transactionHistory, .activity, .give, .buyCurrency, .convertCurrency,
                  .withdrawCurrency, .usdcDepositEducation, .usdcDepositAddress:
                 return .balance
-            case .settingsMyAccount, .changeDisplayName, .settingsAdvancedFeatures,
+            case .settingsMyAccount, .changeDisplayName, .username, .settingsAdvancedFeatures,
                  .settingsAdvancedBetaFeatures, .settingsAppSettings, .settingsAccountSelection,
                  .settingsApplicationLogs, .blockedUsers, .accessKey, .withdraw:
                 return .settings
@@ -121,6 +125,7 @@ extension AppRouter {
             case .usdcDepositAddress:           "usdcDepositAddress"
             case .settingsMyAccount:            "settingsMyAccount"
             case .changeDisplayName:            "changeDisplayName"
+            case .username:                     "username"
             case .settingsAdvancedFeatures:     "settingsAdvancedFeatures"
             case .settingsAdvancedBetaFeatures: "settingsAdvancedBetaFeatures"
             case .settingsAppSettings:          "settingsAppSettings"
@@ -157,6 +162,8 @@ extension AppRouter {
                 return conversationID.description
             case .userProfile(let userID):
                 return userID.uuidString
+            case .username(let username):
+                return username?.value
             case .activity,
                  .discoverCurrencies, .currencyCreationSummary, .currencyCreationWizard,
                  .usdcDepositEducation, .usdcDepositAddress,

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -73,6 +73,9 @@ struct DestinationView: View {
         case .changeDisplayName:
             ChangeDisplayNameScreen(currentName: sessionContainer.session.profile?.displayName ?? "")
 
+        case .username(let username):
+            UsernameEntryScreen(currentUsername: username)
+
         case .settingsAdvancedFeatures:
             SettingsAdvancedFeaturesScreen()
 

--- a/Flipcash/Core/Screens/Main/Bill/BillCanvas.swift
+++ b/Flipcash/Core/Screens/Main/Bill/BillCanvas.swift
@@ -119,13 +119,14 @@ private class _BillCanvasController: UIViewController {
                     mint: mint
                 )
 
-            case .tipcard(let codeData, let name, let avatar):
+            case .tipcard(let codeData, let name, let username, let avatar):
                 TipcardView(
                     size: tipcardSize(),
                     name: name,
                     avatar: avatar,
                     codeData: codeData,
-                    tintOpacity: 0.72
+                    tintOpacity: 0.72,
+                    subtitle: username
                 )
                 .frame(width: canvasSize().width, height: canvasSize().height)
             }

--- a/Flipcash/Core/Screens/Main/Bill/BillState.swift
+++ b/Flipcash/Core/Screens/Main/Bill/BillState.swift
@@ -55,7 +55,7 @@ extension BillState {
         case cash(CashCode.Payload, mint: PublicKey, billColors: [String] = [])
         /// A scanned (or deeplinked) recipient's tipcard, shown over the
         /// camera while the Send a Tip sheet is up.
-        case tipcard(codeData: Data, name: String, avatar: UIImage?)
+        case tipcard(codeData: Data, name: String, username: String?, avatar: UIImage?)
 
         var canSwipeToDismiss: Bool {
             switch self {

--- a/Flipcash/Core/Screens/Main/ScanViewModel.swift
+++ b/Flipcash/Core/Screens/Main/ScanViewModel.swift
@@ -139,7 +139,9 @@ class ScanViewModel {
         }
 
         switch route.path {
-        case .cash, .token, .tip:
+        // `.username` is the vanity form of `.tip` — the same tipcard link, so
+        // a printed handle QR scans where the user id one already does.
+        case .cash, .token, .tip, .username:
             return true
         case .login, .verifyEmail, .chat, .chatSendCash, .give, .balance, .discover, .unknown:
             return false

--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -33,8 +33,10 @@ final class TipFlow {
     private(set) var submission: SendAmountViewModel?
 
     /// A recipient held while the user creates a profile; resumed by
-    /// ``resumeAfterProfileCreation()`` once `isTippable` flips true.
-    @ObservationIgnored private(set) var pendingUserID: UserID?
+    /// ``resumeAfterProfileCreation()`` once `isTippable` flips true. Holds
+    /// whichever identifier the entry carried — a scanned code's user id or a
+    /// vanity link's handle.
+    @ObservationIgnored private(set) var pendingRecipient: ProfileIdentifier?
 
     @ObservationIgnored private var prepTask: Task<Void, Never>?
 
@@ -95,18 +97,33 @@ final class TipFlow {
         // the scan or tap. `showOwnTipCard()` absorbs the repeat calls the
         // per-frame scanner makes until the camera tears down.
         guard userID != session.userID else {
-            keyboard.suppress()
-            router.showOwnTipCard()
+            showOwnTipCard()
             return
         }
-        guard submission == nil, pendingUserID == nil, prepTask == nil else { return }
+        begin(.userID(userID))
+    }
+
+    /// Handles a vanity tipcard link — `app.flipcash.com/<handle>`. The handle
+    /// resolves to the same card a scanned code opens; the own-handle case is
+    /// caught here when the local profile knows its handle, and again after the
+    /// resolve when it doesn't.
+    func begin(username: Username) {
+        guard session.profile?.username != username else {
+            showOwnTipCard()
+            return
+        }
+        begin(.username(username))
+    }
+
+    private func begin(_ identifier: ProfileIdentifier) {
+        guard submission == nil, pendingRecipient == nil, prepTask == nil else { return }
         // A dialog is already asking the user something (commonly this flow's
         // own balance gate) — don't churn it on every decoded camera frame.
         guard session.dialogItem == nil else { return }
 
         guard session.profile?.isTippable == true else {
-            pendingUserID = userID
-            logger.info("Tip held for profile creation", metadata: ["recipient": "\(userID)"])
+            pendingRecipient = identifier
+            logger.info("Tip held for profile creation", metadata: ["recipient": "\(identifier)"])
             // Deliberately unsuppressed: profile creation focuses its name
             // field on appear, and that keyboard is wanted.
             router.present(.tips)
@@ -114,20 +131,25 @@ final class TipFlow {
         }
 
         keyboard.suppress()
-        prepare(userID: userID)
+        prepare(identifier)
+    }
+
+    private func showOwnTipCard() {
+        keyboard.suppress()
+        router.showOwnTipCard()
     }
 
     /// Re-enters a held tip once the profile became tippable.
     func resumeAfterProfileCreation() {
-        guard let pendingUserID, session.profile?.isTippable == true else { return }
-        self.pendingUserID = nil
+        guard let pendingRecipient, session.profile?.isTippable == true else { return }
+        self.pendingRecipient = nil
         router.dismissSheet()
-        begin(userID: pendingUserID)
+        begin(pendingRecipient)
     }
 
     /// Drops a held recipient — the user backed out of profile creation.
     func abandonPendingTip() {
-        pendingUserID = nil
+        pendingRecipient = nil
     }
 
     /// Tears down the card, the sheet, and any in-flight preparation.
@@ -145,7 +167,11 @@ final class TipFlow {
 
     // MARK: - Recipient -
 
-    private func prepare(userID: UserID) {
+    /// Thrown when a handle resolved to a profile the server didn't stamp with
+    /// a user id — a tip has nobody to pay without one.
+    private struct UnidentifiedRecipient: Error {}
+
+    private func prepare(_ identifier: ProfileIdentifier) {
         prepTask = Task {
             defer { prepTask = nil }
             do {
@@ -166,13 +192,37 @@ final class TipFlow {
                         return false
                     }
                 ) {
-                    async let profile = flipClient.fetchProfile(userID: userID, owner: session.ownerKeyPair)
-                    async let destination = flipClient.resolveUserID(userID, owner: session.ownerKeyPair)
+                    async let profile = flipClient.fetchProfile(identifier, owner: session.ownerKeyPair)
+                    async let destination = flipClient.resolve(identifier, owner: session.ownerKeyPair)
                     // The destination is re-resolved (and cached) by the send
                     // itself; here it only proves the user can be paid at all.
                     _ = try await destination
                     return try await profile
                 }
+
+                let userID: UserID
+                switch identifier {
+                case .userID(let resolvedUserID):
+                    userID = resolvedUserID
+                case .username:
+                    // A handle link learns whose card it is only from the
+                    // response, so the id is load-bearing rather than
+                    // confirmatory here.
+                    guard let responseUserID = resolved.userID else {
+                        throw UnidentifiedRecipient()
+                    }
+                    userID = responseUserID
+                }
+
+                guard !Task.isCancelled else { return }
+                // The second half of the own-handle check `begin(username:)`
+                // starts: a link to your own handle followed before the local
+                // profile has loaded its handle only shows itself here.
+                guard userID != session.userID else {
+                    showOwnTipCard()
+                    return
+                }
+
                 session.cacheUserProfile(resolved, for: userID)
                 let recipient = TipRecipient(
                     userID: userID,
@@ -186,7 +236,7 @@ final class TipFlow {
             } catch {
                 guard !Task.isCancelled else { return }
                 logger.error("Failed to prepare tip recipient", metadata: [
-                    "recipient": "\(userID)",
+                    "recipient": "\(identifier)",
                     "error": "\(error)",
                 ])
                 ErrorReporting.captureError(error, reason: "Failed to prepare tip recipient")

--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -103,7 +103,7 @@ final class TipFlow {
         begin(.userID(userID))
     }
 
-    /// Handles a vanity tipcard link — `app.flipcash.com/<handle>`. The handle
+    /// Handles a vanity tipcard link — `flipcash.com/<handle>`. The handle
     /// resolves to the same card a scanned code opens; the own-handle case is
     /// caught here when the local profile knows its handle, and again after the
     /// resolve when it doesn't.

--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -177,6 +177,7 @@ final class TipFlow {
                 let recipient = TipRecipient(
                     userID: userID,
                     displayName: resolved.displayName ?? "",
+                    username: resolved.username,
                     origin: .tipcard
                 )
                 guard !Task.isCancelled else { return }
@@ -224,6 +225,7 @@ final class TipFlow {
         session.billState = BillState(bill: .tipcard(
             codeData: TipCode.Payload(userID: recipient.userID).codeData(),
             name: recipient.displayName,
+            username: recipient.username.map(\.handle),
             avatar: nil
         ))
         session.presentationState = .visible(.pop)
@@ -256,8 +258,8 @@ final class TipFlow {
         await store.load(userID: recipient.userID, picture: picture)
         guard let data = store.data(for: recipient.userID),
               let avatar = UIImage(data: data),
-              case .tipcard(let codeData, let name, _) = session.billState.bill else { return }
-        session.billState.bill = .tipcard(codeData: codeData, name: name, avatar: avatar)
+              case .tipcard(let codeData, let name, let username, _) = session.billState.bill else { return }
+        session.billState.bill = .tipcard(codeData: codeData, name: name, username: username, avatar: avatar)
     }
 
     // MARK: - Amounts -

--- a/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
@@ -76,7 +76,7 @@ struct TipcardScreen: View {
     }
 
     private var url: URL {
-        .tipcard(for: sessionContainer.session.userID)
+        .tipcard(for: sessionContainer.session.userID, username: profile?.username)
     }
 
     private var codeData: Data {
@@ -91,7 +91,8 @@ struct TipcardScreen: View {
             name: name,
             avatar: avatar,
             codeData: codeData,
-            tintOpacity: 0.36
+            tintOpacity: 0.36,
+            subtitle: profile?.username.map(\.handle)
         )
     }
 

--- a/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardView.swift
@@ -24,6 +24,10 @@ struct TipcardView: View {
     /// oversized on the small card and undersized on the big one.
     static let nameFraction: CGFloat = 17.0 / 269.0
 
+    /// The subtitle's size as a fraction of the card's width, scaling with the
+    /// card on the same basis as the name.
+    static let subtitleFraction: CGFloat = 12.0 / 269.0
+
     /// Explicit because a rendered tree has no container to size against.
     let size: CGSize
     let name: String
@@ -38,6 +42,11 @@ struct TipcardView: View {
     /// avatar is gated off by default. Kept as a flag (rather than deleted) so
     /// re-enabling it is a one-line change once the product decision reverts.
     var includePhoto: Bool = false
+
+    /// An optional second line under the name — the owner's `@handle` once they
+    /// have claimed one. Cards without a username pass nil and keep the name
+    /// sitting where it always has.
+    var subtitle: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -76,6 +85,17 @@ struct TipcardView: View {
             .font(.default(size: nameFontSize, weight: .bold))
             .foregroundStyle(Color.textMain)
             .padding(.top, size.height * 0.06)
+
+            if let subtitle {
+                Text(subtitle)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .padding(.horizontal, size.width * 0.08)
+                    .font(.default(size: subtitleFontSize, weight: .medium))
+                    .foregroundStyle(Color.textMain)
+                    .opacity(0.6)
+                    .padding(.top, size.height * 0.015)
+            }
         }
         .frame(width: size.width, height: size.height)
         .background(Color.black.opacity(tintOpacity).background(BackdropBlur(radius: 20)))
@@ -94,6 +114,10 @@ struct TipcardView: View {
 
     private var nameFontSize: CGFloat {
         size.width * Self.nameFraction
+    }
+
+    private var subtitleFontSize: CGFloat {
+        size.width * Self.subtitleFraction
     }
 
     private var codeDimension: CGFloat {

--- a/Flipcash/Core/Screens/Main/Username/DialogItem+Username.swift
+++ b/Flipcash/Core/Screens/Main/Username/DialogItem+Username.swift
@@ -1,0 +1,112 @@
+//
+//  DialogItem+Username.swift
+//  Flipcash
+//
+
+import FlipcashCore
+import FlipcashUI
+
+extension DialogItem {
+
+    /// The catch-all failure. Named rather than written out twice: the screen
+    /// raises it for anything that isn't an `ErrorProfile`, and
+    /// ``usernameSubmission(_:minimum:onAddMoney:)`` for the `ErrorProfile` cases
+    /// the flow doesn't model. One string, one test.
+    ///
+    /// The only dialog in this file that stays destructive. The named rejections
+    /// are things the user can fix by typing something else; this one means the
+    /// claim did not go through and nobody knows why, which is worth both the
+    /// red banner and the analytics event `.error` reports.
+    static var usernameGenericFailure: DialogItem {
+        .error(title: "Couldn't Save Your Username", subtitle: "Try again")
+    }
+
+    /// The balance gate (node 9442:103290). Names the server's minimum rather
+    /// than a constant — the number is a flag, and the copy has to track it.
+    static func usernameMinimumBalance(minimum: FiatAmount, onAddMoney: @escaping () -> Void) -> DialogItem {
+        // Whole amounts read as "$100", not "$100.00" — this is a threshold
+        // being quoted, not a balance being reported.
+        let amount = minimum.formatted(minimumFractionDigits: 0)
+
+        return .info(
+            title: "\(amount) Minimum Balance Required",
+            subtitle: "In order to stop username squatting getting a username requires a total Flipcash balance of at least \(amount) \(minimum.currency.rawValue.uppercased())"
+        ) {
+            .standard("Add Money", action: onAddMoney);
+            .dismiss(kind: .subtle)
+        }
+    }
+
+    /// The three client-side rejections (nodes 9442:5392, 9442:5257,
+    /// 9442:5122). Raised on Next rather than blocked at the keystroke, so the
+    /// user is told which rule they broke.
+    ///
+    /// Informational, not destructive: the designer drew all five rejections on
+    /// the grey banner. A handle that is two characters short is a correction to
+    /// make, not a failure to report.
+    static func usernameValidation(_ failure: UsernameValidator.Failure) -> DialogItem {
+        switch failure {
+        case .tooShort:
+            .info(
+                title: "Too Short",
+                subtitle: "Usernames must be a minimum of \(UsernameValidator.minimumLength) characters"
+            )
+        case .tooLong:
+            .info(
+                title: "Too Long",
+                subtitle: "Usernames must be a maximum of \(UsernameValidator.maximumLength) characters"
+            )
+        case .invalidCharacters:
+            .info(
+                title: "Invalid Characters",
+                subtitle: "Only letters, numbers, and underscores are allowed"
+            )
+        }
+    }
+
+    /// The server's rejections, all on the grey banner for the reason given on
+    /// ``usernameValidation(_:)``. `minimum` is the same flag the entry-point
+    /// gate reads: an `insufficientBalance` that got past the gate — a stale balance,
+    /// or a rule the client doesn't model — lands back on the gate's own dialog
+    /// rather than on a seventh error.
+    static func usernameSubmission(
+        _ error: ErrorProfile,
+        minimum: FiatAmount?,
+        onAddMoney: @escaping () -> Void
+    ) -> DialogItem {
+        // Anything the client doesn't model lands here, including an
+        // `insufficientBalance` raised before user flags carried a minimum.
+        let generic = DialogItem.usernameGenericFailure
+
+        switch error {
+        case .usernameTaken:
+            return .info(title: "Username Taken", subtitle: "Please try a different username")
+
+        case .reservedWord:
+            return .info(
+                title: "Trademarks Not Allowed",
+                subtitle: "Please pick a different name that is not trademarked. If you own the trademark please contact support@flipcash.com"
+            )
+
+        case .moderated:
+            // Subtitle copied from `ProfileNameScreen`'s moderation dialog, per
+            // the designer's "(Please copy from display name error text)".
+            return .info(title: "Inappropriate Username", subtitle: "Try a different name")
+
+        case .invalidUsername:
+            return .info(title: "This Username Isn't Valid", subtitle: "Try a different name")
+
+        case .insufficientBalance:
+            guard let minimum else { return generic }
+            return .usernameMinimumBalance(minimum: minimum, onAddMoney: onAddMoney)
+
+        // Everything the username flow doesn't model. Listed rather than
+        // defaulted so a new `ErrorProfile` case has to be considered here
+        // instead of silently inheriting "try again" — `.denied` in particular
+        // is a real `SetUsername` rejection that is only here because it has no
+        // signed-off copy yet.
+        case .denied, .invalidDisplayName, .blobNotFound, .blobNotReady, .blobRejected, .invalidBlob, .network, .unknown:
+            return generic
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/Username/UsernameEntryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Username/UsernameEntryScreen.swift
@@ -1,0 +1,154 @@
+//
+//  UsernameEntryScreen.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+private let logger = Logger(label: "flipcash.username")
+
+/// Claiming a handle, and changing one (Figma node 9442:103254). Shaped after
+/// `ProfileNameScreen`, which is the existing screen of this kind — one field,
+/// one button.
+///
+/// It owns its text rather than reading it from the environment the way
+/// `ProfileNameScreen` does: that screen shares state with a following photo
+/// step, and this flow has no second step.
+struct UsernameEntryScreen: View {
+
+    /// Seeds the field when the user already has a handle, so "Change Username"
+    /// opens on what they have rather than on an empty box.
+    let currentUsername: Username?
+
+    @Environment(Container.self) private var container
+    @Environment(Session.self) private var session
+    @Environment(AppRouter.self) private var router
+
+    @FocusState private var isFocused: Bool
+    @State private var input: String = ""
+    @State private var submitTask: Task<Void, Never>?
+    @State private var errorDialog: DialogItem?
+
+    private static let validator = UsernameValidator()
+
+    private var isSubmitting: Bool { submitTask != nil }
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Enter username")
+                    .font(.appTextLarge)
+                    .foregroundStyle(Color.textMain)
+                    .padding(.top, 20)
+
+                TextField("Username", text: $input)
+                    .font(.appDisplayMedium)
+                    .foregroundStyle(Color.textMain)
+                    .focused($isFocused)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(.next)
+                    .onSubmit(submit)
+                    // Lowercases as they type, per the spec's "auto lower case
+                    // the username, even if they type upper case". Nothing else
+                    // is filtered: Too Short, Too Long and Invalid Characters
+                    // are dialogs raised on Next, and a field that refused those
+                    // inputs would make three of the six drawn dialogs dead code.
+                    .onChange(of: input) { _, latest in
+                        let lowered = latest.lowercased()
+                        if lowered != latest { input = lowered }
+                    }
+                    .padding(.top, 32)
+                    .disabled(isSubmitting)
+                    .accessibilityIdentifier("username-field")
+
+                Text("This is how you'll be uniquely identified on the platform")
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textSecondary)
+                    .padding(.top, 8)
+
+                Spacer()
+
+                Button(action: submit) {
+                    if isSubmitting {
+                        ProgressView().progressViewStyle(.circular)
+                    } else {
+                        Text("Next")
+                    }
+                }
+                .buttonStyle(.filled)
+                // Enabled for anything non-empty, unlike `ProfileNameScreen`'s
+                // validity-gated Next: the rejections are the point of the
+                // button here, so it has to be reachable while the input is bad.
+                .disabled(input.isEmpty || isSubmitting)
+                .accessibilityIdentifier("username-next-button")
+                .padding(.bottom, 20)
+            }
+            .padding(.horizontal, 20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .dialog(item: $errorDialog)
+        .onAppear {
+            input = currentUsername?.value ?? ""
+            isFocused = true
+        }
+        // Leaving abandons the submission: its only continuation pops a stack
+        // this screen no longer sits on.
+        .onDisappear { submitTask?.cancel() }
+    }
+
+    /// The server's minimum in USD, or nil before user flags have loaded.
+    private var minimumBalance: FiatAmount? {
+        guard let minimum = session.userFlags?.usernameMinBalance else { return nil }
+        return .usd(minimum.decimalValue)
+    }
+
+    private func submit() {
+        guard !isSubmitting else { return }
+
+        if let failure = Self.validator.failure(for: input) {
+            errorDialog = .usernameValidation(failure)
+            return
+        }
+
+        guard let username = Self.validator.validate(input) else { return }
+
+        submitTask = Task {
+            defer { submitTask = nil }
+
+            do {
+                try await container.flipClient.setUsername(
+                    username,
+                    owner: session.ownerKeyPair
+                )
+                try await session.updateProfile()
+
+                guard !Task.isCancelled else { return }
+                router.popTopmost()
+
+            } catch let error as ErrorProfile {
+                guard !Task.isCancelled else { return }
+                logger.info("Username rejected", metadata: ["error": "\(error)"])
+
+                // Captured unconditionally: `ErrorProfile.reportingLevel` already
+                // files every rejection as `.info` — a breadcrumb, never a page —
+                // and only `.unknown` as `.error`. Gating the call here would
+                // duplicate that classification in a second place.
+                ErrorReporting.captureError(error, reason: "Failed to set username")
+
+                errorDialog = .usernameSubmission(error, minimum: minimumBalance) {
+                    router.presentAddMoney(.general, source: .usernameShortfall)
+                }
+
+            } catch {
+                guard !Task.isCancelled else { return }
+                logger.error("Failed to set username", metadata: ["error": "\(error)"])
+                ErrorReporting.captureError(error, reason: "Failed to set username")
+                errorDialog = .usernameGenericFailure
+            }
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/Username/UsernameGate.swift
+++ b/Flipcash/Core/Screens/Main/Username/UsernameGate.swift
@@ -1,0 +1,82 @@
+//
+//  UsernameGate.swift
+//  Flipcash
+//
+
+import Foundation
+import FlipcashCore
+
+/// The one balance the username gate weighs: everything the user holds, summed
+/// and expressed in USD.
+@MainActor
+protocol UsernameBalanceReading: AnyObject {
+    var totalBalance: ExchangedFiat { get }
+}
+
+extension Session: UsernameBalanceReading {}
+
+/// Where the username entry point leads, and — short of the minimum — how far
+/// the balance has to go.
+enum UsernameGate: Equatable {
+    /// The requirement is met, or there isn't one — open the claim screen.
+    case proceed
+    /// Short of the minimum. Carries the minimum and the shortfall so the
+    /// progress card can name both, and `fraction` — the balance's progress
+    /// toward the minimum — so it can size its bar without a second
+    /// balance-vs-minimum calculation of its own.
+    case addMoney(minimum: FiatAmount, shortfall: FiatAmount, fraction: Double)
+
+    /// How far the balance is toward the minimum, clamped to `[0, 1]`. Always
+    /// `1` on `.proceed` — met or waived, there is nothing left to close.
+    var fraction: Double {
+        switch self {
+        case .proceed:
+            return 1
+        case .addMoney(_, _, let fraction):
+            return fraction
+        }
+    }
+}
+
+/// Returns where the username entry point leads, given the user's balances and
+/// the server's minimum (`UserFlags.usernameMinBalance`, nil when flags haven't
+/// loaded).
+///
+/// The comparison is cumulative and USD-denominated, which is what the flag
+/// documents: every mint counts, and the flag's USDF mint is the denomination
+/// rather than the account to measure. `Session.hasSufficientFunds(for:)` is
+/// per-mint and answers a different question; comparing quarks would measure a
+/// real threshold against `ExchangedFiat.total(rate:)`'s documented
+/// USDF-minted placeholder.
+///
+/// Nothing is debited — this is a holding requirement, so there is no fee and
+/// no affordability check.
+///
+/// A zero minimum proceeds. The flag defaults to zero when the server omits it
+/// (`UserFlagsUsernameMinBalanceTests` pins that), and the server owns the
+/// number, so there is no client-side fallback to fall back to.
+///
+/// A nil minimum — flags not loaded yet — proceeds too. That is deliberately
+/// fail-open, and safe because the server enforces the same threshold on
+/// `SetUsername` and returns `ErrorProfile.insufficientBalance`. Someone who
+/// races the flags reaches the claim screen and is turned back there, rather
+/// than being told they don't qualify on the strength of a number the client
+/// hasn't got yet.
+///
+/// The comparison is exact — no rounding to display precision. `canPayLaunchCost`
+/// makes the same call for the same reason: the server has no tolerance here,
+/// so widening the client check would only move the rejection later, after the
+/// user has typed a handle.
+@MainActor
+func usernameGate(session: some UsernameBalanceReading, minimum: TokenAmount?) -> UsernameGate {
+    guard let minimum, minimum.quarks > 0 else { return .proceed }
+
+    let required = FiatAmount.usd(minimum.decimalValue)
+    let balance = session.totalBalance.usdfValue
+    guard balance >= required else {
+        let shortfall = required - balance
+        let fraction = (balance.value / required.value).doubleValue
+        return .addMoney(minimum: required, shortfall: shortfall, fraction: max(0, min(1, fraction)))
+    }
+    return .proceed
+}

--- a/Flipcash/Core/Screens/Main/Username/UsernameProgressCard.swift
+++ b/Flipcash/Core/Screens/Main/Username/UsernameProgressCard.swift
@@ -1,0 +1,112 @@
+//
+//  UsernameProgressCard.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+
+/// The You-tab card offering a username, in the tip-card action group below
+/// Share/Download (Figma nodes 9536:4336 / 9537:1845). Superseded the
+/// settings-row entry point: `YouScreen` shows it only while
+/// `shouldPromptForUsername` holds, in place of the row it used to draw.
+///
+/// Takes plain values rather than reading `Session`/`UsernameGate` itself, so
+/// it can be previewed and tested without a signed-in account — the caller
+/// (`YouScreen`) is the one place that has both.
+struct UsernameProgressCard: View {
+
+    /// Which of the two states the card draws. The title never changes; the
+    /// state governs the bar's colour, the chevron, and where the tap lands.
+    enum State: Equatable {
+        /// Below the server's minimum (node 9536:4336): white bar, the
+        /// shortfall in place of a chevron. Tapping raises the balance gate.
+        case incomplete
+        /// At or above it (node 9537:1845): green bar, chevron. Tapping opens
+        /// the claim screen.
+        case complete
+    }
+
+    private static let title = "Get a custom @username"
+
+    let state: State
+    let subtitle: String
+    /// The shortfall, shown only in `.incomplete`. `nil` in `.complete`.
+    let trailing: String?
+    /// The balance's progress toward the minimum, `0...1`.
+    let fraction: Double
+    /// Runs on tap. Both states are tappable: the card is the entry point to
+    /// the flow either way, and below the minimum that means being told the
+    /// rule rather than being left with an inert bar.
+    let action: VoidAction
+
+    var body: some View {
+        Button(action: action) {
+            chrome
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Self.title)
+        // The shortfall reads as part of the hint rather than as a value: it
+        // is the same sentence the subtitle starts, not a separate reading.
+        .accessibilityHint(trailing.map { "\(subtitle). \($0)" } ?? subtitle)
+    }
+
+    private var chrome: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(Self.title)
+                    .font(.default(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.textMain)
+
+                if let trailing {
+                    Spacer(minLength: 8)
+                    Text(trailing)
+                        .font(.default(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.textMain.opacity(0.5))
+                }
+
+                if state == .complete {
+                    Spacer(minLength: 8)
+                    Image.system(.chevronRight)
+                        .renderingMode(.template)
+                        .frame(width: 20, height: 20)
+                        .foregroundStyle(Color.textMain)
+                }
+            }
+
+            Text(subtitle)
+                .font(.default(size: 12, weight: .medium))
+                .foregroundStyle(Color.textMain.opacity(0.5))
+
+            Spacer(minLength: 0)
+
+            ProgressTrack(fraction: fraction, fill: state == .complete ? .success : Color.white)
+        }
+        .padding(.top, 12)
+        .padding(.bottom, 15)
+        .padding(.horizontal, 15)
+        .frame(height: 88)
+        .background(Color.backgroundRow, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+}
+
+/// The card's progress bar: a 10%-white track with a fill sized to `fraction`.
+private struct ProgressTrack: View {
+
+    let fraction: Double
+    let fill: Color
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(Color.white.opacity(0.1))
+
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(fill)
+                    .frame(width: proxy.size.width * CGFloat(max(0, min(1, fraction))))
+            }
+        }
+        .frame(height: 6)
+    }
+}

--- a/Flipcash/Core/Screens/Main/You/TipCardLinkRow.swift
+++ b/Flipcash/Core/Screens/Main/You/TipCardLinkRow.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import UIKit
+import FlipcashCore
 import FlipcashUI
 
 /// The tip-card link row (Figma node 9276:4748): a chain-link glyph, the
@@ -32,6 +33,15 @@ struct TipCardLinkRow: View {
                     Text(Self.displayText(for: url))
                         .font(.appTextMedium)
                         .lineLimit(1)
+                        // Elides only when the handle genuinely doesn't fit —
+                        // no shrinking to dodge it, which would render the row
+                        // at a smaller size than the ones around it. The forced
+                        // clip in `displayText` is for the uuid form alone; a
+                        // handle keeps every character it has room for and
+                        // loses the tail only past that. On the narrowest
+                        // supported screen (375pt) the budget is 257pt, which
+                        // covers a 15-character handle of average width but not
+                        // one made of the widest glyphs.
                         .truncationMode(.tail)
                 }
 
@@ -74,8 +84,12 @@ struct TipCardLinkRow: View {
         }
     }
 
-    /// The link with its scheme dropped and its identifier clipped to a stub,
-    /// so a full-width uuid doesn't push the row's copy button off the edge.
+    /// The link with its scheme dropped, and a uuid identifier clipped to a
+    /// stub so a full-width one doesn't push the row's copy button off the edge.
+    ///
+    /// A claimed handle is never clipped here. It is at most 15 characters —
+    /// shorter than the `/tip/` segment it replaces — so it is handed to the
+    /// layout whole and elides only if it truly overruns the row.
     static func displayText(for url: URL) -> String {
         let stripped = url.absoluteString
             .replacingOccurrences(of: "https://", with: "")
@@ -84,7 +98,9 @@ struct TipCardLinkRow: View {
         guard let slash = stripped.lastIndex(of: "/") else { return stripped }
 
         let identifier = stripped[stripped.index(after: slash)...]
-        guard identifier.count > identifierStubLength else { return stripped }
+        guard identifier.count > identifierStubLength, Username(String(identifier)) == nil else {
+            return stripped
+        }
 
         return String(stripped[...slash]) + String(identifier.prefix(identifierStubLength)) + "…"
     }

--- a/Flipcash/Core/Screens/Main/You/TipCardLinkRow.swift
+++ b/Flipcash/Core/Screens/Main/You/TipCardLinkRow.swift
@@ -40,8 +40,9 @@ struct TipCardLinkRow: View {
                         // handle keeps every character it has room for and
                         // loses the tail only past that. On the narrowest
                         // supported screen (375pt) the budget is 257pt, which
-                        // covers a 15-character handle of average width but not
-                        // one made of the widest glyphs.
+                        // covered a 15-character handle of average width even
+                        // under the four-character-longer `app.flipcash.com`;
+                        // the apex host only widens that margin.
                         .truncationMode(.tail)
                 }
 

--- a/Flipcash/Core/Screens/Main/You/YouScreen.swift
+++ b/Flipcash/Core/Screens/Main/You/YouScreen.swift
@@ -42,6 +42,9 @@ struct YouScreen: View {
     /// the share sheet has a settled controller to present on.
     @State private var pendingDownload: TipCardDownloadFormat?
 
+    /// The balance gate, raised when the card is tapped below the minimum.
+    @State private var usernameDialog: DialogItem?
+
     /// The card's slot in the page's layout, in global space — where the card
     /// sits before it travels to the middle of the screen.
     @State private var cardSlotFrame: CGRect = .zero
@@ -83,6 +86,20 @@ struct YouScreen: View {
 
     private let rowInsets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
 
+    /// The gap the page keeps between the version footer and the tab bar.
+    private static let tabBarGap: CGFloat = 24
+
+    /// Bottom inset for the scrolling content. Mirrors `WalletScreen`: the iOS 26
+    /// tab bar sits in the safe area, so the gap is the whole inset there; the
+    /// legacy pill floats over the content and has to be cleared on top of it,
+    /// or the footer's last scroll position lands underneath it.
+    private var bottomContentInset: CGFloat {
+        if #available(iOS 26, *) {
+            return Self.tabBarGap
+        }
+        return Self.tabBarGap + HomeTabView.legacyPillClearance
+    }
+
     var body: some View {
         Background(color: .backgroundMain) {
             ZStack {
@@ -107,6 +124,7 @@ struct YouScreen: View {
                             .allowsHitTesting(!isExpanded)
                     }
                     .padding(.horizontal, Self.horizontalInset)
+                    .padding(.bottom, bottomContentInset)
                 }
                 .scrollDisabled(isExpanded)
 
@@ -134,6 +152,7 @@ struct YouScreen: View {
             guard displayName != nil else { return }
             previewCache.warm(TipCode.Payload(userID: sessionContainer.session.userID))
         }
+        .dialog(item: $usernameDialog)
     }
 
     // MARK: - Card -
@@ -166,7 +185,8 @@ struct YouScreen: View {
                             name: name,
                             avatar: nil,
                             codeData: codeData,
-                            tintOpacity: 0.36
+                            tintOpacity: 0.36,
+                            subtitle: username.map(\.handle)
                         )
                         .scaleEffect(cardScale)
                         .offset(y: cardOffset)
@@ -322,6 +342,12 @@ struct YouScreen: View {
                     .accessibilityIdentifier("you-download-button")
                 }
                 .padding(.top, 11)
+
+                if shouldPromptForUsername {
+                    usernameProgressCard
+                        .padding(.top, 11)
+                        .accessibilityIdentifier("you-username-progress-card")
+                }
             }
 
             settingsList
@@ -347,6 +373,41 @@ struct YouScreen: View {
         }
         .font(.appDisplayXS)
         .foregroundStyle(Color.textMain)
+    }
+
+    // MARK: - Username progress -
+
+    /// The balance's standing against the username minimum. Read once per
+    /// render and switched on here rather than re-derived at tap time — the
+    /// card's tappability and this switch's `.proceed` branch already agree
+    /// on the same value.
+    private var usernameProgress: UsernameGate {
+        usernameGate(
+            session: sessionContainer.session,
+            minimum: sessionContainer.session.userFlags?.usernameMinBalance
+        )
+    }
+
+    @ViewBuilder
+    private var usernameProgressCard: some View {
+        switch usernameProgress {
+        case .proceed:
+            UsernameProgressCard(
+                state: .complete,
+                subtitle: "Tap to select your username now",
+                trailing: nil,
+                fraction: 1,
+                action: beginUsernameClaim
+            )
+        case .addMoney(let minimum, let shortfall, let fraction):
+            UsernameProgressCard(
+                state: .incomplete,
+                subtitle: "Get your balance to \(minimum.formatted(minimumFractionDigits: 0)) \(minimum.currency.rawValue.uppercased()) or more to unlock",
+                trailing: "\(shortfall.formatted(minimumFractionDigits: 0)) \(shortfall.currency.rawValue.uppercased()) to go",
+                fraction: fraction,
+                action: { presentBalanceGate(minimum: minimum) }
+            )
+        }
     }
 
     private var versionFooter: some View {
@@ -376,11 +437,18 @@ struct YouScreen: View {
         return name
     }
 
+    private var username: Username? { profile?.username }
+
+    /// Whether to offer the handle. Derived from the handle being absent rather
+    /// than from a separate claimed flag, so a handle that disappears across a
+    /// profile refresh puts the offer back on its own.
+    private var shouldPromptForUsername: Bool { username == nil }
+
     private var codeData: Data {
         TipCode.Payload(userID: sessionContainer.session.userID).codeData()
     }
 
-    private var url: URL { .tipcard(for: sessionContainer.session.userID) }
+    private var url: URL { .tipcard(for: sessionContainer.session.userID, username: username) }
 
     // MARK: - Card geometry -
 
@@ -542,6 +610,22 @@ struct YouScreen: View {
             debugTapCount = 0
         } else {
             debugTapCount += 1
+        }
+    }
+
+    /// Opens the claim screen. Only ever wired to `usernameProgressCard`'s tap
+    /// in its `.complete` state, which already means `usernameProgress` is
+    /// `.proceed` — there is nothing left here to branch on.
+    private func beginUsernameClaim() {
+        router.push(.username(username))
+    }
+
+    /// The `.incomplete` card's tap: names the minimum and offers the way to
+    /// meet it. The card draws the shortfall but not the reason for it, so the
+    /// dialog is where the squatting rule gets stated.
+    private func presentBalanceGate(minimum: FiatAmount) {
+        usernameDialog = .usernameMinimumBalance(minimum: minimum) {
+            router.presentAddMoney(.general, source: .usernameShortfall)
         }
     }
 }

--- a/Flipcash/Core/Screens/Send/SendTarget.swift
+++ b/Flipcash/Core/Screens/Send/SendTarget.swift
@@ -18,8 +18,22 @@ nonisolated enum SendTarget: Hashable, Sendable {
 nonisolated struct TipRecipient: Hashable, Sendable {
     let userID: UserID
     let displayName: String
+    /// The recipient's public handle, shown under their name on the card.
+    /// Defaulted for the test fixtures only — both production sites pass one.
+    let username: Username?
     /// The surface this tip is being sent from — reported to the server.
     let origin: TipOrigin
+
+    // A hand-written init rather than the synthesized memberwise one: a `let`
+    // with an inline default loses its parameter entirely (the default becomes
+    // fixed, unoverridable), so the default has to live here instead to stay
+    // both immutable and omittable by the fixtures that don't supply one.
+    init(userID: UserID, displayName: String, username: Username? = nil, origin: TipOrigin) {
+        self.userID = userID
+        self.displayName = displayName
+        self.username = username
+        self.origin = origin
+    }
 }
 
 extension SendTarget {
@@ -36,7 +50,7 @@ extension SendTarget {
                   let userID = counterpart.userID else {
                 return nil
             }
-            self = .tip(TipRecipient(userID: userID, displayName: counterpart.displayName, origin: .chat))
+            self = .tip(TipRecipient(userID: userID, displayName: counterpart.displayName, username: counterpart.username, origin: .chat))
         case .contactDm, nil:
             guard let target = ResolvedContact.sendTarget(
                 in: conversation,

--- a/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
@@ -16,6 +16,7 @@ struct SettingsMyAccountScreen: View {
 
     @Environment(AppRouter.self) private var router
     @Environment(BetaFlags.self) private var betaFlags
+    @Environment(Session.self) private var session
 
     private let insets = EdgeInsets(top: 25, leading: 0, bottom: 25, trailing: 0)
 
@@ -35,6 +36,16 @@ struct SettingsMyAccountScreen: View {
         VStack(alignment: .leading, spacing: 0) {
             SettingsRow(asset: .profile, title: "Change Display Name", insets: insets) {
                 router.push(.changeDisplayName)
+            }
+
+            // No balance gate here: the gate exists to stop squatting at claim time. A user who
+            // already holds a handle has cleared it, and re-gating a change would hold their
+            // handle hostage to a balance that has since moved.
+            if let username = session.profile?.username {
+                SettingsRow(asset: .profile, title: "Change Username", insets: insets) {
+                    router.push(.username(username))
+                }
+                .accessibilityIdentifier("account-change-username-row")
             }
 
             SettingsRow(systemImage: "nosign", title: "Blocked", insets: insets) {

--- a/Flipcash/Supporting Files/Flipcash.entitlements
+++ b/Flipcash/Supporting Files/Flipcash.entitlements
@@ -8,6 +8,7 @@
 	<array>
 		<string>applinks:send.flipcash.com</string>
 		<string>applinks:app.flipcash.com</string>
+		<string>applinks:flipcash.com</string>
 		<string>applinks:jump.flipcash.com</string>
 		<string>webcredentials:send.flipcash.com</string>
 	</array>

--- a/Flipcash/Utilities/Events.swift
+++ b/Flipcash/Utilities/Events.swift
@@ -140,12 +140,13 @@ extension Analytics {
     /// The `Source` property of `AddMoneyEvent.opened` — where the user
     /// entered the flow. Values are shared verbatim with Android.
     enum AddMoneySource: String {
-        case menu          = "Menu"
-        case giveShortfall = "Give Shortfall"
-        case buyShortfall  = "Buy Shortfall"
-        case chat          = "Chat"
-        case scanner       = "Scanner"
-        case balance       = "Balance"
+        case menu              = "Menu"
+        case giveShortfall     = "Give Shortfall"
+        case buyShortfall      = "Buy Shortfall"
+        case usernameShortfall = "Username Shortfall"
+        case chat              = "Chat"
+        case scanner           = "Scanner"
+        case balance           = "Balance"
     }
 }
 

--- a/Flipcash/Utilities/URL+Links.swift
+++ b/Flipcash/Utilities/URL+Links.swift
@@ -21,10 +21,11 @@ extension URL {
     ///
     /// A claimed handle gets the vanity form — no `/tip/` segment and no `@`,
     /// so the link reads as a name. Both platforms build the URL here and only
-    /// here: the host becomes `flipcash.com` once the web app serves it, and
-    /// that has to be a one-line change on each side.
+    /// here, on the apex host: its `apple-app-site-association` ends in a `/*`
+    /// component, so a bare handle opens the app, and the marketing pages the
+    /// app itself links to are excluded there by path.
     static func tipcard(for userID: UserID, username: Username?) -> URL {
-        let host = "https://app.flipcash.com"
+        let host = "https://flipcash.com"
         if let username {
             return URL(string: "\(host)/\(username.value)")!
         }

--- a/Flipcash/Utilities/URL+Links.swift
+++ b/Flipcash/Utilities/URL+Links.swift
@@ -18,8 +18,17 @@ extension URL {
     }
 
     /// The public page that opens this user's tipcard.
-    static func tipcard(for userID: UserID) -> URL {
-        URL(string: "https://app.flipcash.com/tip/\(userID.uuidString.lowercased())")!
+    ///
+    /// A claimed handle gets the vanity form — no `/tip/` segment and no `@`,
+    /// so the link reads as a name. Both platforms build the URL here and only
+    /// here: the host becomes `flipcash.com` once the web app serves it, and
+    /// that has to be a one-line change on each side.
+    static func tipcard(for userID: UserID, username: Username?) -> URL {
+        let host = "https://app.flipcash.com"
+        if let username {
+            return URL(string: "\(host)/\(username.value)")!
+        }
+        return URL(string: "\(host)/tip/\(userID.uuidString.lowercased())")!
     }
 
     static var privacyPolicy: URL {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Profile.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Profile.swift
@@ -19,7 +19,10 @@ extension FlipClient {
         try await fetchProfile(.username(username), owner: owner)
     }
 
-    private func fetchProfile(_ identifier: ProfileIdentifier, owner: KeyPair) async throws -> Profile {
+    /// Fetches a profile by whichever identifier the caller holds. Used where
+    /// the identifier is data — a deep link that may carry either a user id or
+    /// a handle — rather than a fixed choice at the call site.
+    public func fetchProfile(_ identifier: ProfileIdentifier, owner: KeyPair) async throws -> Profile {
         try await withCheckedThrowingContinuation { c in
             profileService.fetchProfile(identifier, owner: owner) { c.resume(with: $0) }
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Resolver.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Resolver.swift
@@ -33,4 +33,14 @@ extension FlipClient {
             resolverService.resolveUsername(username, owner: owner) { c.resume(with: $0) }
         }
     }
+
+    /// Resolve whichever identifier the caller holds to the Flipcash payment
+    /// destination. The counterpart to ``fetchProfile(_:owner:)`` for callers
+    /// whose identifier is data rather than a fixed choice.
+    public func resolve(_ identifier: ProfileIdentifier, owner: KeyPair) async throws -> PublicKey {
+        switch identifier {
+        case .userID(let userID):     try await resolveUserID(userID, owner: owner)
+        case .username(let username): try await resolveUsername(username, owner: owner)
+        }
+    }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Username.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Username.swift
@@ -6,7 +6,8 @@
 import Foundation
 import FlipcashAPI
 
-/// A user's unique handle on Flipcash, without a leading `@`.
+/// A user's unique handle on Flipcash. ``value`` stores it bare; ``handle``
+/// renders it with the leading `@`.
 ///
 /// The character set matches X — letters, digits and underscores — except that
 /// a handle is always lowercase. Public: the server returns it for any user,
@@ -26,6 +27,11 @@ public struct Username: Codable, Equatable, Hashable, Sendable {
 
         self.value = string
     }
+
+    /// The handle prefixed with `@`, for display only. The `@` is never part of
+    /// ``value``, never in a tip URL, and never submitted — anything talking to the
+    /// server or building a link wants ``value``.
+    public var handle: String { "@\(value)" }
 
     // Mirrors the `validate.rules.string.pattern` on `common.v1.Username`;
     // keep the two in step when the contract moves.

--- a/FlipcashCore/Sources/FlipcashCore/Validation/UsernameValidator.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Validation/UsernameValidator.swift
@@ -1,0 +1,62 @@
+//
+//  UsernameValidator.swift
+//  FlipcashCore
+//
+
+import Foundation
+
+/// Validates a handle typed into the username field: lowercases the input, then
+/// holds it to the `Username` contract.
+///
+/// Lowercasing lives here rather than in `Username.init?` so the model stays
+/// strict — a handle reaching it uppercase is still a caller error. This is the
+/// only place a typed handle is rewritten before it reaches the model.
+public struct UsernameValidator: Validator {
+
+    /// Why an input was rejected. The claim screen raises a different dialog for
+    /// each, so the reason is part of the contract rather than a logging detail.
+    public enum Failure: Equatable, Sendable {
+        case tooShort
+        case tooLong
+        case invalidCharacters
+    }
+
+    /// Mirrors `Username`'s own bounds, which come from the `validate.rules`
+    /// on `common.v1.Username`. Public because the rejection copy names them.
+    /// `UsernameValidatorTests` pins them to what `Username` actually accepts,
+    /// so the two can't drift apart unnoticed.
+    public static let minimumLength = 2
+    public static let maximumLength = 15
+
+    public init() {}
+
+    /// The handle `input` names once normalised, or `nil` when it isn't well
+    /// formed. This exact value is what gets submitted; the raw input stays on
+    /// screen.
+    public func validate(_ input: String) -> Username? {
+        Username(normalized(input))
+    }
+
+    /// Which rule `input` breaks, or `nil` when it breaks none.
+    ///
+    /// Asks ``validate(_:)`` first, so a `nil` here and a non-nil there can
+    /// never disagree. Past that, length is reported ahead of the character
+    /// set: "too short" explains a one-letter input better than "invalid
+    /// characters" would, and an over-long input is over-long whatever it is
+    /// made of.
+    public func failure(for input: String) -> Failure? {
+        let candidate = normalized(input)
+
+        guard Username(candidate) == nil else { return nil }
+
+        if candidate.count < Self.minimumLength { return .tooShort }
+        if candidate.count > Self.maximumLength { return .tooLong }
+        return .invalidCharacters
+    }
+
+    /// Lowercased and stripped of surrounding whitespace. A paste carries both,
+    /// and neither is worth rejecting someone over.
+    private func normalized(_ input: String) -> String {
+        input.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/UsernameTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/UsernameTests.swift
@@ -62,6 +62,13 @@ struct UsernameTests {
         #expect(try JSONDecoder().decode(Username.self, from: data).value == "NotAValidHandle")
     }
 
+    @Test("The display handle prefixes @ without touching the stored value")
+    func handle_prefixesAtSign() {
+        let username = Username("brandon")
+        #expect(username?.handle == "@brandon")
+        #expect(username?.value == "brandon")
+    }
+
     // MARK: - Proto -
 
     @Test("An unset proto handle maps to nil")

--- a/FlipcashCore/Tests/FlipcashCoreTests/UsernameValidatorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/UsernameValidatorTests.swift
@@ -1,0 +1,106 @@
+//
+//  UsernameValidatorTests.swift
+//  FlipcashCoreTests
+//
+
+import Testing
+@testable import FlipcashCore
+
+@Suite("UsernameValidator")
+struct UsernameValidatorTests {
+
+    private let validator = UsernameValidator()
+
+    @Test("Uppercase input is accepted as its lowercase handle")
+    func validate_uppercase_lowercases() {
+        #expect(validator.validate("Taylor")?.value == "taylor")
+    }
+
+    @Test("Surrounding whitespace is trimmed rather than rejected")
+    func validate_surroundingWhitespace_trimmed() {
+        #expect(validator.validate("  taylor ")?.value == "taylor")
+    }
+
+    @Test("Two characters is the shortest accepted handle")
+    func validate_minimumLength_boundary() {
+        #expect(validator.validate("ab")?.value == "ab")
+        #expect(validator.validate("a") == nil)
+    }
+
+    @Test("Fifteen characters is the longest accepted handle")
+    func validate_maximumLength_boundary() {
+        #expect(validator.validate("abcdefghijklmno")?.value == "abcdefghijklmno")
+        #expect(validator.validate("abcdefghijklmnop") == nil)
+    }
+
+    @Test("Digits and underscores are legal, other characters are not")
+    func validate_characterSet() {
+        #expect(validator.validate("a_9")?.value == "a_9")
+        #expect(validator.validate("a-9") == nil)
+        #expect(validator.validate("a 9") == nil)
+        #expect(validator.validate("año") == nil)
+    }
+
+    @Test("A one-character input reports too short")
+    func failure_oneCharacter_tooShort() {
+        #expect(validator.failure(for: "a") == .tooShort)
+    }
+
+    @Test("A sixteen-character input reports too long")
+    func failure_sixteenCharacters_tooLong() {
+        #expect(validator.failure(for: "abcdefghijklmnop") == .tooLong)
+    }
+
+    @Test("Length is reported ahead of the character set")
+    func failure_tooLongWithIllegalCharacter_reportsLength() {
+        #expect(validator.failure(for: "abcdefghijklmno!") == .tooLong)
+    }
+
+    @Test("A legal length with an illegal character reports the character set")
+    func failure_illegalCharacter_invalidCharacters() {
+        #expect(validator.failure(for: "tay-lor") == .invalidCharacters)
+    }
+
+    @Test("A valid handle has no failure")
+    func failure_validHandle_none() {
+        #expect(validator.failure(for: "Taylor") == nil)
+    }
+
+    @Test("The minimum length agrees with what Username itself accepts")
+    func minimumLength_matchesUsername_boundary() {
+        let atMinimum = String(repeating: "a", count: UsernameValidator.minimumLength)
+        let belowMinimum = String(repeating: "a", count: UsernameValidator.minimumLength - 1)
+
+        #expect(Username(atMinimum) != nil)
+        #expect(Username(belowMinimum) == nil)
+    }
+
+    @Test("The maximum length agrees with what Username itself accepts")
+    func maximumLength_matchesUsername_boundary() {
+        let atMaximum = String(repeating: "a", count: UsernameValidator.maximumLength)
+        let aboveMaximum = String(repeating: "a", count: UsernameValidator.maximumLength + 1)
+
+        #expect(Username(atMaximum) != nil)
+        #expect(Username(aboveMaximum) == nil)
+    }
+
+    @Test("An empty field is too short, not invalid")
+    func failure_emptyString_tooShort() {
+        #expect(UsernameValidator().failure(for: "") == .tooShort)
+        #expect(UsernameValidator().validate("") == nil)
+    }
+
+    @Test("A short input reports its length, not its illegal character")
+    func failure_tooShortWithIllegalCharacter_reportsLength() {
+        #expect(UsernameValidator().failure(for: "!") == .tooShort)
+    }
+
+    @Test("Length counts what the user sees, so combining marks read as one character")
+    func failure_combiningMarks_countedAsOneCharacter() {
+        // 17 Unicode scalars, one grapheme cluster. Length is measured the way
+        // the field displays it, so this is short rather than over-long.
+        let accented = "a" + String(repeating: "\u{0301}", count: 16)
+
+        #expect(UsernameValidator().failure(for: accented) == .tooShort)
+    }
+}

--- a/FlipcashTests/RouteTests.swift
+++ b/FlipcashTests/RouteTests.swift
@@ -203,39 +203,48 @@ struct RouteTests {
 
     // MARK: - Sheet Routes -
     //
-    // The home-screen quick actions open sheets via these routes. The
-    // `flipcash://` deep link and the universal link must parse to the same case.
+    // The home-screen quick actions open sheets via these routes, and they emit
+    // the custom scheme (`QuickActionsController`). The universal-link forms are
+    // deliberately NOT routes: `app.flipcash.com/<username>` puts handles in
+    // that namespace, and a claimed `discover` that opened the Discover tab
+    // would be a link that goes somewhere other than the person it names.
 
-    @Test(
-        "Give route parses from both URL formats",
-        arguments: ["flipcash://give", "https://app.flipcash.com/give"]
-    )
-    func giveRoute(urlString: String) throws {
-        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+    @Test("Give route parses from the custom scheme")
+    func giveRoute_customScheme() throws {
+        let path = try #require(Route(url: URL(string: "flipcash://give")!)?.path)
         if case .give = path {} else {
-            Issue.record("\(urlString) should parse as .give")
+            Issue.record("flipcash://give should parse as .give")
         }
     }
 
-    @Test(
-        "Balance route parses from both URL formats",
-        arguments: ["flipcash://balance", "https://app.flipcash.com/balance"]
-    )
-    func balanceRoute(urlString: String) throws {
-        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+    @Test("Balance route parses from the custom scheme")
+    func balanceRoute_customScheme() throws {
+        let path = try #require(Route(url: URL(string: "flipcash://balance")!)?.path)
         if case .balance = path {} else {
-            Issue.record("\(urlString) should parse as .balance")
+            Issue.record("flipcash://balance should parse as .balance")
+        }
+    }
+
+    @Test("Discover route parses from the custom scheme")
+    func discoverRoute_customScheme() throws {
+        let path = try #require(Route(url: URL(string: "flipcash://discover")!)?.path)
+        if case .discover = path {} else {
+            Issue.record("flipcash://discover should parse as .discover")
         }
     }
 
     @Test(
-        "Discover route parses from both URL formats",
-        arguments: ["flipcash://discover", "https://app.flipcash.com/discover"]
+        "Quick-action names are not universal-link routes",
+        arguments: [
+            "https://app.flipcash.com/give",
+            "https://app.flipcash.com/balance",
+            "https://app.flipcash.com/discover",
+        ]
     )
-    func discoverRoute(urlString: String) throws {
+    func quickActionNames_universalLink_areUnknown(urlString: String) throws {
         let path = try #require(Route(url: URL(string: urlString)!)?.path)
-        if case .discover = path {} else {
-            Issue.record("\(urlString) should parse as .discover")
+        if case .unknown = path {} else {
+            Issue.record("\(urlString) should parse as .unknown, not a route")
         }
     }
 

--- a/FlipcashTests/RouteTests.swift
+++ b/FlipcashTests/RouteTests.swift
@@ -234,18 +234,22 @@ struct RouteTests {
     }
 
     @Test(
-        "Quick-action names are not universal-link routes",
+        "Quick-action names are ordinary handles on the web",
         arguments: [
-            "https://app.flipcash.com/give",
-            "https://app.flipcash.com/balance",
-            "https://app.flipcash.com/discover",
+            ("https://app.flipcash.com/give", "give"),
+            ("https://app.flipcash.com/balance", "balance"),
+            ("https://app.flipcash.com/discover", "discover"),
         ]
     )
-    func quickActionNames_universalLink_areUnknown(urlString: String) throws {
+    func quickActionNames_universalLink_areHandles(urlString: String, handle: String) throws {
         let path = try #require(Route(url: URL(string: urlString)!)?.path)
-        if case .unknown = path {} else {
-            Issue.record("\(urlString) should parse as .unknown, not a route")
+        guard case .username(let username) = path else {
+            Issue.record("\(urlString) should parse as .username, not a quick action")
+            return
         }
+        // The server's reserved list decides whether these are claimable; the
+        // client only decides that they aren't quick actions off the custom scheme.
+        #expect(username.value == handle)
     }
 
     // MARK: - Wallet Callback URLs -
@@ -298,4 +302,75 @@ struct RouteTests {
         #expect(Route(url: URL(string: urlString)!) == nil)
     }
 
+    // MARK: - Vanity Handle URLs -
+
+    @Test("A vanity link parses the handle from every host and scheme", arguments: [
+        "https://app.flipcash.com/taylor",
+        "https://flipcash.com/taylor",
+        "flipcash://taylor",
+    ])
+    func usernameRoute(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        guard case .username(let username) = path else {
+            Issue.record("\(urlString) should parse as .username")
+            return
+        }
+        #expect(username.value == "taylor")
+    }
+
+    @Test("A capitalized handle parses as the lowercase one it names", arguments: [
+        "https://app.flipcash.com/Taylor",
+        "https://app.flipcash.com/TAYLOR",
+    ])
+    func usernameRoute_capitalized_lowercased(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        guard case .username(let username) = path else {
+            Issue.record("\(urlString) should parse as .username")
+            return
+        }
+        #expect(username.value == "taylor")
+    }
+
+    @Test("The handle bounds hold at both ends", arguments: [
+        ("https://app.flipcash.com/te", "te"),
+        ("https://app.flipcash.com/abcdefghijklmno", "abcdefghijklmno"),
+        ("https://app.flipcash.com/a_1", "a_1"),
+    ])
+    func usernameRoute_bounds(urlString: String, handle: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        guard case .username(let username) = path else {
+            Issue.record("\(urlString) should parse as .username")
+            return
+        }
+        #expect(username.value == handle)
+    }
+
+    @Test("A segment that can't be a handle stays unknown", arguments: [
+        // One character, sixteen characters, and a hyphen — the three ways the
+        // handle pattern is missed.
+        "https://app.flipcash.com/t",
+        "https://app.flipcash.com/abcdefghijklmnop",
+        "https://app.flipcash.com/not-a-handle",
+        // A handle is the whole path or it isn't a handle.
+        "https://app.flipcash.com/taylor/photos",
+    ])
+    func usernameRoute_malformed_isUnknown(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        if case .unknown = path {} else {
+            Issue.record("\(urlString) should parse as .unknown, not a handle")
+        }
+    }
+
+    @Test("Named routes still win over the handle fallback", arguments: [
+        "https://app.flipcash.com/login",
+        "https://app.flipcash.com/cash",
+        "https://app.flipcash.com/verify",
+        "https://app.flipcash.com/wallet",
+    ])
+    func usernameRoute_doesNotShadowNamedRoutes(urlString: String) throws {
+        let path = try #require(Route(url: URL(string: urlString)!)?.path)
+        if case .username = path {
+            Issue.record("\(urlString) should not parse as a handle")
+        }
+    }
 }

--- a/FlipcashTests/SendTargetTests.swift
+++ b/FlipcashTests/SendTargetTests.swift
@@ -1,0 +1,128 @@
+//
+//  SendTargetTests.swift
+//  FlipcashTests
+//
+
+import Testing
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("SendTarget(conversation:dmChatID:selfUserID:)")
+struct SendTargetTests {
+
+    private let chatID = Data([0xDE, 0xAD, 0xBE, 0xEF])
+
+    private func makeConversation(type: ConversationType, members: [ConversationMember]) -> Conversation {
+        Conversation(
+            id: ConversationID(data: Data(repeating: 0x01, count: 32)),
+            members: members,
+            lastMessage: nil,
+            lastActivity: Date(timeIntervalSince1970: 0),
+            type: type
+        )
+    }
+
+    @Test("A tip DM counterpart with a claimed handle carries it onto the tip target")
+    func tipDMCounterpartWithHandleCarriesUsername() throws {
+        let me = UUID()
+        let counterpartID = UUID()
+        let convo = makeConversation(type: .tipDm, members: [
+            ConversationMember(userID: me, displayName: "Me"),
+            ConversationMember(userID: counterpartID, displayName: "Alice", username: Username("alice")),
+        ])
+
+        let target = try #require(SendTarget(conversation: convo, dmChatID: chatID, selfUserID: me))
+
+        guard case .tip(let recipient) = target else {
+            Issue.record("Expected .tip")
+            return
+        }
+        #expect(recipient.userID == counterpartID)
+        #expect(recipient.displayName == "Alice")
+        #expect(recipient.username == Username("alice"))
+        #expect(recipient.origin == .chat)
+    }
+
+    @Test("A tip DM counterpart with no claimed handle yields a tip target with no username")
+    func tipDMCounterpartWithoutHandleYieldsNilUsername() throws {
+        let me = UUID()
+        let counterpartID = UUID()
+        let convo = makeConversation(type: .tipDm, members: [
+            ConversationMember(userID: me, displayName: "Me"),
+            ConversationMember(userID: counterpartID, displayName: "Alice"),
+        ])
+
+        let target = try #require(SendTarget(conversation: convo, dmChatID: chatID, selfUserID: me))
+
+        guard case .tip(let recipient) = target else {
+            Issue.record("Expected .tip")
+            return
+        }
+        #expect(recipient.username == nil)
+    }
+
+    @Test("A tip DM resolves to the member that isn't the signed-in user")
+    func tipDMResolvesCounterpartExcludingSelf() throws {
+        let me = UUID()
+        let counterpartID = UUID()
+        let convo = makeConversation(type: .tipDm, members: [
+            ConversationMember(userID: counterpartID, displayName: "Alice"),
+            ConversationMember(userID: me, displayName: "Me"),
+        ])
+
+        let target = try #require(SendTarget(conversation: convo, dmChatID: chatID, selfUserID: me))
+
+        guard case .tip(let recipient) = target else {
+            Issue.record("Expected .tip")
+            return
+        }
+        #expect(recipient.userID == counterpartID)
+    }
+
+    @Test("A tip DM counterpart with no user id yields no target")
+    func tipDMCounterpartWithoutUserIDYieldsNil() {
+        let me = UUID()
+        let convo = makeConversation(type: .tipDm, members: [
+            ConversationMember(userID: me, displayName: "Me"),
+            ConversationMember(userID: nil, displayName: "Alice"),
+        ])
+
+        #expect(SendTarget(conversation: convo, dmChatID: chatID, selfUserID: me) == nil)
+    }
+
+    @Test("A group conversation has no single counterpart to pay")
+    func groupConversationYieldsNil() {
+        let me = UUID()
+        let convo = makeConversation(type: .group, members: [
+            ConversationMember(userID: me, displayName: "Me"),
+            ConversationMember(userID: UUID(), displayName: "Alice"),
+            ConversationMember(userID: UUID(), displayName: "Bob"),
+        ])
+
+        #expect(SendTarget(conversation: convo, dmChatID: chatID, selfUserID: me) == nil)
+    }
+
+    @Test("A contact DM resolves through ResolvedContact rather than the tip path")
+    func contactDMResolvesThroughResolvedContact() throws {
+        let me = UUID()
+        let convo = makeConversation(type: .contactDm, members: [
+            ConversationMember(userID: me, displayName: "Me"),
+            ConversationMember(userID: UUID(), displayName: "", phoneE164: "+15551234567"),
+        ])
+
+        let target = try #require(SendTarget(conversation: convo, dmChatID: chatID, selfUserID: me))
+
+        guard case .contact(let resolved) = target else {
+            Issue.record("Expected .contact")
+            return
+        }
+        #expect(resolved.phoneE164 == "+15551234567")
+    }
+
+    @Test("A nil conversation falls through to the contact path and yields no target")
+    func nilConversationYieldsNil() {
+        #expect(SendTarget(conversation: nil, dmChatID: chatID, selfUserID: UUID()) == nil)
+    }
+}

--- a/FlipcashTests/TipCardLinkRowTests.swift
+++ b/FlipcashTests/TipCardLinkRowTests.swift
@@ -14,25 +14,25 @@ struct TipCardLinkRowTests {
 
     @Test("A uuid is still clipped to a stub")
     func displayText_uuid_clipped() {
-        let url = URL(string: "https://app.flipcash.com/tip/b0ced1d2-3f4a-4b5c-8d9e-0f1a2b3c4d5e")!
-        #expect(TipCardLinkRow.displayText(for: url) == "app.flipcash.com/tip/b0ced…")
+        let url = URL(string: "https://flipcash.com/tip/b0ced1d2-3f4a-4b5c-8d9e-0f1a2b3c4d5e")!
+        #expect(TipCardLinkRow.displayText(for: url) == "flipcash.com/tip/b0ced…")
     }
 
     @Test("The longest handle renders whole")
     func displayText_maximumLengthHandle_unclipped() {
-        let url = URL(string: "https://app.flipcash.com/abcdefghijklmno")!
-        #expect(TipCardLinkRow.displayText(for: url) == "app.flipcash.com/abcdefghijklmno")
+        let url = URL(string: "https://flipcash.com/abcdefghijklmno")!
+        #expect(TipCardLinkRow.displayText(for: url) == "flipcash.com/abcdefghijklmno")
     }
 
     @Test("A six-character handle renders whole")
     func displayText_shortHandle_unclipped() {
-        let url = URL(string: "https://app.flipcash.com/taylor")!
-        #expect(TipCardLinkRow.displayText(for: url) == "app.flipcash.com/taylor")
+        let url = URL(string: "https://flipcash.com/taylor")!
+        #expect(TipCardLinkRow.displayText(for: url) == "flipcash.com/taylor")
     }
 
     @Test("A non-handle segment at exactly the stub length is left alone")
     func displayText_nonHandleAtStubLength_unclipped() {
-        let url = URL(string: "https://app.flipcash.com/a-bcd")!
-        #expect(TipCardLinkRow.displayText(for: url) == "app.flipcash.com/a-bcd")
+        let url = URL(string: "https://flipcash.com/a-bcd")!
+        #expect(TipCardLinkRow.displayText(for: url) == "flipcash.com/a-bcd")
     }
 }

--- a/FlipcashTests/TipCardLinkRowTests.swift
+++ b/FlipcashTests/TipCardLinkRowTests.swift
@@ -1,0 +1,38 @@
+//
+//  TipCardLinkRowTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Tip card link row display text")
+struct TipCardLinkRowTests {
+
+    @Test("A uuid is still clipped to a stub")
+    func displayText_uuid_clipped() {
+        let url = URL(string: "https://app.flipcash.com/tip/b0ced1d2-3f4a-4b5c-8d9e-0f1a2b3c4d5e")!
+        #expect(TipCardLinkRow.displayText(for: url) == "app.flipcash.com/tip/b0ced…")
+    }
+
+    @Test("The longest handle renders whole")
+    func displayText_maximumLengthHandle_unclipped() {
+        let url = URL(string: "https://app.flipcash.com/abcdefghijklmno")!
+        #expect(TipCardLinkRow.displayText(for: url) == "app.flipcash.com/abcdefghijklmno")
+    }
+
+    @Test("A six-character handle renders whole")
+    func displayText_shortHandle_unclipped() {
+        let url = URL(string: "https://app.flipcash.com/taylor")!
+        #expect(TipCardLinkRow.displayText(for: url) == "app.flipcash.com/taylor")
+    }
+
+    @Test("A non-handle segment at exactly the stub length is left alone")
+    func displayText_nonHandleAtStubLength_unclipped() {
+        let url = URL(string: "https://app.flipcash.com/a-bcd")!
+        #expect(TipCardLinkRow.displayText(for: url) == "app.flipcash.com/a-bcd")
+    }
+}

--- a/FlipcashTests/TipcardLinkTests.swift
+++ b/FlipcashTests/TipcardLinkTests.swift
@@ -17,12 +17,12 @@ struct TipcardLinkTests {
     @Test("An unclaimed card links by lowercase uuid")
     func tipcard_noUsername_uuidForm() {
         let url = URL.tipcard(for: userID, username: nil)
-        #expect(url.absoluteString == "https://app.flipcash.com/tip/b0ced1d2-3f4a-4b5c-8d9e-0f1a2b3c4d5e")
+        #expect(url.absoluteString == "https://flipcash.com/tip/b0ced1d2-3f4a-4b5c-8d9e-0f1a2b3c4d5e")
     }
 
     @Test("A claimed card links by handle, at the root and without an @")
     func tipcard_username_handleForm() {
         let url = URL.tipcard(for: userID, username: Username("taylor"))
-        #expect(url.absoluteString == "https://app.flipcash.com/taylor")
+        #expect(url.absoluteString == "https://flipcash.com/taylor")
     }
 }

--- a/FlipcashTests/TipcardLinkTests.swift
+++ b/FlipcashTests/TipcardLinkTests.swift
@@ -1,0 +1,28 @@
+//
+//  TipcardLinkTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Tipcard link")
+struct TipcardLinkTests {
+
+    private let userID = UUID(uuidString: "B0CED1D2-3F4A-4B5C-8D9E-0F1A2B3C4D5E")!
+
+    @Test("An unclaimed card links by lowercase uuid")
+    func tipcard_noUsername_uuidForm() {
+        let url = URL.tipcard(for: userID, username: nil)
+        #expect(url.absoluteString == "https://app.flipcash.com/tip/b0ced1d2-3f4a-4b5c-8d9e-0f1a2b3c4d5e")
+    }
+
+    @Test("A claimed card links by handle, at the root and without an @")
+    func tipcard_username_handleForm() {
+        let url = URL.tipcard(for: userID, username: Username("taylor"))
+        #expect(url.absoluteString == "https://app.flipcash.com/taylor")
+    }
+}

--- a/FlipcashTests/UsernameDialogTests.swift
+++ b/FlipcashTests/UsernameDialogTests.swift
@@ -1,0 +1,162 @@
+//
+//  UsernameDialogTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+import FlipcashUI
+// `ErrorProfile.moderated` carries a generated proto enum.
+import FlipcashAPI
+@testable import Flipcash
+
+@MainActor
+@Suite("Username dialogs")
+struct UsernameDialogTests {
+
+    @Test("The gate names the server's minimum in both the title and the body")
+    func gateDialog_namesMinimum() {
+        let item = DialogItem.usernameMinimumBalance(minimum: .usd(100), onAddMoney: {})
+
+        #expect(item.title == "$100 Minimum Balance Required")
+        #expect(item.subtitle?.contains("$100 USD") == true)
+    }
+
+    @Test("The gate drops trailing zeros rather than reading $100.00")
+    func gateDialog_wholeAmountHasNoCents() {
+        let item = DialogItem.usernameMinimumBalance(minimum: .usd(100), onAddMoney: {})
+        #expect(item.title?.contains(".00") == false)
+    }
+
+    @Test("The gate offers Add Money over Dismiss")
+    func gateDialog_actions() {
+        let item = DialogItem.usernameMinimumBalance(minimum: .usd(100), onAddMoney: {})
+
+        #expect(item.actions.count == 2)
+        #expect(item.actions[0].title == "Add Money")
+        #expect(item.actions[1].title == "Dismiss")
+    }
+
+    @Test("Add Money runs the handler it was given")
+    func gateDialog_addMoneyRunsHandler() {
+        var ran = false
+        let item = DialogItem.usernameMinimumBalance(minimum: .usd(100), onAddMoney: { ran = true })
+
+        item.actions[0].action()
+        #expect(ran)
+    }
+
+    @Test("The generic failure names itself, independent of its two callers")
+    func genericFailure_copy() {
+        let item = DialogItem.usernameGenericFailure
+
+        #expect(item.title == "Couldn't Save Your Username")
+        #expect(item.subtitle == "Try again")
+    }
+
+    @Test("Each validation failure gets its own copy")
+    func validationDialogs_copy() {
+        let tooShort = DialogItem.usernameValidation(.tooShort)
+        #expect(tooShort.title == "Too Short")
+        #expect(tooShort.subtitle == "Usernames must be a minimum of 2 characters")
+
+        let tooLong = DialogItem.usernameValidation(.tooLong)
+        #expect(tooLong.title == "Too Long")
+        #expect(tooLong.subtitle == "Usernames must be a maximum of 15 characters")
+
+        let invalid = DialogItem.usernameValidation(.invalidCharacters)
+        #expect(invalid.title == "Invalid Characters")
+        #expect(invalid.subtitle == "Only letters, numbers, and underscores are allowed")
+    }
+
+    @Test("Moderation reuses the display-name copy under a username title")
+    func submissionDialog_moderated() {
+        let item = DialogItem.usernameSubmission(.moderated(.other), minimum: nil, onAddMoney: {})
+
+        #expect(item.title == "Inappropriate Username")
+        #expect(item.subtitle == "Try a different name")
+    }
+
+    @Test("A taken handle asks for a different one")
+    func submissionDialog_taken() {
+        let item = DialogItem.usernameSubmission(.usernameTaken, minimum: nil, onAddMoney: {})
+
+        #expect(item.title == "Username Taken")
+        #expect(item.subtitle == "Please try a different username")
+    }
+
+    @Test("A reserved word points at support")
+    func submissionDialog_reservedWord() {
+        let item = DialogItem.usernameSubmission(.reservedWord, minimum: nil, onAddMoney: {})
+
+        #expect(item.title == "Trademarks Not Allowed")
+        #expect(item.subtitle?.contains("support@flipcash.com") == true)
+    }
+
+    @Test("Insufficient balance reuses the gate dialog rather than a seventh error")
+    func submissionDialog_insufficientBalance_isGateDialog() {
+        let item = DialogItem.usernameSubmission(.insufficientBalance, minimum: .usd(100), onAddMoney: {})
+
+        #expect(item.title == "$100 Minimum Balance Required")
+        #expect(item.actions[0].title == "Add Money")
+    }
+
+    @Test("Insufficient balance falls back to a generic error when no minimum is known")
+    func submissionDialog_insufficientBalance_noMinimum() {
+        let item = DialogItem.usernameSubmission(.insufficientBalance, minimum: nil, onAddMoney: {})
+        #expect(item.title == "Couldn't Save Your Username")
+    }
+
+    @Test("An unmapped server error falls through to try again")
+    func submissionDialog_unknown_generic() {
+        let item = DialogItem.usernameSubmission(.unknown, minimum: nil, onAddMoney: {})
+
+        #expect(item.title == "Couldn't Save Your Username")
+        #expect(item.subtitle == "Try again")
+    }
+
+    @Test("A denied claim currently falls through to the generic error")
+    func submissionDialog_denied_generic() {
+        // Not bespoke copy yet — this pins today's behaviour so the day
+        // `.denied` gets its own dialog, the change is deliberate.
+        let item = DialogItem.usernameSubmission(.denied, minimum: nil, onAddMoney: {})
+
+        #expect(item.title == "Couldn't Save Your Username")
+        #expect(item.subtitle == "Try again")
+    }
+
+    @Test("The gate names the minimum's own currency rather than assuming USD")
+    func gateDialog_nonUSDMinimum_namesItsCurrency() {
+        let item = DialogItem.usernameMinimumBalance(minimum: FiatAmount(value: 100, currency: .cad), onAddMoney: {})
+
+        #expect(item.subtitle?.contains("CAD") == true)
+        #expect(item.subtitle?.contains("USD") == false)
+    }
+
+    @Test("Every rejection the user can type their way out of uses the grey banner")
+    func rejections_areInformational() {
+        let rejections: [DialogItem] = [
+            .usernameValidation(.tooShort),
+            .usernameValidation(.tooLong),
+            .usernameValidation(.invalidCharacters),
+            .usernameSubmission(.usernameTaken, minimum: nil, onAddMoney: {}),
+            .usernameSubmission(.reservedWord, minimum: nil, onAddMoney: {}),
+            .usernameSubmission(.moderated(.other), minimum: nil, onAddMoney: {}),
+            .usernameSubmission(.invalidUsername, minimum: nil, onAddMoney: {}),
+            .usernameMinimumBalance(minimum: .usd(100), onAddMoney: {}),
+        ]
+
+        for rejection in rejections {
+            #expect(rejection.style == .standard, "\(rejection.title ?? "?") should be informational")
+        }
+    }
+
+    @Test("The unexplained failure keeps the red banner")
+    func genericFailure_isDestructive() {
+        // The one dialog in the flow the user cannot act on, so it stays an
+        // error — and stays tracked, which `.info` is not.
+        #expect(DialogItem.usernameGenericFailure.style == .destructive)
+        #expect(DialogItem.usernameGenericFailure.tracked)
+    }
+}

--- a/FlipcashTests/UsernameGateTests.swift
+++ b/FlipcashTests/UsernameGateTests.swift
@@ -1,0 +1,99 @@
+//
+//  UsernameGateTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Username balance gate")
+struct UsernameGateTests {
+
+    /// Stands in for `Session`, which the gate only reads one property from.
+    private final class StubBalances: UsernameBalanceReading {
+        let totalBalance: ExchangedFiat
+
+        init(usd: Decimal) {
+            totalBalance = ExchangedFiat(
+                nativeAmount: .usd(usd),
+                rate: Rate(fx: 1, currency: .usd)
+            )
+        }
+
+        /// Builds the total the way `Session.totalBalance` does: several
+        /// balances, converted into the user's display currency and summed
+        /// there. That round-trips through `rate.fx` in both directions, which
+        /// the single-balance initialiser above never exercises.
+        init(usd amounts: [Decimal], rate: Rate) {
+            totalBalance = amounts
+                .map { ExchangedFiat(nativeAmount: FiatAmount.usd($0).converting(to: rate), rate: rate) }
+                .total(rate: rate)
+        }
+    }
+
+    private func minimum(usd: Decimal) -> TokenAmount {
+        TokenAmount(wholeTokens: usd, mint: .usdf)
+    }
+
+    @Test("A balance below the minimum is sent to Add Money, carrying the shortfall")
+    func gate_belowMinimum_addMoney() {
+        let gate = usernameGate(session: StubBalances(usd: 87.5), minimum: minimum(usd: 100))
+        #expect(gate == .addMoney(minimum: .usd(100), shortfall: .usd(12.5), fraction: 0.875))
+    }
+
+    @Test("A balance exactly at the minimum proceeds")
+    func gate_atMinimum_proceeds() {
+        let gate = usernameGate(session: StubBalances(usd: 100), minimum: minimum(usd: 100))
+        #expect(gate == .proceed)
+        #expect(gate.fraction == 1)
+    }
+
+    @Test("A balance above the minimum proceeds")
+    func gate_aboveMinimum_proceeds() {
+        let gate = usernameGate(session: StubBalances(usd: 101), minimum: minimum(usd: 100))
+        #expect(gate == .proceed)
+    }
+
+    @Test("A zero minimum lets everyone through, with a full bar rather than a division by zero")
+    func gate_zeroMinimum_proceeds() {
+        let gate = usernameGate(session: StubBalances(usd: 0), minimum: minimum(usd: 0))
+        #expect(gate == .proceed)
+        #expect(gate.fraction == 1)
+    }
+
+    @Test("Absent flags let everyone through rather than inventing a minimum, with a full bar")
+    func gate_noFlags_proceeds() {
+        let gate = usernameGate(session: StubBalances(usd: 0), minimum: nil)
+        #expect(gate == .proceed)
+        #expect(gate.fraction == 1)
+    }
+
+    @Test("A zero balance against a real minimum reports no progress rather than a negative one")
+    func gate_zeroBalance_reportsNoProgress() {
+        let gate = usernameGate(session: StubBalances(usd: 0), minimum: minimum(usd: 100))
+        #expect(gate == .addMoney(minimum: .usd(100), shortfall: .usd(100), fraction: 0))
+    }
+
+    @Test("A partial balance reports its fraction of the minimum for the bar to size itself by")
+    func gate_partialBalance_fractionMatchesRatio() {
+        let gate = usernameGate(session: StubBalances(usd: 25), minimum: minimum(usd: 100))
+        #expect(gate.fraction == 0.25)
+    }
+
+    @Test("A foreign-currency balance exactly at the minimum still proceeds")
+    func gate_exactMinimumInForeignCurrency_proceeds() {
+        // Three balances totalling exactly $100, held by someone whose display
+        // currency isn't USD. Every balance reaching `totalBalance` is built as
+        // `usd * fx`, so summing and dividing by `fx` inverts that exactly — no
+        // amount or rate can make this drift today. The test pins that: it fails
+        // the day someone rounds inside `converting`, `convertingToUSD` or
+        // `total(rate:)`, which would cost this user a fraction of a cent and
+        // deny them a username their balance screen says they qualify for.
+        let session = StubBalances(usd: [40, 35, 25], rate: Rate(fx: 1.386523, currency: .cad))
+
+        #expect(usernameGate(session: session, minimum: minimum(usd: 100)) == .proceed)
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/Colors.swift
@@ -39,6 +39,10 @@ extension ShapeStyle where Self == Color {
     public static var unreadIndicator: Color             { Color(r: 10,  g: 132, b: 255) }
 
     public static var checkmarkBackground: Color         { Color.white }
+
+    /// `#34C759` — Apple's system green. Backed by the `success` asset (already
+    /// in the catalog, unused as a named token until the username progress card).
+    public static var success: Color                     { Color("success") }
 }
 
 extension Color {


### PR DESCRIPTION
Phase 1 of usernames: claim a handle, show it on the tip card, and open the card
from the link. Chat lookup by handle (Phase 2) and username-lost handling
(Phase 3) are not in this PR.

## What lands

**The rule.** `Username` and `UsernameValidator` accept lowercase a-z, digits, and
underscore, 2 to 15 characters — the same expression the server enforces in
`profile/username.go`, so a handle the client accepts is one the server will too.

**The gate.** Claiming requires a total balance at or above the server's
`usernameMinBalance` flag. It is a holding requirement rather than a fee: nothing
is debited, the comparison is cumulative and in USD rather than per-mint, and a
`nil` minimum proceeds and lets the server enforce its own threshold on
`SetUsername`.

**The entry points.** A progress card on the You page, below Share/Download and
drawn only until a handle exists, shows the balance against the minimum — white
bar and shortfall below it, green bar and chevron at or above. Both states are
tappable: complete opens the claim screen, incomplete raises the minimum-balance
dialog and its Add Money action. Once a handle is claimed the card gives way to a
Change Username row under My Account.

**The tip card.** A claimed handle draws under the name and travels with the
recipient when the card is scanned or opened from a link. The link row addresses
`app.flipcash.com/<handle>`, falling back to the uuid form for a profile without
one. The uuid is clipped to a stub because it is unreadable either way; a handle
is not, so a long one elides rather than shrinking to fit.

**The link opens.** A single unmatched path segment matching the handle pattern
parses as `.username` and reaches the same tipcard `/tip/{uuid}` does, by way of
`ProfileIdentifier` — the existing userID-or-username enum — so `TipFlow` carries
the identifier as data rather than branching on it. Segments are lowercased first,
so a link a messaging app capitalized still resolves. The own-handle case is
caught before the resolve when the local profile knows its handle and after it
when it doesn't, since a handle link learns whose card it is only from the
response. A vanity QR scans where the uuid form already does.

## Two decisions worth flagging

**Five of the six rejections are informational, not errors.** Too short, too long,
invalid characters, taken, and reserved draw the grey banner and report no
analytics — each is a rule being stated to someone who can fix it by typing
something else. Only the catch-all failure keeps the red banner and the
`errorModalDisplayed` event, because it is the only one that is actually an error.

**`give`, `balance`, and `discover` are now handles on the web.** They matched on
any scheme, so those segments in a web link resolved to home-screen quick actions;
they are now scoped to `flipcash://` and read as handles over https. The server
reserves `balance`, `discover`, and `wallet` as usernames, so those could not have
collided either way; `give` is not on that list and is unclaimable only because of
this scoping. Adding a deep-link keyword in future means checking it against the
server's reserved list first.

## Open, deliberately

- The link is emitted as `app.flipcash.com/<handle>` per product direction; the
  design draws `flipcash.com/<handle>` (node 9442:3673). The host swap is one line
  in `URL+Links.swift`.
- `applinks:flipcash.com` is added to the entitlement so the apex host is ready,
  but it does nothing until that host serves an AASA. Its paths should exclude the
  marketing pages: `flipcash.com/privacy` matches the handle pattern as readily as
  a real handle does, and would otherwise open the app and fail to resolve.
  `www.flipcash.com` is deliberately not claimed, since the app links to
  `/privacy`, `/terms`, and `/download` there.
- A handle that resolves to nobody raises the existing "Tipcard Not Available"
  dialog, which was written for a card that can't receive tips rather than for a
  handle that doesn't exist. Worth its own copy.
- `ErrorProfile.denied` is a real `SetUsername` rejection with no signed-off copy,
  so it falls to the generic dialog for now.
- `Analytics.AddMoneySource.usernameShortfall` is shared verbatim with Android,
  which needs the identical case.