### PR TITLE
fix(tips): re-resolve the send balance when it lands after the sheet opens

### DIFF
--- a/.claude/plans/2026-08-27-tip-sheet-empty-token-selector.md
+++ b/.claude/plans/2026-08-27-tip-sheet-empty-token-selector.md
@@ -1,0 +1,71 @@
+# Send a Tip: empty token selector and a swipe that bounces back
+
+Reported from a production screen recording: opening a tip card from a
+`flipcash.com/<handle>` deep link showed the Send a Tip sheet with an empty
+currency pill (bare chevron, no icon, no token name), and Swipe to Tip animated
+to the end and reset without sending or showing an error.
+
+## Root cause
+
+`SendAmountViewModel.selectedBalance` was nil and never re-resolved.
+
+`SendAmountViewModel.init` called `RatesController.resolveInitialBalance(mint:session:)`
+once and stored the result. Only `selectCurrencyAction(exchangedBalance:)` ever
+reassigned it, so a resolve that came up empty stayed empty for the life of the
+view model.
+
+`TipFlow.present(_:)` builds that view model at the earliest, coldest instant of
+the deep-link flow — before `ensureStreamConnected()` has delivered a rate and
+before the 750 ms the flow itself waits out before deciding whether to show the
+sheet. `resolveInitialBalance` snapshots `session.balances` at that instant, and
+on a cold launch that list can still be empty.
+
+Four observations from the recording line up with that:
+
+1. The pill renders `CurrencyLabel(imageURL: selectedBalance?.stored.imageURL, name: selectedBalance?.stored.name ?? "")` — no icon and no name means the balance is nil, not that the icon failed to load.
+2. The swipe bounced with no dialog. `SwipeControl.commit` catches and resets on any throw; `TipFlow.swipeToTip` throws `TipDismissed` on `.failed`; and the `selectedBalance` guard was the only `.failed` in `submit(entered:)` that set no `session.dialogItem`.
+3. The preset chips still rendered, because they come from `session.userFlags?.tipPresets(for:)` and never touch `selectedBalance`.
+4. The sheet appeared at all, so `giveCashGate` returned `.proceed` at t+750 ms. `giveable().isEmpty` is set-equivalent to `!session.hasGiveableBalance(for:)`, so balances were usable 750 ms after the view model had already frozen at nil.
+
+A $1 custom amount was also accepted against $5/$10/$20 presets. That is
+consistent with `enforceTipMinimum` taking its `selectedBalance == nil`
+early-return, but it is not proof — `TipPresets.minimum` is a separate field from
+the three tiers and may legitimately be at or below $1.
+
+### What makes an empty snapshot realistic in the wild
+
+- `Session.updateableBalances` is an `Updateable` cache, re-queried only on `.databaseDidChange`.
+- `Database.getBalances()` maps rows with `try statement.map { try StoredBalance(...) }`, so one throwing row aborts the whole query; `(try? database.getBalances()) ?? []` then collapses that to an empty list app-wide until the next database change. `StoredBalance.init` throws `missingStoredCoreMintForNonReserveToken` when a `LEFT JOIN mint` miss leaves `supplyFromBonding` nil on a non-USDF symbol.
+- A bonded mint with nil or zero `supplyFromBonding` computes to `safeZero` and is filtered out of `Session.balances(for:)`.
+
+## Fix
+
+`Flipcash/Core/Screens/Send/SendAmountViewModel.swift`:
+
+- When the initial resolve returns nil, arm a re-arming `withObservationTracking`
+  loop over `session.balances` and `ratesController.rateForBalanceCurrency()` and
+  re-run `resolveInitialBalance` on each change until it lands. It stops once a
+  balance resolves or the user picks one, so an explicit pick is never
+  overwritten. This mirrors `Session.observeBalanceCurrencyChanges()`.
+- The `selectedBalance` / `enteredFiat` guard in `submit(entered:)` now reports
+  through `ErrorReporting.captureError` and sets a `session.dialogItem` instead
+  of returning `.failed` silently. That branch involves no RPC and no thrown
+  error, so it was invisible to both the user and Bugsnag — which is why this
+  reached production.
+
+Tests in `FlipcashTests/SendAmountViewModelTests.swift`, both observed failing
+against the unfixed code:
+
+- `testInit_NoBalancesYet_ResolvesWhenBalancesArrive` — builds the view model
+  against an empty database, inserts a launchpad balance, posts
+  `.databaseDidChange`, and expects `selectedBalance` to resolve.
+- `submit_noSelectedBalance_surfacesDialog` — expects the dialog rather than a
+  silent `.failed`.
+- `testInit_ExplicitPick_SurvivesLateBalanceArrival` guards the stop condition.
+
+## Not changed
+
+`GiveViewModel` (`Flipcash/Core/Screens/Main/GiveViewModel.swift:56`) resolves its
+balance the same one-shot way. The Give flow is entered from an already-warm
+wallet screen rather than from a cold deep link, so it is far less exposed, but
+the pattern is identical and worth revisiting.

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -21,6 +21,12 @@ final class SendAmountViewModel {
         case failed
     }
 
+    enum Error: Swift.Error {
+        /// The send reached submission with nothing to spend from — no balance
+        /// resolved, or the resolved balance can't price the entered amount.
+        case noSpendableBalance
+    }
+
     var enteredAmount: String = ""
 
     var depositMint: PublicKey?
@@ -31,6 +37,9 @@ final class SendAmountViewModel {
     @ObservationIgnored let resolver: any RecipientResolving
     @ObservationIgnored let target: SendTarget
     @ObservationIgnored private let amountValidator = AmountValidator()
+
+    /// The mint this flow opened for, replayed by the re-resolve below.
+    @ObservationIgnored private let initialMint: PublicKey?
 
     private(set) var selectedBalance: ExchangedBalance?
 
@@ -85,11 +94,52 @@ final class SendAmountViewModel {
         self.sender          = sender ?? session
         self.resolver        = resolver ?? session
         self.target          = target
+        self.initialMint     = mint
         self.selectedBalance = resolved
 
-        if let resolved, ratesController.selectedTokenMint != resolved.stored.mint {
-            ratesController.selectToken(resolved.stored.mint)
+        if let resolved {
+            syncGlobalTokenSelection(to: resolved)
+        } else {
+            observeBalancesForInitialResolve()
         }
+    }
+
+    // MARK: - Balance resolution -
+
+    /// Re-runs the initial resolve when the balance list or display rate
+    /// changes, until it lands on a balance.
+    ///
+    /// A tip deep link builds this view model at the coldest point of a cold
+    /// launch — before balances have loaded and before the rate stream has
+    /// delivered anything — so the initial resolve can legitimately come up
+    /// empty. Without this the nil snapshot sticks for the life of the flow:
+    /// the token pill renders as a bare chevron and every submission fails the
+    /// `selectedBalance` guard in `submit`. Re-arms after each change since
+    /// `withObservationTracking` is one-shot, and stops once a balance lands or
+    /// the user picks one themselves.
+    private func observeBalancesForInitialResolve() {
+        withObservationTracking {
+            _ = session.balances
+            _ = ratesController.rateForBalanceCurrency()
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, selectedBalance == nil else { return }
+                guard let resolved = ratesController.resolveInitialBalance(
+                    mint: initialMint,
+                    session: session
+                ) else {
+                    observeBalancesForInitialResolve()
+                    return
+                }
+                selectedBalance = resolved
+                syncGlobalTokenSelection(to: resolved)
+            }
+        }
+    }
+
+    private func syncGlobalTokenSelection(to balance: ExchangedBalance) {
+        guard ratesController.selectedTokenMint != balance.stored.mint else { return }
+        ratesController.selectToken(balance.stored.mint)
     }
 
     // MARK: - Action -
@@ -138,7 +188,23 @@ final class SendAmountViewModel {
               let exchangedFiat = selectedBalance.enteredFiat(
                 for: entered,
                 rate: ratesController.rateForBalanceCurrency()
-              ) else { return .failed }
+              ) else {
+            // No RPC and no thrown error, so this is invisible unless reported:
+            // the swipe control just resets its knob and the user sees nothing.
+            ErrorReporting.captureError(
+                Error.noSpendableBalance,
+                reason: "No spendable balance at send submission",
+                metadata: [
+                    "target": targetLogID,
+                    "mint": selectedBalance?.stored.mint.base58 ?? "unresolved",
+                ]
+            )
+            session.dialogItem = .error(
+                title: "Balance Unavailable",
+                subtitle: "We couldn't load your balance. Please try again."
+            )
+            return .failed
+        }
 
         guard enforceTipMinimum(entered: entered) else { return .failed }
 

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -117,6 +117,65 @@ struct SendAmountViewModelTests {
         #expect(container.ratesController.selectedTokenMint == .jeffy)
     }
 
+    @Test("A view model built before balances load resolves once they arrive")
+    func testInit_NoBalancesYet_ResolvesWhenBalancesArrive() async throws {
+        // A tip deep link builds the view model at the coldest point of a cold
+        // launch, before the balance list has loaded. The initial resolve comes
+        // up empty; without a re-resolve that nil sticks for the life of the
+        // flow — an empty token pill and a swipe that fails the `submit` guard.
+        let container = try SessionContainer.makeTest(holdings: [])
+        container.ratesController.configureTestRates(rates: [.oneToOne])
+        container.ratesController.selectedTokenMint = nil
+
+        let viewModel = SendAmountViewModel(
+            sessionContainer: container,
+            target: .tip(TipRecipient(userID: UUID(), displayName: "Fred", origin: .tipcard)),
+            mint: nil
+        )
+        #expect(viewModel.selectedBalance == nil)
+
+        let mint = MintMetadata.makeLaunchpad(
+            address: .jeffy,
+            supplyFromBonding: 10_000 * 10_000_000_000
+        )
+        let now = Date.now
+        try container.database.insert(mints: [mint], date: now)
+        try container.database.transaction { db in
+            try db.insertBalance(quarks: 1_000_000_000_000, mint: mint.address, costBasis: 0, date: now)
+        }
+        NotificationCenter.default.post(name: .databaseDidChange, object: nil)
+
+        try await waitUntil(viewModel) { $0.selectedBalance?.stored.mint == .jeffy }
+        #expect(container.ratesController.selectedTokenMint == .jeffy)
+    }
+
+    @Test("An explicit currency pick is not overwritten when balances later arrive")
+    func testInit_ExplicitPick_SurvivesLateBalanceArrival() async throws {
+        let container = try SessionContainer.makeTest(holdings: [])
+        container.ratesController.configureTestRates(rates: [.oneToOne])
+
+        let viewModel = SendAmountViewModel(
+            sessionContainer: container,
+            target: .contact(Self.makeContact()),
+            mint: nil
+        )
+        viewModel.selectCurrencyAction(exchangedBalance: ExchangedBalance.makeTest())
+
+        let mint = MintMetadata.makeLaunchpad(
+            address: .jeffy,
+            supplyFromBonding: 10_000 * 10_000_000_000
+        )
+        let now = Date.now
+        try container.database.insert(mints: [mint], date: now)
+        try container.database.transaction { db in
+            try db.insertBalance(quarks: 1_000_000_000_000, mint: mint.address, costBasis: 0, date: now)
+        }
+        NotificationCenter.default.post(name: .databaseDidChange, object: nil)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(viewModel.selectedBalance?.stored.mint == .usdf)
+    }
+
     // MARK: - canSend
 
     @Test("canSend is false when no amount is entered")
@@ -495,6 +554,30 @@ struct SendAmountViewModelTests {
         #expect(outcome == .failed)
         #expect(mock.sendCalls.isEmpty)  // the limit gate blocks before sending
         #expect(container.session.dialogItem?.title == "Transaction Limit Reached")
+    }
+
+    @Test("A submission with no resolved balance surfaces a dialog instead of failing silently")
+    func submit_noSelectedBalance_surfacesDialog() async throws {
+        // The swipe control swallows a `.failed` outcome and just resets its
+        // knob, so this branch has to report and dialog for itself.
+        let container = try SessionContainer.makeTest(holdings: [])
+        container.ratesController.configureTestRates(rates: [.oneToOne])
+        let mock = MockSession()
+        let viewModel = SendAmountViewModel(
+            sessionContainer: container,
+            target: .tip(TipRecipient(userID: UUID(), displayName: "Fred", origin: .tipcard)),
+            mint: nil,
+            sender: mock,
+            resolver: mock
+        )
+        #expect(viewModel.selectedBalance == nil)
+
+        let outcome = await viewModel.submit(entered: 5)
+
+        #expect(outcome == .failed)
+        #expect(mock.sendCalls.isEmpty)
+        #expect(mock.resolveUserIDCalls.isEmpty)
+        #expect(container.session.dialogItem?.title == "Balance Unavailable")
     }
 
     // MARK: - Tip targets


### PR DESCRIPTION
Reported from a production screen recording: opening a tip card from a
`flipcash.com/<handle>` deep link showed the Send a Tip sheet with an empty
currency pill — bare chevron, no icon, no token name — and Swipe to Tip animated
to the end and reset without sending or showing an error.

## Root cause

`SendAmountViewModel.selectedBalance` was nil and never re-resolved. `init`
called `resolveInitialBalance(mint:session:)` once and stored the result; only
`selectCurrencyAction(exchangedBalance:)` ever reassigned it, so a resolve that
came up empty stayed empty for the life of the view model.

`TipFlow.present(_:)` builds that view model at the coldest instant of the
deep-link flow — before `ensureStreamConnected()` has delivered a rate, and
before the 750 ms the flow itself waits out before deciding whether to show the
sheet. `resolveInitialBalance` snapshots `session.balances` at that instant, and
on a cold launch that list can still be empty.

Both symptoms follow from the one nil:

- The pill renders `CurrencyLabel(imageURL: selectedBalance?.stored.imageURL, name: selectedBalance?.stored.name ?? "")`, so a nil balance is a bare chevron.
- The `selectedBalance` guard was the only `.failed` path in `submit(entered:)` that set no `session.dialogItem`. `TipFlow.swipeToTip` maps `.failed` to a thrown `TipDismissed`, and `SwipeControl.commit` catches any throw and resets the knob.

Two details that place the failure at the snapshot rather than anywhere else:
the preset chips still rendered, and they come from
`session.userFlags?.tipPresets(for:)` without touching `selectedBalance`; and the
sheet was shown at all, meaning `giveCashGate` returned `.proceed` at t+750 ms —
`giveable().isEmpty` is set-equivalent to `!session.hasGiveableBalance(for:)`, so
balances were usable 750 ms after the view model had already frozen at nil.

## Change

When the initial resolve returns nil, arm a re-arming `withObservationTracking`
loop over `session.balances` and `ratesController.rateForBalanceCurrency()` and
re-run the resolve on each change until it lands. It stops once a balance
resolves or the user picks one, so an explicit pick is never overwritten. Same
shape as `Session.observeBalanceCurrencyChanges()`.

The guard in `submit(entered:)` now reports through
`ErrorReporting.captureError` and sets a `session.dialogItem` instead of
returning `.failed` silently. That branch does no RPC and throws nothing, so it
was invisible to the user and to Bugsnag alike — which is why this shipped.

Three tests; the two that cover the defect were observed failing against the
unfixed code (a 30 s `waitUntil` timeout, and the missing dialog):

- `testInit_NoBalancesYet_ResolvesWhenBalancesArrive`
- `submit_noSelectedBalance_surfacesDialog`
- `testInit_ExplicitPick_SurvivesLateBalanceArrival`, guarding the stop condition

Full analysis in `.claude/plans/2026-08-27-tip-sheet-empty-token-selector.md`,
including the database paths that make an empty snapshot realistic in the wild.

## Left alone

`GiveViewModel.swift:56` resolves its balance the same one-shot way. The Give
flow is entered from an already-warm wallet screen rather than a cold deep link,
so it is far less exposed, but the pattern is identical and worth revisiting
separately.
