### PR TITLE
fix(api): pin Package.resolved to flipcash2-client-protocol 0.2.0

### DIFF
--- a/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/code-payments/flipcash2-client-protocol",
       "state" : {
-        "revision" : "73372b30748d8eb36c1a2f5a18ea9c8d1f7c6241",
-        "version" : "0.1.0"
+        "revision" : "9f6e3805672e955863dc91302bc60e27b7f03977",
+        "version" : "0.2.0"
       }
     },
     {


### PR DESCRIPTION
[#672](https://github.com/code-payments/code-ios-app/pull/672) moved
`FlipcashAPI/Package.swift` to `exact: "0.2.0"` for flipcash2-client-protocol,
but the workspace `Package.resolved` still pins `0.1.0`.

Local builds hide the mismatch — SwiftPM just re-resolves and rewrites the file,
which is why it shows up as a dirty working tree rather than a failure. Xcode
Cloud runs with automatic dependency resolution disabled, so it fails the archive
instead:

```
an out-of-date resolved file was detected at
Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved,
which is not allowed when automatic dependency resolution is disabled
```

Deploy Flipcash #512 is the first Xcode Cloud build of `main` since #672 landed,
and it failed on both `ValidationStep` and `ResolvePackageDependenciesStep` with
that error. The builds in between were release-branch builds on commits that
predate the pin.

This commits the resolution the pin already implies — the same file a local
build produces.
