### PR TITLE
fix(currency-creation): keep the wizard draft alive across a pop

### DIFF
--- a/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
+++ b/Flipcash/Core/Navigation/AppRouter+DestinationView.swift
@@ -44,7 +44,10 @@ struct DestinationView: View {
             CurrencyCreationSummaryScreen()
 
         case .currencyCreationWizard:
-            CurrencyCreationWizardScreen(state: CurrencyCreationState())
+            // Session-scoped, never built here: a draft constructed in this
+            // closure dies with the pop, so an edge swipe out of the wizard
+            // took the name, icon and description with it.
+            CurrencyCreationWizardScreen(state: sessionContainer.currencyCreation)
 
         case .transactionHistory(let mint):
             TransactionHistoryScreen(mint: mint)

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationState.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationState.swift
@@ -26,6 +26,27 @@ struct CreationProgressBar: View {
 @Observable
 final class CurrencyCreationState {
 
+    /// A step of the creation wizard. Lives on the draft rather than in the
+    /// wizard's `@State` so backing out and re-entering resumes where the user
+    /// left off instead of replaying the moderation calls from the name step.
+    enum Step: Int, CaseIterable {
+        case name = 0, icon, description, billCreation, confirmation, paymentSelection
+
+        var next: Step? { Step(rawValue: rawValue + 1) }
+        var previous: Step? { Step(rawValue: rawValue - 1) }
+
+        /// Whether this step joins the progress bar. The payment picker shows a
+        /// title instead, so it opts out — the bar's total derives from this, not
+        /// a hard-coded count.
+        var showsProgressBar: Bool { self != .paymentSelection }
+
+        /// Number of steps the progress bar counts.
+        static let progressStepCount = allCases.filter(\.showsProgressBar).count
+    }
+
+    /// The step the wizard is showing.
+    var step: Step = .name
+
     /// UI clamp and validator bound for the description. The server allows
     /// 4096; 500 is the product choice.
     static let descriptionCharLimit = 500
@@ -72,5 +93,21 @@ final class CurrencyCreationState {
 
     var isCurrencyDescriptionValid: Bool {
         descriptionValidator.validate(currencyDescription) != nil
+    }
+
+    /// Returns the draft to a blank first-run state. Called when a new creation
+    /// starts, so a finished or abandoned attempt doesn't prefill the next one.
+    /// The attestations are cleared explicitly: the field setters only clear
+    /// them on a *change*, and a field that is already empty doesn't change.
+    func reset() {
+        currencyName = ""
+        selectedImage = nil
+        currencyDescription = ""
+        backgroundColors = ColorEditorControl.randomDerivedColors()
+        nameAttestation = nil
+        iconAttestation = nil
+        descriptionAttestation = nil
+        encodedIconData = nil
+        step = .name
     }
 }

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationSummaryScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationSummaryScreen.swift
@@ -11,6 +11,14 @@ struct CurrencyCreationSummaryScreen: View {
     @Environment(AppRouter.self) private var router
     @Environment(Session.self) private var session
     @Environment(RatesController.self) private var ratesController
+    @Environment(SessionContainer.self) private var sessionContainer
+
+    /// The draft outlives the wizard, so it has to be cleared somewhere. This
+    /// screen is that boundary: it is pushed once per creation attempt, and
+    /// popping the wizard back to it doesn't unmount it — so this stays true
+    /// across the wizard's whole lifetime and flips back only on a fresh entry
+    /// from the Wallet.
+    @State private var hasStartedCreation = false
 
     private var purchaseAmount: ExchangedFiat {
         let quarks = session.userFlags?.newCurrencyPurchaseAmount.quarks ?? 0
@@ -66,6 +74,11 @@ struct CurrencyCreationSummaryScreen: View {
         }
         .toolbarTitleDisplayMode(.inline)
         .navigationTitle("Create Your Currency")
+        .onAppear {
+            guard !hasStartedCreation else { return }
+            hasStartedCreation = true
+            sessionContainer.currencyCreation.reset()
+        }
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -22,7 +22,6 @@ struct CurrencyCreationWizardScreen: View {
     @Environment(RatesController.self) private var ratesController
     @Environment(AppRouter.self) private var router
 
-    @State private var step: WizardStep = .name
     @State private var direction: Direction = .forward
     @State private var compressTask: Task<Void, Never>?
     @State private var validationTask: Task<Void, Never>?
@@ -106,21 +105,6 @@ struct CurrencyCreationWizardScreen: View {
         case description
     }
 
-    enum WizardStep: Int, CaseIterable {
-        case name = 0, icon, description, billCreation, confirmation, paymentSelection
-
-        var next: WizardStep? { WizardStep(rawValue: rawValue + 1) }
-        var previous: WizardStep? { WizardStep(rawValue: rawValue - 1) }
-
-        /// Whether this step joins the progress bar. The payment picker shows a
-        /// title instead, so it opts out — the bar's total derives from this, not
-        /// a hard-coded count.
-        var showsProgressBar: Bool { self != .paymentSelection }
-
-        /// Number of steps the progress bar counts.
-        static let progressStepCount = allCases.filter(\.showsProgressBar).count
-    }
-
     enum Direction {
         case forward, backward
 
@@ -139,7 +123,7 @@ struct CurrencyCreationWizardScreen: View {
     var body: some View {
         Background(color: .backgroundMain) {
             ZStack {
-                switch step {
+                switch state.step {
                 case .name:
                     NameStep(
                         state: state,
@@ -208,7 +192,7 @@ struct CurrencyCreationWizardScreen: View {
         }
         .dialog(item: $errorDialog)
         // The picker step names itself; the creation steps show the progress bar.
-        .navigationTitle(step.showsProgressBar ? "" : "Select Payment Currency")
+        .navigationTitle(state.step.showsProgressBar ? "" : "Select Payment Currency")
         .toolbarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled()
@@ -219,15 +203,15 @@ struct CurrencyCreationWizardScreen: View {
                         .foregroundStyle(Color.textMain)
                 }
             }
-            if step.showsProgressBar {
+            if state.step.showsProgressBar {
                 ToolbarItem(placement: .principal) {
                     CreationProgressBar(
-                        current: step.rawValue + 1,
-                        total: WizardStep.progressStepCount
+                        current: state.step.rawValue + 1,
+                        total: CurrencyCreationState.Step.progressStepCount
                     )
                 }
             }
-            if step == .billCreation {
+            if state.step == .billCreation {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(action: advance) {
                         Text("Next")
@@ -271,9 +255,9 @@ struct CurrencyCreationWizardScreen: View {
             }
         }
         .onAppear {
-            if step == .name { focusedField = .name }
+            if state.step == .name { focusedField = .name }
         }
-        .onChange(of: step) { _, newStep in
+        .onChange(of: state.step) { _, newStep in
             switch newStep {
             case .name: focusedField = .name
             case .description: focusedField = .description
@@ -285,20 +269,20 @@ struct CurrencyCreationWizardScreen: View {
     // MARK: - Navigation
 
     private func advance() {
-        guard let next = step.next else { return }
+        guard let next = state.step.next else { return }
         // `direction` must be set outside `withAnimation` so the transition
         // modifier captures the new edge when SwiftUI evaluates the push.
         direction = .forward
         withAnimation(.easeInOut(duration: 0.3)) {
-            step = next
+            state.step = next
         }
     }
 
     private func goBack() {
-        if let previous = step.previous {
+        if let previous = state.step.previous {
             direction = .backward
             withAnimation(.easeInOut(duration: 0.3)) {
-                step = previous
+                state.step = previous
             }
         } else {
             dismiss()

--- a/Flipcash/Core/Session/SessionAuthenticator.swift
+++ b/Flipcash/Core/Session/SessionAuthenticator.swift
@@ -493,6 +493,13 @@ final class SessionContainer {
     /// reference never changes.
     @ObservationIgnored private(set) lazy var tipFlow = TipFlow(sessionContainer: self)
 
+    /// The in-progress currency the creation wizard is editing. Session-scoped
+    /// rather than owned by the wizard's navigation destination, which is
+    /// destroyed by any pop — an edge swipe out of the wizard used to discard
+    /// the name, icon and description with it. `CurrencyCreationSummaryScreen`
+    /// resets it when a new creation starts.
+    let currencyCreation = CurrencyCreationState()
+
     init(
         session: Session,
         database: Database,

--- a/FlipcashTests/Models/CurrencyCreationStateTests.swift
+++ b/FlipcashTests/Models/CurrencyCreationStateTests.swift
@@ -96,4 +96,65 @@ struct CurrencyCreationStateTests {
 
         #expect(state.descriptionAttestation == nil)
     }
+
+    // MARK: - Draft lifetime
+
+    // The draft is session-scoped so popping the wizard — an edge swipe, the
+    // toolbar chevron — no longer discards what the user entered. That makes
+    // `reset()` the only thing standing between one attempt and the next.
+
+    @Test("reset clears every field a previous attempt could have filled")
+    func reset_clearsFilledDraft() {
+        let state = CurrencyCreationState()
+        state.currencyName = "MyCoin"
+        state.currencyDescription = "A coin"
+        state.step = .confirmation
+        state.nameAttestation = ModerationAttestation(rawValue: Data([0x01]))
+        state.encodedIconData = Data([0x02])
+
+        state.reset()
+
+        #expect(state.currencyName == "")
+        #expect(state.currencyDescription == "")
+        #expect(state.step == .name)
+        #expect(state.nameAttestation == nil)
+        #expect(state.encodedIconData == nil)
+    }
+
+    /// The field setters clear their attestation on a *change*. A draft whose
+    /// text is already empty doesn't change, so reset has to clear the
+    /// attestations itself or a stale proof outlives the input it attests to.
+    @Test("reset clears attestations even when the fields are already empty")
+    func reset_clearsAttestationsWithoutFieldChanges() {
+        let state = CurrencyCreationState()
+        state.nameAttestation = ModerationAttestation(rawValue: Data([0x01]))
+        state.iconAttestation = ModerationAttestation(rawValue: Data([0x02]))
+        state.descriptionAttestation = ModerationAttestation(rawValue: Data([0x03]))
+
+        state.reset()
+
+        #expect(state.nameAttestation == nil)
+        #expect(state.iconAttestation == nil)
+        #expect(state.descriptionAttestation == nil)
+    }
+
+    // MARK: - Wizard steps
+
+    @Test("steps walk to the ends of the wizard and stop")
+    func step_boundaries() {
+        #expect(CurrencyCreationState.Step.name.previous == nil)
+        #expect(CurrencyCreationState.Step.paymentSelection.next == nil)
+        #expect(CurrencyCreationState.Step.name.next == .icon)
+        #expect(CurrencyCreationState.Step.icon.previous == .name)
+    }
+
+    /// The payment picker titles itself instead of joining the bar.
+    @Test("the progress bar counts every step but the payment picker")
+    func step_progressStepCount() {
+        #expect(
+            CurrencyCreationState.Step.progressStepCount
+                == CurrencyCreationState.Step.allCases.count - 1
+        )
+        #expect(!CurrencyCreationState.Step.paymentSelection.showsProgressBar)
+    }
 }


### PR DESCRIPTION
Reported in the wild as "currency creation resets to start (info screen) after leaving the app to take an icon photo". Backgrounding turns out not to be the trigger — a probe app confirmed that a background and foreground round trip, including with the image picker's `fullScreenCover` presented, preserves the step, the model identity, the entered text and the stack depth. What does reproduce it is leaving the wizard by a pop: the interactive edge swipe, which `navigationBarBackButtonHidden(true)` does not disable, or the toolbar chevron from the name step.

The draft was constructed inside the navigation destination builder, so it died with the destination and the next entry started blank on the info screen.

## What changed

`CurrencyCreationState` moves onto `SessionContainer`, alongside `tipFlow`, and the destination hands the wizard that instance instead of building one per push.

It has to live above every `NavigationStack`. A `navigationDestination` destination resolves the environment of the stack, not that of the root content the modifier is attached to, so an `.environment(...)` applied on the root compiles and then traps in `EnvironmentValues.subscript.getter` the first time a destination reads it. `SessionContainer` is already injected above the stacks and already read by `DestinationView`, so nothing new is threaded through.

The wizard's `step` moves onto the draft too. Without it the fields survive the pop but the position doesn't, so re-entry replays the moderation calls from the name step — the fix only half-works.

`CurrencyCreationSummaryScreen` resets the draft on its first appearance only. That gives the lifetime the flow wants: it survives a pop and re-push of the wizard, and clears on a fresh entry from the Wallet. Session scope means a logout yields a fresh draft.

## Notes

Four cases added to the existing `CurrencyCreationState` suite, covering `reset()` and the step boundaries. `reset()` clears the three attestations explicitly rather than relying on the field setters, which only clear on a *change* — a field that is already empty doesn't change, and a stale proof would outlive the input it attests to.