### PR TITLE
fix(tips): send the DM-opening tip as TIPCARD, not CHAT

### DIFF
--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -80,6 +80,20 @@ final class SendAmountViewModel {
         ) == nil
     }
 
+    /// Where this send reports as coming from, which is not always the surface
+    /// that composed it.
+    ///
+    /// `CHAT` means "sent from a thread that already exists": the server rejects
+    /// it with `tip dm has not been initialized` when no DM is there yet. The
+    /// payment that opens the DM therefore always reports as `TIPCARD`, however
+    /// it was composed — a scanned card, or the chat the username lookup pushes
+    /// before the thread is real. Matches Android's rule, which reads the same
+    /// flag off a bottom bar still showing "Send a Tip".
+    private var effectiveTipOrigin: TipOrigin? {
+        guard case .tip(let recipient) = target else { return nil }
+        return opensTipDM ? .tipcard : recipient.origin
+    }
+
     /// The floor this entry has to clear when the amount is priced in
     /// `currency`, or nil when it has none.
     ///
@@ -341,7 +355,7 @@ final class SendAmountViewModel {
             // draws, from `ChatMetadata.TipDmPayment.Location`. Both the scanned
             // tipcard flow and the Send Cash action inside a tip thread submit
             // here, and the latter reports as a plain cash send.
-            let isTip = if case .tip(let recipient) = target { recipient.origin == .tipcard } else { false }
+            let isTip = effectiveTipOrigin == .tipcard
             let transferEvent: Analytics.TransferEvent = isTip ? .sentTip : .sentCash
 
             do {
@@ -380,7 +394,7 @@ final class SendAmountViewModel {
         case .tip(let recipient):
             return .tipDm(
                 chatID: .tipDm(between: session.userID, and: recipient.userID),
-                origin: recipient.origin
+                origin: effectiveTipOrigin ?? recipient.origin
             )
         }
     }

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -606,6 +606,53 @@ struct SendAmountViewModelTests {
         #expect(origin == .tipcard)
     }
 
+    @Test("The tip that opens the DM reports as tipcard even when it's composed in a chat")
+    func sendAction_tipOpeningDMFromChat_reportsTipcard() async throws {
+        let container = try await Self.makeReadyToSendContainer()
+        let recipientID = UUID()
+        let mock = MockSession()
+        mock.resolveUserIDHandler = { _ in Self.recipient }
+        mock.sendHandler = { _, _, _ in }
+        // What the username lookup pushes: a tip DM screen for someone the feed
+        // holds no conversation for, so its Send Cash target says `.chat`.
+        let viewModel = Self.makeTipViewModel(container: container, recipientID: recipientID, origin: .chat, mock: mock)
+        viewModel.enteredAmount = "5"
+
+        let outcome = await viewModel.sendAction()
+
+        #expect(outcome == .success)
+        let chat = try #require(mock.sendCalls.first?.chat)
+        guard case .tipDm(_, let origin) = chat else {
+            Issue.record("Expected tipDm metadata, got \(chat)")
+            return
+        }
+        // `CHAT` here is what the server rejects with "tip dm has not been
+        // initialized" — there is no thread yet for this payment to be sent from.
+        #expect(origin == .tipcard)
+    }
+
+    @Test("Once the DM exists, an in-chat send still reports as chat")
+    func sendAction_tipExistingDMFromChat_reportsChat() async throws {
+        let container = try await Self.makeReadyToSendContainer()
+        let recipientID = UUID()
+        try await Self.seedTipDM(in: container, with: recipientID)
+        let mock = MockSession()
+        mock.resolveUserIDHandler = { _ in Self.recipient }
+        mock.sendHandler = { _, _, _ in }
+        let viewModel = Self.makeTipViewModel(container: container, recipientID: recipientID, origin: .chat, mock: mock)
+        viewModel.enteredAmount = "5"
+
+        let outcome = await viewModel.sendAction()
+
+        #expect(outcome == .success)
+        let chat = try #require(mock.sendCalls.first?.chat)
+        guard case .tipDm(_, let origin) = chat else {
+            Issue.record("Expected tipDm metadata, got \(chat)")
+            return
+        }
+        #expect(origin == .chat)
+    }
+
     @Test("A tip below the server minimum is blocked before submission")
     func sendAction_tipTarget_belowMinimumBlocks() async throws {
         let container = try await Self.makeReadyToSendContainer()


### PR DESCRIPTION
Starting a tip DM from the username lookup fails with `denied(unspecified: tip dm has not been initialized)`.

`TipDmPayment.Location.CHAT` means "sent from a thread that already exists", and the server rejects it before the thread is there. The username lookup pushes a chat screen for someone the feed holds no conversation for (`UsernameLookupScreen.swift:160`), and that screen builds its send target with `origin: .chat` (`ConversationScreen.swift:132`), which `SendAmountViewModel` passed straight into the intent app metadata. So the payment meant to create the DM claimed to come from inside one.

`SendAmountViewModel` already knows which send opens the thread: `opensTipDM` is what applies the recipient's fee as the floor. That same rule now picks the reported location, so the invariant lives in one place rather than in each screen that composes a tip target:

```swift
private var effectiveTipOrigin: TipOrigin? {
    guard case .tip(let recipient) = target else { return nil }
    return opensTipDM ? .tipcard : recipient.origin
}
```

It also feeds the `sentTip`/`sentCash` analytics split, matching Android, which reads the same flag off a bottom bar still showing "Send a Tip" (`ChatViewModel.kt:766`). The username-lookup thread's bar says the same thing, so the report now agrees with the button.

Unchanged: the scanned tipcard flow already reported `TIPCARD`, a plain send in an open thread still reports `CHAT`, and the amount rules were already keyed on `opensTipDM`.

Two tests cover the split: the DM-opening send composed in a chat, and an in-chat send once the DM exists.
