### PR TITLE
fix(chat): drop "of Dollars" from the reserve's chat preview

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -774,7 +774,8 @@ final class ConversationController {
 
     /// The feed row's last-message line: the typing indicator while the
     /// counterpart types, the message text, or the cash summary. `currencyName`
-    /// resolves a mint to its display name; nil drops the "of …" suffix.
+    /// resolves a mint to its display name; nil — or the reserve, whose formatted
+    /// amount already names itself — drops the "of …" suffix.
     func lastMessagePreview(for conversation: Conversation, currencyName: (PublicKey) -> String?) -> String? {
         if isCounterpartTyping(in: conversation.id) {
             return "Typing…"
@@ -786,7 +787,8 @@ final class ConversationController {
         case .cash(let amount):
             let verb = message.isFromSelf(selfUserID) ? "You sent" : "You received"
             let formatted = amount.nativeAmount.formatted()
-            guard let name = currencyName(amount.mint) else {
+            // The reserve would read "$1.00 of Dollars" — the amount alone already says it.
+            guard amount.mint != .usdf, let name = currencyName(amount.mint) else {
                 return "\(verb) \(formatted)"
             }
             return "\(verb) \(formatted) of \(name)"

--- a/FlipcashTests/ConversationControllerTests.swift
+++ b/FlipcashTests/ConversationControllerTests.swift
@@ -882,6 +882,41 @@ struct ConversationControllerTests {
         #expect(pointer == MessageID(value: 2))
     }
 
+    // MARK: - Last-message preview -
+
+    private func cashConversation(mint: PublicKey, from sender: UserID?) -> Conversation {
+        Conversation(
+            id: ConversationID.test(1),
+            members: [],
+            lastMessage: ConversationMessage(
+                id: MessageID(value: 1),
+                senderID: sender,
+                content: .cash(ExchangedFiat(
+                    onChainAmount: TokenAmount(quarks: 1_000_000, mint: mint),
+                    nativeAmount: FiatAmount(value: 1, currency: .usd),
+                    currencyRate: Rate(fx: 1, currency: .usd)
+                )),
+                date: Date(timeIntervalSince1970: 1),
+                unreadSeq: 1
+            ),
+            lastActivity: Date(timeIntervalSince1970: 1)
+        )
+    }
+
+    @Test("a reserve cash preview drops the currency name, which the amount already says")
+    func cashPreviewOmitsReserveName() {
+        let controller = makeController(MockConversations())
+        let preview = controller.lastMessagePreview(for: cashConversation(mint: .usdf, from: nil)) { _ in "Dollars" }
+        #expect(preview == "You received $1.00")
+    }
+
+    @Test("a community-currency cash preview names the currency")
+    func cashPreviewNamesCommunityCurrency() {
+        let controller = makeController(MockConversations())
+        let preview = controller.lastMessagePreview(for: cashConversation(mint: .jeffy, from: nil)) { _ in "Jeffy" }
+        #expect(preview == "You received $1.00 of Jeffy")
+    }
+
     // MARK: - DB-backed transcript (no in-memory hold) -
 
     @Test("streamed messages persist to the DB and are read as a bounded window, not held in memory")


### PR DESCRIPTION
The conversation feed row appended `of <currency>` to every cash message, so a reserve transfer read `You received $1.00 of Dollars`. The currency name only restates what the formatted amount already says.

The swap and add-money success screens already special-case `.usdf` for exactly this reason (`SwapProcessingViewModel.swift:29`, `AddMoneyProcessingViewModel.swift:36`); the preview line never did. `lastMessagePreview` now guards on the mint the same way, so USDF reads `You received $1.00` and community currencies keep `You received $1.00 of Jeffy`.

Two tests in `ConversationControllerTests` cover both branches.