### PR TITLE
test(currency): cover the launch step's payment currency label

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -804,6 +804,7 @@ private struct IconStep: View {
             }
             .menuIndicator(.hidden)
             .disabled(isValidating)
+            .accessibilityIdentifier("currency-icon-picker")
 
             if !state.currencyName.isEmpty {
                 Text(state.currencyName)
@@ -970,6 +971,7 @@ private struct ConfirmationStep: View {
             }
             .buttonStyle(.filled)
             .disabled(isValidating)
+            .accessibilityIdentifier("launch-pay-button")
             .padding(.top, 20)
             .padding(.bottom, 20)
         }

--- a/FlipcashUITests/Regression/CurrencyLaunchPaymentCurrencyRegressionTests.swift
+++ b/FlipcashUITests/Regression/CurrencyLaunchPaymentCurrencyRegressionTests.swift
@@ -1,0 +1,88 @@
+//
+//  CurrencyLaunchPaymentCurrencyRegressionTests.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+/// Regression test for the launch wizard's Select Payment Currency step: the
+/// USDF row must read "Dollars", the name the rest of the app uses for the
+/// reserve mint, not the "USDF" symbol.
+///
+/// The step used to pass `usesSymbol: true` to `CurrencyBalanceRow`, which is
+/// the deposit flow's convention for picking an on-chain asset. Deciding how to
+/// pay for a launch is not that, and every other spend surface — Give, Convert,
+/// Buy — labels the same mint "Dollars".
+///
+/// The label is chosen in the view, so `CurrencyPaymentSelectionViewModel`'s
+/// unit tests cannot reach it; asserting it means walking the wizard.
+///
+/// Spends nothing. Reaching the payment step performs one name-availability
+/// check and three moderation calls, all read-only — the launch itself only
+/// starts on a payment row tap, which this test never makes.
+///
+/// **Prerequisites:**
+/// - A valid `FLIPCASH_UI_TEST_ACCESS_KEY` set in `secrets.local.xcconfig`
+/// - The test account must hold enough in a single currency to cover the launch
+///   cost, otherwise Get Started gates on Add Money (the case
+///   `CurrencyCreationGateRegressionTests` covers)
+/// - The account must hold USDF, so the USDF row is drawn
+/// - At least one image in the simulator's photo library, for the icon step
+final class CurrencyLaunchPaymentCurrencyRegressionTests: BaseUITestCase {
+
+    override var requiresAuthentication: Bool { true }
+
+    func testPaymentSelection_usdfRowIsLabelledDollars() throws {
+        let wallet = WalletScreen(app: app)
+        let creation = CurrencyCreationUIScreen(app: app)
+
+        assertMainScreenReached()
+
+        // Wallet → Create a Currency → Create Your Currency summary.
+        wallet.open(from: self)
+        wallet.tapCreateCurrencyTile(from: self)
+        creation.assertSummaryReached()
+
+        guard creation.startWizard(from: self) else {
+            throw XCTSkip("The standing account cannot afford the launch cost — Get Started gated on Add Money")
+        }
+
+        // `checkAvailability` runs against the server, so the name has to be
+        // one no previous run took.
+        creation.completeNameStep(name: Self.uniqueCurrencyName(), from: self)
+
+        guard creation.completeIconStep(from: self) else {
+            throw XCTSkip("The simulator's photo library is empty — the icon step can't be completed")
+        }
+
+        creation.completeDescriptionStep("UI test currency, never launched.", from: self)
+        creation.completeBillStep(from: self)
+        creation.advancePastConfirmation(from: self)
+
+        creation.assertPaymentSelectionReached()
+
+        let usdfRow = creation.usdfPaymentRow
+        XCTAssertTrue(
+            usdfRow.waitForExistence(timeout: 10),
+            "Expected a USDF payment row. On screen: \(visibleText())"
+        )
+
+        // The row's label is its `CurrencyLabel` flattened: name, then amount.
+        XCTAssertTrue(
+            usdfRow.label.contains("Dollars"),
+            "Expected the USDF payment row to be labelled Dollars, got: \(usdfRow.label)"
+        )
+        XCTAssertFalse(
+            usdfRow.label.contains("USDF"),
+            "Expected the USDF payment row not to use the USDF symbol, got: \(usdfRow.label)"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// A name no earlier run can have claimed. Kept short: the step caps input
+    /// at its character limit and silently truncates past it.
+    private static func uniqueCurrencyName() -> String {
+        "UITest\(Int(Date().timeIntervalSince1970) % 1_000_000)"
+    }
+}

--- a/FlipcashUITests/Support/Screens/CurrencyCreationUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/CurrencyCreationUIScreen.swift
@@ -1,0 +1,141 @@
+//
+//  CurrencyCreationUIScreen.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+/// Page object for the currency-creation summary and the launch wizard's steps
+/// up to Select Payment Currency.
+///
+/// Nothing here creates a currency or spends money. The wizard's server calls
+/// before the payment step are one name-availability check and three moderation
+/// requests, all read-only; the launch only starts once a payment row is tapped
+/// and its confirmation dialog is accepted, which this page object deliberately
+/// offers no action for.
+@MainActor
+struct CurrencyCreationUIScreen {
+
+    private let app: XCUIApplication
+
+    init(app: XCUIApplication) {
+        self.app = app
+    }
+
+    // MARK: - Summary
+
+    var summaryNavigationBar: XCUIElement { app.navigationBars["Create Your Currency"] }
+    var getStartedButton: XCUIElement { app.buttons["Get Started"] }
+
+    // MARK: - Wizard steps
+
+    /// Every step's primary CTA carries the same label, and one step is on
+    /// screen at a time, so this stays unambiguous.
+    var nextButton: XCUIElement { app.buttons["Next"] }
+
+    var nameField: XCUIElement { app.textFields["Currency Name"] }
+    var descriptionField: XCUIElement { app.textFields["Description"] }
+
+    /// The icon step's picker. Its label is a `CircleImage`, so there is no text
+    /// to match on; matched against any element type because a `Menu` is not
+    /// guaranteed to surface as a button.
+    var iconPicker: XCUIElement {
+        app.descendants(matching: .any).matching(identifier: "currency-icon-picker").firstMatch
+    }
+
+    var photoLibraryMenuItem: XCUIElement { app.buttons["Photo Library"] }
+
+    /// The confirmation step's CTA. Its label interpolates the launch cost
+    /// ("Pay $20.00 to Create"), hence the identifier.
+    var payToCreateButton: XCUIElement { app.buttons["launch-pay-button"] }
+
+    // MARK: - Payment selection
+
+    var paymentSelectionNavigationBar: XCUIElement { app.navigationBars["Select Payment Currency"] }
+
+    /// The USDF payment row, present whenever the account holds USDF.
+    var usdfPaymentRow: XCUIElement { app.buttons["launch-payment-row-usdf"] }
+
+    /// The non-USDF payment rows.
+    var tokenPaymentRows: XCUIElementQuery { app.buttons.matching(identifier: "launch-payment-row") }
+
+    // MARK: - Actions
+
+    /// Summary → the wizard's name step. Returns false when Get Started diverted
+    /// to the Add Money prompt because no single balance covers the launch cost.
+    func startWizard(from testCase: BaseUITestCase) -> Bool {
+        testCase.waitUntilHittableAndTap(getStartedButton)
+
+        let prompt = AddMoneyStartScreen(app: app).noBalanceTitle
+        let deadline = Date().addingTimeInterval(20)
+        while !nameField.exists && !prompt.exists && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        return nameField.exists
+    }
+
+    /// Fills the name step and advances. The name has to be unused: the step
+    /// checks availability against the server and refuses a taken one.
+    func completeNameStep(name: String, from testCase: BaseUITestCase) {
+        testCase.waitAndTap(nameField)
+        nameField.typeText(name)
+        testCase.waitUntilHittableAndTap(nextButton)
+    }
+
+    /// Picks the first image in the simulator's photo library, accepts the crop
+    /// editor, and advances.
+    ///
+    /// Returns false when the library has nothing to pick — the step's Next is
+    /// disabled until `state.selectedImage` is set, and there is no other way
+    /// past it.
+    func completeIconStep(from testCase: BaseUITestCase) -> Bool {
+        testCase.waitAndTap(iconPicker)
+        testCase.waitUntilHittableAndTap(photoLibraryMenuItem)
+
+        // `ImagePickerWithEditor` stays on `UIImagePickerController` for its
+        // crop editor, which grants read access without a permission prompt.
+        let firstPhoto = app.collectionViews.cells.firstMatch
+        guard firstPhoto.waitForExistence(timeout: 30) else { return false }
+        firstPhoto.tap()
+
+        // "Move and Scale" confirms with "Choose".
+        testCase.waitUntilHittableAndTap(app.buttons["Choose"])
+
+        // Moderation runs on Next, so the button spins for a beat afterwards.
+        testCase.waitUntilHittableAndTap(nextButton)
+        return true
+    }
+
+    func completeDescriptionStep(_ text: String, from testCase: BaseUITestCase) {
+        testCase.waitAndTap(descriptionField)
+        descriptionField.typeText(text)
+        testCase.waitUntilHittableAndTap(nextButton)
+    }
+
+    /// The bill step only picks colours; its Next lives in the toolbar.
+    func completeBillStep(from testCase: BaseUITestCase) {
+        testCase.waitUntilHittableAndTap(nextButton)
+    }
+
+    /// Confirmation → Select Payment Currency. The CTA reads
+    /// "Pay $X to Create"; it commits nothing, the payment row does.
+    func advancePastConfirmation(from testCase: BaseUITestCase) {
+        testCase.waitUntilHittableAndTap(payToCreateButton)
+    }
+
+    // MARK: - Assertions
+
+    func assertSummaryReached(timeout: TimeInterval = 10) {
+        XCTAssertTrue(
+            summaryNavigationBar.waitForExistence(timeout: timeout),
+            "Expected the currency creation summary screen"
+        )
+    }
+
+    func assertPaymentSelectionReached(timeout: TimeInterval = 30) {
+        XCTAssertTrue(
+            paymentSelectionNavigationBar.waitForExistence(timeout: timeout),
+            "Expected the Select Payment Currency step"
+        )
+    }
+}


### PR DESCRIPTION
Follow-up to #689, which stopped the launch flow's Select Payment Currency step from labelling the USDF row "USDF".

The label is chosen in the view, so `CurrencyPaymentSelectionViewModel`'s unit tests can't reach it. `CurrencyLaunchPaymentCurrencyRegressionTests` walks the wizard instead — summary, name, icon, description, bill, confirmation — and asserts the USDF row reads "Dollars" and not "USDF".

It stops at the payment step and spends nothing: reaching it performs one name-availability check and three moderation calls, all read-only, and the launch only starts on a payment row tap. Beyond the funded `FLIPCASH_UI_TEST_ACCESS_KEY` account it needs an image in the simulator's photo library for the icon step, whose Next stays disabled until one is picked; it skips when the library is empty, and when the account cannot afford the launch and Get Started gates on Add Money.

Two steps needed accessibility identifiers to be targetable: the icon picker's label is a `CircleImage` with no text, and the confirmation CTA interpolates the launch cost.
