### PR TITLE
fix(chats): give the Chats tab the standard title and a soft scroll edge

### DIFF
--- a/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoContentV2.swift
+++ b/Flipcash/Core/Screens/Main/Currency Info/CurrencyInfoContentV2.swift
@@ -12,18 +12,6 @@ import SwiftUI
 import FlipcashCore
 import FlipcashUI
 
-/// Softens the top scroll edge on iOS 26+ so content fades under the toolbar
-/// rather than being clipped by the system's hard edge line.
-private struct SoftTopScrollEdge: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(iOS 26.0, *) {
-            content.scrollEdgeEffectStyle(.soft, for: .top)
-        } else {
-            content
-        }
-    }
-}
-
 /// Marks the hero card as the morph destination for the wallet's tapped card.
 /// Without a namespace (pushed hosting, deep links) the card renders plainly.
 private struct HeroCardMatch: ViewModifier {
@@ -195,7 +183,7 @@ struct CurrencyInfoContentV2: View {
         .scrollIndicators(.hidden)
         // Content fades out under the toolbar instead of meeting the system's
         // hard scroll-edge line.
-        .modifier(SoftTopScrollEdge())
+        .softScrollEdge()
         .onScrollGeometryChange(for: Bool.self) { geometry in
             geometry.contentOffset.y + geometry.contentInsets.top > Self.titleHandoffOffset
         } action: { _, scrolledPast in

--- a/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
@@ -15,57 +15,89 @@ struct TipConversationsScreen: View {
     @Environment(AppRouter.self) private var router
 
     /// See ``TipsScreen/isEmbedded`` — v2 drops the inline tip-card button and
-    /// leads with the large "Chats" title.
+    /// titles the screen "Chats".
     var isEmbedded: Bool = false
 
     var body: some View {
         let conversations = conversationController.conversations(of: .tipDm)
 
         Background(color: .backgroundMain) {
-            VStack(alignment: .leading, spacing: 0) {
-                if isEmbedded {
-                    ChatsTabTitle()
-                }
-
-                // v1 keeps its list even when empty — the "Show My Tip Card"
-                // button lives in it, so there is no blank state to fill.
-                if isEmbedded, conversations.isEmpty {
-                    NoChatsView()
-                } else {
-                    List {
-                        // v1 only — v2 reaches the tip card from its own tab.
-                        if !isEmbedded {
-                            Button("Show My Tip Card") {
-                                router.push(.tipcard)
-                            }
-                            .buttonStyle(.filled)
-                            .accessibilityIdentifier("show-my-tipcard-button")
-                            .listRowInsets(EdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20))
-                            .listRowBackground(Color.clear)
-                            .listRowSeparator(.hidden)
+            // v1 keeps its list even when empty — the "Show My Tip Card"
+            // button lives in it, so there is no blank state to fill.
+            if isEmbedded, conversations.isEmpty {
+                NoChatsView()
+            } else {
+                List {
+                    // v1 only — v2 reaches the tip card from its own tab.
+                    if !isEmbedded {
+                        Button("Show My Tip Card") {
+                            router.push(.tipcard)
                         }
+                        .buttonStyle(.filled)
+                        .accessibilityIdentifier("show-my-tipcard-button")
+                        .listRowInsets(EdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20))
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                    }
 
-                        ForEach(conversations) { conversation in
-                            TipConversationRow(conversation: conversation) {
-                                router.push(.tipConversation(conversation.id))
-                            }
+                    ForEach(conversations) { conversation in
+                        TipConversationRow(conversation: conversation) {
+                            router.push(.tipConversation(conversation.id))
                         }
                     }
-                    .listStyle(.plain)
-                    .scrollContentBackground(.hidden)
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                // The list runs under the bar, so its top edge needs the soft
+                // fade rather than the system's default hard cut.
+                .softScrollEdge()
+            }
+        }
+        .navigationTitle(isEmbedded ? "Chats" : "Tips")
+        .toolbarTitleDisplayMode(.inline)
+        .toolbar {
+            if isEmbedded {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NewChatButton()
                 }
             }
         }
-        .navigationTitle(isEmbedded ? "" : "Tips")
-        .toolbar(isEmbedded ? .hidden : .automatic, for: .navigationBar)
-        .toolbarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - NewChatButton -
+
+/// The Chat tab's new-chat affordance, a bar item beside the "Chats" title.
+///
+/// The title used to be a large flush headline drawn in the content (Android
+/// parity — `screenTitleLarge`) with this button laid out next to it, which
+/// meant the tab hid its navigation bar. A scroll edge effect is drawn by the
+/// bar's background, so without a bar the list met the status bar on a hard
+/// line; the standard centred title puts the bar back and lets the list fade
+/// under it.
+private struct NewChatButton: View {
+
+    @Environment(AppRouter.self) private var router
+
+    var body: some View {
+        Button {
+            router.push(.usernameLookup)
+        } label: {
+            // Bar items get their glass from the system on iOS 26, so this
+            // carries no button style of its own.
+            Image.system(.plus)
+                .font(.appTextLarge)
+                .foregroundStyle(Color.textMain)
+        }
+        .accessibilityLabel("New chat")
+        .accessibilityIdentifier("new-chat-button")
     }
 }
 
 // MARK: - NoChatsView -
 
 /// The v2 Chats tab's empty state, shown until the first tip conversation
-/// exists — centred in the space between the "Chats" title and the tab bar, so
+/// exists — centred in the space between the navigation bar and the tab bar, so
 /// it sits at the same height as the tippable-profile intro on this tab.
 private struct NoChatsView: View {
 

--- a/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
@@ -7,39 +7,20 @@ import SwiftUI
 import FlipcashCore
 import FlipcashUI
 
-/// The Tips sheet's root once a profile exists: the Show My Tipcard call to
-/// action over the list of tip conversations — tips sent and received.
+/// The Chats tab: the list of tip conversations — tips sent and received.
 struct TipConversationsScreen: View {
 
     @Environment(ConversationController.self) private var conversationController
     @Environment(AppRouter.self) private var router
 
-    /// See ``TipsScreen/isEmbedded`` — v2 drops the inline tip-card button and
-    /// titles the screen "Chats".
-    var isEmbedded: Bool = false
-
     var body: some View {
         let conversations = conversationController.conversations(of: .tipDm)
 
         Background(color: .backgroundMain) {
-            // v1 keeps its list even when empty — the "Show My Tip Card"
-            // button lives in it, so there is no blank state to fill.
-            if isEmbedded, conversations.isEmpty {
+            if conversations.isEmpty {
                 NoChatsView()
             } else {
                 List {
-                    // v1 only — v2 reaches the tip card from its own tab.
-                    if !isEmbedded {
-                        Button("Show My Tip Card") {
-                            router.push(.tipcard)
-                        }
-                        .buttonStyle(.filled)
-                        .accessibilityIdentifier("show-my-tipcard-button")
-                        .listRowInsets(EdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20))
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                    }
-
                     ForEach(conversations) { conversation in
                         TipConversationRow(conversation: conversation) {
                             router.push(.tipConversation(conversation.id))
@@ -53,13 +34,11 @@ struct TipConversationsScreen: View {
                 .softScrollEdge()
             }
         }
-        .navigationTitle(isEmbedded ? "Chats" : "Tips")
+        .navigationTitle("Chats")
         .toolbarTitleDisplayMode(.inline)
         .toolbar {
-            if isEmbedded {
-                ToolbarItem(placement: .topBarTrailing) {
-                    NewChatButton()
-                }
+            ToolbarItem(placement: .topBarTrailing) {
+                NewChatButton()
             }
         }
     }
@@ -96,7 +75,7 @@ private struct NewChatButton: View {
 
 // MARK: - NoChatsView -
 
-/// The v2 Chats tab's empty state, shown until the first tip conversation
+/// The Chats tab's empty state, shown until the first tip conversation
 /// exists — centred in the space between the navigation bar and the tab bar, so
 /// it sits at the same height as the tippable-profile intro on this tab.
 private struct NoChatsView: View {

--- a/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipConversationsScreen.swift
@@ -21,17 +21,20 @@ struct TipConversationsScreen: View {
                 NoChatsView()
             } else {
                 List {
-                    ForEach(conversations) { conversation in
+                    ForEach(Array(conversations.enumerated()), id: \.element.id) { index, conversation in
                         TipConversationRow(conversation: conversation) {
                             router.push(.tipConversation(conversation.id))
                         }
+                        // Separators divide rows from each other; the first
+                        // row's leading one just draws a line under the bar.
+                        .listRowSeparator(index == 0 ? .hidden : .automatic, edges: .top)
                     }
                 }
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)
-                // The list runs under the bar, so its top edge needs the soft
+                // The list runs under both bars, so each edge needs the soft
                 // fade rather than the system's default hard cut.
-                .softScrollEdge()
+                .softScrollEdge(for: [.top, .bottom])
             }
         }
         .navigationTitle("Chats")

--- a/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
@@ -13,9 +13,9 @@ struct TipsScreen: View {
 
     @Environment(SessionContainer.self) private var sessionContainer
 
-    /// The v2 Chats tab: a large flush "Chats" title and no inline tip-card
+    /// The v2 Chats tab: a "Chats" navigation title and no inline tip-card
     /// button (the tip card has its own tab). Defaults to `false` — the v1 Tips
-    /// sheet keeps its inline nav-bar title and "Show My Tip Card" button.
+    /// sheet keeps its "Tips" title and "Show My Tip Card" button.
     var isEmbedded: Bool = false
 
     var body: some View {
@@ -28,108 +28,57 @@ struct TipsScreen: View {
         if isEmbedded || sessionContainer.session.profile?.isTippable == true {
             TipConversationsScreen(isEmbedded: isEmbedded)
         } else {
-            TipsIntroScreen(isEmbedded: isEmbedded)
+            TipsIntroScreen()
         }
-    }
-}
-
-// MARK: - Chats title -
-
-/// The v2 large, flush start-aligned "Chats" tab title (Android parity —
-/// `screenTitleLarge` / `appTitleLarge`), with the new-chat button beside it.
-struct ChatsTabTitle: View {
-
-    @Environment(AppRouter.self) private var router
-
-    var body: some View {
-        HStack(spacing: 0) {
-            Text("Chats")
-                .font(.appTitleLarge)
-                .foregroundStyle(Color.textMain)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            Button {
-                router.push(.usernameLookup)
-            } label: {
-                // The design draws a 44pt circle (node 9443:8560). On iOS 26
-                // `.buttonStyle(.glass)` pads outside the label, so the label
-                // is 32 and the glass reaches 44; the fallback style draws the
-                // circle at the label's own bounds, so there it is 44 already.
-                if #available(iOS 26, *) {
-                    Image.system(.plus)
-                        .font(.appTextLarge)
-                        .foregroundStyle(Color.textMain)
-                        .frame(width: 32, height: 32)
-                } else {
-                    Image.system(.plus)
-                        .font(.appTextLarge)
-                        .foregroundStyle(Color.textMain)
-                        .frame(width: 44, height: 44)
-                }
-            }
-            .liquidGlassButtonStyle(shape: .circle)
-            .accessibilityLabel("New chat")
-            .accessibilityIdentifier("new-chat-button")
-        }
-        .padding(.horizontal, 20)
-        .padding(.top, 8)
-        .padding(.bottom, 12)
     }
 }
 
 // MARK: - TipsIntroScreen -
 
+/// v1 only — the Tips sheet's profile-creation invitation. v2's Chats tab shows
+/// conversations whatever the profile says, so it never reaches this.
 private struct TipsIntroScreen: View {
 
     @Environment(AppRouter.self) private var router
 
-    let isEmbedded: Bool
-
     var body: some View {
         Background(color: .backgroundMain) {
-            VStack(alignment: .leading, spacing: 0) {
-                if isEmbedded {
-                    ChatsTabTitle()
+            VStack(spacing: 0) {
+                Spacer()
+
+                // The tab-bar asset carries a heavier stroke tuned for 40pt;
+                // at this size it needs the lighter one.
+                Image(.Icons.tipsLarge)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 120, height: 120)
+                    .foregroundStyle(Color.textMain)
+
+                Text("Receive Tips From Everyone")
+                    .font(.appTextLarge)
+                    .foregroundStyle(Color.textMain)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 32)
+
+                Text("Add your name to receive tips")
+                    .font(.appTextSmall)
+                    .foregroundStyle(Color.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 8)
+
+                Spacer()
+
+                Button("Start Receiving Tips") {
+                    router.push(.profileName)
                 }
-
-                VStack(spacing: 0) {
-                    Spacer()
-
-                    // The tab-bar asset carries a heavier stroke tuned for 40pt;
-                    // at this size it needs the lighter one.
-                    Image(.Icons.tipsLarge)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 120, height: 120)
-                        .foregroundStyle(Color.textMain)
-
-                    Text("Receive Tips From Everyone")
-                        .font(.appTextLarge)
-                        .foregroundStyle(Color.textMain)
-                        .multilineTextAlignment(.center)
-                        .padding(.top, 32)
-
-                    Text("Add your name to receive tips")
-                        .font(.appTextSmall)
-                        .foregroundStyle(Color.textSecondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.top, 8)
-
-                    Spacer()
-
-                    Button("Start Receiving Tips") {
-                        router.push(.profileName)
-                    }
-                    .buttonStyle(.filled)
-                    .accessibilityIdentifier("start-receiving-tips-button")
-                    .padding(.bottom, 20)
-                }
-                .padding(.horizontal, 20)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .buttonStyle(.filled)
+                .accessibilityIdentifier("start-receiving-tips-button")
+                .padding(.bottom, 20)
             }
+            .padding(.horizontal, 20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .navigationTitle(isEmbedded ? "" : "Tips")
-        .toolbar(isEmbedded ? .hidden : .automatic, for: .navigationBar)
+        .navigationTitle("Tips")
         .toolbarTitleDisplayMode(.inline)
     }
 }

--- a/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Tips/TipsScreen.swift
@@ -7,26 +7,26 @@ import SwiftUI
 import FlipcashCore
 import FlipcashUI
 
-/// The Tips sheet's root: the tip conversations once a profile exists, the
-/// invitation to create one until then.
+/// The `.tips` stack's root: the tip conversations, or the invitation to create
+/// a profile when the stack was opened to ask for one.
 struct TipsScreen: View {
 
     @Environment(SessionContainer.self) private var sessionContainer
 
-    /// The v2 Chats tab: a "Chats" navigation title and no inline tip-card
-    /// button (the tip card has its own tab). Defaults to `false` — the v1 Tips
-    /// sheet keeps its "Tips" title and "Show My Tip Card" button.
+    /// Hosted by the Chats tab rather than presented as the `.tips` sheet.
+    /// Defaults to `false` — `TipFlow` presents the sheet only to ask for a
+    /// profile, so there it leads with ``TipsIntroScreen``.
     var isEmbedded: Bool = false
 
     var body: some View {
-        // v2's Chats tab is chats, whatever the profile says. A name-less
+        // The Chats tab is chats, whatever the profile says. A name-less
         // account can still send tips, so it can still hold conversations —
         // swapping the tab out for a setup prompt hid them, and hid the "No
         // Chats Yet" empty state behind a second copy of the tip-card
-        // invitation the tip-card tab already makes. v1's sheet keeps the
+        // invitation the tip-card tab already makes. The sheet keeps the
         // intro: it is that flow's only door into profile creation.
         if isEmbedded || sessionContainer.session.profile?.isTippable == true {
-            TipConversationsScreen(isEmbedded: isEmbedded)
+            TipConversationsScreen()
         } else {
             TipsIntroScreen()
         }
@@ -35,7 +35,7 @@ struct TipsScreen: View {
 
 // MARK: - TipsIntroScreen -
 
-/// v1 only — the Tips sheet's profile-creation invitation. v2's Chats tab shows
+/// The `.tips` sheet's profile-creation invitation. The Chats tab shows
 /// conversations whatever the profile says, so it never reaches this.
 private struct TipsIntroScreen: View {
 

--- a/FlipcashUI/Sources/FlipcashUI/Modifiers/ScrollEdge.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Modifiers/ScrollEdge.swift
@@ -1,0 +1,32 @@
+//
+//  ScrollEdge.swift
+//  FlipcashUI
+//
+
+import SwiftUI
+
+extension View {
+
+    /// Softens a scroll view's edge effect on iOS 26+, so content fades out
+    /// under the bar instead of meeting the system's default hard edge line.
+    ///
+    /// No-op below iOS 26, where the effect doesn't exist. The effect is drawn
+    /// by the bar's background, so it renders only where a bar is visible —
+    /// a screen that hides its navigation bar has to draw its own fade.
+    public func softScrollEdge(for edges: Edge.Set = .top) -> some View {
+        modifier(SoftScrollEdge(edges: edges))
+    }
+}
+
+private struct SoftScrollEdge: ViewModifier {
+
+    let edges: Edge.Set
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.scrollEdgeEffectStyle(.soft, for: edges)
+        } else {
+            content
+        }
+    }
+}

--- a/FlipcashUITests/Support/Screens/TipsUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/TipsUIScreen.swift
@@ -25,8 +25,8 @@ struct TipsUIScreen {
     /// The Chat tab on the tab bar.
     var tab: XCUIElement { app.buttons["Chat"] }
 
-    /// The tab's large flush title — its presence means the list has rendered,
-    /// whether or not the account has a conversation.
+    /// The tab's navigation-bar title — its presence means the list has
+    /// rendered, whether or not the account has a conversation.
     var title: XCUIElement { app.staticTexts["Chats"] }
 
     /// The empty state, shown until the first tip conversation exists.

--- a/FlipcashUITests/Support/Screens/TipsUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/TipsUIScreen.swift
@@ -7,10 +7,10 @@ import XCTest
 
 /// Page object for the Chat tab — the list of tip-DM conversations.
 ///
-/// The tab-bar UI embeds this list as a tab rather than presenting it as a
-/// sheet, so there is nothing to close, and `TipsScreen(isEmbedded: true)`
-/// renders the conversations unconditionally: the tip-card intro and its inline
-/// "Show My Tip Card" button are v1 only, and the tip card has its own tab.
+/// The tab hosts this list rather than presenting it as a sheet, so there is
+/// nothing to close, and `TipsScreen(isEmbedded: true)` renders the
+/// conversations unconditionally — the tip-card intro belongs to the sheet that
+/// asks for a profile, and the tip card has its own tab.
 @MainActor
 struct TipsUIScreen {
 
@@ -32,8 +32,8 @@ struct TipsUIScreen {
     /// The empty state, shown until the first tip conversation exists.
     var emptyState: XCUIElement { app.staticTexts["No Chats Yet"] }
 
-    /// The tip-conversation rows. Every cell is a conversation — the v1 list's
-    /// leading "Show My Tip Card" row is gone, so none is skipped.
+    /// The tip-conversation rows. Every cell is a conversation — there is no
+    /// leading call-to-action row to skip.
     private var conversationCells: [XCUIElement] {
         app.cells.allElementsBoundByIndex
     }


### PR DESCRIPTION
The Chat tab drew "Chats" as a large flush headline inside its content (Android parity — `screenTitleLarge`) with the new-chat button laid out beside it, so the tab had to hide its navigation bar. A scroll edge effect is painted by a bar's background, so with no bar there was nothing for the list to fade against: rows met the status bar on the system's hard cut line.

The title moves to `navigationTitle` with `.toolbarTitleDisplayMode(.inline)` and the button to a `.topBarTrailing` toolbar item — the pattern the rest of the app's screens already use. That puts the bar back, so the top edge can take `scrollEdgeEffectStyle(.soft, for: .top)` and the rows blur out under it. The button loses its `.liquidGlassButtonStyle` and the 32/44pt availability split that went with it, since bar items get their glass from the system on iOS 26.

`View.softScrollEdge(for:)` in FlipcashUI is that call behind the availability check, so the app has one implementation of it. `CurrencyInfoContentV2`'s private `SoftTopScrollEdge` was the first copy and now routes through it.

The second commit drops `isEmbedded` from `TipConversationsScreen`. Every use of it picked between the Chats tab and the Tips sheet the tab replaced, and the sheet no longer reaches this screen: `TipFlow` presents `.tips` only to hold a tip while the user makes a profile, and `resumeAfterProfileCreation` dismisses it as soon as the profile turns tippable, so the sheet only ever renders `TipsIntroScreen`. That takes the "Show My Tip Card" row and the "Tips" title with it. `TipsScreen` keeps its own `isEmbedded` — that is what still chooses between the list and the intro, and the intro drops its unused copy of the flag.

The list runs under the tab bar too, so both edges take the effect. Its first row also drew its leading separator, which reads as a line under the navigation bar rather than a divider between rows; that one is hidden. Sweeping the rest of the app's hard edges onto `softScrollEdge()` is separate work.
