### PR TITLE
feat(profile): arm Save on the change screens only once the value differs

### DIFF
--- a/Flipcash/Core/Screens/Main/Profile/ProfileNameScreen.swift
+++ b/Flipcash/Core/Screens/Main/Profile/ProfileNameScreen.swift
@@ -77,10 +77,10 @@ struct ProfileNameScreen: View {
                 }
 
                 Button(action: submit) {
-                    ButtonStateLabel("Next", state: buttonState)
+                    ButtonStateLabel(completion == .tipcard ? "Next" : "Save", state: buttonState)
                 }
                 .buttonStyle(.filled)
-                .disabled(state.validatedDisplayName == nil || isSubmitting)
+                .disabled(!canSubmit || isSubmitting)
                 .accessibilityIdentifier("profile-name-next-button")
                 .padding(.bottom, 20)
             }
@@ -93,6 +93,14 @@ struct ProfileNameScreen: View {
         // Leaving the screen abandons the submission: its only continuation is a
         // push onto a stack this screen no longer sits on.
         .onDisappear { submitTask?.cancel() }
+    }
+
+    /// The name has to be valid and different from the one on the profile:
+    /// re-sending the name already there spends a moderation round trip to
+    /// change nothing.
+    private var canSubmit: Bool {
+        guard let name = state.validatedDisplayName else { return false }
+        return name != sessionContainer.session.profile?.displayName
     }
 
     private func submit() {

--- a/Flipcash/Core/Screens/Main/Profile/ProfilePhotoScreen.swift
+++ b/Flipcash/Core/Screens/Main/Profile/ProfilePhotoScreen.swift
@@ -35,6 +35,11 @@ struct ProfilePhotoScreen: View {
     /// rest of the app shows on a completed action.
     @State private var buttonState: ButtonState = .normal
 
+    /// The picture already on the profile, so a lone edit opens on what it is
+    /// about to replace rather than on an empty circle. Drawn but never
+    /// submitted — Save stays shut until a new photo is picked.
+    @State private var currentPhoto: UIImage?
+
     private static let avatarSize: CGFloat = 158
     private static let plusSize: CGFloat = 64
 
@@ -61,7 +66,11 @@ struct ProfilePhotoScreen: View {
                     Button("Photo Library", systemImage: "photo.on.rectangle") { isShowingPhotoPicker = true }
                     Button("Choose File", systemImage: "folder") { isShowingFilePicker = true }
                 } label: {
-                    CircleImage(image: state.selectedImage, size: Self.avatarSize, plusSize: Self.plusSize)
+                    CircleImage(
+                        image: state.selectedImage ?? currentPhoto,
+                        size: Self.avatarSize,
+                        plusSize: Self.plusSize
+                    )
                 }
                 .menuIndicator(.hidden)
                 .disabled(state.isUploading)
@@ -112,6 +121,19 @@ struct ProfilePhotoScreen: View {
             guard state.hasPendingUpload else { return }
             await upload()
         }
+        // Keyed on the blob so a picture that changes underneath — including the
+        // one this screen just uploaded — is what the circle ends up drawing.
+        .task(id: profilePicture?.thumbnailBlobID) {
+            currentPhoto = await ProfilePictureLoader.thumbnail(
+                for: profilePicture,
+                using: container.flipClient,
+                owner: sessionContainer.session.ownerKeyPair
+            )
+        }
+    }
+
+    private var profilePicture: ProfilePicture? {
+        sessionContainer.session.profile?.profilePicture
     }
 
     private func upload() async {
@@ -129,6 +151,10 @@ struct ProfilePhotoScreen: View {
             // is seen before the screen changes.
             try? await Task.delay(milliseconds: 500)
 
+            // Held as the current picture first: releasing the selection alone
+            // would drop the circle back to whatever was downloaded before this
+            // upload, for as long as the pop takes.
+            currentPhoto = state.selectedImage
             // Released only now: dropping it any earlier empties the avatar back
             // to its placeholder while the checkmark is still up.
             state.releaseSelectedImage()

--- a/Flipcash/Core/Screens/Main/Username/UsernameEntryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Username/UsernameEntryScreen.swift
@@ -78,13 +78,10 @@ struct UsernameEntryScreen: View {
                 Spacer()
 
                 Button(action: submit) {
-                    ButtonStateLabel("Next", state: buttonState)
+                    ButtonStateLabel(currentUsername == nil ? "Next" : "Save", state: buttonState)
                 }
                 .buttonStyle(.filled)
-                // Enabled for anything non-empty, unlike `ProfileNameScreen`'s
-                // validity-gated Next: the rejections are the point of the
-                // button here, so it has to be reachable while the input is bad.
-                .disabled(input.isEmpty || isSubmitting)
+                .disabled(!canSubmit || isSubmitting)
                 .accessibilityIdentifier("username-next-button")
                 .padding(.bottom, 20)
             }
@@ -106,6 +103,17 @@ struct UsernameEntryScreen: View {
     private var minimumBalance: FiatAmount? {
         guard let minimum = session.userFlags?.usernameMinBalance else { return nil }
         return .usd(minimum.decimalValue)
+    }
+
+    /// Enabled for anything non-empty that isn't the handle they already hold,
+    /// unlike `ProfileNameScreen`'s validity-gated button: the rejections are
+    /// the point of this one, so it has to be reachable while the input is bad.
+    private var canSubmit: Bool {
+        guard !input.isEmpty else { return false }
+        guard let current = currentUsername?.value else { return true }
+        // Compared through the validator so a change the validator normalizes
+        // away — a stray space, a different case — isn't treated as an edit.
+        return Self.validator.validate(input)?.value != current
     }
 
     private func submit() {

--- a/Flipcash/Core/Screens/Settings/ChangeProfilePictureScreen.swift
+++ b/Flipcash/Core/Screens/Settings/ChangeProfilePictureScreen.swift
@@ -5,10 +5,10 @@
 
 import SwiftUI
 
-/// Changing the profile picture on its own, reached from the You tab's
-/// "Finish Your Profile" checklist (node 9541:10186). Hosts the profile-setup
-/// photo step, which returns here once the photo uploads instead of carrying on
-/// to the tip card.
+/// Changing the profile picture on its own, reached from My Account and from
+/// the You tab's "Finish Your Profile" checklist (node 9541:10186). Hosts the
+/// profile-setup photo step, which returns here once the photo uploads instead
+/// of carrying on to the tip card.
 struct ChangeProfilePictureScreen: View {
 
     /// The photo step reads the name from the environment: profile setup owns

--- a/FlipcashUITests/Smoke/DisplayNameSmokeTests.swift
+++ b/FlipcashUITests/Smoke/DisplayNameSmokeTests.swift
@@ -56,24 +56,24 @@ final class DisplayNameSmokeTests: BaseUITestCase {
         settings.navigateToMyAccount(from: self)
         waitAndTap(settings.displayNameRow)
 
-        let next = app.buttons["profile-name-next-button"]
-        XCTAssertTrue(next.waitForExistence(timeout: 30), "Expected the name editor")
+        let save = app.buttons["profile-name-next-button"]
+        XCTAssertTrue(save.waitForExistence(timeout: 30), "Expected the name editor")
 
-        // The editor is seeded with the name already on the profile, so Next
-        // starts enabled — clear the field to see it disable.
+        // The editor is seeded with the name already on the profile, and Save
+        // takes an actual change — so it starts disabled on the seeded name.
         let field = app.textFields["Your Name"]
         XCTAssertTrue(field.waitForExistence(timeout: 10), "Expected the name field")
-        XCTAssertTrue(next.isEnabled, "Next must start enabled with the existing name in the field")
+        XCTAssertFalse(save.isEnabled, "Save must start disabled on the name already on the profile")
 
         field.tap()
         let seeded = (field.value as? String) ?? ""
         XCTAssertFalse(seeded.isEmpty, "Expected the editor to be seeded with the current name")
         field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: seeded.count))
-        XCTAssertFalse(next.isEnabled, "Next must disable while the name is empty")
+        XCTAssertFalse(save.isEnabled, "Save must stay disabled while the name is empty")
 
         field.typeText("Renamed \(Int.random(in: 1_000...9_999))")
-        XCTAssertTrue(next.isEnabled, "Next must re-enable once the name is valid")
-        next.tap()
+        XCTAssertTrue(save.isEnabled, "Save must enable once the name is valid and changed")
+        save.tap()
 
         // `ProfileNameScreen(completion: .back)` pops itself only once
         // `SetDisplayName` returns, so landing back on My Account is proof the


### PR DESCRIPTION
The three lone edits — Display Name, Username, Profile Picture — opened with Save active on the value already on the profile, so submitting unchanged spent a moderation or upload round trip to change nothing.

Each is now gated on an actual difference, and the button reads Save rather than Next when it isn't a profile-setup step (node 9553:112962).

Username compares through the validator so a stray space or a case change isn't read as an edit, but stays reachable while the input is invalid — its rejections are what that screen is for.

Set Profile Picture now seeds the circle with the picture it's about to replace, drawn but never submitted, so a lone edit no longer opens on an empty avatar.

Backing out of any of the three still discards the in-flight edit and leaves the saved value alone: each screen builds its own `ProfileCreationState` in `init`, held as `@State`, so the edit dies with the view identity on pop and no RPC runs on the back path.

`DisplayNameSmokeTests` is inverted to match — Save now starts disabled on the seeded name, stays disabled while the field is empty, and enables once the name is both valid and changed.

Stacked on #678.
