### PR TITLE
feat(give): use the left-aligned amount layout Buy and Convert use

### DIFF
--- a/Flipcash/Core/Screens/Main/GiveScreen.swift
+++ b/Flipcash/Core/Screens/Main/GiveScreen.swift
@@ -40,7 +40,6 @@ private struct GiveScreenContent: View {
 
     @State private var viewModel: GiveViewModel
 
-    @State private var isShowingCurrencySelection: Bool = false
     @State private var isShowingTokenSelection: Bool = false
 
     /// True when this screen was pushed (from a currency's Give tile) rather
@@ -93,15 +92,13 @@ private struct GiveScreenContent: View {
                     viewModel.canGive
                 },
                 action: nextAction,
-                currencySelectionAction: showCurrencySelection
+                header: AnyView(SwapAmountHeader(
+                    enteredAmount: $viewModel.enteredAmount,
+                    available: maxLimit
+                ))
             )
             .foregroundStyle(.textMain)
-            .padding(.horizontal, 20)
-            .padding(.bottom, 20)
-            .padding(.top, -40)
-            .sheet(isPresented: $isShowingCurrencySelection) {
-                CurrencySelectionScreen(ratesController: ratesController)
-            }
+            .padding(20)
         }
         .ignoresSafeArea(.keyboard)
         .navigationTitle("")
@@ -142,10 +139,6 @@ private struct GiveScreenContent: View {
 
     private func nextAction() {
         viewModel.giveAction()
-    }
-
-    private func showCurrencySelection() {
-        isShowingCurrencySelection.toggle()
     }
 }
 

--- a/Flipcash/UI/SwapAmountHeader.swift
+++ b/Flipcash/UI/SwapAmountHeader.swift
@@ -2,11 +2,11 @@
 //  SwapAmountHeader.swift
 //  Flipcash
 //
-//  The top half of the Convert / Get amount screen: a left-aligned
-//  amount field over an "$X available" hint. Shared by both flows (Convert
-//  swaps it in for its source amount, Get for the payment amount) and dropped
-//  into `EnterAmountView` via its `header` slot, replacing the default centered
-//  amount + "Enter up to" subtitle.
+//  The top half of the Convert / Get / Give amount screens: a left-aligned
+//  amount field over an "$X available" hint. Shared by all three flows (Convert
+//  swaps it in for its source amount, Get for the payment amount, Give for the
+//  amount to hand over) and dropped into `EnterAmountView` via its `header`
+//  slot, replacing the default centered amount + "Enter up to" subtitle.
 //
 
 import SwiftUI


### PR DESCRIPTION
Give entered its amount through the centered field with a flag prefix and a chevron that opened the fiat-currency picker. Node 9641:16762 replaces that with the layout Buy and Convert already use: the amount left-aligned at the top of the screen over an "$X available" hint, no flag and no chevron.

`SwapAmountHeader` goes into `EnterAmountView`'s `header` slot, fed by the `maxLimit` the subtitle already computed. The slot flips the stack to leading alignment and moves the amount to the top, so the `.top, -40` padding that pulled the centered amount up is no longer needed — `.padding(20)` now matches the other two screens.

Dropping the chevron drops the fiat-currency picker from this screen, along with the state and sheet behind it. `CurrencySelectionScreen` is still reached from the balance header and from the Withdraw, Send, and Tip amount screens.

The design shows no accessory row, so Give gets no equivalent of Buy's "Buy with" or Convert's "Convert to". The token selector stays in the toolbar.

`subtitle: .balanceWithLimit(maxLimit)` is still passed but no longer rendered — `EnterAmountView` draws the subtitle only in the non-header branch, and the balance now appears as "$X available" under the amount instead. Buy and Convert pass it the same way, so this keeps the three call sites identical rather than diverging one of them.
