### PR TITLE
feat(deploy): give ad-hoc builds their own TestFlight notes

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: deploy
-description: Use when the user wants to trigger an Xcode Cloud build for the current branch, kick off the "Deploy Flipcash" workflow, ship an ad-hoc / dogfood build, or push a branch build to a TestFlight group — anything short of a versioned release (for cutting a version, use /release instead).
+description: Use when the user wants to trigger an Xcode Cloud build for the current branch, kick off the "Deploy Flipcash" workflow, ship an ad-hoc / dogfood build, push a branch build to a TestFlight group, or set a TestFlight build's "What to Test" notes — anything short of a versioned release (for cutting a version, use /release instead).
 argument-hint: [testflight-group]
-allowed-tools: Bash(git rev-parse *), Bash(git status *), Bash(git push *), Bash(git ls-remote *), Bash(fastlane deploy *), Bash(fastlane distribute *)
+allowed-tools: Bash(git rev-parse *), Bash(git status *), Bash(git push *), Bash(git ls-remote *), Bash(git fetch *), Bash(git log *), Bash(git merge-base *), Bash(fastlane deploy *), Bash(fastlane distribute *), Read, Write, Agent
 ---
 
 # Deploy
 
-Triggers the **Deploy Flipcash** Xcode Cloud workflow for the **current branch**, and optionally waits and assigns the resulting build to a TestFlight group. Wraps `fastlane deploy`.
+Triggers the **Deploy Flipcash** Xcode Cloud workflow for the **current branch**, and optionally waits, gives the resulting build its TestFlight "What to Test" notes, and assigns it to a TestFlight group. Wraps `fastlane deploy`.
 
 **Not a release.** This builds an arbitrary branch on demand. To cut a version (tag → App Store), use `/release`.
 
@@ -15,6 +15,7 @@ Triggers the **Deploy Flipcash** Xcode Cloud workflow for the **current branch**
 
 - "Trigger a build", "kick off Xcode Cloud", "build this branch", "make a dogfood/TestFlight build"
 - "Deploy this to the Internal group" → include the group
+- "What should testers try?", "add release notes to that build" → the What to Test section below
 
 ## Preconditions
 
@@ -30,6 +31,69 @@ Xcode Cloud builds the commit at the **tip of the branch on origin**, and the la
 
 `fastlane/.env` must hold the ASC API creds (`ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_CONTENT`, `APP_IDENTIFIER`). If the lane reports one missing, tell the user to run `Scripts/pull_secrets fastlane` (or restore `fastlane/.env`).
 
+## What to Test
+
+Give the build its own TestFlight notes — same shape as `/release` step 8a, different mechanism.
+
+**Why a different mechanism.** Xcode Cloud attaches `TestFlight/WhatToTest.en-US.txt` from the
+commit it builds, so a branch build inherits whatever the last release committed — a baseline
+checklist that says nothing about this branch. `/release` solves that by committing the file on the
+release branch. A feature branch can't: that commit would land in the PR. So `/deploy` writes the
+notes onto the finished build through the App Store Connect API instead (`notes_file:`), which
+overwrites what Xcode Cloud attached.
+
+**This requires waiting for the build** (10–30+ min) — the notes can only be set after the build
+uploads, or Xcode Cloud's copy wins. Passing `notes_file:` turns waiting on by itself, the same way
+`group:` does. With `wait:false`, skip the notes and tell the user to run
+`fastlane distribute notes_file:<path>` once the build processes.
+
+### 1. What's on the branch
+
+```bash
+git fetch origin main
+git log $(git merge-base origin/main HEAD)..HEAD --format="- %s" --no-merges
+```
+
+If the user named a different branch, substitute it for `HEAD`. If the branch *is* `main`, use the
+latest release tag as the base instead: `git log $(git describe --tags --match 'flipcash-*' --abbrev=0)..HEAD`.
+
+### 2. Draft the notes
+
+Use the Agent tool with `model: "haiku"`. Pass the commit list with this prompt:
+
+> Given these git commits (conventional commit format), write TestFlight "What to Test" notes.
+> - Plain text, one `•` bullet per item — no markdown headers, no bold
+> - Each bullet is a flow a tester can actually run end to end, not a description of the code
+> - Write for a tester, not a developer — no file names, module names, or internals
+> - Skip commits with nothing to exercise (build config, CI, dependency bumps)
+> - If nothing is testable, output: Nothing branch-specific — run the baseline below.
+> - Output ONLY the bullets
+
+### 3. Assemble and confirm
+
+Read the committed `TestFlight/WhatToTest.en-US.txt` and carry its **Baseline** block over
+unchanged — testers should run the same core-money-flow checklist on every build, and keeping it
+verbatim keeps `/deploy` and `/release` in sync. Assemble:
+
+```
+What to test in this build
+<branch name, and the PR link if there is one>
+
+New on this branch:
+<the step-2 bullets>
+
+Baseline — always verify these core money flows:
+<the Baseline bullets from the committed file, unchanged>
+
+Report anything off — wrong amounts, stuck screens, or crashes.
+```
+
+Show it to the user for approval, then write the approved text to a scratch file (multi-line notes
+through a shell argument is a quoting trap) and pass `notes_file:` on the run.
+
+Cap: Apple rejects over 4000 bytes. The lane truncates rather than failing, but trim the bullets
+instead of relying on that.
+
 ## Run
 
 Run from the repo root.
@@ -40,21 +104,25 @@ Run from the repo root.
 | Just trigger a build | `fastlane deploy` |
 | Trigger a specific branch | `fastlane deploy branch:<name>` |
 | Trigger **and** assign to a TestFlight group | `fastlane deploy group:'<Group Name>'` |
+| Trigger, set "What to Test", assign | `fastlane deploy group:'<Group Name>' notes_file:<path>` |
+| Set "What to Test" without changing groups | `fastlane deploy notes_file:<path>` |
 
 **Pick the group first.** The group name must match a TestFlight group exactly (case-sensitive) or the lane errors. A default lives in the `TESTFLIGHT_GROUP` env var (in `fastlane/.env`, kept out of the repo); an explicit `group:'Name'` overrides it. If neither is set and the user hasn't named one, run `fastlane deploy dry_run:true` — it prints the available groups (and confirms the workflow + branch resolve) without triggering anything — then confirm the group with the user before the real run.
 
 `group:` makes the lane **block** through the whole Xcode Cloud build + processing (10–30+ min) before assigning — expected, not a hang. Stream the output and report progress. If the user doesn't want to wait, run `fastlane deploy group:'<Group>' wait:false` and tell them to run `fastlane distribute group:'<Group>'` once the build finishes processing.
 
-Assign a group to an already-built build without triggering a new one: `fastlane distribute group:'<Group>' [build:<number>]`. Dry-run the upload half with `fastlane distribute group:'<Group>' dry_run:true` — it confirms the group resolves and reports which build would be assigned (and whether it's processed), without assigning and without blocking.
+Act on an already-built build without triggering a new one: `fastlane distribute group:'<Group>' [build:<number>] [notes_file:<path>]` — `group:` and `notes_file:` are independently optional, so this also re-writes the notes on a build that's already with its testers. Dry-run the upload half with `fastlane distribute group:'<Group>' dry_run:true` — it confirms the group resolves and reports which build it would act on (and whether it's processed), without changing anything and without blocking.
 
-**From GitHub instead of locally:** the same flow is exposed as the `Deploy to TestFlight (Xcode Cloud)` workflow (`.github/workflows/deploy.yml`) — Actions tab → Run workflow → pick a branch. It runs the lane on an ubuntu runner using the repo's ASC secrets, and assigns to the `TESTFLIGHT_GROUP` secret when the group field is left blank. Point users there when they can't or don't want to run fastlane locally.
+**From GitHub instead of locally:** the same flow is exposed as the `Deploy to TestFlight (Xcode Cloud)` workflow (`.github/workflows/deploy.yml`) — Actions tab → Run workflow → pick a branch. It runs the lane on an ubuntu runner using the repo's ASC secrets, and assigns to the `TESTFLIGHT_GROUP` secret when the group field is left blank. Its `notes` field is the "What to Test" — a single-line box, so line breaks go in as literal `\n` and the workflow expands them. Point users there when they can't or don't want to run fastlane locally.
 
 ## Report
 
-State the build number the lane printed and where to watch it (App Store Connect → Xcode Cloud → Builds). If a group was requested, confirm the build was assigned once the lane finishes.
+State the build number the lane printed and where to watch it (App Store Connect → Xcode Cloud → Builds). If a group was requested, confirm the build was assigned once the lane finishes. If notes were set, say so — testers see them as the build's "What to Test".
 
 ## Don't
 
 - Don't trigger against a branch whose local HEAD isn't on origin — you'd build stale code. Push first.
 - Don't guess a TestFlight group name. If the user didn't name one, either omit `group:` or ask which group.
+- Don't commit `TestFlight/WhatToTest.en-US.txt` on a feature branch to set the notes — that file is `/release`'s mechanism and the commit would land in the PR. Use `notes_file:`.
+- Don't set notes on a build you didn't wait for — with `wait:false` the write would land before Xcode Cloud attaches the committed file, and be overwritten.
 - Don't use this to cut a release — that's `/release`.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,10 @@ name: Deploy to TestFlight (Xcode Cloud)
 #   APP_IDENTIFIER   - App bundle identifier
 #   TESTFLIGHT_GROUP - default TestFlight group to assign builds to
 #                      (kept in secrets so the name stays out of the repo)
+#
+# The optional "notes" input overwrites the build's TestFlight "What to Test"
+# after it processes; leaving it blank keeps whatever Xcode Cloud attached from
+# the branch's committed TestFlight/WhatToTest.en-US.txt.
 
 on:
   workflow_dispatch:
@@ -25,8 +29,12 @@ on:
         description: 'TestFlight group — leave blank to use the TESTFLIGHT_GROUP secret; type "none" to trigger only'
         required: false
         default: ""
+      notes:
+        description: 'TestFlight "What to Test" — blank keeps the notes Xcode Cloud takes from TestFlight/WhatToTest.en-US.txt. Use \n for line breaks.'
+        required: false
+        default: ""
       wait:
-        description: Wait for the build to finish and assign it to the group
+        description: Wait for the build to finish, set the notes, and assign it to the group
         required: false
         default: true
         type: boolean
@@ -62,10 +70,18 @@ jobs:
           GROUP_SECRET: ${{ secrets.TESTFLIGHT_GROUP }}
           BRANCH: ${{ inputs.branch }}
           GROUP_INPUT: ${{ inputs.group }}
+          NOTES_INPUT: ${{ inputs.notes }}
           WAIT: ${{ inputs.wait }}
         run: |
           set -euo pipefail
           args=(branch:"$BRANCH" wait:"$WAIT")
+          # "What to Test" is set on the finished build via the App Store Connect
+          # API, so it needs the wait. A one-line dispatch input carries line
+          # breaks as literal \n — expand them into a file the lane reads.
+          if [ -n "$NOTES_INPUT" ]; then
+            printf '%b\n' "$NOTES_INPUT" > "$RUNNER_TEMP/what-to-test.txt"
+            args+=(notes_file:"$RUNNER_TEMP/what-to-test.txt")
+          fi
           # blank input  -> use the TESTFLIGHT_GROUP secret (auto-assign)
           # "none"       -> trigger only, assign nothing
           # any name     -> one-off override of the secret

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,7 @@
 #   1. Push your branch to origin
 #   2. Run: fastlane deploy                     (triggers the "Deploy Flipcash" Xcode Cloud workflow)
 #      or:  fastlane deploy group:'Internal'    (also waits, then assigns the build to a TestFlight group)
+#      add: notes_file:<path>                   (sets the build's TestFlight "What to Test")
 #
 # Required environment variables (set in fastlane/.env):
 #   APP_IDENTIFIER  - App bundle identifier
@@ -171,15 +172,18 @@ platform :ios do
   desc "Usage: fastlane deploy"
   desc "       fastlane deploy branch:my-feature"
   desc "       fastlane deploy group:'Internal'          # trigger, wait, then assign to a TestFlight group"
+  desc "       fastlane deploy notes_file:/tmp/what-to-test.txt   # also set the build's TestFlight 'What to Test'"
   desc "       fastlane deploy dry_run:true              # validate creds/workflow/branch + list groups, trigger nothing"
   desc "       fastlane deploy workflow:'Deploy Flipcash'"
   lane :deploy do |options|
     workflow_name = options[:workflow] || "Deploy Flipcash"
     branch = options[:branch] || current_branch
     group_name = options[:group] || ENV["TESTFLIGHT_GROUP"]
+    notes = resolve_beta_notes(options)
     dry_run = options[:dry_run].to_s == "true"
-    # Only block for the (long) Xcode Cloud build when we have a group to hand it to.
-    should_wait = options.key?(:wait) ? options[:wait].to_s == "true" : !group_name.nil?
+    # Only block for the (long) Xcode Cloud build when there's something to do with
+    # the finished build — hand it to a group, give it notes, or both.
+    should_wait = options.key?(:wait) ? options[:wait].to_s == "true" : !(group_name.nil? && notes.nil?)
 
     ensure_branch_on_origin(branch)
 
@@ -194,6 +198,7 @@ platform :ios do
       names = testflight_group_names(token)
       UI.message("TestFlight groups: #{names.empty? ? '(none)' : names.join(', ')}")
       UI.message(group_name ? "group:'#{group_name}' #{names.include?(group_name) ? '✓ matches' : "✗ NOT FOUND — pick one of the above"}" : "Pass group:'<name>' to assign the build to a TestFlight group.")
+      UI.message(notes ? "What to Test: #{notes.bytesize} bytes — would be set once the build finishes processing." : "Pass notes:'…' or notes_file:<path> to set the build's TestFlight 'What to Test'.")
       next
     end
 
@@ -202,55 +207,76 @@ platform :ios do
     UI.success("🚀 Started '#{workflow_name}' build ##{run[:number]} for #{branch}")
     UI.message("Track it in App Store Connect → Xcode Cloud → Builds.")
 
-    next unless group_name
+    next if group_name.nil? && notes.nil?
 
     unless should_wait
-      UI.important("Run `fastlane distribute group:'#{group_name}'` once build ##{run[:number]} finishes processing.")
+      pending = [group_name && "assign it to '#{group_name}'", notes && "set its 'What to Test'"].compact.join(" and ")
+      UI.important("Not waiting. Run `fastlane distribute …` once build ##{run[:number]} finishes processing to #{pending}.")
       next
     end
 
     wait_for_build_run(run[:id])
-    distribute(group: group_name)
+    distribute(group: group_name, notes: notes)
   end
 
   # ──────────────────────────────────────────────────────────────────
   # Distribute Lane (TestFlight)
   # ──────────────────────────────────────────────────────────────────
 
-  desc "Assign a processed build to a TestFlight group"
+  desc "Assign a processed build to a TestFlight group and/or set its 'What to Test'"
   desc "Usage: fastlane distribute group:'Internal'            # latest processed build"
   desc "       fastlane distribute group:'Internal' build:42   # a specific build number"
-  desc "       fastlane distribute group:'Internal' dry_run:true  # validate group + build, assign nothing"
+  desc "       fastlane distribute group:'Internal' notes_file:/tmp/what-to-test.txt"
+  desc "       fastlane distribute notes:'Tip card deep links'    # notes only, no group change"
+  desc "       fastlane distribute group:'Internal' dry_run:true  # validate group + build, change nothing"
   lane :distribute do |options|
     group_name = options[:group] || ENV["TESTFLIGHT_GROUP"]
-    UI.user_error!("Group required. Pass group:'Internal' or set TESTFLIGHT_GROUP in fastlane/.env") unless group_name
+    notes = resolve_beta_notes(options)
     dry_run = options[:dry_run].to_s == "true"
+
+    if group_name.nil? && notes.nil?
+      UI.user_error!("Nothing to do. Pass group:'Internal' (or set TESTFLIGHT_GROUP in fastlane/.env) and/or notes:'…'")
+    end
 
     Spaceship::ConnectAPI.token = asc_token
     app = Spaceship::ConnectAPI::App.find(ENV["APP_IDENTIFIER"])
     UI.user_error!("App '#{ENV['APP_IDENTIFIER']}' not found in App Store Connect") unless app
 
-    group = app.get_beta_groups(filter: { name: group_name }).find { |g| g.name == group_name }
-    UI.user_error!("No TestFlight group named '#{group_name}'") unless group
+    group = nil
+    if group_name
+      group = app.get_beta_groups(filter: { name: group_name }).find { |g| g.name == group_name }
+      UI.user_error!("No TestFlight group named '#{group_name}'") unless group
+    end
+
+    plan = [
+      group_name && "assign → '#{group_name}'",
+      notes && "set 'What to Test' (#{notes.bytesize} bytes)"
+    ].compact.join(", ")
 
     # Dry run reports against whatever's uploaded right now — it never blocks
-    # waiting for processing, and never assigns.
+    # waiting for processing, and never assigns or writes notes.
     if dry_run
       build = latest_build(app, options[:build])
       if build.nil?
-        UI.important("Group '#{group_name}' ✓ found. No matching build uploaded yet — a real run would wait for one.")
+        UI.important("Would #{plan}. No matching build uploaded yet — a real run would wait for one.")
       elsif build.processed?
-        UI.success("Dry run — nothing assigned. Would assign build #{build.version} → '#{group_name}' (processed, ready).")
+        UI.success("Dry run — nothing changed. Would take build #{build.version} and #{plan}.")
       else
-        UI.important("Group '#{group_name}' ✓ found. Build #{build.version} is still processing — a real run would wait, then assign.")
+        UI.important("Would #{plan}. Build #{build.version} is still processing — a real run would wait, then apply.")
       end
       next
     end
 
     build = wait_for_processed_build(app, options[:build])
-    build.add_beta_groups(beta_groups: [group])
 
-    UI.success("✅ Added build #{build.version} to TestFlight group '#{group_name}'")
+    # Notes before the group: adding the group is what notifies testers, and they
+    # should open a build that already carries the right "What to Test".
+    set_beta_build_notes(build, notes) if notes
+
+    if group
+      build.add_beta_groups(beta_groups: [group])
+      UI.success("✅ Added build #{build.version} to TestFlight group '#{group_name}'")
+    end
   end
 
   # ──────────────────────────────────────────────────────────────────
@@ -487,6 +513,66 @@ platform :ios do
       sleep(interval)
       waited += interval
     end
+  end
+
+  # ── TestFlight "What to Test" ────────────────────────────────────────
+
+  # Apple caps a build's "What to Test" at 4000 bytes and rejects longer ones.
+  MAX_BETA_NOTES_BYTES = 4000
+
+  # `notes:` inline, or `notes_file:` pointing at a file — the file form keeps
+  # multi-line notes out of shell quoting. Returns nil when neither is set.
+  def resolve_beta_notes(options)
+    text =
+      if options[:notes_file]
+        path = File.expand_path(options[:notes_file].to_s)
+        UI.user_error!("notes_file '#{path}' not found") unless File.exist?(path)
+        File.read(path)
+      else
+        options[:notes]
+      end
+
+    text = text.to_s.strip
+    text.empty? ? nil : text
+  end
+
+  # Sets a build's TestFlight "What to Test" through the App Store Connect API.
+  #
+  # Xcode Cloud attaches `TestFlight/WhatToTest.en-US.txt` from the commit it
+  # built, so a branch build inherits whatever notes the last release committed.
+  # Patching the build's en-US betaBuildLocalization afterwards is what gives an
+  # ad-hoc build its own notes without committing a notes file to the branch.
+  # It must run after the build has uploaded — Xcode Cloud writes the file's
+  # contents at upload time and would overwrite an earlier write.
+  def set_beta_build_notes(build, notes)
+    notes = truncate_beta_notes(notes)
+    localization = build.get_beta_build_localizations.find { |l| l.locale == "en-US" }
+
+    if localization
+      Spaceship::ConnectAPI.patch_beta_build_localizations(
+        localization_id: localization.id,
+        attributes: { whatsNew: notes }
+      )
+    else
+      Spaceship::ConnectAPI.post_beta_build_localizations(
+        build_id: build.id,
+        attributes: { whatsNew: notes, locale: "en-US" }
+      )
+    end
+
+    UI.success("📝 Set TestFlight 'What to Test' on build #{build.version}")
+  end
+
+  def truncate_beta_notes(notes)
+    return notes if notes.bytesize <= MAX_BETA_NOTES_BYTES
+
+    UI.important("'What to Test' is #{notes.bytesize} bytes, over Apple's #{MAX_BETA_NOTES_BYTES}-byte limit — truncating.")
+    truncated = +""
+    notes.each_char do |char|
+      break if truncated.bytesize + char.bytesize > MAX_BETA_NOTES_BYTES - 3
+      truncated << char
+    end
+    "#{truncated}..."
   end
 
   # Names of every TestFlight group on the app, for picking a `group:` value.


### PR DESCRIPTION
Xcode Cloud attaches `TestFlight/WhatToTest.en-US.txt` from the commit it builds, so a branch build carries whatever notes the last release committed — a baseline checklist that says nothing about the branch. `/release` works around this by committing the file on the release branch (step 8a); a feature branch cannot, because the commit would land in the PR.

So set the notes on the finished build through the App Store Connect API instead.

## Lanes

`deploy` and `distribute` both take `notes:` / `notes_file:`. The file form exists because multi-line notes through a shell argument is a quoting trap.

`distribute` no longer requires a group — group and notes are independently optional, so `fastlane distribute notes_file:<path>` rewrites the notes on a build that is already with its testers. Notes are written before the group is added, since adding the group is what notifies testers.

The write only sticks after the build uploads, or Xcode Cloud's copy wins. `notes_file:` therefore turns waiting on by itself, the same way `group:` already did; with `wait:false` the lane says which follow-up `distribute` call to run.

## Skill

`/deploy` drafts the notes the way `/release` step 8a does: diff the branch against `origin/main`, draft tester-facing bullets, then carry the **Baseline** block over from the committed `WhatToTest.en-US.txt` unchanged — both paths hand testers the same core-money-flow checklist, and reading the committed file keeps them in sync by construction.

## Workflow

`.github/workflows/deploy.yml` gains a `notes` input. The dispatch UI field is single-line, so line breaks go in as literal `\n` and the workflow expands them into a file for the lane.

## Unexercised

The `betaBuildLocalizations` write has not run against App Store Connect. It follows pilot's own `update_localized_build_review_for_lang`: patch when the en-US localization exists, POST when it does not. The first real `fastlane deploy notes_file:…` is where that gets confirmed.
