### PR TITLE
fix(onramp): restore the email AutoFill suggestion on the verify step

### DIFF
--- a/Flipcash/Core/Screens/EmailVerification/EnterEmailScreen.swift
+++ b/Flipcash/Core/Screens/EmailVerification/EnterEmailScreen.swift
@@ -28,12 +28,14 @@ struct EnterEmailScreen<VM: EmailVerifying>: View {
             VStack(alignment: .center, spacing: 15) {
                 Spacer()
                 InputContainer(size: .regular) {
+                    // Autocorrection stays on: turning it off hides the
+                    // QuickType bar, which is where iOS renders the
+                    // `.emailAddress` AutoFill suggestion from the contact card.
                     TextField("Email", text: $viewModel.enteredEmail)
                         .font(.appTextXL)
                         .keyboardType(.emailAddress)
                         .textContentType(.emailAddress)
                         .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .multilineTextAlignment(.leading)
                         .padding([.leading, .trailing], 15)


### PR DESCRIPTION
The email step of the Coinbase onramp verification flow never offered an AutoFill suggestion. Tapping the field brought up the keyboard with nothing above it, so the address had to be typed by hand.

`.autocorrectionDisabled()` on the `TextField` sets `autocorrectionType = .no`, which suppresses the QuickType bar. Unlike `.username` or `.oneTimeCode`, which get a dedicated input accessory view, `.emailAddress` suggestions render *inside* that bar — so turning off autocorrect takes the AutoFill affordance with it.

`EnterPhoneScreen` sets `.textContentType(.telephoneNumber)` with no `.autocorrectionDisabled()`, and autofills correctly. That in-repo A/B is what isolated the line.

Removing the modifier brings the bar back. On device the field now offers Hide My Email where it previously offered nothing, which also confirms iOS is classifying the field as an email field. Whether the user's own address appears alongside it depends on their Contacts My Card being set, which the app has no say in.

### Doesn't this turn autocorrect on?

Not on this field. `keyboardType(.emailAddress)` is still set, and iOS runs no inline correction on the email keyboard — as with `.URL` and the numeric pads, no linguistic correction model is applied to it. `autocorrectionType = .no` was never suppressing corrections here; it was only suppressing the candidate bar, which is the bug. Typing an address through the `@` on device produces no correction.

Third-party keyboards supply their own correction behaviour and ignore `autocorrectionType`, so they were never covered by the old code either.

### Scope

`EnterEmailScreen` is the app's only free-entry email input, reachable only from `VerifyInfoScreen`. Nothing outside the Coinbase onramp flow is affected.
