### PR TITLE
fix(currency-creation): name the USDF payment row "Dollars"

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -1008,8 +1008,7 @@ private struct PaymentSelectionStep: View {
                         exchangedBalance: row,
                         accessibilityIdentifier: isUSDF ? "launch-payment-row-usdf" : "launch-payment-row",
                         accessory: isPaying ? .loader : .chevron,
-                        amountStyle: .pill,
-                        usesSymbol: isUSDF
+                        amountStyle: .pill
                     ) {
                         viewModel.select(row, onConfirm: onConfirm)
                     }


### PR DESCRIPTION
The launch flow's Select Payment Currency step showed "USDF" where the rest of the app shows "Dollars".

`PaymentSelectionStep` passed `usesSymbol: isUSDF` to `CurrencyBalanceRow`, which renders `stored.symbol` in place of `stored.name`. The server's mint row carries name "Dollars" and symbol "USDF", so that flag was the only thing producing the ticker. Every other balance picker — Give, Withdraw, and Convert's destination sheet — and the wallet card render `stored.name`.

Dropping the flag is the whole change; `isUSDF` still selects the row's accessibility identifier.

Deposit keeps `usesSymbol`. `DepositCurrencyListScreen` and `DepositScreen` pick an on-chain asset alongside USDC, where the ticker is the right label.
