### PR TITLE
fix: phrase in-chat payments as sends, not tips

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/ActivityRow.swift
+++ b/Flipcash/Core/Screens/Main/Home/ActivityRow.swift
@@ -12,9 +12,9 @@ import FlipcashCore
 /// Transaction history (Figma 8966:1910, ported from Android's `ActivityFeedRow`):
 /// a 40pt avatar, the title + relative time, and a signed amount. The avatar is
 /// the counterparty's profile photo for peer activity (tips/sends), the token
-/// image for token activity (deposits, buys), or a monogram fallback. A sent tip
-/// reads "Tipped <name>" once the counterparty resolves, and a swap reads
-/// "<From> → <To>" once both token names resolve.
+/// image for token activity (deposits, buys), or a monogram fallback. A peer
+/// payment reads "Tipped <name>" or "Sent to <name>" once the counterparty
+/// resolves, and a swap reads "<From> → <To>" once both token names resolve.
 struct ActivityRow: View {
 
     let activity: Activity
@@ -87,9 +87,8 @@ struct ActivityRow: View {
 
     // MARK: - Title
 
-    /// Peer tips render with the resolved counterparty name — "Tipped <name>"
-    /// for a sent tip, "Tip from <name>" for a received one — and a swap renders
-    /// its two token names, once they resolve; every other row uses the
+    /// A peer payment renders with the resolved counterparty name, and a swap
+    /// renders its two token names, once they resolve; every other row uses the
     /// server-rendered title.
     private var displayTitle: String {
         if let swap = activity.swapMetadata {
@@ -99,14 +98,38 @@ struct ActivityRow: View {
             ) ?? activity.title
         }
 
-        if let name = counterpartyName, !name.isEmpty {
-            switch activity.kind {
-            case .gave:     return "Tipped \(name)"
-            case .received: return "Tip from \(name)"
-            default:        break
-            }
+        return Self.peerTitle(
+            kind: activity.kind,
+            name: counterpartyName,
+            serverTitle: activity.title
+        ) ?? activity.title
+    }
+
+    /// How a peer payment is titled once its counterparty resolves — "Tipped
+    /// <name>" / "Tip from <name>" for a tip, "Sent to <name>" / "Received from
+    /// <name>" for a plain send. Returns `nil` for a row that is not a peer
+    /// payment, or whose counterparty has not resolved yet, so the caller falls
+    /// back to the server-rendered title.
+    ///
+    /// The tip/send split rides on the server's verb alone: the backend picks it
+    /// from the payment's `ChatMetadata.TipDmPayment.Location`, so a tip-card tip
+    /// arrives titled "Tipped" and an in-chat send "Sent". `activity/v1` models
+    /// both as plain sent/received crypto with no structured tip flag, so there
+    /// is no other signal to read. Matching the verb is safe while `serverTitle`
+    /// is English-only; a localized feed would need the distinction promoted into
+    /// the notification metadata.
+    static func peerTitle(kind: Activity.Kind, name: String?, serverTitle: String) -> String? {
+        guard let name, !name.isEmpty else { return nil }
+        let isTip = serverTitle
+            .trimmingCharacters(in: .whitespaces)
+            .lowercased()
+            .hasPrefix("tip")
+
+        switch kind {
+        case .gave:     return isTip ? "Tipped \(name)" : "Sent to \(name)"
+        case .received: return isTip ? "Tip from \(name)" : "Received from \(name)"
+        default:        return nil
         }
-        return activity.title
     }
 
     /// The conversion pair a swap row is titled with, or `nil` when either leg's
@@ -247,8 +270,8 @@ struct ActivityRow: View {
     /// A cached full profile (someone you've viewed or tipped) is authoritative;
     /// otherwise fall back to the tip conversation's member, which carries the
     /// name + picture for counterparties you've only *received* tips from (those
-    /// are never written to the profile cache). Without this, received tips show
-    /// the server title and a monogram instead of "Tip from <name>".
+    /// are never written to the profile cache). Without this, received payments
+    /// show the server title and a monogram instead of a named row.
     private func resolveUser(_ userID: UserID) async {
         let picture: ProfilePicture?
 

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -198,10 +198,9 @@ final class SendAmountViewModel {
             // Only a tip card payment is a tip — the same line the activity feed
             // draws, from `ChatMetadata.TipDmPayment.Location`. Both the scanned
             // tipcard flow and the Send Cash action inside a tip thread submit
-            // here, and the latter reports as a plain cash send. `Origin` is a
-            // `Sent Tip` property, so it goes nil with the event.
-            let tipOrigin: TipOrigin? = if case .tip(let recipient) = target, recipient.origin == .tipcard { .tipcard } else { nil }
-            let transferEvent: Analytics.TransferEvent = tipOrigin == nil ? .sentCash : .sentTip
+            // here, and the latter reports as a plain cash send.
+            let isTip = if case .tip(let recipient) = target { recipient.origin == .tipcard } else { false }
+            let transferEvent: Analytics.TransferEvent = isTip ? .sentTip : .sentCash
 
             do {
                 try await sender.send(
@@ -210,10 +209,10 @@ final class SendAmountViewModel {
                     to: recipient,
                     chat: chatPaymentMetadata()
                 )
-                Analytics.transfer(event: transferEvent, exchangedFiat: amountToSend, grabTime: nil, successful: true, error: nil, origin: tipOrigin)
+                Analytics.transfer(event: transferEvent, exchangedFiat: amountToSend, grabTime: nil, successful: true, error: nil)
                 return .success
             } catch {
-                Analytics.transfer(event: transferEvent, exchangedFiat: amountToSend, grabTime: nil, successful: false, error: error, origin: tipOrigin)
+                Analytics.transfer(event: transferEvent, exchangedFiat: amountToSend, grabTime: nil, successful: false, error: error)
                 showSendError()
                 return .failed
             }

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -195,11 +195,12 @@ final class SendAmountViewModel {
                 return .failed
             }
 
-            // A payment into a tip DM reports as a tip; a contact DM is a plain
-            // cash send. This covers both the scanned-tipcard flow and the
-            // Send Cash action inside a tip thread, since both submit here —
-            // `Origin` is what tells the two apart.
-            let tipOrigin: TipOrigin? = if case .tip(let recipient) = target { recipient.origin } else { nil }
+            // Only a tip card payment is a tip — the same line the activity feed
+            // draws, from `ChatMetadata.TipDmPayment.Location`. Both the scanned
+            // tipcard flow and the Send Cash action inside a tip thread submit
+            // here, and the latter reports as a plain cash send. `Origin` is a
+            // `Sent Tip` property, so it goes nil with the event.
+            let tipOrigin: TipOrigin? = if case .tip(let recipient) = target, recipient.origin == .tipcard { .tipcard } else { nil }
             let transferEvent: Analytics.TransferEvent = tipOrigin == nil ? .sentCash : .sentTip
 
             do {

--- a/Flipcash/Utilities/Events.swift
+++ b/Flipcash/Utilities/Events.swift
@@ -204,8 +204,9 @@ extension Analytics {
         )
     }
 
-    /// `origin` applies to `Sent Tip` only: which surface the tip came from —
-    /// a scanned/opened tip card, or the money button inside an existing tip chat.
+    /// `origin` applies to `Sent Tip` only: which surface the tip came from. A
+    /// payment sent from inside a tip thread reports `Sent Cash` and passes no
+    /// origin, so this is `tipcard` in practice.
     static func transfer(event: TransferEvent, exchangedFiat: ExchangedFiat?, grabTime: Double?, successful: Bool, error: Error?, origin: TipOrigin? = nil) {
         var properties: [Property: AnalyticsValue] = exchangedFiat.map(amountProperties) ?? [:]
         properties[.state] = successful ? String.success : String.failure

--- a/Flipcash/Utilities/Events.swift
+++ b/Flipcash/Utilities/Events.swift
@@ -204,19 +204,12 @@ extension Analytics {
         )
     }
 
-    /// `origin` applies to `Sent Tip` only: which surface the tip came from. A
-    /// payment sent from inside a tip thread reports `Sent Cash` and passes no
-    /// origin, so this is `tipcard` in practice.
-    static func transfer(event: TransferEvent, exchangedFiat: ExchangedFiat?, grabTime: Double?, successful: Bool, error: Error?, origin: TipOrigin? = nil) {
+    static func transfer(event: TransferEvent, exchangedFiat: ExchangedFiat?, grabTime: Double?, successful: Bool, error: Error?) {
         var properties: [Property: AnalyticsValue] = exchangedFiat.map(amountProperties) ?? [:]
         properties[.state] = successful ? String.success : String.failure
 
         if let grabTime {
             properties[.grabTime] = grabTime
-        }
-
-        if let origin {
-            properties[.origin] = origin.analyticsValue
         }
 
         track(
@@ -359,16 +352,6 @@ extension DepositMethod {
     }
 }
 
-extension TipOrigin {
-    /// The `Origin` property value, shared verbatim with Android.
-    var analyticsValue: String {
-        switch self {
-        case .tipcard: "Tipcard"
-        case .chat:    "Chat"
-        }
-    }
-}
-
 // MARK: - Wallet -
 
 extension Analytics {
@@ -479,7 +462,6 @@ extension Analytics {
 
         case state             = "State"
         case source            = "Source"
-        case origin            = "Origin"
         case method            = "Method"
         case quarks            = "Quarks"
         case mint              = "Mint"

--- a/FlipcashTests/ActivityRowPeerTitleTests.swift
+++ b/FlipcashTests/ActivityRowPeerTitleTests.swift
@@ -1,0 +1,43 @@
+//
+//  ActivityRowPeerTitleTests.swift
+//  FlipcashTests
+//
+
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@Suite("Peer payment row title")
+struct ActivityRowPeerTitleTests {
+
+    @Test("A tip keeps the tip phrasing on both sides")
+    func tipPhrasing() {
+        #expect(ActivityRow.peerTitle(kind: .gave, name: "Sally", serverTitle: "Tipped") == "Tipped Sally")
+        #expect(ActivityRow.peerTitle(kind: .received, name: "Sally", serverTitle: "Tipped") == "Tip from Sally")
+    }
+
+    @Test("An in-chat send reads as a send, not a tip")
+    func sendPhrasing() {
+        #expect(ActivityRow.peerTitle(kind: .gave, name: "Sally", serverTitle: "Sent") == "Sent to Sally")
+        #expect(ActivityRow.peerTitle(kind: .received, name: "Sally", serverTitle: "Sent") == "Received from Sally")
+        #expect(ActivityRow.peerTitle(kind: .received, name: "Sally", serverTitle: "Received") == "Received from Sally")
+    }
+
+    @Test("The verb is read from an already-substituted title")
+    func substitutedTitle() {
+        #expect(ActivityRow.peerTitle(kind: .received, name: "Sally", serverTitle: "Tipped Bob") == "Tip from Sally")
+        #expect(ActivityRow.peerTitle(kind: .received, name: "Sally", serverTitle: "Sent to Bob") == "Received from Sally")
+    }
+
+    @Test("An unresolved counterparty falls back to the server-rendered title")
+    func unresolvedCounterpartyFallsBack() {
+        #expect(ActivityRow.peerTitle(kind: .received, name: nil, serverTitle: "Sent") == nil)
+        #expect(ActivityRow.peerTitle(kind: .received, name: "", serverTitle: "Sent") == nil)
+    }
+
+    @Test("Non-peer activity falls back to the server-rendered title")
+    func nonPeerActivityFallsBack() {
+        #expect(ActivityRow.peerTitle(kind: .bought, name: "Sally", serverTitle: "Purchased") == nil)
+        #expect(ActivityRow.peerTitle(kind: .withdrew, name: "Sally", serverTitle: "Withdrew") == nil)
+    }
+}

--- a/FlipcashTests/Analytics/ReceivedEventsTests.swift
+++ b/FlipcashTests/Analytics/ReceivedEventsTests.swift
@@ -4,18 +4,11 @@
 //
 
 import Testing
-import FlipcashCore
 @testable import Flipcash
 
 @MainActor
-@Suite("Received & origin event contract")
+@Suite("Received event contract")
 struct ReceivedEventsTests {
-
-    @Test("Tip origin property values are shared verbatim with Android")
-    func tipOriginValues() {
-        #expect(TipOrigin.tipcard.analyticsValue == "Tipcard")
-        #expect(TipOrigin.chat.analyticsValue == "Chat")
-    }
 
     @Test("Display name event names are the shared contract")
     func displayNameEventNames() {


### PR DESCRIPTION
A payment sent inside a chat showed up in the recipient's activity history as
"Tip from <name>".

The send side is already correct. The payment stamps
`ChatMetadata.TipDmPayment.Location` — `TIPCARD` for a tip card or deeplink,
`CHAT` for an in-chat send — and the server picks the activity verb from it, so a
tip arrives as "Tipped" and an in-chat send as "Sent". `ActivityRow.displayTitle`
discarded that verb and hardcoded the tip phrasing for both `.gave` and
`.received`.

It now reads the verb and phrases the row from it:

| server verb | `.gave` | `.received` |
| --- | --- | --- |
| `Tipped` | Tipped Sally | Tip from Sally |
| `Sent` | Sent to Sally | Received from Sally |

The `switch` moves out of `displayTitle` into a static `peerTitle(kind:name:serverTitle:)`,
matching `swapTitle`'s testable shape, and returns `nil` for a non-peer row or an
unresolved counterparty so the caller keeps its existing fallback to the
server-rendered title. Swaps and every other row are untouched.

`activity.title` arrives already substitution-rendered on iOS, so it can read
"Tipped Bob" rather than a bare verb; the prefix match covers both, and there's
a test for it.

## Analytics

The transfer events drew the line the other way: `Sent Tip` vs `Sent Cash` was
chosen by whether the target was a tip recipient, so a payment into a tip DM
reported as a tip whether it came from a tip card or the money button inside the
thread. No data was lost, since the event carried `Origin: Chat`, but any count
on `Sent Tip` that didn't split on `Origin` read in-chat sends as tips.

The second commit draws the same line as the feed: only a `.tipcard` origin is a
tip, so a send from inside a tip thread reports `Sent Cash`.

That leaves `Origin` constant at `Tipcard` on every `Sent Tip`, so the third
commit drops the parameter, the `Property.origin` key, and the
`TipOrigin.analyticsValue` mapping behind it. `TipOrigin` itself stays — it still
selects the payment's `Location`.

Net effect on the event stream:

| payment | before | after |
| --- | --- | --- |
| tip card / deeplink | `Sent Tip`, `Origin: Tipcard` | `Sent Tip`, no `Origin` |
| in-chat send to a tip peer | `Sent Tip`, `Origin: Chat` | `Sent Cash` |
| in-chat send to a contact | `Sent Cash` | unchanged |

Existing queries that count `Sent Tip` without splitting on `Origin` will see the
in-chat volume move to `Sent Cash` from the release forward; historical events
keep their `Origin` values.

### Known limit

The verb is the only signal available: `activity/v1` models a peer payment as
plain `directly_sent_crypto` / `received_crypto` with no structured tip flag.
Matching an English prefix holds while the rendered title is English-only. A
localized feed would need the tip/send distinction promoted into the
notification metadata upstream.

Mirrors code-payments/code-android-app#1332.
