### PR TITLE
feat(profile): set a minimum tip from My Account and the profile checklist

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter+Destination.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Destination.swift
@@ -62,6 +62,10 @@ extension AppRouter {
         /// Account. One destination for both: the screen seeds itself from the
         /// handle already on the profile, so there is nothing to distinguish.
         case username(Username?)
+        /// The minimum a tipper must pay to open a DM. `isSetupStep` is the
+        /// You tab's checklist, which labels the button "Next"; My Account is
+        /// a lone edit and labels it "Save".
+        case setMinimumTip(isSetupStep: Bool)
         case settingsAdvancedFeatures
         case settingsAdvancedBetaFeatures
         case settingsAppSettings
@@ -110,7 +114,7 @@ extension AppRouter {
                  .withdrawCurrency, .usdcDepositEducation, .usdcDepositAddress:
                 return .balance
             case .settingsMyAccount, .changeDisplayName, .changeProfilePicture, .username,
-                 .settingsAdvancedFeatures,
+                 .setMinimumTip, .settingsAdvancedFeatures,
                  .settingsAdvancedBetaFeatures, .settingsAppSettings, .settingsAccountSelection,
                  .settingsApplicationLogs, .blockedUsers, .accessKey, .withdraw:
                 return .you
@@ -145,6 +149,7 @@ extension AppRouter {
             case .changeDisplayName:            "changeDisplayName"
             case .changeProfilePicture:         "changeProfilePicture"
             case .username:                     "username"
+            case .setMinimumTip:                "setMinimumTip"
             case .settingsAdvancedFeatures:     "settingsAdvancedFeatures"
             case .settingsAdvancedBetaFeatures: "settingsAdvancedBetaFeatures"
             case .settingsAppSettings:          "settingsAppSettings"
@@ -186,6 +191,8 @@ extension AppRouter {
                 return userID.uuidString
             case .username(let username):
                 return username?.value
+            case .setMinimumTip(let isSetupStep):
+                return isSetupStep ? "setup" : "settings"
             case .activity,
                  .discoverCurrencies, .currencyCreationSummary, .currencyCreationWizard,
                  .usdcDepositEducation, .usdcDepositAddress,

--- a/Flipcash/Core/Navigation/AppRouter+Destination.swift
+++ b/Flipcash/Core/Navigation/AppRouter+Destination.swift
@@ -62,9 +62,9 @@ extension AppRouter {
         /// Account. One destination for both: the screen seeds itself from the
         /// handle already on the profile, so there is nothing to distinguish.
         case username(Username?)
-        /// The minimum a tipper must pay to open a DM. `isSetupStep` is the
-        /// You tab's checklist, which labels the button "Next"; My Account is
-        /// a lone edit and labels it "Save".
+        /// The minimum a tipper must pay to open a DM. `isSetupStep` marks the
+        /// You tab's checklist apart from a lone edit in My Account; it reaches
+        /// the payload only, since the screen is the same from either.
         case setMinimumTip(isSetupStep: Bool)
         case settingsAdvancedFeatures
         case settingsAdvancedBetaFeatures

--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -79,6 +79,9 @@ struct DestinationView: View {
         case .username(let username):
             UsernameEntryScreen(currentUsername: username)
 
+        case .setMinimumTip(let isSetupStep):
+            SetMinimumTipScreen(isSetupStep: isSetupStep)
+
         case .settingsAdvancedFeatures:
             SettingsAdvancedFeaturesScreen()
 

--- a/Flipcash/Core/Screens/Main/Buy/BuyAmountScreen.swift
+++ b/Flipcash/Core/Screens/Main/Buy/BuyAmountScreen.swift
@@ -81,9 +81,9 @@ private struct BuyAmountScreenContent: View {
                 action: { viewModel.primaryAction(router: router) },
                 actionTitle: viewModel.actionTitle,
                 accessory: AnyView(paymentSelector),
-                header: AnyView(SwapAmountHeader(
+                header: AnyView(EnterAmountHeader(
                     enteredAmount: $viewModel.enteredAmount,
-                    available: viewModel.maxPossibleAmount
+                    hint: .available(viewModel.maxPossibleAmount)
                 ))
             )
             .foregroundStyle(.textMain)

--- a/Flipcash/Core/Screens/Main/Currency Convert/ConvertAmountScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Convert/ConvertAmountScreen.swift
@@ -67,9 +67,9 @@ private struct ConvertAmountScreenContent: View {
                 actionEnabled: { _ in viewModel.canPerformAction },
                 action: { viewModel.showConfirmation(router: router) },
                 accessory: AnyView(destinationSelector),
-                header: AnyView(SwapAmountHeader(
+                header: AnyView(EnterAmountHeader(
                     enteredAmount: $viewModel.enteredAmount,
-                    available: viewModel.maxPossibleAmount
+                    hint: .available(viewModel.maxPossibleAmount)
                 ))
             )
             .foregroundStyle(.textMain)

--- a/Flipcash/Core/Screens/Main/GiveScreen.swift
+++ b/Flipcash/Core/Screens/Main/GiveScreen.swift
@@ -92,9 +92,9 @@ private struct GiveScreenContent: View {
                     viewModel.canGive
                 },
                 action: nextAction,
-                header: AnyView(SwapAmountHeader(
+                header: AnyView(EnterAmountHeader(
                     enteredAmount: $viewModel.enteredAmount,
-                    available: maxLimit
+                    hint: .available(maxLimit)
                 ))
             )
             .foregroundStyle(.textMain)

--- a/Flipcash/Core/Screens/Main/You/YouScreen.swift
+++ b/Flipcash/Core/Screens/Main/You/YouScreen.swift
@@ -664,10 +664,7 @@ struct YouScreen: View {
         case .profilePicture:
             router.push(.changeProfilePicture)
         case .minimumTipAmount:
-            // Stubbed: setting the minimum tip is separate work. The row still
-            // renders and counts, and checks itself off if the profile already
-            // carries a fee.
-            break
+            router.push(.setMinimumTip(isSetupStep: true))
         }
     }
 

--- a/Flipcash/Core/Screens/Settings/SetMinimumTipScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SetMinimumTipScreen.swift
@@ -1,0 +1,169 @@
+//
+//  SetMinimumTipScreen.swift
+//  Flipcash
+//
+
+import SwiftUI
+import FlipcashUI
+import FlipcashCore
+
+private let logger = Logger(label: "flipcash.minimum-tip")
+
+/// Sets the minimum another user must pay to open a tip DM (node 9553:113170).
+/// Reached from My Account and from the You tab's "Finish Your Profile"
+/// checklist.
+///
+/// Nothing is written until Save, so backing out discards the entry — the
+/// behaviour node 9553:113241 asks for.
+struct SetMinimumTipScreen: View {
+
+    /// The floor, stated under the amount so a rejection is the exception
+    /// rather than the flow. Client-side: the contract carries no minimum, and
+    /// the server reports a breach as `ErrorSetMinDmChatInitFee.invalidAmount`,
+    /// which lands on the same dialog.
+    private static let minimumValue: Decimal = 1
+
+    @Environment(Container.self) private var container
+    @Environment(SessionContainer.self) private var sessionContainer
+    @Environment(RatesController.self) private var ratesController
+    @Environment(AppRouter.self) private var router
+
+    /// True when this is a step in the profile checklist, which labels the
+    /// button "Next"; a lone edit from My Account labels it "Save".
+    let isSetupStep: Bool
+
+    @State private var enteredAmount: String = ""
+    @State private var actionState: ButtonState = .normal
+    @State private var dialog: DialogItem?
+    @State private var submitTask: Task<Void, Never>?
+
+    private var currency: CurrencyCode { ratesController.balanceCurrency }
+
+    private var minimum: FiatAmount {
+        FiatAmount(value: Self.minimumValue, currency: currency)
+    }
+
+    /// The fee already on the profile, in the currency being entered. A fee set
+    /// in another currency isn't comparable, so it seeds nothing.
+    private var existingFee: FiatAmount? {
+        guard let fee = sessionContainer.session.profile?.minDmChatInitFee,
+              fee.currency == currency else { return nil }
+        return fee
+    }
+
+    var body: some View {
+        Background(color: .backgroundMain) {
+            EnterAmountView(
+                mode: .minimumTip,
+                enteredAmount: $enteredAmount,
+                subtitle: .hidden,
+                actionState: $actionState,
+                actionEnabled: { _ in canSubmit },
+                action: submit,
+                actionTitle: isSetupStep ? "Next" : nil,
+                header: AnyView(EnterAmountHeader(
+                    enteredAmount: $enteredAmount,
+                    hint: .caption("\(minimum.formatted()) minimum")
+                ))
+            )
+            .foregroundStyle(.textMain)
+            .padding(20)
+        }
+        .ignoresSafeArea(.keyboard)
+        .navigationTitle("Set Minimum Tip")
+        .toolbarTitleDisplayMode(.inline)
+        .dialog(item: $dialog)
+        .onAppear(perform: seedFromProfile)
+        // The only continuation is a pop off a stack this screen has left.
+        .onDisappear { submitTask?.cancel() }
+    }
+
+    // MARK: - Submission -
+
+    /// Save stays dark until the entry is a real amount that differs from the
+    /// fee already set — re-sending the current fee changes nothing. Amounts
+    /// under the minimum keep it live and raise a dialog on tap (node
+    /// 9544:20160), so the reason for the refusal is spelled out.
+    private var canSubmit: Bool {
+        guard let value = AmountValidator().validate(enteredAmount), value > 0 else { return false }
+        return value != existingFee?.value
+    }
+
+    private func submit() {
+        guard let value = AmountValidator().validate(enteredAmount),
+              submitTask == nil else { return }
+
+        guard value >= Self.minimumValue else {
+            dialog = minimumDialog()
+            return
+        }
+
+        let fee = FiatAmount(value: value, currency: currency)
+
+        actionState = .loading
+        submitTask = Task {
+            defer { submitTask = nil }
+
+            do {
+                try await container.flipClient.setMinDmChatInitFee(
+                    fee,
+                    owner: sessionContainer.session.ownerKeyPair
+                )
+                try await sessionContainer.session.updateProfile()
+
+                actionState = .success
+                // The same beat the other profile edits hold their checkmark
+                // for, so the confirmation is seen before the screen leaves.
+                try? await Task.delay(milliseconds: 500)
+
+                guard !Task.isCancelled else { return }
+                router.popTopmost()
+
+            } catch {
+                actionState = .normal
+                guard !Task.isCancelled else { return }
+
+                logger.error("Failed to set minimum tip", metadata: ["error": "\(error)"])
+                ErrorReporting.captureError(error, reason: "Failed to set minimum tip")
+
+                switch error as? ErrorSetMinDmChatInitFee {
+                case .invalidAmount:
+                    dialog = minimumDialog()
+                case .ok, .denied, .unknown, .transportFailure, .cancelled, .rejected, .none:
+                    dialog = .error(
+                        title: "Couldn't Save Your Minimum Tip",
+                        subtitle: "Try again"
+                    )
+                }
+            }
+        }
+    }
+
+    private func minimumDialog() -> DialogItem {
+        .info(
+            title: "\(minimum.formatted()) Minimum Tip",
+            subtitle: "Please enter a higher amount"
+        )
+    }
+
+    // MARK: - Seeding -
+
+    /// Starts the field on the fee already set, so the screen opens showing
+    /// what it is about to replace.
+    private func seedFromProfile() {
+        guard enteredAmount.isEmpty, let fee = existingFee, fee.isPositive else { return }
+        enteredAmount = AmountValidator().string(
+            from: fee.value,
+            fractionDigits: Self.fractionDigits(for: fee)
+        )
+    }
+
+    /// Whole fees seed without decimals ("5", not "5.00") so the field reads
+    /// the way the user would have typed it.
+    private static func fractionDigits(for fee: FiatAmount) -> Int {
+        var value = fee.value
+        var truncated = Decimal()
+        NSDecimalRound(&truncated, &value, 0, .down)
+        return truncated == value ? 0 : fee.currency.maximumFractionDigits
+    }
+}

--- a/Flipcash/Core/Screens/Settings/SetMinimumTipScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SetMinimumTipScreen.swift
@@ -28,8 +28,9 @@ struct SetMinimumTipScreen: View {
     @Environment(RatesController.self) private var ratesController
     @Environment(AppRouter.self) private var router
 
-    /// True when this is a step in the profile checklist, which labels the
-    /// button "Next"; a lone edit from My Account labels it "Save".
+    /// True when this is a step in the profile checklist rather than a lone
+    /// edit from My Account. Only the navigation payload distinguishes them —
+    /// the screen itself is identical either way.
     let isSetupStep: Bool
 
     @State private var enteredAmount: String = ""
@@ -60,7 +61,6 @@ struct SetMinimumTipScreen: View {
                 actionState: $actionState,
                 actionEnabled: { _ in canSubmit },
                 action: submit,
-                actionTitle: isSetupStep ? "Next" : nil,
                 header: AnyView(EnterAmountHeader(
                     enteredAmount: $enteredAmount,
                     hint: .caption("\(minimum.formatted()) minimum")

--- a/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
+++ b/Flipcash/Core/Screens/Settings/SettingsMyAccountScreen.swift
@@ -13,9 +13,8 @@ import FlipcashCore
 /// deals with, and the profile it presents. The account-level actions — Access
 /// Key, Switch Accounts, Log Out, Delete Account — live on Advanced.
 ///
-/// The design also lists Minimum Tip and Require Biometrics. Neither is here:
-/// the minimum-tip editor is still to be built, and iOS has no biometrics
-/// setting to toggle.
+/// The design also lists Require Biometrics, which isn't here: iOS has no
+/// biometrics setting to toggle.
 ///
 /// The row icons track Android's (`MyAccountMenuItems.kt`) through the nearest
 /// SF Symbol, so the two platforms read alike without importing Material into
@@ -60,6 +59,11 @@ struct SettingsMyAccountScreen: View {
                 router.push(.changeProfilePicture)
             }
             .accessibilityIdentifier("account-profile-picture-row")
+
+            SettingsRow(asset: .coins, title: "Minimum Tip", insets: insets) {
+                router.push(.setMinimumTip(isSetupStep: false))
+            }
+            .accessibilityIdentifier("account-minimum-tip-row")
 
             SettingsRow(systemImage: "nosign", title: "Blocked", insets: insets) {
                 router.push(.blockedUsers)

--- a/Flipcash/UI/EnterAmountCalculator.swift
+++ b/Flipcash/UI/EnterAmountCalculator.swift
@@ -23,7 +23,7 @@ nonisolated struct EnterAmountCalculator {
 
     var currency: CurrencyCode {
         switch mode {
-        case .currency, .buy, .sell, .convert, .withdraw, .addMoney:
+        case .currency, .buy, .sell, .convert, .withdraw, .addMoney, .minimumTip:
             selectedCurrency
         }
     }
@@ -48,6 +48,10 @@ nonisolated struct EnterAmountCalculator {
             return limit.maxPerDay
         case .sell, .convert, .withdraw:
             // No per-transaction limits for these flows — capped by balance.
+            return nil
+        case .minimumTip:
+            // Not a transaction — the only bound is the minimum, which the
+            // screen states itself.
             return nil
         }
     }

--- a/Flipcash/UI/EnterAmountHeader.swift
+++ b/Flipcash/UI/EnterAmountHeader.swift
@@ -1,22 +1,32 @@
 //
-//  SwapAmountHeader.swift
+//  EnterAmountHeader.swift
 //  Flipcash
 //
-//  The top half of the Convert / Get / Give amount screens: a left-aligned
-//  amount field over an "$X available" hint. Shared by all three flows (Convert
-//  swaps it in for its source amount, Get for the payment amount, Give for the
-//  amount to hand over) and dropped into `EnterAmountView` via its `header`
-//  slot, replacing the default centered amount + "Enter up to" subtitle.
+//  The top half of the left-aligned amount screens — Convert / Get / Give and
+//  Set Minimum Tip: a large amount field over a one-line hint. Dropped into
+//  `EnterAmountView` via its `header` slot, replacing the default centered
+//  amount + "Enter up to" subtitle.
 //
 
 import SwiftUI
 import FlipcashUI
 import FlipcashCore
 
-struct SwapAmountHeader: View {
+struct EnterAmountHeader: View {
+
+    /// The line under the amount.
+    enum Hint {
+        /// "$X available", reddening once the entry exceeds it — the spend
+        /// flows, where the balance is the ceiling.
+        case available(ExchangedFiat)
+        /// Fixed secondary copy, e.g. "$1.00 minimum". Never reddens: flows
+        /// that use it state their bound up front and report a breach through
+        /// a dialog on submit rather than by colouring the hint.
+        case caption(String)
+    }
+
     @Binding var enteredAmount: String
-    /// The spendable balance shown as "$X available" and used to flag overrun.
-    let available: ExchangedFiat
+    let hint: Hint
 
     @Environment(RatesController.self) private var ratesController
 
@@ -25,11 +35,19 @@ struct SwapAmountHeader: View {
     /// Mirrors `EnterAmountView`'s overrun colouring: the hint turns red once the
     /// entry exceeds what's available.
     private var isExceeding: Bool {
+        guard case .available(let available) = hint else { return false }
         guard let value = AmountValidator().validate(enteredAmount), value > 0 else { return false }
         return !EnterAmountCalculator.isWithinDisplayLimit(
             enteredAmount: enteredAmount,
             max: available.nativeAmount
         )
+    }
+
+    private var hintText: String {
+        switch hint {
+        case .available(let available): "\(available.nativeAmount.formatted()) available"
+        case .caption(let text):        text
+        }
     }
 
     var body: some View {
@@ -50,7 +68,7 @@ struct SwapAmountHeader: View {
             )
             .foregroundStyle(enteredAmount.isEmpty ? Color.textTertiary : Color.textMain)
 
-            Text("\(available.nativeAmount.formatted()) available")
+            Text(hintText)
                 .font(.appTextMedium)
                 .foregroundStyle(isExceeding ? Color.textError : Color.textSecondary)
         }

--- a/Flipcash/UI/EnterAmountView.swift
+++ b/Flipcash/UI/EnterAmountView.swift
@@ -28,8 +28,8 @@ public struct EnterAmountView: View {
     /// "Convert to [currency]" destination selector lives here.
     private let accessory: AnyView?
     /// Optional replacement for the default centered amount + subtitle block.
-    /// The Convert / Get flows pass a left-aligned `SwapAmountHeader`; when set,
-    /// the amount sits at the top rather than centered in the upper area.
+    /// The left-aligned flows pass an `EnterAmountHeader`; when set, the amount
+    /// sits at the top rather than centered in the upper area.
     private let header: AnyView?
 
     // MARK: - Calculator -
@@ -156,6 +156,9 @@ public struct EnterAmountView: View {
                                 .fixedSize()
                                 .foregroundStyle(.textError)
                                 .font(.appTextMedium)
+
+                        case .hidden:
+                            EmptyView()
                         }
                     }
                     .frame(maxWidth: .infinity)
@@ -213,17 +216,20 @@ extension EnterAmountView {
         case sell
         case convert
         case addMoney
+        /// Setting the minimum tip another user must pay to DM you. Not a
+        /// transaction, so no send limit applies.
+        case minimumTip
 
         fileprivate func formatter(with currency: CurrencyCode) -> NumberFormatter {
             switch self {
-            case .currency, .withdraw, .buy, .sell, .convert, .addMoney:
+            case .currency, .withdraw, .buy, .sell, .convert, .addMoney, .minimumTip:
                 return .fiat(currency: currency, minimumFractionDigits: 0)
             }
         }
 
         fileprivate var defaultValue: AmountField.DefaultValue {
             switch self {
-            case .currency, .withdraw, .buy, .sell, .convert, .addMoney: return .number("0")
+            case .currency, .withdraw, .buy, .sell, .convert, .addMoney, .minimumTip: return .number("0")
             }
         }
 
@@ -235,12 +241,13 @@ extension EnterAmountView {
             case .sell:     return "Next"
             case .convert:  return "Next"
             case .addMoney: return "Add Money"
+            case .minimumTip: return "Save"
             }
         }
 
         fileprivate var buttonStyle: CodeButton.Style {
             switch self {
-            case .currency, .withdraw, .buy, .sell, .convert, .addMoney: return .filled
+            case .currency, .withdraw, .buy, .sell, .convert, .addMoney, .minimumTip: return .filled
             }
         }
     }
@@ -255,6 +262,9 @@ extension EnterAmountView {
         /// Always rendered in `textError`. Use for soft-validation copy where
         /// Next stays enabled and the caller surfaces a dialog on tap.
         case error(String)
+        /// Nothing under the amount — for screens that pass a `header`, which
+        /// replaces this block outright.
+        case hidden
     }
 }
 


### PR DESCRIPTION
Adds the Set Minimum Tip screen — the minimum another user must pay to open a tip DM. The `setMinDmChatInitFee` RPC and `Profile.minDmChatInitFee` already existed; this is the UI that reaches them.

## Entry points

- **My Account → Minimum Tip**, a new row between Profile Picture and Blocked (node 9544:18478's order).
- **You tab → Finish Your Profile → "Set your minimum tip amount"**, replacing the stub in `handleProfileTutorialTap`.

Both reach the same screen, and the button reads **Save** from either — it pops back to where it came from, so there is no next step to promise. The destination still carries `isSetupStep` to separate the two in the navigation payload.

## Behaviour

Nothing is written until the button is tapped, so backing out discards the entry (node 9553:113241). The field seeds from the fee already on the profile when the currency matches, and Save stays disabled until the entry parses above zero and differs from it — re-sending the current fee isn't possible.

The $1.00 floor is client-side. The contract carries no minimum, so the screen states it under the amount and refuses a lower entry with a dialog (node 9544:20160). A sub-minimum entry keeps the button live and raises that dialog on tap rather than sitting disabled, per node 9553:113170. A server-side `ErrorSetMinDmChatInitFee.invalidAmount` routes to the same dialog as a backstop; every other case gets the generic failure dialog. `ErrorReporting.captureError` runs on all of them.

On success the button holds a checkmark for 500ms before popping — the beat the other profile edits use.

## Shared header

`SwapAmountHeader` becomes `EnterAmountHeader` and takes a `Hint`:

- `.available(ExchangedFiat)` — the spend flows' "$X available", which reddens once the entry exceeds the balance. Give, Buy and Convert move to it unchanged.
- `.caption(String)` — this screen's static "$1.00 minimum", which never reddens: the bound is stated up front and a breach is reported by dialog.

The old name never fit Give, which the previous PR moved onto it, and fits a minimum-tip screen less.

`EnterAmountView` gains `Mode.minimumTip` (no send limit — it isn't a transaction) and `Subtitle.hidden`, so a screen passing a `header` doesn't have to name a subtitle the header already replaces.
