### PR TITLE
feat(send): left-align the in-chat send amount screen

### DIFF
--- a/Flipcash/Core/Screens/Send/SendAmountScreen.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountScreen.swift
@@ -32,7 +32,6 @@ private struct SendAmountScreenContent: View {
     @Environment(AppRouter.self) private var router
 
     @State private var viewModel: SendAmountViewModel
-    @State private var isShowingCurrencySelection: Bool = false
     @State private var isShowingTokenSelection: Bool = false
     @State private var didSucceed: Bool = false
 
@@ -63,6 +62,17 @@ private struct SendAmountScreenContent: View {
 
     // MARK: - Body -
 
+    /// The tip floor when one applies, otherwise what's left to spend. A tip
+    /// states its minimum up front and reports a breach through a dialog on
+    /// submit, so the hint never reddens on that path.
+    private var hint: EnterAmountHeader.Hint {
+        if let minimum = viewModel.tipMinimum {
+            .caption("\(minimum.formatted()) minimum")
+        } else {
+            .available(maxLimit)
+        }
+    }
+
     var body: some View {
         Background(color: .backgroundMain) {
             EnterAmountView(
@@ -70,9 +80,12 @@ private struct SendAmountScreenContent: View {
                 enteredAmount: $viewModel.enteredAmount,
                 subtitle: .balanceWithLimit(maxLimit),
                 actionEnabled: { _ in viewModel.canSend },
-                currencySelectionAction: { isShowingCurrencySelection.toggle() }
+                header: AnyView(EnterAmountHeader(
+                    enteredAmount: $viewModel.enteredAmount,
+                    hint: hint
+                ))
             ) {
-                SwipeControl(text: "Swipe to Send") {
+                SwipeControl(text: viewModel.isTipTarget ? "Swipe to Tip" : "Swipe to Send") {
                     switch await viewModel.sendAction() {
                     case .success:
                         didSucceed = true
@@ -85,12 +98,7 @@ private struct SendAmountScreenContent: View {
                 }
             }
             .foregroundStyle(.textMain)
-            .padding(.horizontal, 20)
-            .padding(.bottom, 20)
-            .padding(.top, -40)
-            .sheet(isPresented: $isShowingCurrencySelection) {
-                CurrencySelectionScreen(ratesController: ratesController)
-            }
+            .padding(20)
         }
         .ignoresSafeArea(.keyboard)
         .navigationTitle("")

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -61,6 +61,23 @@ final class SendAmountViewModel {
         return enteredFiat.onChainAmount.quarks > 0
     }
 
+    /// True when this send pays a tip recipient rather than a contact. Drives
+    /// the swipe label and whether a minimum applies.
+    var isTipTarget: Bool {
+        if case .tip = target { true } else { false }
+    }
+
+    /// The tip floor for the display currency, stated under the amount so a
+    /// rejection is the exception rather than the flow. Nil for a contact send,
+    /// and until the server's presets arrive.
+    var tipMinimum: FiatAmount? {
+        guard isTipTarget,
+              let presets = session.userFlags?.tipPresets(for: ratesController.balanceCurrency) else {
+            return nil
+        }
+        return FiatAmount(value: presets.minimum, currency: presets.currency)
+    }
+
     /// The keypad buffer parsed to a positive amount, or nil.
     private var validatedEntered: Decimal? {
         guard let amount = amountValidator.validate(enteredAmount), amount > 0 else { return nil }
@@ -170,9 +187,11 @@ final class SendAmountViewModel {
             }
             guard presets.meetsMinimum(exchangedFiat) else {
                 let minimum = FiatAmount(value: presets.minimum, currency: presets.currency)
-                session.dialogItem = .error(
-                    title: "Tips Start at \(minimum.formatted())",
-                    subtitle: "Enter a larger amount to send this tip"
+                // Grey rather than red: the entry is under a stated floor, not a
+                // failure, and the floor is already on screen (node 9553:20236).
+                session.dialogItem = .info(
+                    title: "\(minimum.formatted()) Minimum Tip",
+                    subtitle: "Please enter a higher amount"
                 )
                 return false
             }

--- a/Flipcash/UI/EnterAmountView.swift
+++ b/Flipcash/UI/EnterAmountView.swift
@@ -78,6 +78,7 @@ public struct EnterAmountView: View {
         subtitle: Subtitle,
         actionEnabled: @escaping (String) -> Bool,
         currencySelectionAction: (() -> Void)? = nil,
+        header: AnyView? = nil,
         @ViewBuilder actionContent: () -> ActionContent
     ) {
         self.mode                    = mode
@@ -90,7 +91,7 @@ public struct EnterAmountView: View {
         self.actionOverride          = AnyView(actionContent())
         self.actionTitle             = nil
         self.accessory               = nil
-        self.header                  = nil
+        self.header                  = header
     }
     
     // MARK: - Computed -

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -637,7 +637,7 @@ struct SendAmountViewModelTests {
 
         #expect(outcome == .failed)
         #expect(mock.sendCalls.isEmpty)
-        #expect(container.session.dialogItem?.title == "Tips Start at $1.00")
+        #expect(container.session.dialogItem?.title == "$1.00 Minimum Tip")
     }
 
     @Test("A tip at exactly the displayed minimum is allowed")

--- a/FlipcashTests/WithdrawViewModelTests.swift
+++ b/FlipcashTests/WithdrawViewModelTests.swift
@@ -651,7 +651,7 @@ struct WithdrawViewModelSummaryHelpersTests {
         switch viewModel.amountSubtitle {
         case .balanceWithLimit:
             break
-        case .singleTransactionLimit, .error:
+        case .singleTransactionLimit, .error, .hidden:
             Issue.record("Expected .balanceWithLimit subtitle for valid amount")
         }
     }
@@ -668,7 +668,7 @@ struct WithdrawViewModelSummaryHelpersTests {
         case .error(let copy):
             #expect(copy.contains("Minimum withdrawal"))
             #expect(copy.contains("0.51"))
-        case .balanceWithLimit, .singleTransactionLimit:
+        case .balanceWithLimit, .singleTransactionLimit, .hidden:
             Issue.record("Expected .error subtitle for amount below fee")
         }
     }


### PR DESCRIPTION
The amount entry reached from a chat — Send Cash, and Send a Tip in a tip DM — was the last
keypad screen still centring its amount over an "Enter up to" subtitle. Buy, Convert and Give
moved to the left-aligned header in earlier PRs; this brings the send screen with them, per
node 9641:16760.

`EnterAmountView`'s swipe-control initialiser hardcoded `header = nil`, so it takes a `header`
now like the button variant does.

**Tip minimum.** A tip target puts its floor under the amount ("$5.00 minimum") in place of the
available balance, so the bound is on screen before the swipe rather than only after it. The
dialog raised on a sub-minimum entry moves from a red error to the grey `.info` dialog Set
Minimum Tip already uses, with the design's copy:

    "Tips Start at $1.00" / "Enter a larger amount to send this tip"
    → "$1.00 Minimum Tip" / "Please enter a higher amount"

The floor itself is unchanged — still the server's `tipPresets` minimum for the display
currency, enforced in the same place.

**Swipe label.** "Swipe to Tip" for a tip recipient, "Swipe to Send" for a contact, matching
the "Send a Tip" title the tip DM's bottom bar already shows.

**Dropped.** Tapping the amount no longer opens fiat currency selection. The left-aligned
header draws no chevron, so that sheet had no way in — the same trade the other three screens
made. The token pill in the nav bar is untouched.

Also makes two `WithdrawViewModelTests` switches exhaustive over `Subtitle.hidden`. The
minimum-tip PR added the case without updating them, so `FlipcashTests` does not compile on
`main` as it stands.
