### PR TITLE
fix(you): make the version footer's toast findable in UI tests

### DIFF
--- a/Flipcash/Core/Screens/Main/You/YouScreen.swift
+++ b/Flipcash/Core/Screens/Main/You/YouScreen.swift
@@ -427,6 +427,10 @@ struct YouScreen: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        // On the button rather than the composed view: an identifier applied
+        // outside the overlay propagates onto the toast too, and an element
+        // carrying an identifier is no longer addressable by its label.
+        .accessibilityIdentifier("you-version-footer")
         // Overlaid rather than stacked: the countdown speaks on consecutive
         // taps, and a toast that took up space would walk the version string
         // out from under the finger.
@@ -438,10 +442,10 @@ struct YouScreen: View {
                         .offset(x: 0, y: 20)
                         .combined(with: .opacity.animation(.easeOutFastest))
                     )
+                    .accessibilityIdentifier("you-version-toast")
             }
         }
         .animation(.springFaster, value: versionUnlock.message)
-        .accessibilityIdentifier("you-version-footer")
     }
 
     // MARK: - Content -

--- a/FlipcashUITests/Smoke/BetaAccessUnlockSmokeTests.swift
+++ b/FlipcashUITests/Smoke/BetaAccessUnlockSmokeTests.swift
@@ -13,8 +13,10 @@ import XCTest
 /// Accounts is gone". This drives both.
 ///
 /// **State.** Beta access is stored in the keychain and outlives a launch;
-/// `nukeForUITesting` does not clear it. The test locks it again at the end so
-/// it leaves the simulator as it found it.
+/// `nukeForUITesting` does not clear it. The starting state is therefore
+/// whatever the last run left behind — including a run that failed halfway
+/// through the toggle — so the test locks it first and locks it again at the
+/// end, and leaves the simulator as it found it.
 ///
 /// **Prerequisites:** the `FLIPCASH_UI_TEST_ACCESS_KEY` account only needs to be
 /// loggable in.
@@ -28,10 +30,11 @@ final class BetaAccessUnlockSmokeTests: BaseUITestCase {
 
         assertMainScreenReached()
         settings.open(from: self)
+        lockBetaAccessIfUnlocked(settings)
 
         settings.tapVersionFooter(10, from: self)
         XCTAssertTrue(
-            app.staticTexts["You are now a developer!"].waitForExistence(timeout: 5),
+            settings.versionToast("You are now a developer!").waitForExistence(timeout: 5),
             "Expected the tenth tap to say beta access is unlocked"
         )
 
@@ -45,7 +48,7 @@ final class BetaAccessUnlockSmokeTests: BaseUITestCase {
 
         settings.tapVersionFooter(10, from: self)
         XCTAssertTrue(
-            app.staticTexts["Beta features are hidden again"].waitForExistence(timeout: 5),
+            settings.versionToast("Beta features are hidden again").waitForExistence(timeout: 5),
             "Expected ten more taps to lock beta access again"
         )
 
@@ -57,6 +60,26 @@ final class BetaAccessUnlockSmokeTests: BaseUITestCase {
         XCTAssertFalse(
             settings.switchAccountsRow.exists,
             "Expected Switch Accounts to go away with beta access"
+        )
+    }
+
+    /// Locks beta access when a previous run left it unlocked, so the taps the
+    /// test makes always start from the locked state and unlock.
+    ///
+    /// Switch Accounts is the readable signal for the stored flag: the footer
+    /// itself says nothing until it is tapped, and a tap is the thing under
+    /// test.
+    private func lockBetaAccessIfUnlocked(_ settings: SettingsUIScreen) {
+        settings.navigateToMyAccount(from: self)
+        let isUnlocked = settings.switchAccountsRow.waitForExistence(timeout: 5)
+        settings.leaveMyAccount(from: self)
+
+        guard isUnlocked else { return }
+
+        settings.tapVersionFooter(10, from: self)
+        XCTAssertTrue(
+            settings.versionToast("Beta features are hidden again").waitForExistence(timeout: 5),
+            "Expected to lock the beta access a previous run left behind"
         )
     }
 }

--- a/FlipcashUITests/Support/Screens/SettingsScreen.swift
+++ b/FlipcashUITests/Support/Screens/SettingsScreen.swift
@@ -44,6 +44,23 @@ struct SettingsUIScreen {
     /// beta-access easter egg.
     var versionFooter: XCUIElement { app.buttons["you-version-footer"] }
 
+    /// The toast the version footer raises, matched on the message it carries.
+    ///
+    /// Identifier and label are matched in one predicate because the toast
+    /// clears itself two seconds after it appears: finding the element first
+    /// and reading its label second races that timer.
+    func versionToast(_ message: String) -> XCUIElement {
+        app.staticTexts
+            .matching(
+                NSPredicate(
+                    format: "identifier == %@ AND label == %@",
+                    "you-version-toast",
+                    message
+                )
+            )
+            .firstMatch
+    }
+
     // MARK: - Actions
 
     /// Opens the You tab, which hosts the settings list.


### PR DESCRIPTION
`BetaAccessUnlockSmokeTests` has never passed. It went in with the feature it covers (#665), and `deploy.yml` runs no tests, so nothing ran it until it blocked the 2026.8.5 release gate.

The accessibility identifier sat after `.overlay`, so it applied to the button and the toast together. An element carrying an explicit identifier is no longer addressable by its label, so `staticTexts["You are now a developer!"]` could never match — the run log shows all ten taps landing, then the assertion burning its full five seconds.

The identifier moves onto the button and the toast gets its own. The test queries it by identifier and label in one predicate: the toast clears itself after two seconds, so finding the element and reading its label separately races that timer.

The test also locks beta access before it starts. The flag lives in the keychain and `nukeForUITesting` does not clear it, so a run that failed between the two toggles left the next run starting from the opposite state — which is how a first failure turns into a different second one.