### PR TITLE
fix(discovery): call holders members, not people

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/CurrencyDiscoveryRow.swift
@@ -101,7 +101,7 @@ struct CurrencyDiscoveryRow: View {
 
     @ViewBuilder private var holdersText: some View {
         if let metrics = mint.holderMetrics {
-            Text("\(metrics.currentHolders, format: .number.notation(.compactName)) \(metrics.currentHolders == 1 ? "person" : "people")")
+            Text("\(metrics.currentHolders, format: .number.notation(.compactName)) \(metrics.currentHolders == 1 ? "member" : "members")")
         }
     }
 

--- a/Flipcash/Core/Screens/Main/Currency Discovery/LeaderboardSectionTitle.swift
+++ b/Flipcash/Core/Screens/Main/Currency Discovery/LeaderboardSectionTitle.swift
@@ -42,7 +42,7 @@ struct LeaderboardSectionTitle: View {
         )
         session.dialogItem = .info(
             title: "Leaderboard Ranking",
-            subtitle: "People must have a minimum balance of \(amount.nativeAmount.formatted(minimumFractionDigits: 0)) USD to be counted"
+            subtitle: "Members must have a minimum balance of \(amount.nativeAmount.formatted(minimumFractionDigits: 0)) USD to be counted"
         )
     }
 }


### PR DESCRIPTION
Discovery said "people" in two places: the holder count under each currency row, and the leaderboard ranking info dialog. Both now say "members".

- `CurrencyDiscoveryRow` — `"1 person" / "N people"` becomes `"1 member" / "N members"`.
- `LeaderboardSectionTitle` — the ranking dialog subtitle now opens "Members must have a minimum balance…".

These were the only two occurrences of "people" or "person" in the Currency Discovery folder.