### PR TITLE
perf(profile): draw the cached avatar before minting a download URL

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/TabBarProfilePhoto.swift
+++ b/Flipcash/Core/Screens/Main/Home/TabBarProfilePhoto.swift
@@ -7,8 +7,6 @@ import SwiftUI
 import FlipcashCore
 import FlipcashUI
 
-private let logger = Logger(label: "flipcash.tab-bar-photo")
-
 /// The You tab's icon once the profile carries a picture: the photo in a white
 /// ring, standing in the slot the outline glyph otherwise occupies (Figma node
 /// 9641:17115).
@@ -79,23 +77,15 @@ final class TabBarProfilePhoto {
         // this runs again whenever the profile is refreshed.
         guard blobID != loadedBlobID else { return }
 
-        do {
-            // Download URLs expire, so one is minted per load and never stored.
-            guard let url = try await client.blobDownloadURL(blobID: blobID, owner: owner) else {
-                logger.info("Profile picture blob has no download URL", metadata: ["blobId": "\(blobID)"])
-                return
-            }
+        // A failed fetch leaves the previous icon up rather than clearing it: the
+        // tab keeps whatever it was already drawing.
+        guard let image = await ProfilePictureLoader.thumbnail(for: picture, using: client, owner: owner),
+              !Task.isCancelled
+        else { return }
 
-            let image = try await RemoteImageLoader.image(at: url, cacheKey: blobID.description)
-            guard !Task.isCancelled else { return }
-
-            photo = image
-            itemImages = Self.render(image)
-            loadedBlobID = blobID
-        } catch {
-            guard !Task.isCancelled else { return }
-            logger.info("Failed to load the profile picture for the tab bar", metadata: ["error": "\(error)"])
-        }
+        photo = image
+        itemImages = Self.render(image)
+        loadedBlobID = blobID
     }
 
     /// Draws the icon into the pair of images a `UITabBarItem` holds.

--- a/Flipcash/Core/Screens/Main/Profile/ProfilePictureLoader.swift
+++ b/Flipcash/Core/Screens/Main/Profile/ProfilePictureLoader.swift
@@ -1,0 +1,49 @@
+//
+//  ProfilePictureLoader.swift
+//  Flipcash
+//
+
+import UIKit
+import FlipcashCore
+import FlipcashUI
+
+private let logger = Logger(label: "flipcash.profile-picture")
+
+/// Fetches the thumbnail behind a profile picture.
+///
+/// Every surface that draws one — the tab bar, the tip card, the photo editor —
+/// fetches it the same way, and none of them treat a failure as fatal: each
+/// falls back to what it drew before there was a picture.
+enum ProfilePictureLoader {
+
+    /// The picture's thumbnail, or nil when there is no picture, the blob has no
+    /// download URL, or the fetch failed.
+    static func thumbnail(
+        for picture: ProfilePicture?,
+        using client: FlipClient,
+        owner: KeyPair
+    ) async -> UIImage? {
+        guard let blobID = picture?.thumbnailBlobID else { return nil }
+
+        // Answered from the cache before the round trip below, so a relaunch draws
+        // the picture at first paint instead of after a download URL comes back.
+        // Safe to trust: a blob is immutable, so a new picture is a new key.
+        if let cached = await RemoteImageLoader.cachedImage(cacheKey: blobID.description) {
+            return cached
+        }
+
+        do {
+            // Download URLs expire, so one is minted per load and never stored.
+            guard let url = try await client.blobDownloadURL(blobID: blobID, owner: owner) else {
+                logger.info("Profile picture blob has no download URL", metadata: ["blobId": "\(blobID)"])
+                return nil
+            }
+
+            return try await RemoteImageLoader.image(at: url, cacheKey: blobID.description)
+        } catch {
+            guard !Task.isCancelled else { return nil }
+            logger.info("Failed to load a profile picture", metadata: ["error": "\(error)"])
+            return nil
+        }
+    }
+}

--- a/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipcardScreen.swift
@@ -103,24 +103,12 @@ struct TipcardScreen: View {
         // on the card, least of all baked into the export.
         avatar = nil
 
-        guard let blobID = profilePicture?.thumbnailBlobID else { return }
-
-        do {
-            // Download URLs expire, so one is minted per load and never stored.
-            guard let url = try await container.flipClient.blobDownloadURL(
-                blobID: blobID,
-                owner: sessionContainer.session.ownerKeyPair
-            ) else {
-                logger.info("Profile picture blob has no download URL", metadata: ["blobId": "\(blobID)"])
-                return
-            }
-
-            avatar = try await RemoteImageLoader.image(at: url, cacheKey: blobID.description)
-        } catch {
-            guard !Task.isCancelled else { return }
-            // The card still renders and shares without the photo.
-            logger.info("Failed to load profile picture for the tipcard", metadata: ["error": "\(error)"])
-        }
+        // The card still renders and shares without the photo.
+        avatar = await ProfilePictureLoader.thumbnail(
+            for: profilePicture,
+            using: container.flipClient,
+            owner: sessionContainer.session.ownerKeyPair
+        )
     }
 
     private func renderExportImage() {

--- a/FlipcashUI/Sources/FlipcashUI/Images/RemoteImageLoader.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Images/RemoteImageLoader.swift
@@ -18,4 +18,12 @@ public enum RemoteImageLoader {
         let resource = KF.ImageResource(downloadURL: url, cacheKey: cacheKey)
         return try await KingfisherManager.shared.retrieveImage(with: resource).image
     }
+
+    /// The image already cached under `cacheKey`, or nil when it isn't cached.
+    ///
+    /// Never touches the network, so a caller holding a durable key can draw a
+    /// previously-fetched image before it mints a signed URL to re-fetch it.
+    public static func cachedImage(cacheKey: String) async -> UIImage? {
+        try? await KingfisherManager.shared.cache.retrieveImage(forKey: cacheKey).image
+    }
 }


### PR DESCRIPTION
The tab bar drew the tip-card icon for the first moment of every cold launch, then swapped to the avatar.

The blob ID is hydrated from SQLite at `Session` init, and Kingfisher keys its cache on that blob ID rather than the URL — so on a relaunch the bytes were already on disk. The delay was the `blobDownloadURL` round trip running ahead of the cache lookup.

`ProfilePictureLoader` now checks the cache first and returns on a hit. A blob is immutable, so a new picture is a new key; a stale hit isn't possible.

Three surfaces fetched the same thumbnail the same way — the tab bar, the tip card, and the photo editor — so the fetch moves into `ProfilePictureLoader` and they all get the fast path.

Stacked on #677.
