### PR TITLE
fix(amounts): accept an entry equal to the displayed maximum

### DIFF
--- a/Flipcash/UI/EnterAmountCalculator.swift
+++ b/Flipcash/UI/EnterAmountCalculator.swift
@@ -58,14 +58,11 @@ nonisolated struct EnterAmountCalculator {
         guard let amount = AmountValidator().validate(enteredAmount), amount > 0 else {
             return false
         }
-        // Use a currency-aware formatter to parse back the display value.
-        // The generic parsers in NumberFormatter.decimal(from:) can't parse
-        // currency symbols that don't match the device locale (e.g. ¥ on en_US).
-        let formatter = NumberFormatter.fiat(
-            currency: max.currency,
-            minimumFractionDigits: max.currency.maximumFractionDigits
-        )
-        let displayMax = formatter.number(from: max.formatted())?.decimalValue ?? 0
+        // Round to the currency's display precision the same way the formatter
+        // does, in Decimal. Formatting the max and parsing the string back went
+        // through a double — "$8.54" returned 8.539999999999999, rejecting an
+        // entry of exactly the displayed balance.
+        let displayMax = max.value.rounded(to: max.currency.maximumFractionDigits)
         return amount <= displayMax
     }
 

--- a/FlipcashTests/Regressions/Regression_max_entry_display_parse.swift
+++ b/FlipcashTests/Regressions/Regression_max_entry_display_parse.swift
@@ -1,0 +1,61 @@
+//
+//  Regression_max_entry_display_parse.swift
+//  Flipcash
+//
+//  Bug: entering the displayed maximum turned the "Enter up to $8.54" subtitle
+//       red and disabled Next, so the full balance could not be withdrawn.
+//
+//  Cause: isWithinDisplayLimit compared the entry against the max round-tripped
+//         through NumberFormatter.number(from:), which yields a double-derived
+//         NSNumber even with generatesDecimalNumbers set — "$8.54" parses back
+//         as 8.539999999999999, putting an exact 8.54 entry over the cap. 85 of
+//         the first 2000 cent values land on such a value.
+//
+//  Fix: derive the display cap by rounding the max with Decimal arithmetic
+//       instead of formatting it and parsing the string back.
+//
+
+import Foundation
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Regression: entering the displayed maximum is accepted")
+struct Regression_max_entry_display_parse {
+
+    @Test("The reported case: $8.54 entered against an $8.54 cap")
+    func reportedCase_usd854() {
+        let max = FiatAmount(value: Decimal(string: "8.54")!, currency: .usd)
+        #expect(EnterAmountCalculator.isWithinDisplayLimit(enteredAmount: "8.54", max: max) == true)
+    }
+
+    @Test("Every cent value up to $20 accepts its own displayed maximum")
+    func everyCentValue_acceptsItsOwnDisplayedMax() {
+        let rejected: [String] = (1...2_000).compactMap { cents in
+            let max = FiatAmount(value: Decimal(cents) / 100, currency: .usd)
+            let entered = AmountValidator(separator: ".").string(from: max.value, fractionDigits: 2)
+            let accepted = EnterAmountCalculator.isWithinDisplayLimit(enteredAmount: entered, max: max)
+            return accepted ? nil : entered
+        }
+
+        #expect(rejected.isEmpty, "displayed maximums rejected: \(rejected)")
+    }
+
+    @Test("A cent above the displayed maximum is still rejected")
+    func oneCentOver_isRejected() {
+        let max = FiatAmount(value: Decimal(string: "8.54")!, currency: .usd)
+        #expect(EnterAmountCalculator.isWithinDisplayLimit(enteredAmount: "8.55", max: max) == false)
+    }
+
+    @Test("Withdraw: the full balance keeps Next enabled")
+    func withdraw_atFullBalance_canProceed() throws {
+        // $8.54 of USDF — the balance in the report.
+        let (container, usdf) = try WithdrawViewModelTestHelpers.makeUSDFFixture(quarks: 8_540_000)
+        let viewModel = WithdrawViewModel(container: .mock, sessionContainer: container)
+        viewModel.kind = .usdfToUsdc(usdf)
+        viewModel.enteredAmount = "8.54"
+
+        #expect(viewModel.canProceedToAddress == true)
+    }
+}


### PR DESCRIPTION
Entering the full balance on the Amount to Withdraw screen turned the "Enter up to $8.54" subtitle red and left `Next` disabled, so the balance could not be withdrawn.

## Cause

`EnterAmountCalculator.isWithinDisplayLimit` derived its cap by formatting the maximum and parsing the string back:

```swift
let displayMax = formatter.number(from: max.formatted())?.decimalValue ?? 0
return amount <= displayMax
```

`NumberFormatter.number(from:)` returns a double-derived `NSNumber` even with `generatesDecimalNumbers` set, so `"$8.54"` comes back as `8.539999999999999`. The entry parses exactly through `AmountValidator`, so `8.54 <= 8.539999999999999` is false. 42 of the first 2000 cent values land on a cap below their own displayed value, which is why it shows up on some balances and not others.

The round trip has been there since #110, but it was harmless then: both sides went through `NumberFormatter.decimal(from:)` and derived the same double, so they compared equal. #372 routed the entry through `KeyPadView.amount(from:)` (exact `Decimal(string:)`) to fix comma-locale parsing and left the cap on the lossy path. That asymmetry is the bug.

## Fix

Round the maximum to the currency's display precision with `NSDecimalRound` instead of formatting and reparsing. `.plain` matches the formatter's `.halfUp` for positive amounts, so the accepted cap still equals what the subtitle shows. Dropping the parse also removes the reason #125 needed a currency-aware formatter here — there is no string left to misread a `¥` in.

The gate backs withdraw, convert, add money, buy, and the "$X available" hint in `SwapAmountHeader`, so all five flows were rejecting the full balance on affected values.

## Tests

`Regression_max_entry_display_parse` covers the reported `$8.54` case, every cent value up to $20 accepting its own displayed maximum, a cent over still being rejected, and the full balance keeping `Next` enabled through `WithdrawViewModel`. Three of its four tests fail on `main`.