### PR TITLE
fix(profile): hold the You tab's slot with the picture's BlurHash

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/HomeTabBar.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabBar.swift
@@ -17,9 +17,9 @@ struct HomeTabBar: View {
     /// Per-tab unread badge counts; a tab absent or mapped to 0 shows no badge.
     var badgeCounts: [HomeTab: Int] = [:]
 
-    /// The signed-in profile's picture, which the You tab wears in place of its
-    /// glyph. Nil keeps the glyph.
-    var profilePhoto: UIImage?
+    /// The circle the You tab wears in place of its glyph, once the profile
+    /// carries a picture. Nil keeps the glyph.
+    var profileSlot: ProfileTabSlot?
 
     private let tabs = HomeTab.allCases
 
@@ -91,8 +91,8 @@ struct HomeTabBar: View {
     /// and a profile without a picture, keeps the outline glyph.
     @ViewBuilder
     private func icon(for tab: HomeTab) -> some View {
-        if tab == .tipCard, let profilePhoto {
-            ProfileTabIcon(photo: profilePhoto)
+        if tab == .tipCard, let profileSlot {
+            ProfileTabIcon(photo: profileSlot.preview)
         } else {
             Image(tab.iconName(isSelected: tab == selection))
                 .renderingMode(.template)

--- a/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabView.swift
@@ -117,6 +117,31 @@ struct HomeTabView: View {
         sessionContainer.session.profile?.profilePicture
     }
 
+    /// What the You tab wears right now, or nil for a profile with no picture.
+    ///
+    /// Derived in the body rather than waited on: the profile is hydrated from
+    /// the database before the first paint, so a cold launch knows a picture is
+    /// coming — and can decode its BlurHash — while the thumbnail is still being
+    /// read back. Keying only on the loaded photo would show the glyph until it
+    /// landed, which is the tip card's icon on somebody who has a picture.
+    private var profileSlot: ProfileTabSlot? {
+        if let photo = profilePhoto.photo { return .photo(photo) }
+        guard let picture = profilePicture, picture.thumbnailBlobID != nil else { return nil }
+        return .pending(BlurHashCache.shared.image(for: picture.thumbnailBlurhash))
+    }
+
+    /// `profileSlot` in the form the iOS 26 bar takes its item images in.
+    private var profileItemImages: TabBarProfilePhoto.ItemImages? {
+        guard let profileSlot else { return nil }
+
+        switch profileSlot {
+        case .photo:
+            return profilePhoto.itemImages
+        case .pending(let preview):
+            return TabBarProfilePhoto.pendingItemImages(preview: preview)
+        }
+    }
+
     /// Brings the tab the router asked for forward and clears the request.
     private func selectRequestedTab() {
         guard let requested = router.requestedTabStack,
@@ -161,7 +186,7 @@ struct HomeTabView: View {
         // handing it the pair is what makes the icons fill under the finger
         // rather than when the drag commits — the binding does not change until
         // the finger lifts.
-        .background(TabBarSelectedIcons(tabs: HomeTab.allCases, profileImages: profilePhoto.itemImages))
+        .background(TabBarSelectedIcons(tabs: HomeTab.allCases, profileImages: profileItemImages))
     }
 
     /// The unselected icon for a tab. The filled counterpart is handed to UIKit
@@ -172,7 +197,7 @@ struct HomeTabView: View {
     /// image from this label whenever it rebuilds the bar, so a label that
     /// disagreed would take turns with the probe and flicker between the two.
     @ViewBuilder private func tabLabel(for tab: HomeTab) -> some View {
-        if tab == .tipCard, let photo = profilePhoto.itemImages?.normal {
+        if tab == .tipCard, let photo = profileItemImages?.normal {
             Image(uiImage: photo).renderingMode(.original)
         } else {
             Image(tab.iconName(isSelected: false))
@@ -198,7 +223,7 @@ struct HomeTabView: View {
                 HomeTabBar(
                     selection: $selection,
                     badgeCounts: [.chat: chatBadgeCount],
-                    profilePhoto: profilePhoto.photo
+                    profileSlot: profileSlot
                 )
                     // Figma insets the pill ~42pt from each edge (318pt wide on the
                     // 402pt frame); a fixed margin keeps the floating look across

--- a/Flipcash/Core/Screens/Main/Home/TabBarProfilePhoto.swift
+++ b/Flipcash/Core/Screens/Main/Home/TabBarProfilePhoto.swift
@@ -7,12 +7,37 @@ import SwiftUI
 import FlipcashCore
 import FlipcashUI
 
+/// What the You tab draws in its icon slot, for a profile that has a picture.
+///
+/// Nil-vs-case rather than a bare optional photo: "no picture at all" and "a
+/// picture that hasn't loaded" want different slots, and only the first of them
+/// should fall back to the outline glyph.
+enum ProfileTabSlot: Equatable {
+    /// The picture's thumbnail hasn't been read back yet, carrying its BlurHash
+    /// preview — nil for a picture stored before the hash was, which draws the
+    /// ring empty rather than falling back to the glyph.
+    case pending(UIImage?)
+    case photo(UIImage)
+
+    /// What `ProfileTabIcon` draws inside the ring.
+    var preview: UIImage? {
+        switch self {
+        case .pending(let blurred): blurred
+        case .photo(let picture):   picture
+        }
+    }
+}
+
 /// The You tab's icon once the profile carries a picture: the photo in a white
 /// ring, standing in the slot the outline glyph otherwise occupies (Figma node
 /// 9641:17115).
+///
+/// A nil photo draws the ring empty. That is the state a cold launch starts in:
+/// the profile says a picture exists well before its thumbnail is read back, and
+/// the ring holds the slot so the glyph never shows to someone who has one.
 struct ProfileTabIcon: View {
 
-    let photo: UIImage
+    let photo: UIImage?
 
     /// The slot every tab glyph is drawn into, so the photo sits on the same
     /// baseline as its neighbours.
@@ -22,15 +47,21 @@ struct ProfileTabIcon: View {
     private static let ringWidth: CGFloat = 2
 
     var body: some View {
-        Image(uiImage: photo)
-            .resizable()
-            .scaledToFill()
-            .frame(width: Self.circleSize, height: Self.circleSize)
-            .clipShape(Circle())
-            .overlay {
-                Circle().strokeBorder(Color.white, lineWidth: Self.ringWidth)
+        Group {
+            if let photo {
+                Image(uiImage: photo)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Color.white.opacity(0.2)
             }
-            .frame(width: Self.slotSize, height: Self.slotSize)
+        }
+        .frame(width: Self.circleSize, height: Self.circleSize)
+        .clipShape(Circle())
+        .overlay {
+            Circle().strokeBorder(Color.white, lineWidth: Self.ringWidth)
+        }
+        .frame(width: Self.slotSize, height: Self.slotSize)
     }
 }
 
@@ -88,12 +119,30 @@ final class TabBarProfilePhoto {
         loadedBlobID = blobID
     }
 
+    /// The bar renditions of a slot that is still loading, so the iOS 26 bar
+    /// shows the BlurHash where the pill shows it too.
+    ///
+    /// Memoized on the preview because this is read from a view body: the decode
+    /// behind it is already cached, but the two `ImageRenderer` passes are not.
+    /// One entry is enough — a launch only ever waits on one picture.
+    static func pendingItemImages(preview: UIImage?) -> ItemImages? {
+        if memoizedPreview === preview, let memoizedPending { return memoizedPending }
+
+        let rendered = render(preview)
+        memoizedPreview = preview
+        memoizedPending = rendered
+        return rendered
+    }
+
+    private static var memoizedPreview: UIImage?
+    private static var memoizedPending: ItemImages?
+
     /// Draws the icon into the pair of images a `UITabBarItem` holds.
     ///
     /// The bar tints template glyphs per state, but a photo has to render as its
     /// own colours — so the unselected dimming is baked in here instead, at the
     /// half opacity the pill applies to every other icon.
-    static func render(_ photo: UIImage) -> ItemImages? {
+    static func render(_ photo: UIImage?) -> ItemImages? {
         guard let selected = image(of: ProfileTabIcon(photo: photo)),
               let normal = image(of: ProfileTabIcon(photo: photo).opacity(0.5))
         else { return nil }

--- a/FlipcashTests/TabBarProfilePhotoTests.swift
+++ b/FlipcashTests/TabBarProfilePhotoTests.swift
@@ -31,6 +31,42 @@ struct TabBarProfilePhotoTests {
         #expect(images.normal.pngData() != images.selected.pngData())
     }
 
+    /// A cold launch knows a picture exists before it has one to draw, and the
+    /// slot has to hold the space regardless — an empty ring is still not the
+    /// tip card's glyph.
+    @Test("A slot with no picture yet still renders at the glyph slot size")
+    func pendingRenditionsFillTheGlyphSlot() throws {
+        let images = try #require(TabBarProfilePhoto.pendingItemImages(preview: nil))
+        let slot = CGSize(width: ProfileTabIcon.slotSize, height: ProfileTabIcon.slotSize)
+
+        #expect(images.normal.size == slot)
+        #expect(images.selected.size == slot)
+    }
+
+    /// The pending renditions are read from a view body, so re-rendering them on
+    /// every pass would put two `ImageRenderer` passes in the layout path.
+    @Test("The same preview renders once and is reused")
+    func pendingRenditionsAreMemoized() throws {
+        let preview = Self.photo(side: 24)
+
+        let first = try #require(TabBarProfilePhoto.pendingItemImages(preview: preview))
+        let second = try #require(TabBarProfilePhoto.pendingItemImages(preview: preview))
+
+        #expect(first.normal === second.normal)
+        #expect(first.selected === second.selected)
+    }
+
+    /// `ProfileTabIcon` draws whatever the slot carries, so the BlurHash preview
+    /// has to reach it by the same route the loaded photo does.
+    @Test("A pending slot offers its BlurHash preview as the icon's picture")
+    func pendingSlotCarriesItsPreview() throws {
+        let preview = Self.photo(side: 24)
+
+        #expect(ProfileTabSlot.pending(preview).preview === preview)
+        #expect(ProfileTabSlot.pending(nil).preview == nil)
+        #expect(ProfileTabSlot.photo(preview).preview === preview)
+    }
+
     private static func photo(side: CGFloat) -> UIImage {
         UIGraphicsImageRenderer(size: CGSize(width: side, height: side)).image { context in
             UIColor.systemTeal.setFill()


### PR DESCRIPTION
On a cold launch the You tab drew the tip card's outline glyph for as long as the
profile picture took to load, so somebody who has a picture saw the wrong icon
first.

The wait isn't in reading the profile. `Session.init` hydrates it from SQLite
synchronously, so the thumbnail's blob ID and its BlurHash are both known at the
first paint. What runs late is the `.task` that follows it: a Kingfisher disk
read, then two `ImageRenderer` passes.

So derive what the tab wears in the view body rather than waiting on that task. A
profile carrying a picture resolves to a `ProfileTabSlot` — `.pending` while the
thumbnail is still being read, holding the ring with the picture's BlurHash the
way `ContactAvatarView` does, then `.photo` when the bytes land. Only a profile
with no picture at all falls back to the glyph.

Both bars take the same slot, so the iOS 26 native bar and the iOS 18–25 pill stay
in agreement. The native bar's item images are rendered from a view body now
instead of a task, so `pendingItemImages(preview:)` memoizes them on the preview —
one entry, since a launch only ever waits on one picture.
