### PR TITLE
fix(withdraw): drop zero balances from the currency picker

### DIFF
--- a/Flipcash/Core/Screens/Main/ExchangedBalance.swift
+++ b/Flipcash/Core/Screens/Main/ExchangedBalance.swift
@@ -20,11 +20,22 @@ struct ExchangedBalance: Identifiable, Hashable {
 
 extension Array where Element == ExchangedBalance {
 
-    /// Balances eligible to give, send, or tip. Dollars appears only when it
-    /// carries a displayable value: `balances(for:)` keeps USDF at any value so
-    /// the wallet can render a zero Dollars card, and an amount-entry picker has
-    /// no use for a balance that can't fund anything.
+    /// Balances eligible to give, send, or tip.
     func giveable() -> [ExchangedBalance] {
+        fundable()
+    }
+
+    /// Balances eligible to withdraw.
+    func withdrawable() -> [ExchangedBalance] {
+        fundable()
+    }
+
+    /// Balances that can fund an outgoing amount. Dollars appears only when it
+    /// carries a displayable value: `balances(for:)` keeps USDF at any value so
+    /// the wallet can render a zero Dollars card, and a picker that funds an
+    /// outgoing amount has no use for a balance that can't fund anything. Every
+    /// other mint is already filtered to a displayable value upstream.
+    private func fundable() -> [ExchangedBalance] {
         filter { balance in
             guard balance.stored.mint == .usdf else { return true }
             return balance.exchangedFiat.hasDisplayableValue()

--- a/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
+++ b/Flipcash/Core/Screens/Settings/Withdraw/WithdrawScreen.swift
@@ -10,8 +10,10 @@ import FlipcashUI
 import FlipcashCore
 
 /// The withdraw flow's first screen: a currency picker listing every balance
-/// (Dollars included). Selecting Dollars detours through the "Withdraw as USDC"
-/// intro; any other currency goes straight to the amount screen.
+/// that carries a displayable value, Dollars included — a balance rounding to
+/// zero can't fund a withdrawal, so it's left out. Selecting Dollars detours
+/// through the "Withdraw as USDC" intro; any other currency goes straight to
+/// the amount screen.
 struct WithdrawScreen: View {
 
     @Environment(Session.self) private var session
@@ -21,6 +23,7 @@ struct WithdrawScreen: View {
 
     private var balances: [ExchangedBalance] {
         session.balances(for: ratesController.rateForBalanceCurrency())
+            .withdrawable()
     }
 
     var body: some View {

--- a/FlipcashTests/SessionTests.swift
+++ b/FlipcashTests/SessionTests.swift
@@ -590,6 +590,48 @@ struct SessionBalancesUSDFInclusionTests {
 }
 
 @MainActor
+@Suite("Outgoing-amount pickers drop zero balances")
+struct FundableBalanceFilterTests {
+
+    @Test("USDF at zero is dropped — the withdraw picker can't fund from $0.00")
+    func withdrawable_dropsZeroUSDF() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 0),
+            .init(
+                mint: .makeLaunchpad(
+                    address: .jeffy,
+                    supplyFromBonding: 1_000_000 * 10_000_000_000
+                ),
+                quarks: 10 * 10_000_000_000
+            ),
+        ])
+
+        let mints = container.session.balances(for: .oneToOne).withdrawable().map(\.stored.mint)
+        #expect(mints.contains(.usdf) == false, "Dollars at $0.00 must not be offered")
+        #expect(mints.contains(.jeffy), "funded balances continue to appear")
+    }
+
+    @Test("USDF dust that displays as $0.00 is dropped")
+    func withdrawable_dropsUSDFDust() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 1_000), // $0.001
+        ])
+
+        #expect(container.session.balances(for: .oneToOne).withdrawable().isEmpty)
+    }
+
+    @Test("Funded USDF is kept")
+    func withdrawable_keepsFundedUSDF() throws {
+        let container = try SessionContainer.makeTest(holdings: [
+            .init(mint: .usdf, quarks: 5 * 10_000_000_000),
+        ])
+
+        let mints = container.session.balances(for: .oneToOne).withdrawable().map(\.stored.mint)
+        #expect(mints == [.usdf])
+    }
+}
+
+@MainActor
 @Suite("Session.withdraw verified state")
 struct SessionWithdrawVerifiedStateTests {
 

--- a/FlipcashUITests/Regression/WithdrawPickerEmptyRegressionTests.swift
+++ b/FlipcashUITests/Regression/WithdrawPickerEmptyRegressionTests.swift
@@ -5,10 +5,11 @@
 
 import XCTest
 
-/// Redesign guard: the withdraw picker now lists **every** balance, Dollars
-/// included — USDF is no longer filtered out. A USDF-only account must therefore
-/// show its Dollars row (and *not* the empty state, which is reserved for an
-/// account with no displayable balances at all).
+/// Redesign guard: the withdraw picker lists every balance carrying a
+/// displayable value, Dollars included — USDF is no longer filtered out on mint
+/// alone. A USDF-only account holding a displayable balance must therefore show
+/// its Dollars row (and *not* the empty state, which is reserved for an account
+/// with no displayable balances at all).
 ///
 /// **Prerequisites:**
 /// - `FLIPCASH_UI_TEST_USDF_ONLY_ACCESS_KEY` set in `secrets.local.xcconfig`


### PR DESCRIPTION
The withdraw currency picker offers a Dollars row at $0.00, which can't fund a withdrawal.

`Session.balances(for:)` already filters out any balance whose fiat value rounds to zero — except USDF, which it keeps deliberately so the wallet can render a Dollars card at $0.00. The withdraw picker consumed that list unfiltered and inherited the exception.

`WithdrawScreen` now calls a new `withdrawable()`. It sits alongside `giveable()` over one private `fundable()` predicate that drops USDF without a displayable value; every other mint is already filtered upstream. The two rules are identical today, so the split is naming rather than behaviour — it gives withdraw somewhere to diverge if it ever needs a higher bar (a minimum above the network fee, say) without moving the give pickers. The callers of `giveable()`, `SelectCurrencyScreen` and `RatesController.resolveInitialBalance`, are untouched.

An account holding only $0.00 Dollars now lands on the existing "No currencies to withdraw" empty state.

Entering the flow with a preselected mint still skips the picker, so the Withdraw button on a zero Dollars card reaches the amount screen. That path is a deliberate per-currency entry rather than the token list, so I left it alone — say the word if it should gate too.

The doc on `WithdrawPickerEmptyRegressionTests` claimed the picker lists USDF unconditionally. Its assertions still hold, since that account holds a displayable balance, so only the comment changes.
