### PR TITLE
fix(currency): put the minus ahead of the currency symbol

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Formatters/CompactCurrencyFormatStyle.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Formatters/CompactCurrencyFormatStyle.swift
@@ -21,6 +21,9 @@ import Foundation
 ///
 /// Text(99_999, format: .compactCurrency(code: .usd))
 /// // → "$100K"
+///
+/// Text(-12_400, format: .compactCurrency(code: .usd))
+/// // → "-$12K"
 /// ```
 public struct CompactCurrencyFormatStyle: FormatStyle {
 
@@ -32,8 +35,12 @@ public struct CompactCurrencyFormatStyle: FormatStyle {
 
     public func format(_ value: Double) -> String {
         let symbol = currencyCode.singleCharacterCurrencySymbols ?? ""
-        let compact = Int(value).formatted(.number.notation(.compactName))
-        return "\(symbol)\(compact)"
+        let whole = Int(value)
+        // The sign belongs outside the symbol ("-$12K"), so format the magnitude
+        // and prepend the minus ourselves rather than letting it land after the symbol.
+        let sign = whole < 0 ? "-" : ""
+        let compact = whole.magnitude.formatted(.number.notation(.compactName))
+        return "\(sign)\(symbol)\(compact)"
     }
 }
 

--- a/FlipcashCore/Sources/FlipcashCore/Formatters/CurrencyFormatter.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Formatters/CurrencyFormatter.swift
@@ -94,7 +94,9 @@ extension NumberFormatter {
 
         let prefix = currency.singleCharacterCurrencySymbols ?? ""
         f.positivePrefix = prefix
-        f.negativePrefix = prefix
+        // Setting a negative prefix replaces the locale's whole "-$" pattern, so the
+        // minus has to be carried explicitly or negatives format as if positive.
+        f.negativePrefix = "-\(prefix)"
         f.positiveSuffix = resolvedSuffix
         f.negativeSuffix = resolvedSuffix
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/CompactCurrencyFormatStyleTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/CompactCurrencyFormatStyleTests.swift
@@ -34,6 +34,14 @@ struct CompactCurrencyFormatStyleTests {
         #expect(format.format(200.17) == "$200")
     }
 
+    @Test("Negative values put the sign before the currency symbol")
+    func negativeValues() {
+        #expect(format.format(-12_400) == "-$12K")
+        #expect(format.format(-6_600) == "-$6.6K")
+        #expect(format.format(-384) == "-$384")
+        #expect(format.format(-1_299_217.10) == "-$1.3M")
+    }
+
     @Test("Zero formats correctly")
     func zero() {
         #expect(format.format(0) == "$0")

--- a/FlipcashTests/FiatAmountDisplayTests.swift
+++ b/FlipcashTests/FiatAmountDisplayTests.swift
@@ -135,6 +135,12 @@ struct FiatAmountFormattedTests {
             (.jpy,             Decimal(1000),             nil,     nil,     "¥1,000"),
             (.jpy,             Decimal(10),               nil,     nil,     "¥10"),
             (.jpy,             Decimal(string: "10.5")!,  nil,     nil,     "¥11"),     // halfUp
+
+            // Negatives — the minus leads the currency symbol.
+            (.usd,             Decimal(-10),              nil,     nil,     "-$10.00"),
+            (.usd,             Decimal(string: "-10.5")!, Int?(0), nil,     "-$10.5"),
+            (.usd,             Decimal(-10),              Int?(0), " USD",  "-$10 USD"),
+            (.jpy,             Decimal(-1000),            nil,     nil,     "-¥1,000"),
         ] as [(CurrencyCode, Decimal, Int?, String?, String)]
     )
     func formatted(currency: CurrencyCode, value: Decimal, minimumFractionDigits: Int?, suffix: String?, expected: String) {


### PR DESCRIPTION
Negative market-cap deltas render as `$-12K` on the Discover leaderboard, with the minus stranded between the symbol and the digits.

`CompactCurrencyFormatStyle` built its output by prepending the currency symbol to an already-formatted number, and for a negative value that number carries its own leading minus. Format the magnitude and place the sign ahead of the symbol instead. That matches what the rest of the app does — `StockChart` builds `"- $17.52"` from `abs(valueChange)`.

`NumberFormatter.fiat` had the same mistake with a worse outcome. Assigning `negativePrefix` replaces the locale's entire `-$` pattern, so setting it to the bare symbol dropped the sign altogether and formatted `-10` as `$10`, indistinguishable from positive ten. I found no caller that passes it a negative today, so it was latent rather than visible, but it's the same fix.

The leaderboard row itself needed no change: `CurrencyDiscoveryRow.formatMarketCapDelta` already adds `+` only for non-negative deltas and leaves the minus to the formatter, which now puts it in the right place. Jeffy's row reads `-$12K this week`.

Tests cover both formatters with negatives — four cases in `CompactCurrencyFormatStyleTests`, and four rows added to the `FiatAmountFormattedTests` table spanning default precision, a `minimumFractionDigits` override, a suffix, and zero-decimal JPY.

One behaviour left alone: a delta between -$1 and $0 truncates to `$0` and prints with no sign, while an exact zero prints `+$0`. Signing it `-$0` would read worse.
