### PR TITLE
fix(fastlane): read TestFlight notes as UTF-8, not in the caller's locale

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -522,17 +522,22 @@ platform :ios do
 
   # `notes:` inline, or `notes_file:` pointing at a file — the file form keeps
   # multi-line notes out of shell quoting. Returns nil when neither is set.
+  #
+  # Both sources are read as UTF-8 rather than in the caller's locale encoding:
+  # under a non-UTF-8 locale (e.g. `LC_ALL=C`) Ruby tags file contents and ARGV
+  # US-ASCII, and stripping notes that contain a `•` or `—` then raises
+  # Encoding::CompatibilityError.
   def resolve_beta_notes(options)
     text =
       if options[:notes_file]
         path = File.expand_path(options[:notes_file].to_s)
         UI.user_error!("notes_file '#{path}' not found") unless File.exist?(path)
-        File.read(path)
+        File.read(path, encoding: "UTF-8")
       else
-        options[:notes]
+        options[:notes].to_s.dup.force_encoding(Encoding::UTF_8)
       end
 
-    text = text.to_s.strip
+    text = text.strip
     text.empty? ? nil : text
   end
 


### PR DESCRIPTION
`resolve_beta_notes` read the `notes_file:` with a bare `File.read`, so Ruby tagged the bytes with the shell's external encoding. Under a non-UTF-8 locale that is US-ASCII, and the `strip` on the next line raised:

```
Fastfile:535:in 'String#strip': invalid byte sequence in US-ASCII (Encoding::CompatibilityError)
```

That fires for any notes containing a `•` or an em dash, which is every realistic notes file — the `/deploy` skill's own template uses both. The lane aborted before `ensure_branch_on_origin`, so nothing was triggered, but the backtrace pointed at `strip` rather than at the encoding of the read. It only shows up on a machine whose locale isn't UTF-8, which is also the case fastlane warns about on every run.

The fix reads the file as UTF-8 and reinterprets inline `notes:` the same way — Ruby tags ARGV with the locale encoding too, so `notes:'• …'` had the same exposure. `text.to_s` then becomes redundant, since both branches now yield a String.

This is the only `File.read` in the Fastfile. `TestFlight/WhatToTest.en-US.txt` never passes through Ruby here — Xcode Cloud reads it from the built commit at upload time.
