### PR TITLE
fix(wallet): bring the wallet forward for scanned grabs only

### DIFF
--- a/Flipcash/Core/Screens/Main/Bill/BillOverlayView.swift
+++ b/Flipcash/Core/Screens/Main/Bill/BillOverlayView.swift
@@ -294,12 +294,15 @@ private struct BillOverlayContent: View {
     /// Takes a grabbed deposit to the wallet: the bill comes down and the wallet
     /// comes forward, where the balance is seen to rise.
     ///
-    /// With ``BetaFlags/Option/walletDepositArrival`` off the bill is simply
-    /// dismissed where it stands. The single gate is here because everything
-    /// downstream hangs off the release: an unreleased deposit is discarded by
-    /// `dismissCashBill`, and the wallet only plays one it has been released.
+    /// Only a scanned grab arms a deposit, so a claimed cash link takes the
+    /// plain dismissal here, as does any receive with
+    /// ``BetaFlags/Option/walletDepositArrival`` off. The single gate is here
+    /// because everything downstream hangs off the release: an unreleased
+    /// deposit is discarded by `dismissCashBill`, and the wallet only plays one
+    /// it has been released.
     private func putInWallet() {
-        guard betaFlags.hasEnabled(.walletDepositArrival) else {
+        guard betaFlags.hasEnabled(.walletDepositArrival),
+              session.walletDeposit.isArmed else {
             session.dismissCashBill(style: .slide)
             return
         }

--- a/Flipcash/Core/Screens/Main/Home/WalletDeposit.swift
+++ b/Flipcash/Core/Screens/Main/Home/WalletDeposit.swift
@@ -39,6 +39,11 @@ final class WalletDeposit {
     /// Whether the user has asked for the wallet, releasing it to play.
     private(set) var isReleased = false
 
+    /// Whether a deposit is waiting on the wallet at all. False for a receive
+    /// that was never armed — a cash link, which does not bring the wallet
+    /// forward.
+    var isArmed: Bool { landing != nil }
+
     /// The deposit the wallet has been released to play, or `nil` when nothing
     /// is waiting on it.
     var releasedLanding: Landing? { isReleased ? landing : nil }

--- a/Flipcash/Core/Session/Session.swift
+++ b/Flipcash/Core/Session/Session.swift
@@ -1124,6 +1124,13 @@ class Session {
 
                 let metadata = try await operation.start()
 
+                // Armed before the refresh below, which is what puts the
+                // deposit into the balances — the figures the wallet rewinds to
+                // are the ones showing right now. Scanned grabs only: a cash
+                // link claimed from outside the app has no wallet to bring
+                // forward, so it keeps the plain dismissal.
+                armWalletDeposit(mint: metadata.exchangedFiat.mint)
+
                 updatePostTransaction()
 
                 showCashBill(.init(
@@ -1191,10 +1198,6 @@ class Session {
     func showCashBill(_ billDescription: BillDescription) {
         // Only inbound bills enqueue a "+$" deposit toast; sent bills don't.
         if billDescription.received {
-            // Armed here rather than after the grab's balance refresh: that
-            // refresh is what the wallet needs the figures from *before*.
-            armWalletDeposit(mint: billDescription.exchangedFiat.mint)
-
             enqueue(toast: .init(
                 amount: billDescription.exchangedFiat.nativeAmount,
                 isDeposit: true

--- a/FlipcashTests/WalletDepositTests.swift
+++ b/FlipcashTests/WalletDepositTests.swift
@@ -54,6 +54,19 @@ struct WalletDepositTests {
         #expect(deposit.isReleased == false)
     }
 
+    @Test("nothing is armed until a scanned grab arms it")
+    func isArmed_onlyAfterArming() {
+        let deposit = WalletDeposit()
+        #expect(deposit.isArmed == false, "a cash link never arms one, so its receive takes the plain dismissal")
+
+        deposit.arm(mint: .usdf, previousTotal: Self.fiat(5), previousMints: [])
+        #expect(deposit.isArmed == true)
+
+        deposit.release()
+        deposit.consume()
+        #expect(deposit.isArmed == false)
+    }
+
     // MARK: - Release
 
     @Test("releasing hands the deposit to the wallet")


### PR DESCRIPTION
Follow-up to #697, which brought the wallet forward after **Put in Wallet** and played the deposit arriving. It fired for claimed cash links as well as scanned grabs: both paths call `showCashBill` with `received: true`, and that is where the deposit was armed.

The arming moves up into `receiveCash`, the scan path, still ahead of the `updatePostTransaction()` that puts the deposit into the balances — the figures the wallet rewinds to have to be the ones showing before that lands.

`putInWallet()` now also requires an armed deposit, not just the beta flag. Releasing an unarmed deposit was already a no-op, so the wallet would have played nothing, but the routing would still have run and dropped the user on the wallet after claiming a link. A link now keeps the plain dismissal it had before #697.

`WalletDeposit.isArmed` is the new distinction, covered by a test alongside the existing arm/release/discard/consume ones.
