### PR TITLE
feat(home): give the You tab's photo an unselected ring

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/HomeTabBar.swift
+++ b/Flipcash/Core/Screens/Main/Home/HomeTabBar.swift
@@ -92,7 +92,7 @@ struct HomeTabBar: View {
     @ViewBuilder
     private func icon(for tab: HomeTab) -> some View {
         if tab == .tipCard, let profileSlot {
-            ProfileTabIcon(photo: profileSlot.preview)
+            ProfileTabIcon(photo: profileSlot.preview, isSelected: tab == selection)
         } else {
             Image(tab.iconName(isSelected: tab == selection))
                 .renderingMode(.template)

--- a/Flipcash/Core/Screens/Main/Home/TabBarProfilePhoto.swift
+++ b/Flipcash/Core/Screens/Main/Home/TabBarProfilePhoto.swift
@@ -28,9 +28,14 @@ enum ProfileTabSlot: Equatable {
     }
 }
 
-/// The You tab's icon once the profile carries a picture: the photo in a white
-/// ring, standing in the slot the outline glyph otherwise occupies (Figma node
-/// 9641:17115).
+/// The You tab's icon once the profile carries a picture: the photo in a ring,
+/// standing in the slot the outline glyph otherwise occupies (Figma node
+/// 9713:664).
+///
+/// The ring is the selection: the active tab wears a 2pt solid white one, an
+/// inactive tab a 1pt half-opacity one. That is a state the glyph tabs don't
+/// have — they only ever dim — so it has to be drawn here rather than left to
+/// whichever bar is hosting the icon.
 ///
 /// A nil photo draws the ring empty. That is the state a cold launch starts in:
 /// the profile says a picture exists well before its thumbnail is read back, and
@@ -39,12 +44,26 @@ struct ProfileTabIcon: View {
 
     let photo: UIImage?
 
+    /// Whether the You tab is the active one, which picks the ring.
+    let isSelected: Bool
+
     /// The slot every tab glyph is drawn into, so the photo sits on the same
     /// baseline as its neighbours.
     static let slotSize: CGFloat = 32
 
     private static let circleSize: CGFloat = 28
-    private static let ringWidth: CGFloat = 2
+    private static let selectedRingWidth: CGFloat = 2
+    private static let unselectedRingWidth: CGFloat = 1
+
+    private var ringWidth: CGFloat {
+        isSelected ? Self.selectedRingWidth : Self.unselectedRingWidth
+    }
+
+    private var ringColor: Color {
+        // Half opacity on top of the half the whole icon is already drawn at,
+        // so the inactive ring lands at the quarter alpha Figma specifies.
+        isSelected ? .white : Color.white.opacity(0.5)
+    }
 
     var body: some View {
         Group {
@@ -59,7 +78,7 @@ struct ProfileTabIcon: View {
         .frame(width: Self.circleSize, height: Self.circleSize)
         .clipShape(Circle())
         .overlay {
-            Circle().strokeBorder(Color.white, lineWidth: Self.ringWidth)
+            Circle().strokeBorder(ringColor, lineWidth: ringWidth)
         }
         .frame(width: Self.slotSize, height: Self.slotSize)
     }
@@ -140,11 +159,12 @@ final class TabBarProfilePhoto {
     /// Draws the icon into the pair of images a `UITabBarItem` holds.
     ///
     /// The bar tints template glyphs per state, but a photo has to render as its
-    /// own colours — so the unselected dimming is baked in here instead, at the
-    /// half opacity the pill applies to every other icon.
+    /// own colours — so the unselected state is baked in here instead: the
+    /// thinner half-opacity ring, and the half opacity the pill applies to every
+    /// other icon.
     static func render(_ photo: UIImage?) -> ItemImages? {
-        guard let selected = image(of: ProfileTabIcon(photo: photo)),
-              let normal = image(of: ProfileTabIcon(photo: photo).opacity(0.5))
+        guard let selected = image(of: ProfileTabIcon(photo: photo, isSelected: true)),
+              let normal = image(of: ProfileTabIcon(photo: photo, isSelected: false).opacity(0.5))
         else { return nil }
 
         return ItemImages(normal: normal, selected: selected)

--- a/FlipcashTests/TabBarProfilePhotoTests.swift
+++ b/FlipcashTests/TabBarProfilePhotoTests.swift
@@ -3,6 +3,7 @@
 //  FlipcashTests
 //
 
+import SwiftUI
 import UIKit
 import Testing
 @testable import Flipcash
@@ -29,6 +30,18 @@ struct TabBarProfilePhotoTests {
         let images = try #require(TabBarProfilePhoto.render(Self.photo(side: 64)))
 
         #expect(images.normal.pngData() != images.selected.pngData())
+    }
+
+    /// The unselected tab wears its own thinner, half-opacity ring rather than
+    /// the selected ring dimmed, so the two differ at matched opacity too.
+    @Test("The unselected icon wears a different ring, not just less opacity")
+    func unselectedIconWearsItsOwnRing() throws {
+        let photo = Self.photo(side: 64)
+
+        let selected = try #require(Self.render(ProfileTabIcon(photo: photo, isSelected: true)))
+        let unselected = try #require(Self.render(ProfileTabIcon(photo: photo, isSelected: false)))
+
+        #expect(selected.pngData() != unselected.pngData())
     }
 
     /// A cold launch knows a picture exists before it has one to draw, and the
@@ -65,6 +78,10 @@ struct TabBarProfilePhotoTests {
         #expect(ProfileTabSlot.pending(preview).preview === preview)
         #expect(ProfileTabSlot.pending(nil).preview == nil)
         #expect(ProfileTabSlot.photo(preview).preview === preview)
+    }
+
+    private static func render(_ icon: ProfileTabIcon) -> UIImage? {
+        ImageRenderer(content: icon).uiImage
     }
 
     private static func photo(side: CGFloat) -> UIImage {


### PR DESCRIPTION
The You tab's photo icon had one ring — 2pt solid white — and an unselected tab was that ring at half opacity. Figma node 9713:664 draws the inactive state as its own frame: a 1pt white-50% ring, with the frame itself at 50% opacity.

`ProfileTabIcon` now takes `isSelected` and picks the ring from it. Both hosts pass it through:

- the legacy pill reads the binding directly;
- `TabBarProfilePhoto.render` bakes the unselected ring into the `normal` `UITabBarItem` image, which is the iOS 26 bar's only route to it — a photo renders `.alwaysOriginal`, so the bar never tints it per state.

The element-level 50% opacity both bars already applied is unchanged, so the inactive ring lands at the quarter alpha Figma multiplies out to. The no-picture state (the 32pt outline glyph) already matched and is untouched.

A new test renders the two states at matched opacity and asserts they differ, so "unselected" cannot collapse back into "selected, dimmed".
