### PR TITLE
feat(username): find someone by their handle

### DIFF
--- a/Flipcash/Core/Controllers/Database/Database+Conversations.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Conversations.swift
@@ -63,7 +63,8 @@ nonisolated extension Database {
                     phoneE164: row[m.phoneE164],
                     readPointer: row[m.readPointer].map(MessageID.init(value:)),
                     readPointerTimestamp: row[m.readPointerTimestamp].map { Date(timeIntervalSinceReferenceDate: $0) },
-                    profilePicture: memberProfilePicture(from: row)
+                    profilePicture: memberProfilePicture(from: row),
+                    username: row[m.username].flatMap(Username.init)
                 )
             )
         }
@@ -319,7 +320,8 @@ nonisolated extension Database {
                     m.readPointerTimestamp  <- member.readPointerTimestamp?.timeIntervalSinceReferenceDate,
                     m.profilePictureBlobID          <- member.profilePicture?.blobID.data,
                     m.profilePictureThumbnailBlobID <- member.profilePicture?.thumbnailBlobID.data,
-                    m.profilePictureThumbnailBlurhash <- member.profilePicture?.thumbnailBlurhash
+                    m.profilePictureThumbnailBlurhash <- member.profilePicture?.thumbnailBlurhash,
+                    m.username <- member.username?.value
                 )
             )
         }

--- a/Flipcash/Core/Controllers/Database/Schema.swift
+++ b/Flipcash/Core/Controllers/Database/Schema.swift
@@ -243,6 +243,9 @@ nonisolated struct ConversationMemberTable: Sendable {
     let profilePictureThumbnailBlobID = Expression <Data?>   ("profilePictureThumbnailBlobID")
     // The thumbnail rendition's BlurHash preview, when present.
     let profilePictureThumbnailBlurhash = Expression <String?> ("profilePictureThumbnailBlurhash")
+    // The member's claimed handle, when they have one. Carried on the same
+    // profile the feed embeds, so it is cached rather than refetched.
+    let username = Expression <String?> ("username")
 }
 
 // One row per message; cash content is decomposed across the amount columns
@@ -497,6 +500,7 @@ nonisolated extension Database {
                 t.column(conversationMemberTable.profilePictureBlobID)
                 t.column(conversationMemberTable.profilePictureThumbnailBlobID)
                 t.column(conversationMemberTable.profilePictureThumbnailBlurhash)
+                t.column(conversationMemberTable.username)
             })
         }
 

--- a/Flipcash/Core/Navigation/AppRouter+Destination.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Destination.swift
@@ -72,6 +72,9 @@ extension AppRouter {
         case profilePhoto
         /// The signed-in user's own tipcard, pushed from the Tips list.
         case tipcard
+        /// Finding someone by their Flipcash handle, opened from the Chats tab.
+        /// Distinct from `.username`, which claims the signed-in user's own.
+        case usernameLookup
         /// A tip DM conversation, pushed onto the `.tips` stack — from the
         /// Tips list or a tip-DM push notification.
         case tipConversation(ConversationID)
@@ -81,6 +84,10 @@ extension AppRouter {
         /// trace shows "post-tip, keyboard up" distinctly, and so the ordinary
         /// tip-list / push-notification opens stay keyboard-closed untouched.
         case tipConversationWithKeyboard(ConversationID)
+        /// A tip DM named by its counterpart rather than its chat id — the
+        /// username lookup's destination. The chat is created by the first tip,
+        /// so before then there is no id to push; the screen derives one.
+        case tipConversationForUser(UserID)
         /// The counterpart's Flipcash profile, pushed from a tip DM's title/card; hosts the Block action.
         case userProfile(UserID)
 
@@ -97,8 +104,9 @@ extension AppRouter {
                  .settingsAdvancedBetaFeatures, .settingsAppSettings, .settingsAccountSelection,
                  .settingsApplicationLogs, .blockedUsers, .accessKey, .withdraw:
                 return .settings
-            case .profileName, .profilePhoto, .tipcard,
-                 .tipConversation, .tipConversationWithKeyboard, .userProfile:
+            case .profileName, .profilePhoto, .tipcard, .usernameLookup,
+                 .tipConversation, .tipConversationWithKeyboard, .tipConversationForUser,
+                 .userProfile:
                 return .tips
             }
         }
@@ -137,8 +145,10 @@ extension AppRouter {
             case .profileName:                  "profileName"
             case .profilePhoto:                 "profilePhoto"
             case .tipcard:                      "tipcard"
+            case .usernameLookup:               "usernameLookup"
             case .tipConversation:              "tipConversation"
             case .tipConversationWithKeyboard:  "tipConversationWithKeyboard"
+            case .tipConversationForUser:       "tipConversationForUser"
             case .userProfile:                  "userProfile"
             }
         }
@@ -160,7 +170,8 @@ extension AppRouter {
             case .tipConversation(let conversationID),
                  .tipConversationWithKeyboard(let conversationID):
                 return conversationID.description
-            case .userProfile(let userID):
+            case .userProfile(let userID),
+                 .tipConversationForUser(let userID):
                 return userID.uuidString
             case .username(let username):
                 return username?.value
@@ -170,7 +181,7 @@ extension AppRouter {
                  .settingsMyAccount, .changeDisplayName, .settingsAdvancedFeatures,
                  .settingsAdvancedBetaFeatures, .settingsAppSettings, .settingsAccountSelection,
                  .settingsApplicationLogs, .blockedUsers, .accessKey, .withdraw,
-                 .profileName, .profilePhoto, .tipcard:
+                 .profileName, .profilePhoto, .tipcard, .usernameLookup:
                 return nil
             }
         }

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -144,6 +144,9 @@ struct DestinationView: View {
         case .tipcard:
             TipcardScreen()
 
+        case .usernameLookup:
+            UsernameLookupScreen()
+
         case .tipConversation(let conversationID):
             // `.id` forces fresh view identity per conversation.
             ConversationScreen(context: .existing(conversationID))
@@ -154,6 +157,12 @@ struct DestinationView: View {
             // comes up. `.id` forces fresh view identity per conversation.
             ConversationScreen(context: .existing(conversationID), openKeyboard: true)
                 .id(conversationID)
+
+        case .tipConversationForUser(let userID):
+            // Opened before the chat exists, so the screen is given the person
+            // and derives the chat id itself. `.id` forces fresh view identity.
+            ConversationScreen(context: .tipDM(counterpart: userID))
+                .id(userID)
 
         case .userProfile(let userID):
             UserProfileScreen(userID: userID)

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -57,7 +57,11 @@ struct ConversationBottomBar: View {
                     symbol: symbol,
                     composing: model.isComposing,
                     standalone: !chatExists,
-                    alwaysMinimized: isTipDm,
+                    // A tip chat sits minimized beside its composer, but before
+                    // the first tip there is no composer to sit beside: the
+                    // design draws the full-width "Send a Tip" (node 9443:8928).
+                    alwaysMinimized: isTipDm && chatExists,
+                    expandedTitle: isTipDm ? "Send a Tip" : nil,
                     action: onSendCash
                 )
             }
@@ -196,6 +200,9 @@ struct SendCashMorphButton: View {
     /// Forces the compact symbol-only presentation regardless of composing.
     /// Tip chats always show it minimized; ordinary chats expand at rest.
     var alwaysMinimized: Bool = false
+    /// Replaces "Send <symbol>" while expanded. A tip chat names the tip
+    /// instead of the currency, because the amount is chosen on the next screen.
+    var expandedTitle: String?
     let action: () -> Void
 
     /// The compact glass "€" presentation: while composing, or always in a tip
@@ -214,15 +221,19 @@ struct SendCashMorphButton: View {
         Button(action: action) {
             HStack(spacing: 4) {
                 if !minimized {
-                    Text("Send")
+                    Text(expandedTitle ?? "Send")
                         .font(.appTextMedium)
                         .transition(.opacity)
                 }
-                Text(symbol)
-                    // Same persistent Text — .interpolate animates the glyph
-                    // between sizes; swapping views would crossfade.
-                    .font(minimized ? .appTextXL : .appTextMedium)
-                    .contentTransition(.interpolate)
+                // Suppressed while a custom title is showing: "Send a Tip $"
+                // isn't a label. It returns when the button minimizes.
+                if minimized || expandedTitle == nil {
+                    Text(symbol)
+                        // Same persistent Text — .interpolate animates the glyph
+                        // between sizes; swapping views would crossfade.
+                        .font(minimized ? .appTextXL : .appTextMedium)
+                        .contentTransition(.interpolate)
+                }
             }
             .foregroundStyle(minimized ? Color.textMain : Color.textAction)
             // The label must never reflow to "Se…" mid-morph; overflow is
@@ -243,7 +254,7 @@ struct SendCashMorphButton: View {
         }
         .glassBackground(cornerRadius: cornerRadius)
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-        .accessibilityLabel("Send Cash")
+        .accessibilityLabel(expandedTitle ?? "Send Cash")
         .accessibilityIdentifier("send-cash-button")
     }
 }

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -16,9 +16,14 @@ import FlipcashUI
 private let logger = Logger(label: "flipcash.conversation")
 
 /// How a conversation is reached: an existing DM chat (only tip DMs are
-/// surfaced now — contact/phone DMs were retired with the Send tab).
+/// surfaced now — contact/phone DMs were retired with the Send tab), or a tip
+/// DM named by its counterpart before the chat exists server-side.
 nonisolated enum ConversationContext: Hashable {
     case existing(ConversationID)
+    /// A tip DM opened from the username lookup. The chat is created by the
+    /// first tip, so until then there is no record to reach it by — only the
+    /// counterpart, whose id derives the chat's own id locally.
+    case tipDM(counterpart: UserID)
 
     /// Resolves the counterpart's synced contact from the directory — the one
     /// rule the nav title, transcript profile card, and profile page share.
@@ -26,6 +31,9 @@ nonisolated enum ConversationContext: Hashable {
         switch self {
         case .existing(let conversationID):
             directory.first { $0.dmChatID == conversationID.data }
+        case .tipDM:
+            // A tip DM's counterpart is known by profile, never by address book.
+            nil
         }
     }
 }
@@ -75,15 +83,31 @@ struct ConversationScreen: View {
         switch context {
         case .existing(let conversationID):
             return conversationID
+        case .tipDM(let counterpart):
+            // The same derivation the server uses, so the id is known before
+            // the chat is — and matches the one the first tip creates.
+            return .tipDm(between: conversationController.selfUserID, and: counterpart)
         }
     }
 
-    /// The tip DM counterpart, when this conversation is a tip DM.
+    /// The counterpart this screen was opened for, when it was opened by
+    /// person rather than by chat.
+    private var counterpartUserID: UserID? {
+        switch context {
+        case .existing: nil
+        case .tipDM(let counterpart): counterpart
+        }
+    }
+
+    /// The tip DM counterpart, when this conversation is a tip DM. Falls back
+    /// to the cached profile before the first tip creates the chat.
     private var tipCounterpart: ConversationMember? {
-        guard let conversationID,
-              let conversation = conversationController.conversation(withID: conversationID),
-              conversation.type == .tipDm else { return nil }
-        return conversation.counterpart(excluding: conversationController.selfUserID)
+        if let conversationID,
+           let conversation = conversationController.conversation(withID: conversationID),
+           conversation.type == .tipDm {
+            return conversation.counterpart(excluding: conversationController.selfUserID)
+        }
+        return Self.cachedCounterpart(counterpartUserID, session: session)
     }
 
     /// Who Send Cash pays: the tip counterpart in a tip DM, the synced
@@ -95,17 +119,35 @@ struct ConversationScreen: View {
             return .contact(contact)
         }
         guard let conversationID else { return nil }
-        return SendTarget(
+        if let target = SendTarget(
             conversation: conversationController.conversation(withID: conversationID),
             dmChatID: conversationID.data,
             selfUserID: conversationController.selfUserID
-        )
+        ) {
+            return target
+        }
+        // No conversation record to read the counterpart from yet, so the
+        // cached profile is what the tip is addressed to.
+        guard let member = tipCounterpart, let userID = member.userID else { return nil }
+        return .tip(TipRecipient(
+            userID: userID,
+            displayName: member.displayName,
+            username: member.username,
+            origin: .chat
+        ))
     }
 
-    /// Whether the conversation resolves to a server-side chat id. A tip DM
-    /// always carries one once resolved.
+    /// Whether a chat exists to hold a transcript. An `existing` conversation
+    /// was reached by its chat id, so it does by construction; a tip DM opened
+    /// by counterpart does not until the first tip creates it server-side.
     private var chatExists: Bool {
-        conversationID != nil
+        guard let conversationID else { return false }
+        switch context {
+        case .existing:
+            return true
+        case .tipDM:
+            return conversationController.conversation(withID: conversationID) != nil
+        }
     }
 
     /// For a tip DM, all counterpart taps open the profile screen — even when
@@ -134,6 +176,11 @@ struct ConversationScreen: View {
     }
 
     private var title: String {
+        // Without a chat there is no conversation record to name, so the
+        // counterpart's cached profile is the only source for the title.
+        if !chatExists, let name = tipCounterpart?.displayName {
+            return name
+        }
         if let conversationID {
             return conversationController.displayName(forConversationID: conversationID)
         }
@@ -153,7 +200,9 @@ struct ConversationScreen: View {
         // no SwiftUI `.safeAreaInset` bar here.
         ChatScreenRepresentable(
             items: coordinator?.items ?? [],
-            onReachTop: { coordinator?.reachedTop() },
+            // Paging history for a chat the server hasn't created yet fetches
+            // against an id it doesn't know and error-reports.
+            onReachTop: { if chatExists { coordinator?.reachedTop() } },
             onRetry: retry,
             onCashCardTap: openCurrencyInfo,
             onOpenURL: openLink,
@@ -365,17 +414,49 @@ struct ConversationScreen: View {
                 session: session,
                 // `tipAvatars` is captured directly so the coordinator retains
                 // one small store, not the whole session container.
-                profileCard: { [context, contactSyncController, conversationController, tipAvatars = sessionContainer.tipAvatars] in
+                profileCard: { [context, contactSyncController, conversationController, session, counterpartUserID, tipAvatars = sessionContainer.tipAvatars] in
                     Self.profileCard(
                         context: context,
                         conversationID: id,
                         directory: contactSyncController.resolvedContacts.onFlipcash,
                         controller: conversationController,
-                        tipAvatars: tipAvatars
+                        tipAvatars: tipAvatars,
+                        // Resolved inside the closure, not captured: the card
+                        // must pick up the conversation the first tip creates.
+                        fallbackCounterpart: Self.cachedCounterpart(counterpartUserID, session: session)
                     )
                 }
             )
         }
+    }
+
+    /// The card relationship for a tip DM. A tip DM has no address-book
+    /// relationship to fall back on, so a counterpart who hasn't claimed a
+    /// handle keeps the name-only card they had before handles existed.
+    static func tipDMCounterpart(_ member: ConversationMember?) -> ChatProfileCard.Counterpart {
+        guard let username = member?.username else { return .none }
+        return .handle(username)
+    }
+
+    /// The counterpart of a tip DM that has no chat yet, built from a fetched
+    /// profile. Gives the title, card, and Send Cash target the same member
+    /// shape a synced conversation would supply.
+    static func counterpart(userID: UserID, profile: Profile) -> ConversationMember {
+        ConversationMember(
+            userID: userID,
+            // A name-less account can still be tipped, and the chat has to be
+            // titled either way — the same fallback a conversation gets.
+            displayName: profile.displayName ?? ConversationController.fallbackCounterpartName,
+            profilePicture: profile.profilePicture,
+            username: profile.username
+        )
+    }
+
+    /// ``counterpart(userID:profile:)`` against the profile cache the username
+    /// lookup writes on its way here.
+    private static func cachedCounterpart(_ userID: UserID?, session: Session) -> ConversationMember? {
+        guard let userID, let profile = session.cachedUserProfile(for: userID) else { return nil }
+        return counterpart(userID: userID, profile: profile)
     }
 
     /// The transcript's profile card for the counterpart, resolved live from the directory the
@@ -387,7 +468,8 @@ struct ConversationScreen: View {
         conversationID: ConversationID,
         directory: [ResolvedContact],
         controller: ConversationController,
-        tipAvatars: TipAvatarStore
+        tipAvatars: TipAvatarStore,
+        fallbackCounterpart: ConversationMember? = nil
     ) -> ChatProfileCard {
         if let conversation = controller.conversation(withID: conversationID),
            conversation.type == .tipDm {
@@ -397,7 +479,17 @@ struct ConversationScreen: View {
                 avatarID: counterpart?.userID?.uuidString ?? conversationID.description,
                 imageData: tipAvatars.data(for: counterpart?.userID),
                 blurhash: counterpart?.profilePicture?.thumbnailBlurhash,
-                counterpart: .none
+                counterpart: Self.tipDMCounterpart(counterpart)
+            )
+        }
+        // No conversation record yet — the same card, from the cached profile.
+        if let counterpart = fallbackCounterpart {
+            return ChatProfileCard(
+                name: counterpart.displayName,
+                avatarID: counterpart.userID?.uuidString ?? conversationID.description,
+                imageData: tipAvatars.data(for: counterpart.userID),
+                blurhash: counterpart.profilePicture?.thumbnailBlurhash,
+                counterpart: Self.tipDMCounterpart(counterpart)
             )
         }
         if let contact = context.resolvedContact(in: directory) {

--- a/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
@@ -82,7 +82,7 @@ private struct NoChatsView: View {
                 .foregroundStyle(Color.textMain)
                 .multilineTextAlignment(.center)
 
-            Text("Send a tip or share your Tip Card to start chatting")
+            Text("Start a new chat, or share your profile")
                 .font(.appTextSmall)
                 .foregroundStyle(Color.textSecondary)
                 .multilineTextAlignment(.center)

--- a/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipFlow.swift
@@ -168,10 +168,22 @@ final class TipFlow {
     // MARK: - Recipient -
 
     /// Thrown when a handle resolved to a profile the server didn't stamp with
-    /// a user id — a tip has nobody to pay without one.
-    private struct UnidentifiedRecipient: Error {}
+    /// a user id — a tip has nobody to pay without one. `fetchProfile` answers
+    /// an unclaimed handle with `Profile.empty` rather than throwing, so this
+    /// is the shape that case arrives in.
+    private struct UnidentifiedRecipient: ServerError {
+        var reportingLevel: ErrorReportingLevel { .info }
+    }
 
     private func prepare(_ identifier: ProfileIdentifier) {
+        // Whether the link named a handle rather than an id decides both the
+        // retry policy below and which copy a failure gets.
+        let handle: Username?
+        switch identifier {
+        case .userID:                 handle = nil
+        case .username(let username): handle = username
+        }
+
         prepTask = Task {
             defer { prepTask = nil }
             do {
@@ -187,7 +199,14 @@ final class TipFlow {
                     maxAttempts: 3,
                     delay: .milliseconds(500),
                     shouldRetry: { error in
-                        if let error = error as? ErrorResolve { return error == .notFound || error.isRetryable }
+                        if let error = error as? ErrorResolve {
+                            // `.notFound` is retried for an id only: there it means a
+                            // just-made-tippable recipient whose destination hasn't
+                            // propagated yet. For a handle it is the settled answer,
+                            // so retrying only spends the backoff before saying so.
+                            if error == .notFound { return handle == nil }
+                            return error.isRetryable
+                        }
                         if let error = error as? ErrorFetchProfile { return error.isRetryable }
                         return false
                     }
@@ -240,11 +259,44 @@ final class TipFlow {
                     "error": "\(error)",
                 ])
                 ErrorReporting.captureError(error, reason: "Failed to prepare tip recipient")
-                session.dialogItem = .error(
-                    title: "Tipcard Not Available",
-                    subtitle: "This tipcard can't receive tips right now. Please try again."
-                )
+                session.dialogItem = Self.failureDialog(for: error, handle: handle)
             }
+        }
+    }
+
+    /// The dialog a failed resolve earns.
+    ///
+    /// An id comes off a code the camera just read, so a miss there is a fetch
+    /// that didn't land. A handle is the opposite: it is typed, printed on
+    /// merch, or pasted out of a bio, and it goes stale the moment its owner
+    /// changes it. An unclaimed one is therefore a fact about the link rather
+    /// than a fault in the app — informational, and specific about whose handle
+    /// went nowhere. Only the network case is ours to apologise for.
+    ///
+    /// Copy is shared with Android, which splits the same two cases.
+    static func failureDialog(for error: Error, handle: Username?) -> DialogItem {
+        if let handle, isUnclaimed(error) {
+            return .info(
+                title: "No Such Account",
+                subtitle: "Nobody has claimed @\(handle.value)"
+            )
+        }
+
+        return .error(
+            title: "Couldn't Open Tip Card",
+            subtitle: "Please check your connection and try again"
+        )
+    }
+
+    /// Whether `error` means the handle belongs to nobody. Both halves of the
+    /// resolve can say so: `resolve` throws `.notFound`, while `fetchProfile`
+    /// returns an id-less `Profile.empty` that becomes `UnidentifiedRecipient`.
+    private static func isUnclaimed(_ error: Error) -> Bool {
+        switch error {
+        case is UnidentifiedRecipient:      true
+        case let error as ErrorResolve:     error == .notFound
+        case let error as ErrorFetchProfile: error == .notFound
+        default:                            false
         }
     }
 

--- a/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
@@ -36,16 +36,44 @@ struct TipsScreen: View {
 // MARK: - Chats title -
 
 /// The v2 large, flush start-aligned "Chats" tab title (Android parity —
-/// `screenTitleLarge` / `appTitleLarge`).
+/// `screenTitleLarge` / `appTitleLarge`), with the new-chat button beside it.
 struct ChatsTabTitle: View {
+
+    @Environment(AppRouter.self) private var router
+
     var body: some View {
-        Text("Chats")
-            .font(.appTitleLarge)
-            .foregroundStyle(Color.textMain)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 20)
-            .padding(.top, 8)
-            .padding(.bottom, 12)
+        HStack(spacing: 0) {
+            Text("Chats")
+                .font(.appTitleLarge)
+                .foregroundStyle(Color.textMain)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button {
+                router.push(.usernameLookup)
+            } label: {
+                // The design draws a 44pt circle (node 9443:8560). On iOS 26
+                // `.buttonStyle(.glass)` pads outside the label, so the label
+                // is 32 and the glass reaches 44; the fallback style draws the
+                // circle at the label's own bounds, so there it is 44 already.
+                if #available(iOS 26, *) {
+                    Image.system(.plus)
+                        .font(.appTextLarge)
+                        .foregroundStyle(Color.textMain)
+                        .frame(width: 32, height: 32)
+                } else {
+                    Image.system(.plus)
+                        .font(.appTextLarge)
+                        .foregroundStyle(Color.textMain)
+                        .frame(width: 44, height: 44)
+                }
+            }
+            .liquidGlassButtonStyle(shape: .circle)
+            .accessibilityLabel("New chat")
+            .accessibilityIdentifier("new-chat-button")
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 8)
+        .padding(.bottom, 12)
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Username/DialogItem+Username.swift
+++ b/Flipcash/Core/Screens/Main/Username/DialogItem+Username.swift
@@ -109,4 +109,40 @@ extension DialogItem {
             return generic
         }
     }
+
+    /// The lookup screen's miss (node 9442:103386). Informational for the same
+    /// reason the claim screen's rejections are: nobody has claimed this handle
+    /// is an answer, not a fault, and the user fixes it by typing something else.
+    ///
+    /// Deliberately different copy from the tip card's `No Such Account` /
+    /// `Nobody has claimed @x`. That one is reached by following someone's link,
+    /// where naming the handle back is what explains the dead end; here the
+    /// handle is still in the field the user is looking at.
+    static var usernameNotFound: DialogItem {
+        .info(title: "Username Not Found", subtitle: "Please try a different username")
+    }
+
+    /// A lookup that never got an answer. Keeps the red banner and the apology,
+    /// because unlike a miss this one is worth retrying.
+    static var usernameLookupFailure: DialogItem {
+        .error(
+            title: "Couldn't Look Up Username",
+            subtitle: "Please check your connection and try again"
+        )
+    }
+
+    /// Which of the two a thrown lookup gets. `ProfileService` turns the
+    /// server's own `notFound` into `Profile.empty` rather than a throw, so the
+    /// caller detects a miss from the result and this mapper mostly answers
+    /// with the failure. It maps `.notFound` anyway, because the alternative if
+    /// that ever changes is telling the user their connection is broken.
+    static func usernameLookup(for error: Error) -> DialogItem {
+        guard let error = error as? ErrorFetchProfile else { return .usernameLookupFailure }
+        switch error {
+        case .notFound:
+            return .usernameNotFound
+        case .ok, .unknown, .transportFailure, .cancelled, .rejected:
+            return .usernameLookupFailure
+        }
+    }
 }

--- a/Flipcash/Core/Screens/Main/Username/UsernameLookupScreen.swift
+++ b/Flipcash/Core/Screens/Main/Username/UsernameLookupScreen.swift
@@ -1,0 +1,197 @@
+//
+//  UsernameLookupScreen.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+private let logger = Logger(label: "flipcash.username-lookup")
+
+/// Finding someone by their handle (Figma node 9491:6298). Sibling of
+/// `UsernameEntryScreen`: same one field and one button, opposite direction —
+/// that screen claims a handle, this one spends someone else's.
+///
+/// It resolves the handle itself rather than handing it to `TipFlow`, so a miss
+/// lands here with the typed handle still in the field. Handing it over would
+/// pop this screen first and report the miss over whatever replaced it, in copy
+/// written for a followed tipcard link.
+///
+/// A hit shows the button's success checkmark, holds it, then pushes the chat
+/// with that person (node 9443:8928), where the tip is composed — not the
+/// tipcard overlay `TipFlow` raises for a scanned code. The beat is the one the
+/// verification screens use (`PhoneVerificationViewModel.swift:320-329`), and so
+/// is the push.
+///
+/// This screen then drops out from under the chat, since a chat's Back belongs
+/// on the chat list. It goes while the push is still animating: the removal is a
+/// whole-path rewrite, which remounts the chat, and a freshly-mounted chat
+/// settles its layout a beat after it appears. Under the transition that settle
+/// is hidden — the same way it is on every other push into a chat.
+struct UsernameLookupScreen: View {
+
+    @Environment(Container.self) private var container
+    @Environment(SessionContainer.self) private var sessionContainer
+    @Environment(Session.self) private var session
+    @Environment(AppRouter.self) private var router
+
+    private static let validator = UsernameValidator()
+
+    @FocusState private var isFocused: Bool
+    @State private var input: String = ""
+    @State private var lookupTask: Task<Void, Never>?
+    @State private var buttonState: ButtonState = .normal
+    @State private var errorDialog: DialogItem?
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Enter Flipcash username")
+                    .font(.appTextLarge)
+                    .foregroundStyle(Color.textMain)
+                    .padding(.top, 20)
+
+                TextField("Username", text: $input)
+                    .font(.appDisplayMedium)
+                    .foregroundStyle(Color.textMain)
+                    .focused($isFocused)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(.next)
+                    .onSubmit(submit)
+                    // Handles are stored lowercase, so an uppercase keystroke is
+                    // a handle the server can never match. Same treatment as the
+                    // claim screen, for the same reason.
+                    .onChange(of: input) { _, latest in
+                        let lowered = latest.lowercased()
+                        if lowered != latest { input = lowered }
+                    }
+                    .padding(.top, 32)
+                    .disabled(!buttonState.isNormal)
+                    .accessibilityIdentifier("username-lookup-field")
+
+                Text("Enter the Flipcash username of the person you want to chat with")
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textSecondary)
+                    .padding(.top, 8)
+
+                Spacer()
+
+                Button(action: submit) {
+                    ButtonStateLabel("Next", state: buttonState)
+                }
+                .buttonStyle(.filled)
+                // Disabled for every state but `.normal`: that dims the pill
+                // behind the spinner and the checkmark, and stops a second tap.
+                .disabled(input.isEmpty || !buttonState.isNormal)
+                .accessibilityIdentifier("username-lookup-next-button")
+                .padding(.bottom, 20)
+            }
+            .padding(.horizontal, 20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .dialog(item: $errorDialog)
+        .onAppear { isFocused = true }
+        // Backing out abandons the lookup rather than pushing a chat onto a
+        // stack the user has left. Fires on the hand-off too, once the chat
+        // covers this screen, which is why the hand-off detaches itself first.
+        .onDisappear { lookupTask?.cancel() }
+    }
+
+    private func submit() {
+        guard buttonState.isNormal else { return }
+
+        // Unlike the claim screen, a malformed handle isn't told which rule it
+        // broke: the designer drew one dialog for this screen, and a handle that
+        // cannot exist is a handle nobody has claimed.
+        guard let username = Self.validator.validate(input) else {
+            errorDialog = .usernameNotFound
+            return
+        }
+
+        buttonState = .loading
+        lookupTask = Task {
+            defer {
+                lookupTask = nil
+                buttonState = .normal
+            }
+
+            do {
+                let profile = try await container.flipClient.fetchProfile(
+                    username: username,
+                    owner: session.ownerKeyPair
+                )
+                guard !Task.isCancelled else { return }
+
+                // An unclaimed handle answers with `Profile.empty` rather than
+                // throwing (`ProfileService.swift:47-49`), so the miss is an
+                // absent id here, not an error in the catch below.
+                guard let userID = profile.userID else {
+                    logger.info("Username not found", metadata: ["username": "\(username)"])
+                    errorDialog = .usernameNotFound
+                    return
+                }
+
+                logger.info("Username resolved", metadata: ["username": "\(username)"])
+
+                try await Task.delay(milliseconds: 500)
+                buttonState = .success
+                try await Task.delay(milliseconds: 500)
+
+                // Your own handle has no chat to open — one tipcard is what
+                // scanning your own code already shows.
+                guard userID != session.userID else {
+                    sessionContainer.tipFlow.begin(userID: userID)
+                    return
+                }
+
+                // The chat is created by the first tip, so until then the
+                // screen's only source for the counterpart's name, picture, and
+                // handle is the profile this lookup just fetched.
+                session.cacheUserProfile(profile, for: userID)
+
+                // Detached before the push: covering this screen fires the
+                // `onDisappear` cancel, and what follows the push is cleanup
+                // that has to run anyway.
+                lookupTask = nil
+
+                let chat = AppRouter.Destination.tipConversationForUser(userID)
+                router.push(chat)
+
+                // Well inside the push transition, so the remounted chat settles
+                // behind the animation rather than in front of the user. Late
+                // enough that SwiftUI has committed the push as its own update:
+                // rewriting in the same tick coalesces the two into a leaf swap,
+                // which it draws as a cut.
+                try await Task.delay(milliseconds: 150)
+
+                // Unless they went back while it landed: the lookup left with
+                // them, and rewriting the path would drag the chat back.
+                guard router[.tips].count == 2 else { return }
+
+                // Unanimated, because nothing is arriving — only the entry
+                // underneath is leaving. Animated, SwiftUI stages the remount as
+                // a second push: the same chat sliding in over the one already
+                // on screen.
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    router.setPath([chat], on: .tips)
+                }
+
+            } catch {
+                guard !Task.isCancelled else { return }
+                logger.error("Failed to look up username", metadata: ["error": "\(error)"])
+
+                // Captured unconditionally: `ErrorFetchProfile.reportingLevel`
+                // already files `.notFound` as `.info` and a transport failure as
+                // `.suppressed`, so gating here would duplicate that judgement.
+                ErrorReporting.captureError(error, reason: "Failed to look up username")
+
+                errorDialog = .usernameLookup(for: error)
+            }
+        }
+    }
+}

--- a/Flipcash/Supporting Files/Info.plist
+++ b/Flipcash/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 		<string>com.flipcash.app.openChat</string>
 	</array>
 	<key>SQLiteVersion</key>
-	<integer>33</integer>
+	<integer>34</integer>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatProfileCard.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatProfileCard.swift
@@ -21,12 +21,16 @@ public struct ChatProfileCard: Hashable, Sendable, Codable {
     public var blurhash: String?
     public var counterpart: Counterpart
 
-    /// How the counterpart relates to the address book.
+    /// What the card's subtitle line says about the counterpart, and whether it
+    /// offers a contact action.
     public enum Counterpart: Hashable, Sendable, Codable {
         /// In the address book: the subtitle is their number and the CTA views their contact card.
         case contact(phone: String)
         /// Not in the address book: an "Unknown Contact" subtitle and a CTA that adds them.
         case unknown
+        /// Known by their Flipcash handle: the subtitle is `@handle` and there is no
+        /// contact CTA — the address book has nothing to say about them.
+        case handle(Username)
         /// No address-book relationship to surface (e.g. a tip DM counterpart known by
         /// profile only): just the avatar and name, no subtitle and no contact CTA.
         case none

--- a/FlipcashTests/ChatProfileCardCounterpartTests.swift
+++ b/FlipcashTests/ChatProfileCardCounterpartTests.swift
@@ -1,0 +1,37 @@
+//
+//  ChatProfileCardCounterpartTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Tip DM profile card counterpart")
+struct ChatProfileCardCounterpartTests {
+
+    @Test("A counterpart who has claimed a handle shows it")
+    func claimedHandle_isShown() {
+        let member = ConversationMember(
+            userID: UUID(),
+            displayName: "Fred Wilson",
+            username: Username("fred_wilson")
+        )
+        #expect(ConversationScreen.tipDMCounterpart(member) == .handle(Username("fred_wilson")!))
+    }
+
+    @Test("A counterpart with no handle renders as it did before handles existed")
+    func unclaimedHandle_fallsBackToNone() {
+        // A handle can also go away across a profile refresh, and the card has
+        // to survive that rather than show an empty line.
+        let member = ConversationMember(userID: UUID(), displayName: "Fred Wilson")
+        #expect(ConversationScreen.tipDMCounterpart(member) == ChatProfileCard.Counterpart.none)
+    }
+
+    @Test("A conversation with no counterpart at all renders the same way")
+    func missingMember_fallsBackToNone() {
+        #expect(ConversationScreen.tipDMCounterpart(nil) == ChatProfileCard.Counterpart.none)
+    }
+}

--- a/FlipcashTests/Database/Database+ConversationsTests.swift
+++ b/FlipcashTests/Database/Database+ConversationsTests.swift
@@ -650,6 +650,30 @@ struct DatabaseConversationsTests {
         #expect(remaining.first?.members.map(\.displayName) == ["Fred"])
     }
 
+    @Test("A member's handle round-trips, and an unclaimed member stays nil")
+    func roundTripPreservesMemberUsername() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let claimed = UUID()
+        let unclaimed = UUID()
+        let tip = Conversation(
+            id: ConversationID.test(1),
+            members: [
+                ConversationMember(userID: claimed, displayName: "Fred", username: Username("fred_wilson")),
+                ConversationMember(userID: unclaimed, displayName: "Anna"),
+            ],
+            lastMessage: nil,
+            lastActivity: Date(timeIntervalSince1970: 100),
+            type: .tipDm
+        )
+
+        try database.upsertConversation(tip)
+        let restored = try #require(try database.getConversations().first)
+
+        #expect(restored.members.first(where: { $0.userID == claimed })?.username == Username("fred_wilson"))
+        #expect(restored.members.first(where: { $0.userID == unclaimed })?.username == nil)
+    }
+
     @Test("The crossed window is the half-open interval (after, through]")
     func crossedWindowIsHalfOpen() throws {
         let (database, url) = try Database.makeTemp()

--- a/FlipcashTests/TipFlowFailureDialogTests.swift
+++ b/FlipcashTests/TipFlowFailureDialogTests.swift
@@ -1,0 +1,50 @@
+//
+//  TipFlowFailureDialogTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+import FlipcashUI
+@testable import Flipcash
+
+@MainActor
+@Suite("Tip resolve failure copy")
+struct TipFlowFailureDialogTests {
+
+    private let handle = Username("taylor")!
+
+    @Test("An unclaimed handle is informational and names the handle")
+    func unclaimedHandle_infoNamingTheHandle() {
+        let item = TipFlow.failureDialog(for: ErrorResolve.notFound, handle: handle)
+        #expect(item.style == .standard)
+        #expect(item.title == "No Such Account")
+        #expect(item.subtitle == "Nobody has claimed @taylor")
+    }
+
+    @Test("A profile the server didn't stamp with an id reads the same as a miss")
+    func idlessProfile_readsAsUnclaimed() {
+        // `fetchProfile` answers an unclaimed handle with `Profile.empty`, so the
+        // flow's own error stands in for the server's `.notFound` on that half.
+        let item = TipFlow.failureDialog(for: ErrorFetchProfile.notFound, handle: handle)
+        #expect(item.title == "No Such Account")
+    }
+
+    @Test("A network failure on a handle apologises instead of blaming the link")
+    func transportFailure_genericError() {
+        let item = TipFlow.failureDialog(for: ErrorResolve.transportFailure, handle: handle)
+        #expect(item.style == .destructive)
+        #expect(item.title == "Couldn't Open Tip Card")
+        #expect(item.subtitle == "Please check your connection and try again")
+    }
+
+    @Test("A scanned code never claims nobody holds it")
+    func scannedCode_neverSaysUnclaimed() {
+        // There is no handle to name, and a miss on an id is a fetch that didn't
+        // land rather than a wrong address.
+        let item = TipFlow.failureDialog(for: ErrorResolve.notFound, handle: nil)
+        #expect(item.style == .destructive)
+        #expect(item.title == "Couldn't Open Tip Card")
+    }
+}

--- a/FlipcashTests/UsernameLookupDialogTests.swift
+++ b/FlipcashTests/UsernameLookupDialogTests.swift
@@ -1,0 +1,53 @@
+//
+//  UsernameLookupDialogTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+import FlipcashUI
+@testable import Flipcash
+
+@MainActor
+@Suite("Username lookup dialogs")
+struct UsernameLookupDialogTests {
+
+    @Test("A handle nobody has claimed is informational, not an error")
+    func notFound_isInformational() {
+        let item = DialogItem.usernameNotFound
+        #expect(item.style == .standard)
+        #expect(item.title == "Username Not Found")
+        #expect(item.subtitle == "Please try a different username")
+    }
+
+    @Test("The not-found dialog offers a single OK")
+    func notFound_singleAction() {
+        let item = DialogItem.usernameNotFound
+        #expect(item.actions.count == 1)
+        #expect(item.actions[0].title == "OK")
+    }
+
+    @Test("A thrown notFound still lands on the not-found copy")
+    func thrownNotFound_readsAsNotFound() {
+        let item = DialogItem.usernameLookup(for: ErrorFetchProfile.notFound)
+        #expect(item.style == .standard)
+        #expect(item.title == "Username Not Found")
+    }
+
+    @Test("A fetch that didn't land apologises instead of claiming the handle is free")
+    func transportFailure_apologises() {
+        let item = DialogItem.usernameLookup(for: ErrorFetchProfile.transportFailure)
+        #expect(item.style == .destructive)
+        #expect(item.title == "Couldn't Look Up Username")
+        #expect(item.subtitle == "Please check your connection and try again")
+    }
+
+    @Test("An error the screen doesn't model apologises rather than misreporting a miss")
+    func unknownError_apologises() {
+        struct Boom: Error {}
+        let item = DialogItem.usernameLookup(for: Boom())
+        #expect(item.style == .destructive)
+        #expect(item.title == "Couldn't Look Up Username")
+    }
+}

--- a/FlipcashTests/UsernameLookupRoutingTests.swift
+++ b/FlipcashTests/UsernameLookupRoutingTests.swift
@@ -1,0 +1,115 @@
+//
+//  UsernameLookupRoutingTests.swift
+//  FlipcashTests
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+/// The username lookup opens the counterpart's chat (node 9443:8928), which
+/// does not exist server-side until the first tip. These cover what the screen
+/// has to resolve from the fetched profile alone in the meantime.
+@MainActor
+@Suite("Username lookup routing")
+struct UsernameLookupRoutingTests {
+
+    private static func profile(displayName: String?, username: String? = nil) -> Profile {
+        Profile(
+            displayName: displayName,
+            phone: Optional<Phone>.none,
+            email: nil,
+            username: username.flatMap { Username($0) }
+        )
+    }
+
+    // MARK: - Destination -
+
+    @Test("The chat destination belongs to the tips stack")
+    func destination_ownedByTipsStack() {
+        #expect(AppRouter.Destination.tipConversationForUser(UUID()).owningStack == .tips)
+    }
+
+    @Test("The chat destination logs the counterpart as its payload")
+    func destination_payloadIsCounterpart() {
+        let userID = UUID()
+        let destination = AppRouter.Destination.tipConversationForUser(userID)
+        #expect(destination.description == "tipConversationForUser")
+        #expect(destination.payload == userID.uuidString)
+    }
+
+    @Test("Two lookups of the same person are the same destination")
+    func destination_isStablePerCounterpart() {
+        let userID = UUID()
+        #expect(
+            AppRouter.Destination.tipConversationForUser(userID)
+                == AppRouter.Destination.tipConversationForUser(userID)
+        )
+    }
+
+    // MARK: - Context -
+
+    @Test("The chat id is the one the server derives for the pair")
+    func context_derivesTheTipDmChatID() {
+        // The screen derives it locally so the chat can be opened before it
+        // exists; the first tip must land in that same chat.
+        let (me, them) = (UUID(), UUID())
+        #expect(ConversationID.tipDm(between: me, and: them) == .tipDm(between: them, and: me))
+    }
+
+    @Test("A tip DM counterpart is never matched to an address-book contact")
+    func context_neverResolvesAContact() {
+        // Tip DMs identify people by profile. A directory entry that happens to
+        // carry the derived chat id must not retitle the screen or redirect the
+        // send to a phone number.
+        let (me, them) = (UUID(), UUID())
+        let chatID = ConversationID.tipDm(between: me, and: them)
+        let contact = ResolvedContact(
+            contactId: "abc",
+            displayName: "Fred From My Phone",
+            phoneE164: "+15551234567",
+            nationalPhone: "(555) 123-4567",
+            imageData: nil,
+            dmChatID: chatID.data
+        )
+        let context = ConversationContext.tipDM(counterpart: them)
+        #expect(context.resolvedContact(in: [contact]) == nil)
+        // The same directory does resolve for a chat reached by its id.
+        #expect(ConversationContext.existing(chatID).resolvedContact(in: [contact]) != nil)
+    }
+
+    // MARK: - Counterpart -
+
+    @Test("The fetched profile supplies the name and handle the chat shows")
+    func counterpart_carriesNameAndHandle() {
+        let userID = UUID()
+        let member = ConversationScreen.counterpart(
+            userID: userID,
+            profile: Self.profile(displayName: "Fred Wilson", username: "fred_wilson")
+        )
+        #expect(member.userID == userID)
+        #expect(member.displayName == "Fred Wilson")
+        #expect(member.username == Username("fred_wilson"))
+    }
+
+    @Test("A name-less account still titles the chat")
+    func counterpart_fallsBackForANamelessAccount() {
+        // Claiming a handle doesn't require a display name, so this is a real
+        // account, not a malformed response — the chat needs a title regardless.
+        let member = ConversationScreen.counterpart(
+            userID: UUID(),
+            profile: Self.profile(displayName: nil, username: "fred_wilson")
+        )
+        #expect(member.displayName == ConversationController.fallbackCounterpartName)
+    }
+
+    @Test("A counterpart with no handle renders the name-only card")
+    func counterpart_withoutAHandleShowsNoHandleLine() {
+        let member = ConversationScreen.counterpart(
+            userID: UUID(),
+            profile: Self.profile(displayName: "Fred Wilson")
+        )
+        #expect(ConversationScreen.tipDMCounterpart(member) == ChatProfileCard.Counterpart.none)
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatProfileCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatProfileCardCell.swift
@@ -46,7 +46,7 @@ private struct ProfileCardView: View {
             case .contact, .unknown:
                 ContactActionPill(counterpart: card.counterpart, action: onContactAction)
                     .padding(.top, 16)
-            case .none:
+            case .handle, .none:
                 EmptyView()
             }
         }
@@ -110,6 +110,9 @@ private struct ProfileCardSubtitle: View {
         case .unknown:
             Text("Unknown Contact")
                 .foregroundStyle(Color.warning)
+        case .handle(let username):
+            Text(username.handle)
+                .foregroundStyle(Color.textSecondary)
         case .none:
             // No relationship to surface — renders nothing.
             EmptyView()
@@ -145,6 +148,16 @@ private struct ProfileCardSubtitle: View {
                 avatarID: "raul",
                 imageData: nil,
                 counterpart: .none
+            ),
+            onContactAction: {},
+            onProfileTap: nil
+        )
+        ProfileCardView(
+            card: ChatProfileCard(
+                name: "Fred Wilson",
+                avatarID: "fred",
+                imageData: nil,
+                counterpart: .handle(Username("fred_wilson")!)
             ),
             onContactAction: {},
             onProfileTap: nil

--- a/FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift
@@ -48,7 +48,8 @@ public enum SystemSymbol: String {
     case circleCheck = "checkmark.circle.fill"
     case circlePerson = "person.circle"
     case personBadgePlus = "person.badge.plus"
-    
+    case plus = "plus"
+
     case arrowUp = "arrow.up"
     case arrowDown = "arrow.down"
     case arrowRight = "arrow.right"

--- a/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactActionPill.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/Contacts/ContactActionPill.swift
@@ -50,7 +50,7 @@ private struct ContactActionLabel: View {
             } icon: {
                 Image.system(.personBadgePlus)
             }
-        case .none:
+        case .handle, .none:
             // Carries no contact action; the hosting card omits the pill entirely.
             EmptyView()
         }


### PR DESCRIPTION
Phase 2 of usernames: an "Enter Flipcash username" screen that resolves a handle
and opens the resulting chat, reached from a `+` in the Chats tab header. The
chat header now shows a counterpart's `@handle` when they have claimed one.

Phase 1 shipped the claim flow and the `flipcash.com/<handle>` deep link, which
opens a tip card. Neither changes here.

## What the flow does

- The `+` in the Chats tab header pushes the lookup screen on the tips stack,
  keyboard up, `Next` disabled until something is typed.
- `Next` resolves the handle, shows the button's success checkmark, and pushes
  the chat with that person. Once the chat has landed the lookup drops out from
  under it, so Back goes to the chat list. Until the first tip creates the chat
  there is no transcript and no composer — just the profile card and a
  full-width "Send a Tip" (node 9443:8928).
- A handle nobody has claimed raises an informational "Username Not Found". A
  lookup that never got an answer raises "Couldn't Look Up Username".
- The empty Chats state now reads "Start a new chat, or share your profile".

Tipping from this flow reuses the existing minimum-amount error rather than a
new one, per the design note.

## What the chat needs before it exists

The tip creates the chat, so the screen is opened by counterpart rather than by
chat id and derives the id itself with the same `tipDm` derivation the server
uses. The counterpart's name, picture, and handle come from the profile the
lookup just fetched, cached on the way in. `chatExists` now means "a
conversation record exists" rather than "an id resolves", which is what keeps
the composer and the transcript fetch out until there is a chat to hold them.

## Decisions Android should mirror

Android is implementing the same phase separately, and each of these is
user-visible if the two platforms differ.

1. **The lookup call is `fetchProfile(username:)`, not `resolveUsername`.** The
   profile response carries the user id the hand-off needs; resolve returns only
   a payment destination.
2. **A miss arrives as `Profile.empty`, not as a throw.** `ProfileService`
   converts the server's `notFound` into an empty profile, so the caller detects
   a miss from an absent `userID` on a successful call.
   `ErrorFetchProfile.notFound` is mapped in the error path too, but nothing
   reaches it today.
3. **Reserved words and other content rules stay on the server.** The screen
   validates shape, not policy — only what `Username.init` validates.
4. **A malformed input gets "Username Not Found"**, not the claim screen's Too
   Short / Too Long / Invalid Characters. The design draws one dialog for this
   screen, and a handle that cannot exist is a handle nobody has claimed.
   Judgment call — mirror it or say why not.
5. **Input is normalised before it is resolved.** It goes through
   `UsernameValidator`, which trims and lowercases, so a handle pasted with
   surrounding whitespace resolves instead of reporting not found. The claim
   screen already went through the same validator for the same field.
6. **The not-found copy diverges from the tip card's, deliberately.** This
   screen says "Username Not Found" / "Please try a different username" (node
   `9442:103386`); the tip card keeps "No Such Account" / "Nobody has claimed
   `@<handle>`". Both ship.
7. **A transport failure gets "Couldn't Look Up Username" / "Please check your
   connection and try again".** The design doesn't draw this state; the copy is
   the tip card's apology retitled for what failed. Judgment call.
8. **A resolved handle opens the chat, not the tip card.** The tip is composed
   from inside the chat, so the tipcard overlay and Send a Tip sheet that a
   scanned tipcode raises are not part of this flow. Looking up your own handle
   is the one exception and still shows your own tip card.
9. **The hand-off is the verification screens' beat**: loading, then the
   checkmark, then a push. The lookup leaves the back stack afterwards, since a
   chat's Back belongs on the chat list — but 150ms afterwards, while the push
   is still animating. Removing it means rewriting the whole path (SwiftUI
   can't address the entry beneath the top), which remounts the chat, and a
   fresh chat settles its layout a beat after it appears. Under the transition
   that settle is hidden; after it, it reads as the chat shifting. Removing the
   lookup *before* the push instead collapses both into a leaf swap, which
   SwiftUI draws as a cut with no animation at all.
10. **`SQLiteVersion` goes 33 → 34.** Members' handles are now cached, so the
    database rebuilds from the server on first launch of this build.

Node `9442:103386` is a dialog over the entry screen, not a full screen state.
The design brief described it as the latter; the render settles it.

## Structure

`.usernameLookup` is a sibling of the existing `.username` destination rather
than a parameter on it. One claims the signed-in user's own handle from
Settings, the other spends someone else's from Chats, and they sit on different
stacks.


