### PR TITLE
fix(chat): discard the composer's resignFirstResponder result

### DIFF
--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -141,7 +141,9 @@ public final class ChatScreenViewController: UIViewController {
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.bar.firstTextInputResponder?.resignFirstResponder() }
+            MainActor.assumeIsolated {
+                _ = self?.bar.firstTextInputResponder?.resignFirstResponder()
+            }
         }
     }
 


### PR DESCRIPTION
`MainActor.assumeIsolated` infers its generic result type from the closure body. As the single expression in a Void-returning notification handler, the body binds `T` to both `Bool?` — from the optional-chained `resignFirstResponder()` — and `Void`:

```
Conflicting arguments to generic parameter 'T' ('Void' vs. 'Bool?')
ChatScreenViewController.swift:144
```

The Xcode 27 beta accepts it, so #643 built locally and merged clean. Xcode Cloud's compiler does not, and the tag-triggered build 503 for 2026.8.4 failed on it.

Discarding the result explicitly leaves one binding for `T`. The other three `assumeIsolated` call sites already yield `Void` and are unaffected.

Needs to land before 2026.8.4 can build.