### PR TITLE
feat(settings): add the Profile Picture row to My Account

### DIFF
--- a/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
@@ -9,9 +9,13 @@ import SwiftUI
 import FlipcashUI
 import FlipcashCore
 
-/// The My Account settings list (Figma node 9277:121893): who this account
-/// deals with. The account-level actions — Access Key, Log Out, Delete
-/// Account — live on Advanced.
+/// The My Account settings list (Figma node 9544:18478): who this account
+/// deals with, and the profile it presents. The account-level actions — Access
+/// Key, Log Out, Delete Account — live on Advanced.
+///
+/// The design also lists Minimum Tip and Require Biometrics. Neither is here:
+/// the minimum-tip editor is still to be built, and iOS has no biometrics
+/// setting to toggle.
 struct SettingsMyAccountScreen: View {
 
     @Environment(AppRouter.self) private var router
@@ -34,15 +38,20 @@ struct SettingsMyAccountScreen: View {
     @ViewBuilder
     private func list() -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            SettingsRow(asset: .profile, title: "Change Display Name", insets: insets) {
+            SettingsRow(asset: .profile, title: "Display Name", insets: insets) {
                 router.push(.changeDisplayName)
             }
+
+            SettingsRow(asset: .photo, title: "Profile Picture", insets: insets) {
+                router.push(.changeProfilePicture)
+            }
+            .accessibilityIdentifier("account-profile-picture-row")
 
             // No balance gate here: the gate exists to stop squatting at claim time. A user who
             // already holds a handle has cleared it, and re-gating a change would hold their
             // handle hostage to a balance that has since moved.
             if let username = session.profile?.username {
-                SettingsRow(asset: .profile, title: "Change Username", insets: insets) {
+                SettingsRow(asset: .profile, title: "Username", insets: insets) {
                     router.push(.username(username))
                 }
                 .accessibilityIdentifier("account-change-username-row")

--- a/FlipcashUITests/Smoke/DisplayNameSmokeTests.swift
+++ b/FlipcashUITests/Smoke/DisplayNameSmokeTests.swift
@@ -54,7 +54,7 @@ final class DisplayNameSmokeTests: BaseUITestCase {
 
         // MARK: Change the name from My Account.
         settings.navigateToMyAccount(from: self)
-        waitAndTap(settings.changeDisplayNameRow)
+        waitAndTap(settings.displayNameRow)
 
         let next = app.buttons["profile-name-next-button"]
         XCTAssertTrue(next.waitForExistence(timeout: 30), "Expected the name editor")
@@ -81,7 +81,7 @@ final class DisplayNameSmokeTests: BaseUITestCase {
         // behind a dialog. It pops just the one screen, so this is My Account
         // rather than the You tab root.
         XCTAssertTrue(
-            settings.changeDisplayNameRow.waitForExistence(timeout: 60),
+            settings.displayNameRow.waitForExistence(timeout: 60),
             "Expected the name editor to pop back to My Account once the name saved. On screen: [\(visibleText())]"
         )
 

--- a/FlipcashUITests/Support/Screens/SettingsScreen.swift
+++ b/FlipcashUITests/Support/Screens/SettingsScreen.swift
@@ -31,7 +31,7 @@ struct SettingsUIScreen {
     var applicationLogsRow: XCUIElement { app.buttons["Application Logs"] }
 
     /// The My Account row that opens the display-name editor.
-    var changeDisplayNameRow: XCUIElement { app.buttons["Change Display Name"] }
+    var displayNameRow: XCUIElement { app.buttons["Display Name"] }
 
     /// The My Account row that opens the Blocked list.
     var blockedRow: XCUIElement { app.buttons["Blocked"] }


### PR DESCRIPTION
Partially implements the My Account reorganization (node 9544:18478).

- Adds a **Profile Picture** row under Display Name, pushing the same standalone photo editor the You tab's "Finish Your Profile" checklist opens.
- Drops the "Change" prefix from the name rows: "Change Display Name" → "Display Name", "Change Username" → "Username".

Two rows in the design are deliberately left out. The minimum-tip editor is separate work that hasn't been built, and iOS has no biometrics setting for Require Biometrics to toggle.

Stacked on #676.
