### PR TITLE
fix(tips): abbreviate tip presets that run past three digits

### DIFF
--- a/Flipcash/Core/Screens/Main/Tips/SendTipSheet.swift
+++ b/Flipcash/Core/Screens/Main/Tips/SendTipSheet.swift
@@ -76,13 +76,14 @@ struct SendTipSheet: View {
 
     // MARK: - Chips -
 
-    /// Chips sit four to a row, so a preset is abbreviated past three digits
+    /// Chips sit four to a row, so an amount is abbreviated past three digits
     /// ("$1.5K") rather than shrunk to fit — presets run large in currencies
-    /// with small units.
+    /// with small units. VoiceOver still reads the amount in full.
     private func presetChip(_ tier: TipSelection) -> some View {
-        let amount = tipFlow.amount(for: tier)
+        let amount = tipFlow.amount(for: tier).map { FiatAmount(value: $0, currency: displayCurrency) }
         return TipAmountChip(
-            title: amount.map { FiatAmount(value: $0, currency: displayCurrency).formattedAbbreviated(minimumFractionDigits: 0) } ?? "–",
+            title: amount?.formattedAbbreviated() ?? "–",
+            accessibilityLabel: amount?.formattedDroppingZeroFraction(),
             isSelected: tipFlow.selection == tier
         ) {
             tipFlow.selection = tier
@@ -94,21 +95,15 @@ struct SendTipSheet: View {
     /// The fourth slot: "…" until a custom amount is set, then that amount.
     /// Tapping always opens the amount entry, so a set amount can be changed.
     private var customChip: some View {
-        TipAmountChip(
-            title: tipFlow.amount(for: .custom).map(customTitle) ?? "…",
+        let amount = tipFlow.amount(for: .custom).map { FiatAmount(value: $0, currency: displayCurrency) }
+        return TipAmountChip(
+            title: amount?.formattedAbbreviated() ?? "…",
+            accessibilityLabel: amount?.formattedDroppingZeroFraction() ?? "Enter a custom amount",
             isSelected: tipFlow.selection == .custom
         ) {
             localSheet = .customAmount
         }
         .accessibilityIdentifier("tip-custom-chip")
-    }
-
-    /// Formats a custom amount, dropping the fraction only when it's whole
-    /// (`$11`, not `$11.00`) while keeping real fractions intact (`$2.50`).
-    private func customTitle(_ amount: Decimal) -> String {
-        let isWhole = amount == amount.rounded(to: 0)
-        return FiatAmount(value: amount, currency: displayCurrency)
-            .formatted(minimumFractionDigits: isWhole ? 0 : nil)
     }
 
     // MARK: - Currency -
@@ -134,6 +129,8 @@ struct SendTipSheet: View {
 private struct TipAmountChip: View {
 
     let title: String
+    /// Read instead of the abbreviated title; defaults to the title itself.
+    var accessibilityLabel: String?
     let isSelected: Bool
     let action: () -> Void
 
@@ -150,6 +147,7 @@ private struct TipAmountChip: View {
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel ?? title)
     }
 }
 

--- a/Flipcash/Core/Screens/Main/Tips/SendTipSheet.swift
+++ b/Flipcash/Core/Screens/Main/Tips/SendTipSheet.swift
@@ -76,10 +76,13 @@ struct SendTipSheet: View {
 
     // MARK: - Chips -
 
+    /// Chips sit four to a row, so a preset is abbreviated past three digits
+    /// ("$1.5K") rather than shrunk to fit — presets run large in currencies
+    /// with small units.
     private func presetChip(_ tier: TipSelection) -> some View {
         let amount = tipFlow.amount(for: tier)
         return TipAmountChip(
-            title: amount.map { FiatAmount(value: $0, currency: displayCurrency).formatted(minimumFractionDigits: 0) } ?? "–",
+            title: amount.map { FiatAmount(value: $0, currency: displayCurrency).formattedAbbreviated(minimumFractionDigits: 0) } ?? "–",
             isSelected: tipFlow.selection == tier
         ) {
             tipFlow.selection = tier

--- a/FlipcashCore/Sources/FlipcashCore/Formatters/CompactCurrencyFormatStyle.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Formatters/CompactCurrencyFormatStyle.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// A `FormatStyle` that formats numeric values as compact currency strings —
-/// the `FormatStyle` entry point onto ``FiatAmount/formattedAbbreviated(minimumFractionDigits:)``,
+/// the `FormatStyle` entry point onto ``FiatAmount/formattedAbbreviated(maxDigits:)``,
 /// for the `Double` figures (market caps, deltas) SwiftUI formats inline.
 ///
 /// Sub-unit precision is dropped before formatting: at this scale it is noise,
@@ -15,7 +15,7 @@ import Foundation
 /// Usage with SwiftUI `Text`:
 /// ```swift
 /// Text(1_029_331.15, format: .compactCurrency(code: .usd))
-/// // → "$1M"
+/// // → "$1.03M"
 ///
 /// Text(690_272.45, format: .compactCurrency(code: .usd))
 /// // → "$690K"
@@ -24,7 +24,7 @@ import Foundation
 /// // → "$100K"
 ///
 /// Text(-12_400, format: .compactCurrency(code: .usd))
-/// // → "-$12K"
+/// // → "-$12.4K"
 /// ```
 public struct CompactCurrencyFormatStyle: FormatStyle {
 
@@ -36,7 +36,7 @@ public struct CompactCurrencyFormatStyle: FormatStyle {
 
     public func format(_ value: Double) -> String {
         FiatAmount(value: Decimal(Int(value)), currency: currencyCode)
-            .formattedAbbreviated(minimumFractionDigits: 0)
+            .formattedAbbreviated()
     }
 }
 

--- a/FlipcashCore/Sources/FlipcashCore/Formatters/CompactCurrencyFormatStyle.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Formatters/CompactCurrencyFormatStyle.swift
@@ -5,11 +5,12 @@
 
 import Foundation
 
-/// A `FormatStyle` that formats numeric values as compact currency strings.
+/// A `FormatStyle` that formats numeric values as compact currency strings —
+/// the `FormatStyle` entry point onto ``FiatAmount/formattedAbbreviated(minimumFractionDigits:)``,
+/// for the `Double` figures (market caps, deltas) SwiftUI formats inline.
 ///
-/// Uses the system's `.compactName` notation for large numbers and prepends
-/// the currency symbol from `CurrencyCode`. Values below 100,000 are formatted
-/// as whole numbers with grouping separators.
+/// Sub-unit precision is dropped before formatting: at this scale it is noise,
+/// and a market cap reads `$200`, not `$200.17`.
 ///
 /// Usage with SwiftUI `Text`:
 /// ```swift
@@ -34,20 +35,15 @@ public struct CompactCurrencyFormatStyle: FormatStyle {
     }
 
     public func format(_ value: Double) -> String {
-        let symbol = currencyCode.singleCharacterCurrencySymbols ?? ""
-        let whole = Int(value)
-        // The sign belongs outside the symbol ("-$12K"), so format the magnitude
-        // and prepend the minus ourselves rather than letting it land after the symbol.
-        let sign = whole < 0 ? "-" : ""
-        let compact = whole.magnitude.formatted(.number.notation(.compactName))
-        return "\(sign)\(symbol)\(compact)"
+        FiatAmount(value: Decimal(Int(value)), currency: currencyCode)
+            .formattedAbbreviated(minimumFractionDigits: 0)
     }
 }
 
 // MARK: - FormatStyle Extension -
 
 extension FormatStyle where Self == CompactCurrencyFormatStyle {
-    /// Formats a number as a compact currency string (e.g. `$1M`, `$100K`, `$99,999`).
+    /// Formats a number as a compact currency string (e.g. `$1M`, `$100K`, `$999`).
     public static func compactCurrency(code: CurrencyCode) -> CompactCurrencyFormatStyle {
         CompactCurrencyFormatStyle(code: code)
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/FiatAmount.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/FiatAmount.swift
@@ -112,6 +112,58 @@ extension FiatAmount {
     }
 }
 
+// MARK: - Abbreviation -
+
+extension FiatAmount {
+
+    /// The scales an abbreviated figure steps through, smallest first.
+    private static let abbreviationSuffixes = ["K", "M", "B"]
+
+    /// Format for a fixed-width slot where only three digits fit. Up to `$999`
+    /// this is plain ``formatted(minimumFractionDigits:suffix:)``; past it the
+    /// figure is scaled and suffixed — `$1.5K`, `$15K`, `$150K`, `$2.4M`, `$1B`.
+    /// The scaled figure keeps a decimal only while it is a single digit, so the
+    /// number never runs past three characters.
+    ///
+    /// The scale is chosen from the value, not the currency, so a currency whose
+    /// natural amounts are large (¥, Rp) abbreviates on the same rule. Rounding
+    /// is half-up like every other displayed figure, so `$10.5M` reads `$11M`.
+    ///
+    /// This is the one abbreviation rule; ``CompactCurrencyFormatStyle`` is the
+    /// `FormatStyle` entry point onto it.
+    public func formattedAbbreviated(minimumFractionDigits: Int? = nil) -> String {
+        guard abs(value) >= 1000 else {
+            return formatted(minimumFractionDigits: minimumFractionDigits)
+        }
+
+        var scaled = value / 1000
+        var scale = 0
+        while abs(scaled) >= 1000, scale < Self.abbreviationSuffixes.count - 1 {
+            scaled /= 1000
+            scale += 1
+        }
+
+        var fractionDigits = abs(scaled) < 10 ? 1 : 0
+        var rounded = scaled.rounded(to: fractionDigits)
+        // 999,999 scales to 999.999K, which rounds back into a fourth digit;
+        // carry it up a scale ("$1M") rather than print "$1,000K". Values past
+        // 999B have nowhere left to carry and stay in `B`.
+        if abs(rounded) >= 1000, scale < Self.abbreviationSuffixes.count - 1 {
+            scale += 1
+            fractionDigits = 1
+            rounded = (scaled / 1000).rounded(to: fractionDigits)
+        }
+
+        return NumberFormatter.fiat(
+            currency: currency,
+            minimumFractionDigits: 0,
+            maximumFractionDigits: fractionDigits,
+            truncated: false,
+            suffix: Self.abbreviationSuffixes[scale],
+        ).string(from: rounded as NSDecimalNumber)!
+    }
+}
+
 // MARK: - Display Threshold -
 
 extension FiatAmount {

--- a/FlipcashCore/Sources/FlipcashCore/Models/FiatAmount.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/FiatAmount.swift
@@ -110,57 +110,85 @@ extension FiatAmount {
             suffix: suffix,
         ).string(from: value as NSDecimalNumber)!
     }
+
+    /// Format for display, dropping the fraction when the amount is whole (`$11`,
+    /// not `$11.00`) and keeping it when it isn't (`$2.50`). This is how amounts
+    /// are shown in fixed-width controls, and the unabbreviated form the same
+    /// controls hand to VoiceOver.
+    ///
+    /// Paired with Android's `Fiat.FormattingRule.Truncated`.
+    public func formattedDroppingZeroFraction() -> String {
+        formatted(minimumFractionDigits: value == value.rounded(to: 0) ? 0 : nil)
+    }
 }
 
 // MARK: - Abbreviation -
 
 extension FiatAmount {
 
-    /// The scales an abbreviated figure steps through, smallest first.
-    private static let abbreviationSuffixes = ["K", "M", "B"]
+    /// The scales an abbreviated figure steps through, ascending; the largest one
+    /// the amount clears is the one it is printed in.
+    private static let abbreviationScales: [(scale: Decimal, suffix: String)] = [
+        (1_000, "K"),
+        (1_000_000, "M"),
+        (1_000_000_000, "B"),
+        (1_000_000_000_000, "T"),
+    ]
 
-    /// Format for a fixed-width slot where only three digits fit. Up to `$999`
-    /// this is plain ``formatted(minimumFractionDigits:suffix:)``; past it the
-    /// figure is scaled and suffixed — `$1.5K`, `$15K`, `$150K`, `$2.4M`, `$1B`.
-    /// The scaled figure keeps a decimal only while it is a single digit, so the
-    /// number never runs past three characters.
+    /// The amount formatted to fit a fixed-width control, capped at `maxDigits`
+    /// digits: anything under the first scale is formatted as usual, and larger
+    /// amounts are scaled to K/M/B/T with only as many decimals as the cap leaves
+    /// room for — trailing zeros dropped.
     ///
-    /// The scale is chosen from the value, not the currency, so a currency whose
-    /// natural amounts are large (¥, Rp) abbreviates on the same rule. Rounding
-    /// is half-up like every other displayed figure, so `$10.5M` reads `$11M`.
+    /// The cap is what keeps a localized amount inside its button: a $20 tip stays
+    /// `$20`, but the same tip in rupiah is 332,000, which shows as `332K` rather
+    /// than overflowing. The scale is chosen from the value, not the currency, so a
+    /// currency whose everyday amounts are large abbreviates on the same rule.
     ///
-    /// This is the one abbreviation rule; ``CompactCurrencyFormatStyle`` is the
-    /// `FormatStyle` entry point onto it.
-    public func formattedAbbreviated(minimumFractionDigits: Int? = nil) -> String {
-        guard abs(value) >= 1000 else {
-            return formatted(minimumFractionDigits: minimumFractionDigits)
+    /// Paired with Android's `Fiat.abbreviated(maxDigits:)` — the two produce the
+    /// same string for the same amount. ``CompactCurrencyFormatStyle`` is the
+    /// `FormatStyle` entry point onto this.
+    public func formattedAbbreviated(maxDigits: Int = 3) -> String {
+        guard value != 0 else { return formattedDroppingZeroFraction() }
+
+        // Round to `maxDigits` significant digits before picking the scale, so a
+        // value that carries into the next one (999,999 → 1M) is scaled by the one
+        // it lands in rather than printed as "1,000K".
+        let rounded = value.rounded(to: maxDigits - 1 - value.leadingExponent)
+
+        guard let step = Self.abbreviationScales.last(where: { abs(rounded) >= $0.scale }) else {
+            return formattedDroppingZeroFraction()
         }
 
-        var scaled = value / 1000
-        var scale = 0
-        while abs(scaled) >= 1000, scale < Self.abbreviationSuffixes.count - 1 {
-            scaled /= 1000
-            scale += 1
-        }
-
-        var fractionDigits = abs(scaled) < 10 ? 1 : 0
-        var rounded = scaled.rounded(to: fractionDigits)
-        // 999,999 scales to 999.999K, which rounds back into a fourth digit;
-        // carry it up a scale ("$1M") rather than print "$1,000K". Values past
-        // 999B have nowhere left to carry and stay in `B`.
-        if abs(rounded) >= 1000, scale < Self.abbreviationSuffixes.count - 1 {
-            scale += 1
-            fractionDigits = 1
-            rounded = (scaled / 1000).rounded(to: fractionDigits)
-        }
+        let scaled = rounded / step.scale
+        let wholeDigits = scaled.leadingExponent + 1
+        let fractionDigits = max(0, maxDigits - wholeDigits)
 
         return NumberFormatter.fiat(
             currency: currency,
             minimumFractionDigits: 0,
             maximumFractionDigits: fractionDigits,
             truncated: false,
-            suffix: Self.abbreviationSuffixes[scale],
-        ).string(from: rounded as NSDecimalNumber)!
+            suffix: step.suffix,
+        ).string(from: scaled as NSDecimalNumber)!
+    }
+}
+
+private extension Decimal {
+    /// The power of ten of the leading digit — `floor(log10(abs(self)))`. Zero has
+    /// no leading digit and answers `0`.
+    var leadingExponent: Int {
+        var magnitude = abs(self)
+        var exponent = 0
+        while magnitude >= 10 {
+            magnitude /= 10
+            exponent += 1
+        }
+        while magnitude > 0, magnitude < 1 {
+            magnitude *= 10
+            exponent -= 1
+        }
+        return exponent
     }
 }
 

--- a/FlipcashCore/Tests/FlipcashCoreTests/CompactCurrencyFormatStyleTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/CompactCurrencyFormatStyleTests.swift
@@ -15,11 +15,11 @@ struct CompactCurrencyFormatStyleTests {
     @Test("Millions are formatted with M suffix")
     func millions() {
         #expect(format.format(1_000_000) == "$1M")
-        #expect(format.format(1_029_331.15) == "$1M")
+        // Three digits, so the scaled figure keeps two decimals here and one at
+        // 10.5M — the cap decides, not the scale.
+        #expect(format.format(1_029_331.15) == "$1.03M")
         #expect(format.format(1_299_217.10) == "$1.3M")
-        // Half-up, like every other displayed figure — ICU's compact notation
-        // rounded this half-even to "$10M".
-        #expect(format.format(10_500_000) == "$11M")
+        #expect(format.format(10_500_000) == "$10.5M")
     }
 
     @Test("Thousands are formatted with K suffix")
@@ -32,7 +32,7 @@ struct CompactCurrencyFormatStyleTests {
     @Test("Small values use compact notation")
     func smallValues() {
         #expect(format.format(99_999) == "$100K")
-        #expect(format.format(1_234) == "$1.2K")
+        #expect(format.format(1_234) == "$1.23K")
         // Under a thousand the figure is shown whole — sub-unit precision is
         // dropped rather than rounded into the display.
         #expect(format.format(200.17) == "$200")
@@ -41,7 +41,7 @@ struct CompactCurrencyFormatStyleTests {
 
     @Test("Negative values put the sign before the currency symbol")
     func negativeValues() {
-        #expect(format.format(-12_400) == "-$12K")
+        #expect(format.format(-12_400) == "-$12.4K")
         #expect(format.format(-6_600) == "-$6.6K")
         #expect(format.format(-384) == "-$384")
         #expect(format.format(-1_299_217.10) == "-$1.3M")
@@ -61,6 +61,6 @@ struct CompactCurrencyFormatStyleTests {
     @Test("Works with Text format syntax")
     func formatStyleExtension() {
         let result = 1_029_331.15.formatted(.compactCurrency(code: .usd))
-        #expect(result == "$1M")
+        #expect(result == "$1.03M")
     }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/CompactCurrencyFormatStyleTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/CompactCurrencyFormatStyleTests.swift
@@ -17,7 +17,9 @@ struct CompactCurrencyFormatStyleTests {
         #expect(format.format(1_000_000) == "$1M")
         #expect(format.format(1_029_331.15) == "$1M")
         #expect(format.format(1_299_217.10) == "$1.3M")
-        #expect(format.format(10_500_000) == "$10M")
+        // Half-up, like every other displayed figure — ICU's compact notation
+        // rounded this half-even to "$10M".
+        #expect(format.format(10_500_000) == "$11M")
     }
 
     @Test("Thousands are formatted with K suffix")
@@ -31,7 +33,10 @@ struct CompactCurrencyFormatStyleTests {
     func smallValues() {
         #expect(format.format(99_999) == "$100K")
         #expect(format.format(1_234) == "$1.2K")
+        // Under a thousand the figure is shown whole — sub-unit precision is
+        // dropped rather than rounded into the display.
         #expect(format.format(200.17) == "$200")
+        #expect(format.format(999.99) == "$999")
     }
 
     @Test("Negative values put the sign before the currency symbol")

--- a/FlipcashTests/FiatAmountDisplayTests.swift
+++ b/FlipcashTests/FiatAmountDisplayTests.swift
@@ -157,61 +157,63 @@ struct FiatAmountFormattedTests {
 struct FiatAmountAbbreviatedTests {
 
     @Test(
-        "formattedAbbreviated(minimumFractionDigits:) keeps the figure to three digits",
+        "formattedAbbreviated(maxDigits:) caps the figure at three digits",
         arguments: [
-            // currency, value,                        minFrac, expected
+            // currency, value, expected
 
-            // Under a thousand — plain formatting, untouched.
-            (CurrencyCode.usd, Decimal(1),                 Int?(0), "$1"),
-            (.usd,             Decimal(999),               Int?(0), "$999"),
-            (.usd,             Decimal(string: "2.50")!,   nil,     "$2.50"),
-            (.usd,             Decimal(999),               nil,     "$999.00"),
+            // Under the first scale — formatted as usual, fraction dropped when whole.
+            (CurrencyCode.usd, Decimal(5),                    "$5"),
+            (.usd,             Decimal(999),                  "$999"),
+            (.usd,             Decimal(string: "12.50")!,     "$12.50"),
 
-            // Thousands — a decimal only while the figure is a single digit.
-            (.usd,             Decimal(1_000),             Int?(0), "$1K"),
-            (.usd,             Decimal(1_500),             Int?(0), "$1.5K"),
-            (.usd,             Decimal(1_550),             Int?(0), "$1.6K"),   // halfUp
-            (.usd,             Decimal(9_999),             Int?(0), "$10K"),
-            (.usd,             Decimal(15_000),            Int?(0), "$15K"),
-            (.usd,             Decimal(150_000),           Int?(0), "$150K"),
-            (.usd,             Decimal(999_499),           Int?(0), "$999K"),
+            // Thousands, with the cap deciding how many decimals survive.
+            (.usd,             Decimal(1_000),                "$1K"),
+            (.usd,             Decimal(1_500),                "$1.5K"),
+            (.usd,             Decimal(1_234),                "$1.23K"),
+            (.usd,             Decimal(12_345),               "$12.3K"),
+            (.usd,             Decimal(123_456),              "$123K"),
 
-            // The rounding carry: 999.5K is a fourth digit, so it becomes $1M.
-            (.usd,             Decimal(999_500),           Int?(0), "$1M"),
+            // Millions, billions and trillions get their own suffix.
+            (.usd,             Decimal(1_000_000),            "$1M"),
+            (.usd,             Decimal(2_500_000),            "$2.5M"),
+            (.usd,             Decimal(1_000_000_000),        "$1B"),
+            (.usd,             Decimal(1_000_000_000_000),    "$1T"),
 
-            // Millions and billions.
-            (.usd,             Decimal(2_400_000),         Int?(0), "$2.4M"),
-            (.usd,             Decimal(25_000_000),        Int?(0), "$25M"),
-            (.usd,             Decimal(1_000_000_000),     Int?(0), "$1B"),
-            (.usd,             Decimal(1_250_000_000),     Int?(0), "$1.3B"),
+            // An amount that rounds into the next scale is printed in that scale.
+            (.usd,             Decimal(999_999),              "$1M"),
 
-            // Past the largest scale there is nowhere to carry, so it stays in B.
-            (.usd,             Decimal(1_000_000_000_000), Int?(0), "$1,000B"),
+            (.usd,             Decimal(0),                    "$0"),
 
             // A zero-decimal currency abbreviates on the value, not its precision.
-            (.jpy,             Decimal(1_500),             Int?(0), "¥1.5K"),
-            (.jpy,             Decimal(250_000),           Int?(0), "¥250K"),
+            (.jpy,             Decimal(750),                  "¥750"),
+            (.jpy,             Decimal(3_000),                "¥3K"),
 
-            // Small-unit currencies, where every everyday amount is four digits
-            // or more — the case the tip presets abbreviate for. ARS values are
-            // roughly the $1 / $25 / $1,000 tiers.
-            (.ars,             Decimal(1_400),             Int?(0), "$1.4K"),
-            (.ars,             Decimal(35_000),            Int?(0), "$35K"),
-            (.ars,             Decimal(1_400_000),         Int?(0), "$1.4M"),
-            (.cop,             Decimal(97_500),            Int?(0), "$98K"),
-            (.vnd,             Decimal(650_000),           Int?(0), "₫650K"),
+            // Small-unit currencies, where every everyday amount is four digits or
+            // more — the case the tip presets abbreviate for. The ARS figures are
+            // the $5 / $10 / $20 tiers in pesos.
+            (.ars,             Decimal(7_500),                "$7.5K"),
+            (.ars,             Decimal(15_000),               "$15K"),
+            (.ars,             Decimal(30_000),               "$30K"),
+            (.ars,             Decimal(25_500),               "$25.5K"),
+            (.ars,             Decimal(123_456),              "$123K"),
+            (.cop,             Decimal(97_500),               "$97.5K"),
+            (.vnd,             Decimal(126_000),              "₫126K"),
+            (.vnd,             Decimal(1_315_000),            "₫1.32M"),
             // IDR has no single-character symbol, so it formats bare.
-            (.idr,             Decimal(400_000),           Int?(0), "400K"),
+            (.idr,             Decimal(332_000),              "332K"),
+            (.idr,             Decimal(500),                  "500"),
 
             // Negatives keep the minus ahead of the symbol.
-            (.usd,             Decimal(-1_500),            Int?(0), "-$1.5K"),
-            (.usd,             Decimal(-2_400_000),        Int?(0), "-$2.4M"),
-        ] as [(CurrencyCode, Decimal, Int?, String)]
+            (.usd,             Decimal(-1_500),               "-$1.5K"),
+            (.usd,             Decimal(-2_400_000),           "-$2.4M"),
+        ] as [(CurrencyCode, Decimal, String)]
     )
-    func formattedAbbreviated(currency: CurrencyCode, value: Decimal, minimumFractionDigits: Int?, expected: String) {
-        #expect(
-            FiatAmount(value: value, currency: currency)
-                .formattedAbbreviated(minimumFractionDigits: minimumFractionDigits) == expected
-        )
+    func formattedAbbreviated(currency: CurrencyCode, value: Decimal, expected: String) {
+        #expect(FiatAmount(value: value, currency: currency).formattedAbbreviated() == expected)
+    }
+
+    @Test("A lower cap allows fewer digits")
+    func lowerCap() {
+        #expect(FiatAmount.usd(1_234).formattedAbbreviated(maxDigits: 2) == "$1.2K")
     }
 }

--- a/FlipcashTests/FiatAmountDisplayTests.swift
+++ b/FlipcashTests/FiatAmountDisplayTests.swift
@@ -152,3 +152,66 @@ struct FiatAmountFormattedTests {
         )
     }
 }
+
+@Suite("FiatAmount Abbreviated")
+struct FiatAmountAbbreviatedTests {
+
+    @Test(
+        "formattedAbbreviated(minimumFractionDigits:) keeps the figure to three digits",
+        arguments: [
+            // currency, value,                        minFrac, expected
+
+            // Under a thousand — plain formatting, untouched.
+            (CurrencyCode.usd, Decimal(1),                 Int?(0), "$1"),
+            (.usd,             Decimal(999),               Int?(0), "$999"),
+            (.usd,             Decimal(string: "2.50")!,   nil,     "$2.50"),
+            (.usd,             Decimal(999),               nil,     "$999.00"),
+
+            // Thousands — a decimal only while the figure is a single digit.
+            (.usd,             Decimal(1_000),             Int?(0), "$1K"),
+            (.usd,             Decimal(1_500),             Int?(0), "$1.5K"),
+            (.usd,             Decimal(1_550),             Int?(0), "$1.6K"),   // halfUp
+            (.usd,             Decimal(9_999),             Int?(0), "$10K"),
+            (.usd,             Decimal(15_000),            Int?(0), "$15K"),
+            (.usd,             Decimal(150_000),           Int?(0), "$150K"),
+            (.usd,             Decimal(999_499),           Int?(0), "$999K"),
+
+            // The rounding carry: 999.5K is a fourth digit, so it becomes $1M.
+            (.usd,             Decimal(999_500),           Int?(0), "$1M"),
+
+            // Millions and billions.
+            (.usd,             Decimal(2_400_000),         Int?(0), "$2.4M"),
+            (.usd,             Decimal(25_000_000),        Int?(0), "$25M"),
+            (.usd,             Decimal(1_000_000_000),     Int?(0), "$1B"),
+            (.usd,             Decimal(1_250_000_000),     Int?(0), "$1.3B"),
+
+            // Past the largest scale there is nowhere to carry, so it stays in B.
+            (.usd,             Decimal(1_000_000_000_000), Int?(0), "$1,000B"),
+
+            // A zero-decimal currency abbreviates on the value, not its precision.
+            (.jpy,             Decimal(1_500),             Int?(0), "¥1.5K"),
+            (.jpy,             Decimal(250_000),           Int?(0), "¥250K"),
+
+            // Small-unit currencies, where every everyday amount is four digits
+            // or more — the case the tip presets abbreviate for. ARS values are
+            // roughly the $1 / $25 / $1,000 tiers.
+            (.ars,             Decimal(1_400),             Int?(0), "$1.4K"),
+            (.ars,             Decimal(35_000),            Int?(0), "$35K"),
+            (.ars,             Decimal(1_400_000),         Int?(0), "$1.4M"),
+            (.cop,             Decimal(97_500),            Int?(0), "$98K"),
+            (.vnd,             Decimal(650_000),           Int?(0), "₫650K"),
+            // IDR has no single-character symbol, so it formats bare.
+            (.idr,             Decimal(400_000),           Int?(0), "400K"),
+
+            // Negatives keep the minus ahead of the symbol.
+            (.usd,             Decimal(-1_500),            Int?(0), "-$1.5K"),
+            (.usd,             Decimal(-2_400_000),        Int?(0), "-$2.4M"),
+        ] as [(CurrencyCode, Decimal, Int?, String)]
+    )
+    func formattedAbbreviated(currency: CurrencyCode, value: Decimal, minimumFractionDigits: Int?, expected: String) {
+        #expect(
+            FiatAmount(value: value, currency: currency)
+                .formattedAbbreviated(minimumFractionDigits: minimumFractionDigits) == expected
+        )
+    }
+}


### PR DESCRIPTION
Four chips share a row in the Send a Tip sheet, and a preset is a converted USD tier, so in a small-unit currency every tier is four digits or more. In ARS the three presets render `$1,400` / `$35,000` / `$1,400,000`, and `Text`'s `minimumScaleFactor(0.5)` shrinks them to half size to fit the chip.

`FiatAmount.formattedAbbreviated(maxDigits:)` caps the figure at three digits. Under the first scale it is plain `formatted(...)`; past that the value is scaled and suffixed `K`/`M`/`B`/`T`, keeping only the decimals the cap leaves room for.

| Currency | Presets before | After |
|---|---|---|
| ARS | `$1,400` `$35,000` `$1,400,000` | `$1.4K` `$35K` `$1.4M` |
| COP | `$97,500` | `$97.5K` |
| VND | `₫650,000` | `₫650K` |
| IDR | `400,000` | `400K` |
| USD | `$1` `$5` `$25` | unchanged |

It formats through the same `NumberFormatter.fiat` path as `formatted`, so the symbol, grouping, and the negative form (`-$1.5K`) come from one place.

## The same rule as Android

code-payments/code-android-app#1381 does this on Android, and the first version here did not produce the same strings: it kept a decimal only while the scaled figure was a single digit, so it spent two digits of a three-digit budget — `$1.2K` against `$1.23K`, `$12K` against `$12.3K`, `26K` against `25.5K` for an ARS preset. Android's rule is the one that answers "three digits", so this takes it.

The implementation now mirrors `Fiat.abbreviated(maxDigits:)` step for step: round to `maxDigits` significant digits, pick the largest scale the rounded value clears, spend what is left on decimals. Rounding first is what makes 999,999 print `$1M` instead of `$1,000K`, and it is half-up on both sides. Two behaviours came along with it — the `T` scale, where `1e12` used to print `$1,000B`, and `999.99`, which now carries up to `$1K` rather than printing five digits.

`formattedDroppingZeroFraction()` is Android's `FormattingRule.Truncated`: the fraction is dropped when the amount is whole and kept when it isn't. It formats the amounts under the first scale, and replaces the local `customTitle` helper the sheet had for the same job.

Two more things Android does that this now does:

- The custom "…" chip abbreviates as well. Android's slot is the same composable for presets and the custom amount, so it always did.
- Both chips hand VoiceOver the unabbreviated amount, matching Android's content description. The abbreviation is visual only.

## One abbreviation rule, not two

`CompactCurrencyFormatStyle` — the market-cap and weekly-delta style in Currency Discovery — was a second abbreviation rule, built on ICU's `.compactName` with its own symbol and sign handling. It is now a two-line `FormatStyle` entry point onto `formattedAbbreviated`, for the `Double` figures SwiftUI formats inline.

Market caps therefore move with the shared rule, and being capped at three digits rather than two they gain a digit: `$1,029,331` reads `$1.03M` rather than `$1M`, `-12,400` reads `-$12.4K`. `$10.5M` no longer reads `$10M` — ICU compact notation rounds half-even, display rounding in this app is half-up.

That the row follows the tip chips is the intent, not a side effect. It is not width-constrained the way a chip is, and getting ICU's shape back would take a second digit budget that caps decimals without capping whole digits — `maxDigits: 2` is not it, since it rounds `$211K` down to `$210K`. That is a third rule to keep in step with Android for the sake of one row.

The style's `Int(value)` truncation is kept, so a market cap still reads `$200` rather than `$200.17`.

## Two divergences this does not close

Both are older than either PR and need an Android-side call, so they are worth naming rather than papering over:

- **ARS and COP symbols.** Both platforms take the first single-character symbol the locale table offers. Apple's data gives ARS and COP a `$`; Android's does not, so the same peso preset reads `$7.5K` here and `7.5K` there. IDR (bare) and VND (`₫`) agree.
- **Market caps.** Android keeps two abbreviation rules — `Fiat.abbreviated` for the tip chips and the uncapped `Number.abbreviated` for `TokenMetricsRow`, which always prints two decimals. A $690,272 cap reads `$690K` here and `$690.27K` there.

The parameterized cases in `FiatAmountAbbreviatedTests` follow Android's `FiatTest` — the scale boundaries, the decimal cap, the carry into the next scale, and the ARS/COP/VND/IDR/JPY rows — plus the negatives and the lower-cap case.

