### PR TITLE
fix(currency-creation): pop the creation flow when a launch finishes

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
+++ b/Flipcash/Core/Screens/Main/Currency Creation/CurrencyCreationWizardScreen.swift
@@ -261,12 +261,7 @@ struct CurrencyCreationWizardScreen: View {
                     paymentMint: context.paymentMint
                 )
                 .environment(\.dismissParentContainer, {
-                    // Sheet dismiss unmounts the wizard, taking the
-                    // fullScreenCover with it as a single animation.
-                    // Nilling the cover binding here would stage a separate
-                    // cover-dismiss before the sheet animation; the @State
-                    // is freed automatically when the wizard unmounts.
-                    router.dismissSheet()
+                    Self.dismissCreationFlow(router: router)
                 })
             }
         }
@@ -280,6 +275,17 @@ struct CurrencyCreationWizardScreen: View {
             case .icon, .billCreation, .confirmation, .paymentSelection: focusedField = nil
             }
         }
+    }
+
+    /// Unwinds the whole creation flow once the launch cover is done with it —
+    /// both the finished handoff and the failure dismissal come through here.
+    ///
+    /// The flow is pushed onto the Wallet tab's stack, so it comes off by
+    /// popping that stack to its root. Naming the stack rather than using
+    /// `popToRoot()`'s topmost lookup keeps this working while the cover is up,
+    /// since the tab host clears `activeTabStack` when it disappears.
+    static func dismissCreationFlow(router: AppRouter) {
+        router.popToRoot(on: AppRouter.Destination.currencyCreationWizard.owningStack)
     }
 
     // MARK: - Navigation

--- a/FlipcashTests/Navigation/CurrencyCreationFlowDismissalTests.swift
+++ b/FlipcashTests/Navigation/CurrencyCreationFlowDismissalTests.swift
@@ -1,0 +1,43 @@
+//
+//  CurrencyCreationFlowDismissalTests.swift
+//  FlipcashTests
+//
+
+import SwiftUI
+import Testing
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Currency Creation Flow Dismissal")
+struct CurrencyCreationFlowDismissalTests {
+
+    /// Pushes the flow the way the Wallet tile does: summary, then wizard.
+    private func routerInCreationFlow() -> AppRouter {
+        let router = AppRouter()
+        router.activeTabStack = .balance
+        router.push(.currencyCreationSummary)
+        router.push(.currencyCreationWizard)
+        return router
+    }
+
+    @Test("Finishing the launch cover pops the creation flow off the Wallet stack")
+    func dismissCreationFlow_popsHostStack() {
+        let router = routerInCreationFlow()
+
+        CurrencyCreationWizardScreen.dismissCreationFlow(router: router)
+
+        #expect(router[.balance].isEmpty, "the wizard must not stay mounted under the dismissed cover")
+    }
+
+    @Test("Unwinds even though the cover hid the tab host and cleared the active stack")
+    func dismissCreationFlow_withoutActiveTabStack_popsHostStack() {
+        let router = routerInCreationFlow()
+        // `HomeTabView.onDisappear` clears this while the fullScreenCover is up.
+        router.activeTabStack = nil
+
+        CurrencyCreationWizardScreen.dismissCreationFlow(router: router)
+
+        #expect(router[.balance].isEmpty, "the unwind must not depend on the tab host still being mounted")
+    }
+}


### PR DESCRIPTION
Someone who finishes creating a currency and taps the post-launch reward bill gets stuck in the creation wizard once that bill is claimed. The only control left is the wizard's back chevron; the reporter force-quit the app to get out.

The launch screen is a `fullScreenCover` presented from the wizard, and it wired `dismissParentContainer` to `router.dismissSheet()`:

```swift
func dismissSheet() {
    guard let dismissing = presentedSheets.popLast() else { return }
```

The creation flow is pushed onto the Wallet tab's stack (`WalletScreen` tile → `.currencyCreationSummary` → `.currencyCreationWizard`), so `presentedSheets` is empty and the call returns early. Both exits from `CurrencyLaunchProcessingScreen` — the finished handoff in `handleReceiveLaunchedCurrency()` and the `.failed` button — were therefore no-ops, and the screen sets `navigationBarBackButtonHidden(true)` and `interactiveDismissDisabled(true)`, so nothing else could unwind it either.

The claim itself is not the bug. A `received: true` bill is deliberately a live `SendCashOperation` that others can grab; it just exposed the dead exit.

This pops the wizard's owning stack to root instead, matching `ConvertFlowDestinationView` and the pushed Buy flow. It names the stack rather than relying on `popToRoot()`'s topmost lookup, because `HomeTabView.onDisappear` clears `activeTabStack` while the cover is up. The wizard is only ever pushed, never a sheet root, so there is no host to branch on the way `BuyAmountScreen` does.

The wiring was correct when it landed in #213 — `.balance` was sheet-hosted then, and dismissing the sheet tore down the whole flow. #619 made `.balance` tab-hosted and this call site was missed.

`CurrencyCreationFlowDismissalTests` covers both the ordinary case and the one where the cover has already cleared `activeTabStack`.
