### PR TITLE
fix(profile): grey the three reversible profile change dialogs

### DIFF
--- a/Flipcash/Core/Screens/Settings/DialogItem+ProfileChange.swift
+++ b/Flipcash/Core/Screens/Settings/DialogItem+ProfileChange.swift
@@ -35,11 +35,23 @@ extension DialogItem {
                 // the only one of the four the user may not be able to undo.
                 "Are you sure you want to permanently change your username? You might not be able to get your old username back"
             case .displayName:
-                "Are you sure you want to permanently change your display name?"
+                "This will change your display name"
             case .profilePicture:
-                "Are you sure you want to permanently change your profile picture?"
+                "This will change your profile photo"
             case .minimumTip:
-                "Are you sure you want to permanently change your minimum tip?"
+                "This will change your minimum tip"
+            }
+        }
+
+        /// Whether the change can cost the user something they can't take back.
+        /// Only the username can, so only it gets the red banner and the
+        /// destructive button; the rest confirm in the grey informational one.
+        var isIrreversible: Bool {
+            switch self {
+            case .username:
+                true
+            case .displayName, .profilePicture, .minimumTip:
+                false
             }
         }
     }
@@ -54,9 +66,19 @@ extension DialogItem {
         _ field: ProfileField,
         onConfirm: @escaping () -> Void
     ) -> DialogItem {
-        .alert(title: "Change \(field.title)?", subtitle: field.subtitle) {
-            DialogAction.destructive("Change \(field.title)", action: onConfirm)
-            DialogAction.cancel()
+        let title = "Change \(field.title)?"
+        let confirm = "Change \(field.title)"
+
+        if field.isIrreversible {
+            return .alert(title: title, subtitle: field.subtitle) {
+                DialogAction.destructive(confirm, action: onConfirm)
+                DialogAction.cancel()
+            }
+        } else {
+            return .info(title: title, subtitle: field.subtitle) {
+                DialogAction.standard(confirm, action: onConfirm)
+                DialogAction.cancel()
+            }
         }
     }
 }

--- a/FlipcashTests/ProfileChangeDialogTests.swift
+++ b/FlipcashTests/ProfileChangeDialogTests.swift
@@ -12,7 +12,7 @@ import FlipcashUI
 @Suite("Profile change confirmation dialog")
 struct ProfileChangeDialogTests {
 
-    @Test("Names the field in the title, the body and the confirming button", arguments: [
+    @Test("Names the field in the title and the confirming button", arguments: [
         (DialogItem.ProfileField.username, "Username"),
         (.displayName, "Display Name"),
         (.profilePicture, "Profile Picture"),
@@ -22,11 +22,21 @@ struct ProfileChangeDialogTests {
         let item = DialogItem.confirmProfileChange(field) {}
 
         #expect(item.title == "Change \(label)?")
-        #expect(item.subtitle?.contains("permanently change your \(label.lowercased())") == true)
         #expect(item.actions.first?.title == "Change \(label)")
     }
 
-    @Test("Confirms destructively over Cancel", arguments: [
+    @Test("States the change in the body", arguments: [
+        (DialogItem.ProfileField.displayName, "This will change your display name"),
+        (.profilePicture, "This will change your profile photo"),
+        (.minimumTip, "This will change your minimum tip"),
+    ])
+    func statesTheChange(field: DialogItem.ProfileField, body: String) {
+        let item = DialogItem.confirmProfileChange(field) {}
+
+        #expect(item.subtitle == body)
+    }
+
+    @Test("Confirms over Cancel", arguments: [
         DialogItem.ProfileField.username,
         .displayName,
         .profilePicture,
@@ -36,7 +46,6 @@ struct ProfileChangeDialogTests {
         let item = DialogItem.confirmProfileChange(field) {}
 
         #expect(item.actions.count == 2)
-        #expect(item.actions[0].kind == .destructive)
         #expect(item.actions[1].title == "Cancel")
     }
 
@@ -72,11 +81,27 @@ struct ProfileChangeDialogTests {
         }
     }
 
-    @Test("Red banner, but not an error worth reporting")
-    func styleIsUntrackedDestructive() {
-        let item = DialogItem.confirmProfileChange(.minimumTip) {}
+    /// The banner carries the warning, so only the irreversible change is red.
+    @Test("Red banner for the username, grey for the reversible three")
+    func usernameAloneIsDestructive() {
+        let username = DialogItem.confirmProfileChange(.username) {}
+        #expect(username.style == .destructive)
+        #expect(username.actions[0].kind == .destructive)
 
-        #expect(item.style == .destructive)
-        #expect(item.tracked == false)
+        for field in [DialogItem.ProfileField.displayName, .profilePicture, .minimumTip] {
+            let item = DialogItem.confirmProfileChange(field) {}
+            #expect(item.style == .standard)
+            #expect(item.actions[0].kind == .standard)
+        }
+    }
+
+    @Test("Not an error worth reporting", arguments: [
+        DialogItem.ProfileField.username,
+        .displayName,
+        .profilePicture,
+        .minimumTip,
+    ])
+    func untracked(field: DialogItem.ProfileField) {
+        #expect(DialogItem.confirmProfileChange(field) {}.tracked == false)
     }
 }


### PR DESCRIPTION
All four My Account confirmation dialogs used the red banner and a destructive button, so changing a display name looked as consequential as changing a username. Only the username change is irreversible: a released handle is claimable by anyone, while the other three fields can simply be set again.

`ProfileField` now carries `isIrreversible`, and `confirmProfileChange` branches on it. Username keeps `.alert` (red `bannerError`) with a `.destructive` button. Display name, profile picture and minimum tip use `.info` (grey `backgroundSecondary`) with a `.standard` button, matching the grey confirm dialog already in `BlockedUsersScreen`. The button kind has to move with the banner: `.destructive` renders red text on white, which reads as an error against grey.

The three bodies are now "This will change your display name / profile photo / minimum tip", replacing "Are you sure you want to permanently change your ...". The username warning about losing the old handle is untouched.

`ProfileChangeDialogTests` previously asserted the destructive style for all four fields and the old body phrasing. It now pins the red/grey split, the button kind on each side, and the per-field body text.
