### PR TITLE
docs(release): demote the Sanitizers plan from release gate to advisory

### DIFF
--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -41,11 +41,17 @@ Use the project scripts — they encode the correct scheme and destination:
 - **`Sanitizers`** — `FlipcashTests` + `FlipcashCoreTests` under Thread Sanitizer:
   `xcodebuild test -scheme Flipcash -destination 'platform=iOS Simulator,name=iPhone 17' -testPlan Sanitizers`
 
-TSan is scoped to the unit targets because its runtime crashes the app under test during
-XCUITest's accessibility snapshots — the crash is inside the sanitizer, not app code, and no race
-report is produced. Details and repro steps in
-[2026-08-25-tsan-ui-test-crash.md](../plans/2026-08-25-tsan-ui-test-crash.md). Don't move TSan
-back onto `AllTargets` without re-checking that analysis against the current Xcode.
+**`Sanitizers` cannot currently pass.** The TSan runtime aborts the host partway through and
+xcodebuild marks everything in flight as failed, so the run exits 65 with hundreds of failures and
+no race report. Those failures are casualties, not findings — they all report `(0.000 seconds)`
+and record no issue. Neither target completes alone, so there is no narrower scope that works. The
+release checklist runs it as an advisory step and reads only the race count; see
+[the release skill](../skills/release/SKILL.md) step 6a for the classification commands.
+
+TSan came off the UI tests first, where its runtime crashes during XCUITest's accessibility
+snapshots. The crash is inside the sanitizer, not app code, in both cases. Details, evidence, and
+repro steps in [2026-08-25-tsan-ui-test-crash.md](../plans/2026-08-25-tsan-ui-test-crash.md).
+Don't move TSan back onto `AllTargets` without re-checking that analysis against the current Xcode.
 
 **Never run `swift test` in a package directory** (`FlipcashCore`, `FlipcashUI`, etc.). Packages are iOS-only; `swift test` targets the macOS host and fails with code-signing errors. Always go through `./Scripts/test.sh` (which routes through the `Flipcash` scheme on the iOS Simulator).
 

--- a/.claude/plans/2026-08-25-tsan-ui-test-crash.md
+++ b/.claude/plans/2026-08-25-tsan-ui-test-crash.md
@@ -1,12 +1,18 @@
-# TSan aborts the app under test during UI tests — analysis
+# TSan aborts the app under test — analysis
 
-**Date:** 2026-08-25
+**Date:** 2026-08-25 (amended same day — the scope is wider than the original title implied)
 
 **Symptom:** any authenticated `FlipcashUITests` run under the `AllTargets` plan loses the app
 within seconds. XCUITest reports `Failed to get matching snapshots: Lost connection to the
 application (pid N)` or `Application com.flipcash.app.ios is not running`; `runningboardd` logs
 `termination reported by launchd (0, 0, 16896)` — wait status 16896 is exit code 66, Thread
 Sanitizer's default `exitcode`.
+
+**It is not confined to UI tests.** The `Sanitizers` plan added to work around this aborts as well,
+and so does each of its two targets run alone. Every unsanitized run of the same tests passes. The
+UI-test analysis below is intact as far as it goes; the scope claim it carried was wrong. Evidence
+in [The unit targets abort too](#the-unit-targets-abort-too), and what the release checklist does
+about it in [Amended](#amended-what-the-release-checklist-does-with-sanitizers).
 
 ## It is not a data race
 
@@ -51,19 +57,88 @@ The two reports differ only in which intercepted function was running:
 Different intercepted functions, different callers, same fault — it follows `DoReset`, not any
 particular app code.
 
-## Why it lands on UI tests specifically
+## Why it surfaces fastest on UI tests
 
 Both stacks sit under `-[NSObject(UIAccessibilityAutomation) _accessibilityUserTestingSnapshotWithOptions:]`,
 driven by `XCTAutomationSupport`'s snapshot request over `AXRuntime`. That traversal is a single
 synchronous main-thread burst of many thousands of intercepted sync calls, so it both consumes
 epoch space fast enough to trigger `DoReset` and maximises the chance that the interceptor
-re-entered inside `DoReset` finds its trace part exactly full. App-hosted unit tests take no
-accessibility snapshots and have run clean under TSan — see
-[2026-07-27](2026-07-27-xcode27-swift64-support.md), where TSan caught the real zxing race.
+re-entered inside `DoReset` finds its trace part exactly full.
+
+> **Corrected 2026-08-25 (same day).** This section originally claimed "App-hosted unit tests take
+> no accessibility snapshots and have run clean under TSan", and the change below was built on it.
+> That claim is wrong — the unit targets abort too. The snapshot burst is what makes the UI-test
+> case fast and reliable, not what makes it possible: ordinary unit-test execution reaches
+> `DoReset` on its own, just later. See [The unit targets abort too](#the-unit-targets-abort-too).
 
 The screen does not matter. It has been observed opening the region picker from the wallet
 balance header, switching to the Chats tab, and on the Amount to Tip keypad before any picker
 opens.
+
+## The unit targets abort too
+
+The `Sanitizers` plan does not survive a run either, so scoping TSan to the unit targets did not
+avoid the crash — it only moved it. Seven runs, all on `libclang_rt.tsan_iossim_dynamic.dylib`
+from Xcode's clang 21 against the iOS 27.0 simulator:
+
+```
+xcodebuild test -scheme Flipcash -destination 'platform=iOS Simulator,name=iPhone 17' -testPlan Sanitizers
+```
+
+Every one exits 65, and every one loses the host mid-run and restarts it. Five of the seven carry
+the same banner the UI tests produced — `ThreadSanitizer:DEADLYSIGNAL` followed by
+`ThreadSanitizer: nested bug in the same thread, aborting.`, then one `Restarting after unexpected
+exit`. The two `-only-testing:FlipcashTests` runs aborted and restarted with no banner in the
+xcodebuild log at all, so the banner is corroboration rather than the thing to test for. Failures
+are reported as "The test runner exited with code 66 before finishing running tests"; 66 is TSan's
+default `exitcode`.
+
+| run | scope | failing tests | ran before abort | after restart | data races |
+|---|---|---|---|---|---|
+| 1 | both targets | 1186 | 575 | 62 | 0 |
+| 2 | both targets | 1351 | 578 | 62 | 0 |
+| 3 | both targets | 1136 | 571 | 62 | 0 |
+| 4 | `-only-testing:FlipcashCoreTests` | 799 | 111 suites | — | 0 |
+| 5 | `-only-testing:FlipcashCoreTests` | 398 | 111 suites | — | 0 |
+| 6 | `-only-testing:FlipcashTests` | 597 | 580 | 62 | 0 |
+| 7 | `-only-testing:FlipcashTests` | 613 | 564 | 62 | 0 |
+
+**Neither target completes on its own.** Both bundles load into a single `Flipcash` host process,
+so within the combined plan one abort takes both down — but that is not the whole explanation,
+because each target aborts alone as well. There is no narrower scope that finishes.
+
+**No run reported a race.** `WARNING: ThreadSanitizer: data race` appears zero times across all
+seven, and no test recorded an issue. The unit targets are in exactly the position the UI tests
+were: TSan kills the host before producing the output it exists to produce.
+
+**Every reported failure is a casualty, not a finding.** The abort lands mid-run and xcodebuild
+marks everything still in flight as failed. In run 1 the first launch (pid 57682) passed 575 tests
+and then reported 677 failures, every one of them at `(0.000 seconds)` — they never executed. The
+restarted launch (pid 57866) ran 62 tests with zero failures. Across all seven runs, not one
+failure has a non-zero duration and not one records an issue. The `-only-testing:FlipcashCoreTests`
+runs make it starkest: 111 suites passed, 0 suites failed, 0 issues recorded — and 799 tests
+reported as failing.
+
+The blast radius is the only thing that varies, and it varies widely: 1136–1351 failing tests in
+the combined runs here, against 15 in the report that opened this investigation. What gets killed
+depends on what happens to be in flight when `DoReset` fires. The abort point itself is stable —
+roughly 575 tests into the combined run, every time.
+
+The control settles the attribution. The same two targets with TSan off pass end to end:
+
+```
+xcodebuild test -scheme Flipcash -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -testPlan AllTargets -only-testing:FlipcashTests -only-testing:FlipcashCoreTests
+```
+
+Exit 0, `** TEST SUCCEEDED **`, 1324 passed, 0 failed, one host process, no restart, and no
+repetition consumed despite `AllTargets`' `retryOnFailure` being available. Nothing is wrong with
+the tests.
+
+A stable abort point is also the one piece of value left here. TSan does instrument the prefix it
+reaches, and a race in those first ~575 tests would still be reported; that is how the zxing
+Reed-Solomon race was caught in [2026-07-27](2026-07-27-xcode27-swift64-support.md). Everything
+ordered after the abort point gets no TSan coverage at all.
 
 ## Why a suppression file cannot fix it
 
@@ -95,6 +170,34 @@ app before producing any.
 sanitized. Use `-testPlan Sanitizers` to run the unit targets under TSan. The release checklist
 runs both plans.
 
+### Amended: what the release checklist does with `Sanitizers`
+
+The change above assumed `Sanitizers` would pass. It does not, and it cannot be made to — no
+narrower scope finishes. Three options were on the table: drop the plan, narrow it to whatever
+still completes, or keep it and stop treating the abort as a failure.
+
+Narrowing is out on the evidence — runs 4–7 above show neither target completes alone.
+
+Dropping it would give up the prefix TSan still instruments, which is real coverage and the only
+TSan surface left in the repo. So the plan stays, and the release checklist stops treating the
+abort as a release blocker. `Any failure → STOP` cannot stand for a step that fails every time; a
+gate that can never pass is one the operator learns to wave through, which is worse than not
+running it.
+
+The abort is separable from a real finding by signature, so this is a decidable check rather than a
+judgement call. Treat the run as **inconclusive** — not failed — when all of these hold:
+
+- no `WARNING: ThreadSanitizer: data race` in the log,
+- `ThreadSanitizer:DEADLYSIGNAL` and `nested bug in the same thread` present,
+- every reported failure at `(0.000 seconds)`, and no test recording an issue.
+
+Anything else — a race report, or a failure with a real duration — is a genuine finding and still
+stops the release. Step 6 of [the release skill](../skills/release/SKILL.md) carries the
+commands.
+
+Revisit when a newer Xcode ships a fixed TSan runtime: if `Sanitizers` starts passing end to end,
+restore it as a hard gate and delete the inconclusive branch.
+
 ## One failure the crash was hiding
 
 With the app surviving, `CurrencySelectionSmokeTests` failed three runs in a row at
@@ -106,12 +209,31 @@ than that — around t=15s in these runs — so the helper returned early and th
 tab bar, whichever lands first, which keeps the already-granted case as fast as it was. Unrelated
 to TSan; it was simply unreachable while the app died first.
 
-Revisit when a newer Xcode ships a TSan runtime that does not re-enter its interceptors from
-`DoReset`.
-
 ## Reproducing
 
-Patch `UITargetAppEnvironmentVariables['TSAN_OPTIONS']` on the `IsUITestBundle` target of a built
+The unit-target abort needs no setup — run the plan and read the classification:
+
+```
+xcodebuild test -scheme Flipcash -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -testPlan Sanitizers 2>&1 | tee /tmp/sanitizers.log
+grep -c 'WARNING: ThreadSanitizer: data race' /tmp/sanitizers.log   # 0 = no finding
+grep -c 'nested bug in the same thread' /tmp/sanitizers.log         # 1 = the known abort
+grep ' failed on ' /tmp/sanitizers.log | grep -vc '(0.000 seconds)' # 0 = all casualties
+```
+
+Note that the crash reports the UI-test investigation relied on are not available here: TSan's own
+fault handlers are on under the plan, so it exits 66 with nothing written to
+`~/Library/Logs/DiagnosticReports/`. The `DEADLYSIGNAL` banner reaches the xcodebuild log in most
+runs but not all — two of the seven runs above dropped it while still aborting and restarting, so
+count host pids rather than trusting the banner:
+
+```
+grep -oE 'iPhone 17 - Flipcash \([0-9]+\)' /tmp/sanitizers.log | sort -u
+```
+
+More than one pid means the runner died and restarted.
+
+For the UI-test case, patch `UITargetAppEnvironmentVariables['TSAN_OPTIONS']` on the `IsUITestBundle` target of a built
 `.xctestrun`, then `test-without-building`. Set `log_path` to the device-level tmp directory
 (`<device>/data/tmp/tsan`), not the app data container — the container path changes on reinstall
 — plus `log_exe_name=1` and `verbosity=1`. Turning off TSan's fault handlers is what lets the

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -115,16 +115,56 @@ xcodebuild test -scheme Flipcash \
 ```
 The `AllTargets` test plan already includes UI tests. Do NOT run UI tests separately.
 
-Then the unit targets under Thread Sanitizer:
+**Any `AllTargets` failure → STOP.** This is the release gate.
+
+### 6a. Thread Sanitizer (advisory, not a blocker)
+
 ```bash
 xcodebuild test -scheme Flipcash \
   -destination 'platform=iOS Simulator,name=iPhone 17' \
-  -testPlan Sanitizers
+  -testPlan Sanitizers 2>&1 | tee /tmp/sanitizers.log
 ```
-`Sanitizers` covers `FlipcashTests` + `FlipcashCoreTests` only; TSan cannot run against the UI
-tests (see `.claude/plans/2026-08-25-tsan-ui-test-crash.md`).
 
-Any failure → STOP.
+`Sanitizers` covers `FlipcashTests` + `FlipcashCoreTests` only; TSan cannot run against the UI
+tests. **Expect this to exit 65 with hundreds of failures — that is the current known state, not a
+regression.** The TSan runtime re-enters its own interceptors from `DoReset` and aborts the host
+partway through, and xcodebuild marks everything in flight as failed. Neither target completes
+alone, so there is no narrower scope to fall back to. Full evidence in
+`.claude/plans/2026-08-25-tsan-ui-test-crash.md`.
+
+Do not read the failure count — it is 1100–1400 on a healthy-as-it-gets run. Classify with these
+three numbers instead:
+
+```bash
+grep -c 'WARNING: ThreadSanitizer: data race' /tmp/sanitizers.log   # A: races reported
+grep ' failed on ' /tmp/sanitizers.log | grep -vc '(0.000 seconds)' # B: failures that actually ran
+grep -c 'recorded an issue' /tmp/sanitizers.log                     # C: Swift Testing failures
+```
+
+- **A > 0 → STOP.** A data race is a genuine finding; triage before shipping.
+- **B > 0 or C > 0 → STOP.** Something failed on its own merits rather than as an abort casualty.
+- **A, B and C all 0 → continue the release**, whatever the exit code and failure count. If the run
+  exited non-zero, record it as "TSan inconclusive (known runtime abort)" in the release thread so
+  the skipped coverage is on the record.
+- **A, B, C all 0 *and* exit 0 → the runtime is fixed.** Tell the user: step 6a should go back to
+  being a hard gate, and the inconclusive branch should be deleted here and in the plan doc.
+
+C is the one that carries the weight: every test target here is Swift Testing (the codebase has no
+`import XCTest`), so a genuine failure always records an issue no matter how fast it failed. B is a
+backstop for anything that reports through the XCTest bridge instead. Don't substitute `grep
+'error:'` for either — several parameterized test names contain the literal `error:expected:`, and
+they match while passing.
+
+Deliberately not part of the test: the `ThreadSanitizer:DEADLYSIGNAL` banner. It reaches the
+xcodebuild log in most runs but went missing in two of the seven recorded in the plan doc, while
+the host still died and restarted. If you want to confirm an abort happened, count host pids —
+more than one means the runner died and restarted:
+
+```bash
+grep -oE 'iPhone 17 - Flipcash \([0-9]+\)' /tmp/sanitizers.log | sort -u
+```
+
+(That only reports pids while `FlipcashTests` is in scope, which it is for the plan as run above.)
 
 ### 7. Generate changelog
 Use the Agent tool with `model: "haiku"`. Pass the commit list with this prompt:


### PR DESCRIPTION
Step 6 of the release skill says "any failure → STOP" for a test plan that fails every run. Following it as written stalls a good release over a sanitizer bug — or, more likely, teaches the operator that step 6 is the one you wave through, which is a habit that carries to the `AllTargets` gate next to it.

## What the runs show

Seven runs of `-testPlan Sanitizers` against Xcode's clang 21 TSan runtime on the iOS 27.0 simulator:

| run | scope | failing | ran before abort | after restart | races |
|---|---|---|---|---|---|
| 1–3 | both targets | 1186 / 1351 / 1136 | ~575 | 62 | 0 |
| 4–5 | `-only-testing:FlipcashCoreTests` | 799 / 398 | 111 suites | — | 0 |
| 6–7 | `-only-testing:FlipcashTests` | 597 / 613 | ~570 | 62 | 0 |

Every failure is a casualty of the runtime aborting the host mid-run, not a finding: all of them report `(0.000 seconds)`, none records an issue, and all land on the dead first-launch pid. The same two targets with TSan off exit 0 at 1324 passed / 0 failed, one host process, no restart. The abort point is stable at ~575 tests; the blast radius is not.

Neither target completes on its own, so narrowing the plan to "the targets that still pass" is not an option — there aren't any.

## What changes

Step 6 splits. `AllTargets` stays the hard release gate, unchanged. Step 6a runs `Sanitizers` as an advisory step and classifies it by three counts: races reported, failures with a real duration, and Swift Testing's `recorded an issue`. All three zero → inconclusive, release continues. A race or a real failure → stop. All three zero *and* exit 0 → the runtime is fixed, restore the hard gate.

The `recorded an issue` count carries the weight, since the repo is entirely Swift Testing (0 `import XCTest`, 237 `import Testing`) and a genuinely failing test that finished in 0.000s would otherwise slip past the duration check. The skill warns off `grep 'error:'` explicitly — parameterized test *names* contain the literal `error:expected:` and match while passing. The `ThreadSanitizer:DEADLYSIGNAL` banner is deliberately not part of the test: it was missing from the xcodebuild log in 2 of the 7 runs while the abort still happened. Counting distinct host pids is the reliable tell.

## The corrected claim

`2026-08-25-tsan-ui-test-crash.md` claimed app-hosted unit tests "have run clean under TSan", and that is what justified carving the `Sanitizers` plan out in f735e310 (#644). It is wrong, and it was load-bearing — left standing, the next person to hit this rebuilds the same workaround on the same premise. The claim is corrected in place, the title no longer scopes the bug to UI tests, and the evidence above is recorded alongside repro commands.

## Why keep the plan at all

TSan still instruments the ~575 tests it reaches before aborting, and a race in those is still reported. That is how the zxing Reed-Solomon race was caught in [2026-07-27](https://github.com/code-payments/code-ios-app/blob/main/.claude/plans/2026-07-27-xcode27-swift64-support.md). Deleting the plan takes that to zero. Revisit when an Xcode ships a TSan runtime that does not re-enter its own interceptors from `DoReset`.

Docs and skill only — no code, and no CI references test plans.
