### PR TITLE
feat(payments): scaffold Balance service for GetBalance

### DIFF
--- a/FlipcashAPI/Package.swift
+++ b/FlipcashAPI/Package.swift
@@ -34,7 +34,7 @@ let contractDependencies: [Package.Dependency] = protoLocalRoot.map { root in
         .package(path: "\(root)/flipcash2-client-protocol"),
     ]
 } ?? [
-    .package(url: "https://github.com/code-payments/ocp-client-protocol", exact: "0.1.0"),
+    .package(url: "https://github.com/code-payments/ocp-client-protocol", exact: "0.2.0"),
     .package(url: "https://github.com/code-payments/flipcash2-client-protocol", exact: "0.1.0"),
 ]
 

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Balance.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client+Balance.swift
@@ -1,0 +1,17 @@
+//
+//  Client+Balance.swift
+//  FlipcashCore
+//
+
+import Foundation
+import FlipcashAPI
+
+extension Client {
+    /// Fetches the core-mint balance for any owner account. No signature is
+    /// required — the server allows reading balance for any owner.
+    public func getBalance(owner: PublicKey) async throws -> TokenAmount {
+        try await withCheckedThrowingContinuation { c in
+            balanceService.getBalance(owner: owner) { c.resume(with: $0) }
+        }
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Client.swift
@@ -27,6 +27,7 @@ public class Client: ObservableObject {
     internal let transactionService: TransactionService
     internal let currencyService: CurrencyService
     internal let messagingService: MessagingService
+    internal let balanceService: BalanceService
 
     // MARK: - Init -
 
@@ -53,6 +54,7 @@ public class Client: ObservableObject {
         self.transactionService = TransactionService(client: client)
         self.currencyService    = CurrencyService(client: client)
         self.messagingService   = MessagingService(client: client)
+        self.balanceService     = BalanceService(client: client)
     }
 
     deinit {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/BalanceService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Payments API/Services/BalanceService.swift
@@ -1,0 +1,72 @@
+//
+//  BalanceService.swift
+//  FlipcashCore
+//
+
+import Foundation
+import FlipcashAPI
+import GRPCCore
+
+private let logger = Logger(label: "flipcash.balance-service")
+
+final class BalanceService: Sendable {
+
+    private let service: Ocp_Balance_V1_Balance.Client<AppTransport>
+
+    init(client: GRPCClient<AppTransport>) {
+        self.service = Ocp_Balance_V1_Balance.Client(wrapping: client)
+    }
+
+    /// Fetches the core-mint balance for any owner account. Unlike every other
+    /// Payments API request, `GetBalanceRequest` carries no auth/signature field —
+    /// the server allows reading balance for any owner, not just the caller's own,
+    /// so this takes a bare `PublicKey` rather than a signing `KeyPair`.
+    func getBalance(owner: PublicKey, completion: @Sendable @escaping (Result<TokenAmount, ErrorGetBalance>) -> Void) {
+        logger.info("Fetching balance")
+
+        let request = Ocp_Balance_V1_GetBalanceRequest.with {
+            $0.owner = owner.solanaAccountID
+        }
+
+        Task {
+            do {
+                let response = try await service.getBalance(request, options: .unaryDefault)
+                let error = ErrorGetBalance(rawValue: response.result.rawValue) ?? .unknown
+                guard error == .ok else {
+                    logger.error("Failed to fetch balance", metadata: ["error": "\(error)"])
+                    await MainActor.run { completion(.failure(error)) }
+                    return
+                }
+                let balance = TokenAmount(quarks: response.coreMintValue, mint: .usdf)
+                await MainActor.run { completion(.success(balance)) }
+            } catch let error as RPCError {
+                await MainActor.run { completion(.failure(.from(transportError: error))) }
+            } catch {
+                await MainActor.run { completion(.failure(.unknown)) }
+            }
+        }
+    }
+}
+
+// MARK: - Errors -
+
+public enum ErrorGetBalance: Int, Error, Equatable, Sendable {
+    case ok
+    case denied
+    case notFound
+    case unknown          = -1
+    case transportFailure = -2
+    case cancelled        = -3
+    case rejected         = -4
+}
+
+extension ErrorGetBalance: ServerError, TransportClassifiableError {
+    public var reportingLevel: ErrorReportingLevel {
+        switch self {
+        case .ok, .transportFailure: .suppressed
+        case .cancelled: .info
+        case .denied, .notFound: .info
+        case .unknown, .rejected: .error
+        }
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/TransportClassificationTests.swift
@@ -40,6 +40,7 @@ struct TransportClassificationTests {
     // MARK: - Registry (one line per TransportClassifiableError conformer) -
 
     @Test func errorFetchBalance() { assertClassifies(ErrorFetchBalance.self) }
+    @Test func errorGetBalance() { assertClassifies(ErrorGetBalance.self) }
 
     @Test func errorRegisterAccount() { assertClassifies(ErrorRegisterAccount.self) }
     @Test func errorLoginAccount() { assertClassifies(ErrorLoginAccount.self) }


### PR DESCRIPTION
Scaffolds the OpenCode `Balance` service added upstream in `ocp-protobuf-api@ea6418c5`, and bumps the `ocp-client-protocol` pin to `0.2.0` to pick it up.

## What the contract adds

One unary RPC, `ocp.balance.v1.Balance/GetBalance`. The request takes an owner account; the response carries a result enum (`OK`/`DENIED`/`NOT_FOUND`) and `core_mint_value`, a `uint64` in quarks. Nothing pre-existing changed, so no existing result enum was renumbered and no existing `Error*(rawValue:)` mapping shifts.

## What this adds

`BalanceService` → `ErrorGetBalance` → `Client.getBalance`, registered on `Client`, plus the `TransportClassificationTests` registry line every new `TransportClassifiableError` conformer needs.

Nothing consumes it yet. No screen, view model, or `Session` integration, because there is no balance surface asking for this today.

Two calls worth review:

- **The request is not signed.** `GetBalanceRequest` has no auth field, unlike every other Payments API request, so `getBalance` takes a bare `PublicKey` rather than a signing `KeyPair`. That asymmetry is in the contract, not an oversight in this scaffold.
- **`core_mint_value` maps to `TokenAmount(quarks:mint:.usdf)`.** The mint is not on the wire: the field is core-mint quarks by definition, and the contract carries a core mint address nowhere, so USDF is a client-side constant here exactly as it is in `SwapInstructionBuilder+NewCurrency.swift`, which takes `MintMetadata.usdf` as `coreMint`. If the core mint ever stops being USDF, this call site is one of the places that has to change.

Android keeps the same field as a raw `Long` rather than materializing the implied mint. Both platforms hold the same information; only the domain typing differs.

`ErrorGetBalance` orders `ok`/`denied`/`notFound` at rawValues 0/1/2 to match the proto, with the transport cases at negative rawValues as this codebase does elsewhere.

## Blocked on

`0.2.0` does not exist yet. `exact: "0.2.0"` has no tag to resolve until code-payments/ocp-client-protocol#4 merges and is published, so this stays a draft until then.
