### PR TITLE
feat(chat): render tombstones and resolve message capabilities

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -52,17 +52,26 @@ extension ChatItem {
         gap: TimeInterval = 15 * 60,
         counterpartRead: (pointer: MessageID, date: Date?)? = nil,
         suppressReceiptFor: String? = nil,
-        cashBranding: (ExchangedFiat) -> (token: String, iconURL: URL?) = { _ in ("Cash", nil) }
+        cashBranding: (ExchangedFiat) -> (token: String, iconURL: URL?) = { _ in ("Cash", nil) },
+        deletedPresentation: DeletedMessagePresentation = .hidden,
+        capabilities: (ConversationMessage) -> Set<MessageCapability> = { _ in [] }
     ) -> [ChatItem] {
-        // Tombstoned (deleted) messages are retained in the store for gapless ordering but rendered
-        // nowhere. Drop them up front so they never skew a date separator, group an adjacent bubble to
-        // an invisible row, or steal the "Delivered"/"Read" receipt anchor below.
-        let messages = messages.filter { if case .deleted = $0.content { false } else { true } }
+        // Tombstoned (deleted) messages are retained in the store for gapless ordering. Under
+        // `.hidden` they are dropped up front so they never skew a date separator, group an adjacent
+        // bubble to an invisible row, or steal the "Delivered"/"Read" receipt anchor below.
+        let messages: [ConversationMessage] = switch deletedPresentation {
+        case .hidden:      messages.filter { !$0.isDeleted }
+        case .placeholder: messages
+        }
 
         // "Delivered"/"Read" rides the latest *confirmed* self message, so an in-flight or failed send
         // trailing it doesn't strip the receipt off the last delivered bubble. A sending row shows
         // nothing; a failed row shows its own "Not Delivered" line (each independently retryable).
-        let latestSentFromSelfID = messages.last { $0.isFromSelf(selfUserID) && $0.status == .sent }?.stableID
+        // A tombstone has nothing to acknowledge, so it must not take the receipt from the last row
+        // that does — it is skipped here even when it is the newest self message.
+        let latestSentFromSelfID = messages.last {
+            $0.isFromSelf(selfUserID) && $0.status == .sent && !$0.isDeleted
+        }?.stableID
         var items: [ChatItem] = []
         for (index, message) in messages.enumerated() {
             let isFromSelf = message.isFromSelf(selfUserID)
@@ -100,8 +109,13 @@ extension ChatItem {
                     isTip: message.cashAction == .tipped
                 ))
                 linkPreview = nil
-            case .deleted:
-                continue // filtered out above; unreachable, kept for switch exhaustiveness
+            case .deleted(let deletion):
+                content = .deleted(
+                    deletion.deletedBy == selfUserID
+                        ? "You deleted this message"
+                        : "This message was deleted"
+                )
+                linkPreview = nil
             }
 
             // The status line rides on the bubble itself (not a separate row, so a send is a clean
@@ -131,10 +145,18 @@ extension ChatItem {
                 isContinuationFromPrevious: groupedAbove,
                 isContinuedByNext: groupedBelow,
                 receipt: receipt,
-                linkPreview: linkPreview
+                linkPreview: linkPreview,
+                isEdited: message.lastEditedTs != nil && !message.isDeleted,
+                actions: orderedActions(capabilities(message))
             )))
         }
         return items
+    }
+
+    /// Menu order is fixed here, not at the call site — a `Set` has no order, and the context menu
+    /// must not shuffle its rows between renders of the same message.
+    nonisolated private static func orderedActions(_ capabilities: Set<MessageCapability>) -> [MessageCapability] {
+        [.copy, .reply, .edit, .delete].filter(capabilities.contains)
     }
 
     /// "Read 3:42 PM" / "Read Yesterday" / "Read Monday" / "Read Tue, Jun 17" once the counterpart's

--- a/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
@@ -72,8 +72,8 @@ final class ConversationLoadCoordinator {
     }
 
     private func currentInputs() -> Inputs {
-        let read = controller.conversation(withID: conversationID)?
-            .counterpartReadReceipt(excluding: controller.selfUserID)
+        let conversation = controller.conversation(withID: conversationID)
+        let read = conversation?.counterpartReadReceipt(excluding: controller.selfUserID)
         let window = loader.messages
         var branding: [PublicKey: Inputs.Branding] = [:]
         for message in window {
@@ -92,7 +92,9 @@ final class ConversationLoadCoordinator {
             // The card heads only a short transcript — long or paged histories drop it; the
             // nav title opens the same contact card.
             profileCard: loader.isEntireHistory(windowCount: window.count) ? profileCard() : nil,
-            branding: branding
+            branding: branding,
+            conversation: conversation,
+            policy: .default
         )
     }
 
@@ -105,6 +107,20 @@ final class ConversationLoadCoordinator {
             cashBranding: { fiat in
                 guard let branding = inputs.branding[fiat.mint] else { return ("Cash", nil) }
                 return (branding.token, branding.iconURL)
+            },
+            deletedPresentation: inputs.policy.deletedPresentation,
+            // `now: message.date` is deliberate: the default policy has no edit window, so `now` is
+            // unread, and passing the message's own date keeps `map` a pure function of `Inputs`.
+            // Introducing an edit window makes this a real clock and costs `map` its purity — that
+            // change needs a re-map trigger, not just a different argument here.
+            capabilities: { message in
+                MessageCapability.resolve(
+                    for: message,
+                    in: inputs.conversation,
+                    as: inputs.selfUserID,
+                    policy: inputs.policy,
+                    now: message.date
+                )
             }
         )
         if inputs.isTyping {
@@ -128,6 +144,8 @@ final class ConversationLoadCoordinator {
         var isTyping: Bool
         var profileCard: ChatProfileCard?
         var branding: [PublicKey: Branding]
+        var conversation: Conversation?
+        var policy: MessagePolicy
 
         struct Branding: Equatable, Sendable {
             var token: String

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift
@@ -23,6 +23,9 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
     public enum Content: Hashable, Sendable, Codable {
         case text(String)
         case cash(ChatCashContent)
+        /// A deleted message's placeholder copy, already resolved for the viewer — "You deleted this
+        /// message" or "This message was deleted". The mapper decides which; the view just draws it.
+        case deleted(String)
     }
 
     public let id: String
@@ -43,6 +46,10 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
     /// The web link this text row contains, or nil when it carries none — marks the row to render as
     /// tappable text. Derived from the text at map time (not stored/sent) — cash rows never carry one.
     public let linkPreview: LinkPreview?
+    /// Whether to draw the muted "Edited" marker after the body.
+    public let isEdited: Bool
+    /// What the context menu offers for this row, already ordered. Empty means no menu.
+    public let actions: [MessageCapability]
 
     public init(
         id: String,
@@ -51,7 +58,9 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
         isContinuationFromPrevious: Bool = false,
         isContinuedByNext: Bool = false,
         receipt: ChatReceipt? = nil,
-        linkPreview: LinkPreview? = nil
+        linkPreview: LinkPreview? = nil,
+        isEdited: Bool = false,
+        actions: [MessageCapability] = []
     ) {
         self.id = id
         self.content = content
@@ -60,6 +69,8 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
         self.isContinuedByNext = isContinuedByNext
         self.receipt = receipt
         self.linkPreview = linkPreview
+        self.isEdited = isEdited
+        self.actions = actions
     }
 
     /// Convenience for text rows.
@@ -70,7 +81,9 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
         isContinuationFromPrevious: Bool = false,
         isContinuedByNext: Bool = false,
         receipt: ChatReceipt? = nil,
-        linkPreview: LinkPreview? = nil
+        linkPreview: LinkPreview? = nil,
+        isEdited: Bool = false,
+        actions: [MessageCapability] = []
     ) {
         self.init(
             id: id,
@@ -79,7 +92,9 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
             isContinuationFromPrevious: isContinuationFromPrevious,
             isContinuedByNext: isContinuedByNext,
             receipt: receipt,
-            linkPreview: linkPreview
+            linkPreview: linkPreview,
+            isEdited: isEdited,
+            actions: actions
         )
     }
 }

--- a/FlipcashTests/Chat/ChatBubbleViewTests.swift
+++ b/FlipcashTests/Chat/ChatBubbleViewTests.swift
@@ -75,3 +75,126 @@ struct ChatMessageCellAlignmentTests {
         #expect(bubble.frame.maxX < cell.contentView.bounds.width - 12)
     }
 }
+
+@MainActor
+@Suite("Chat bubble deleted and edited rendering")
+struct ChatBubbleDeletedTests {
+
+    @Test("A deleted bubble shows the tombstone copy")
+    func deletedBubbleShowsCopy() {
+        let text = ChatBubbleView.displayText(
+            for: ChatMessage(id: "1", content: .deleted("You deleted this message"), sender: .me)
+        )
+        #expect(text?.string == "You deleted this message")
+    }
+
+    @Test("An edited bubble reserves the marker's width after the body, drawn clear")
+    func editedBubbleReservesMarker() {
+        let text = ChatBubbleView.displayText(
+            for: ChatMessage(id: "1", content: .text("hello"), sender: .me, isEdited: true)
+        )
+        #expect(text?.string == "hello  Edited")
+
+        // The reservation holds the space; the visible marker is the corner label, so the run in
+        // the body must not draw.
+        let markerColor = text?.attribute(.foregroundColor, at: 7, effectiveRange: nil) as? UIColor
+        #expect(markerColor == UIColor.clear)
+    }
+
+    @Test("Only a message with a body left to revise carries the marker")
+    func markerIsForRevisableBodies() {
+        #expect(ChatBubbleView.showsEditedMarker(
+            for: ChatMessage(id: "1", content: .text("hello"), sender: .me, isEdited: true)
+        ))
+        #expect(!ChatBubbleView.showsEditedMarker(
+            for: ChatMessage(id: "1", content: .text("hello"), sender: .me)
+        ))
+        #expect(!ChatBubbleView.showsEditedMarker(
+            for: ChatMessage(id: "1", content: .deleted("You deleted this message"), sender: .me, isEdited: true)
+        ))
+    }
+
+    private static let maxWidth: CGFloat = 250
+
+    /// A bubble laid out through the real cell, so the width cap and self-sizing apply. The cell is
+    /// measured the way the collection view measures it — a fixed frame height would stretch the
+    /// bubble to fill it and hide the wrap.
+    private func laidOutBubble(text: String, isEdited: Bool) -> ChatBubbleView {
+        let cell = ChatMessageCell(frame: CGRect(x: 0, y: 0, width: 320, height: 80))
+        cell.configure(
+            with: ChatMessage(id: "1", content: .text(text), sender: .me, isEdited: isEdited),
+            maxWidth: Self.maxWidth
+        )
+        let fitted = cell.contentView.systemLayoutSizeFitting(
+            CGSize(width: 320, height: 0),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        cell.frame = CGRect(x: 0, y: 0, width: 320, height: fitted.height)
+        cell.layoutIfNeeded()
+        return cell.bubbleView
+    }
+
+    private func marker(in bubble: ChatBubbleView) -> UILabel? {
+        bubble.subviews.compactMap { $0 as? UILabel }.first { $0.text == EditedMarker.text }
+    }
+
+    @Test("The marker sits in the bubble's bottom-trailing corner")
+    func markerSitsInTheCorner() throws {
+        let bubble = laidOutBubble(text: "hello", isEdited: true)
+        let marker = try #require(marker(in: bubble))
+
+        #expect(!marker.isHidden)
+        #expect(abs(marker.frame.maxX - (bubble.bounds.width - EditedMarker.trailingInset)) < 0.5)
+        #expect(abs(marker.frame.maxY - (bubble.bounds.height - 9)) < 0.5)
+    }
+
+    @Test("A last line with room keeps the marker on it, widening the bubble")
+    func markerStaysOnALastLineWithRoom() {
+        let plain = laidOutBubble(text: "hello", isEdited: false)
+        let edited = laidOutBubble(text: "hello", isEdited: true)
+
+        #expect(abs(edited.bounds.height - plain.bounds.height) < 0.5) // still one line
+        #expect(edited.bounds.width > plain.bounds.width)              // grew to hold the marker
+    }
+
+    @Test("A last line with no room drops the marker onto a line of its own")
+    func markerWrapsOffAFullLastLine() throws {
+        // Pack short words onto one line until one more would wrap it, so the leftover room on that
+        // line is narrower than a word — and narrower still than the marker. Measured off the
+        // laid-out bubble rather than off the font, so the insets and the width cap are the real
+        // ones.
+        let oneLine = laidOutBubble(text: "w", isEdited: false).bounds.height
+        var body = "w"
+        while laidOutBubble(text: body + " w", isEdited: false).bounds.height == oneLine { body += " w" }
+
+        let plain = laidOutBubble(text: body, isEdited: false)
+        let edited = laidOutBubble(text: body, isEdited: true)
+        let marker = try #require(marker(in: edited))
+
+        #expect(abs(plain.bounds.height - oneLine) < 0.5)   // the body itself still fits one line
+        #expect(edited.bounds.height > plain.bounds.height) // the marker took a line of its own
+        #expect(abs(marker.frame.maxX - (edited.bounds.width - EditedMarker.trailingInset)) < 0.5)
+    }
+
+    @Test("An unedited bubble is just its body")
+    func uneditedBubbleIsPlain() {
+        let text = ChatBubbleView.displayText(
+            for: ChatMessage(id: "1", content: .text("hello"), sender: .me)
+        )
+        #expect(text?.string == "hello")
+    }
+
+    @Test("A cash row has no bubble text — it uses its own cell")
+    func cashRowHasNoBubbleText() {
+        let cash = ChatCashContent(amount: "$5.00", token: "Cash", flagImageName: nil, iconURL: nil, isTip: false)
+        #expect(ChatBubbleView.displayText(for: ChatMessage(id: "1", content: .cash(cash), sender: .me)) == nil)
+    }
+
+    @Test("A deleted message reuses the plain text cell, so a delete reconfigures in place")
+    func deletedReusesTextCell() {
+        let deleted = ChatItem.message(ChatMessage(id: "1", content: .deleted("Message deleted"), sender: .other))
+        let plain = ChatItem.message(ChatMessage(id: "1", text: "hi", sender: .other))
+        #expect(deleted.differenceIdentifier == plain.differenceIdentifier)
+    }
+}

--- a/FlipcashTests/Chat/ChatMessageMappingTests.swift
+++ b/FlipcashTests/Chat/ChatMessageMappingTests.swift
@@ -54,8 +54,8 @@ struct ChatMessageMappingTests {
         messageRows(items).map(\.isFailed)
     }
 
-    private func deleted(_ id: UInt64, _ sender: UUID, after offset: TimeInterval) -> ConversationMessage {
-        ConversationMessage(id: MessageID(value: id), senderID: sender, content: .deleted(.init(deletedBy: sender, deletedAt: base.addingTimeInterval(offset))), date: base.addingTimeInterval(offset), unreadSeq: id, eventSequence: id)
+    private func deleted(_ id: UInt64, _ sender: UUID, deletedBy: UUID? = nil, after offset: TimeInterval) -> ConversationMessage {
+        ConversationMessage(id: MessageID(value: id), senderID: sender, content: .deleted(.init(deletedBy: deletedBy ?? sender, deletedAt: base.addingTimeInterval(offset))), date: base.addingTimeInterval(offset), unreadSeq: id, eventSequence: id)
     }
 
     @Test("a deleted tombstone is dropped: no stray separator, no grouping to an invisible row, receipt intact")
@@ -290,5 +290,60 @@ struct ChatMessageMappingTests {
             selfUserID: me
         ))
         #expect(rows.first?.linkPreview == nil)
+    }
+
+    @Test("In placeholder mode my own deletion reads as mine")
+    func placeholderNamesTheDeleter() {
+        let items = ChatItem.from(
+            [deleted(1, me, deletedBy: me, after: 0)],
+            selfUserID: me,
+            deletedPresentation: .placeholder
+        )
+        #expect(messageRows(items).first?.content == .deleted("You deleted this message"))
+    }
+
+    @Test("In placeholder mode someone else's deletion reads impersonally")
+    func placeholderIsImpersonalForOthers() {
+        let items = ChatItem.from(
+            [deleted(1, them, deletedBy: them, after: 0)],
+            selfUserID: me,
+            deletedPresentation: .placeholder
+        )
+        #expect(messageRows(items).first?.content == .deleted("This message was deleted"))
+    }
+
+    @Test("A tombstone never anchors the delivery receipt, even when it is my newest row")
+    func tombstoneDoesNotAnchorReceipt() {
+        let items = ChatItem.from(
+            [text(1, me, "hello", after: 0), deleted(2, me, deletedBy: me, after: 60)],
+            selfUserID: me,
+            deletedPresentation: .placeholder
+        )
+        let rows = messageRows(items)
+        #expect(rows.count == 2)
+        #expect(rows[0].receipt?.displayText == "Delivered")
+        #expect(rows[1].receipt == nil)
+    }
+
+    @Test("An edited message is flagged for the edited marker")
+    func editedMessageIsFlagged() {
+        let plain = text(1, me, "after", after: 0)
+        let edited = ConversationMessage(
+            id: plain.id, senderID: plain.senderID, content: plain.content,
+            date: plain.date, unreadSeq: plain.unreadSeq, eventSequence: 2,
+            lastEditedTs: base.addingTimeInterval(30)
+        )
+        let items = ChatItem.from([edited], selfUserID: me)
+        #expect(messageRows(items).first?.isEdited == true)
+    }
+
+    @Test("Actions come back in menu order, never in set order")
+    func actionsAreOrdered() {
+        let items = ChatItem.from(
+            [text(1, me, "hi", after: 0)],
+            selfUserID: me,
+            capabilities: { _ in [.delete, .edit, .copy] }
+        )
+        #expect(messageRows(items).first?.actions == [.copy, .edit, .delete])
     }
 }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatBubbleView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatBubbleView.swift
@@ -17,6 +17,7 @@ public final class ChatBubbleView: UIView {
 
     private let background = BubbleBackgroundView()
     private let label = UILabel()
+    private let editedLabel = EditedMarker.makeLabel()
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -31,10 +32,10 @@ public final class ChatBubbleView: UIView {
         addSubview(background)
 
         label.numberOfLines = 0
-        label.font = .default(size: 16, weight: .medium)
-        label.textColor = .white
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
+
+        addSubview(editedLabel)
 
         NSLayoutConstraint.activate([
             background.topAnchor.constraint(equalTo: topAnchor),
@@ -46,6 +47,11 @@ public final class ChatBubbleView: UIView {
             label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -9),
             label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+
+            // Bottom-trailing corner: the body's reservation run keeps the space clear, so the
+            // marker lands on the last line where it fits and on the wrapped line where it doesn't.
+            editedLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -EditedMarker.trailingInset),
+            editedLabel.bottomAnchor.constraint(equalTo: label.bottomAnchor),
         ])
     }
 
@@ -54,10 +60,9 @@ public final class ChatBubbleView: UIView {
     var maskingPath: UIBezierPath { background.maskingPath }
 
     public func configure(with message: ChatMessage) {
-        switch message.content {
-        case .text(let text): label.text = text
-        case .cash: label.text = nil // cash rows use a dedicated cell, not this bubble
-        }
+        label.attributedText = Self.displayText(for: message)
+        editedLabel.isHidden = !Self.showsEditedMarker(for: message)
+
         background.apply(
             fill: BubbleBackgroundView.fill(isFromSelf: message.sender == .me),
             radii: BubbleBackgroundView.radii(
@@ -67,6 +72,51 @@ public final class ChatBubbleView: UIView {
             ),
             identity: message.id
         )
+    }
+
+    /// Whether the bubble draws the "Edited" marker: a revised message that still has a body to
+    /// revise, so a tombstone or a cash row never carries one.
+    public static func showsEditedMarker(for message: ChatMessage) -> Bool {
+        switch message.content {
+        case .text:    message.isEdited
+        case .deleted: false
+        case .cash:    false
+        }
+    }
+
+    /// The bubble's rendered text: the body, a muted italic placeholder for a tombstone, and the
+    /// "Edited" marker's reservation where the sender has revised the message — the marker itself is
+    /// a separate label pinned to the bubble's corner. `nil` for cash rows, which use a dedicated
+    /// cell rather than this bubble.
+    public static func displayText(for message: ChatMessage) -> NSAttributedString? {
+        let body: String
+        let isPlaceholder: Bool
+        switch message.content {
+        case .text(let text):
+            body = text
+            isPlaceholder = false
+        case .deleted(let placeholder):
+            body = placeholder
+            isPlaceholder = true
+        case .cash:
+            return nil
+        }
+
+        let bodyFont: UIFont = isPlaceholder
+            ? .italicSystemFont(ofSize: 16)
+            : .default(size: 16, weight: .medium)
+        let bodyColor: UIColor = isPlaceholder ? UIColor.white.withAlphaComponent(0.55) : .white
+
+        let result = NSMutableAttributedString(
+            string: body,
+            attributes: [.font: bodyFont, .foregroundColor: bodyColor]
+        )
+
+        if Self.showsEditedMarker(for: message) {
+            result.append(EditedMarker.reservation)
+        }
+
+        return result
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem+Differentiable.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatItem+Differentiable.swift
@@ -35,6 +35,10 @@ extension ChatItem {
             switch message.content {
             case .text:
                 message.linkPreview != nil ? ChatLinkMessageCell.reuseIdentifier : ChatMessageCell.reuseIdentifier
+            case .deleted:
+                // Deliberately the same cell class as plain text: a message becoming a tombstone
+                // then diffs as an in-place reconfigure rather than a delete-and-insert.
+                ChatMessageCell.reuseIdentifier
             case .cash:
                 ChatCashCardCell.reuseIdentifier
             }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -517,6 +517,8 @@ extension ChatViewController {
             switch message.content {
             case .text(let text):
                 body = text
+            case .deleted:
+                return nil
             case .cash:
                 return nil
             }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/EditedMarker.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/EditedMarker.swift
@@ -1,0 +1,54 @@
+//
+//  EditedMarker.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+import FlipcashCore
+
+/// The "Edited" marker's type and placement, shared by both bubble kinds so they render it the
+/// same way. WhatsApp puts the marker on the bubble's metadata line, flush to the trailing edge;
+/// we have no per-bubble timestamp, so the marker takes that corner on its own — on the last line
+/// of the body where there is room for it, on a line of its own where there isn't.
+enum EditedMarker {
+
+    static let text = "Edited"
+
+    /// The receipt line's type and color, so the two pieces of bubble metadata read as one family
+    /// rather than drifting apart. WhatsApp sets its marker at the timestamp's size, not the body's.
+    static let font: UIFont = .default(size: 11, weight: .medium)
+    static let color: UIColor = ChatReceiptView.defaultColor
+
+    /// Inset from the bubble's trailing edge — the body's own inset, so the marker lines up with
+    /// the text above it.
+    static let trailingInset: CGFloat = 12
+
+    /// The run appended to the body to hold the marker's place: the marker's own string in its own
+    /// font, drawn in clear. Reserving with the real glyphs makes the gap exactly the width the
+    /// overlaid label needs, and the leading spaces are breakable, so a last line with no room for
+    /// the marker drops the reservation onto a new line instead of dragging the last word with it.
+    static var reservation: NSAttributedString {
+        NSAttributedString(
+            string: "  \(text)",
+            attributes: [.font: font, .foregroundColor: UIColor.clear]
+        )
+    }
+
+    /// The label that draws the marker, to be pinned to the bubble's bottom-trailing corner.
+    static func makeLabel() -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = font
+        label.textColor = color
+        // The body already carries the marker in its reservation run, so VoiceOver reads it in
+        // place; this label would only repeat it.
+        label.isAccessibilityElement = false
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+}
+#endif

--- a/FlipcashUI/Sources/FlipcashUI/Chat/LinkableBubbleView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/LinkableBubbleView.swift
@@ -16,6 +16,7 @@ public final class LinkableBubbleView: UIView {
 
     private let background = BubbleBackgroundView()
     private let textView = LinkTextView()
+    private let editedLabel = EditedMarker.makeLabel()
 
     /// Called when the user taps a detected link.
     var onOpenURL: ((URL) -> Void)?
@@ -48,6 +49,8 @@ public final class LinkableBubbleView: UIView {
         textView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(textView)
 
+        addSubview(editedLabel)
+
         NSLayoutConstraint.activate([
             background.topAnchor.constraint(equalTo: topAnchor),
             background.bottomAnchor.constraint(equalTo: bottomAnchor),
@@ -58,6 +61,10 @@ public final class LinkableBubbleView: UIView {
             textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -9),
             textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
             textView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+
+            // Same bottom-trailing corner as the plain bubble, off the same reservation run.
+            editedLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -EditedMarker.trailingInset),
+            editedLabel.bottomAnchor.constraint(equalTo: textView.bottomAnchor),
         ])
     }
 
@@ -69,10 +76,12 @@ public final class LinkableBubbleView: UIView {
     }
 
     public func configure(with message: ChatMessage) {
-        switch message.content {
-        case .text(let text): textView.text = text
-        case .cash: textView.text = nil
-        }
+        // Shares the plain bubble's text builder so a link message gets the same body styling, the
+        // same tombstone copy, and the same "Edited" reservation. Data detection still runs — the
+        // text view is non-editable, so it detects over `attributedText` as it did over `text`.
+        textView.attributedText = ChatBubbleView.displayText(for: message)
+        editedLabel.isHidden = !ChatBubbleView.showsEditedMarker(for: message)
+
         background.apply(
             fill: BubbleBackgroundView.fill(isFromSelf: message.sender == .me),
             radii: BubbleBackgroundView.radii(

--- a/NotificationContent/NotificationTranscriptView.swift
+++ b/NotificationContent/NotificationTranscriptView.swift
@@ -78,6 +78,8 @@ private struct NotificationMessageRow: View {
             switch message.content {
             case .text(let text):
                 NotificationTextBubble(text: text, isFromSelf: message.sender == .me)
+            case .deleted(let placeholder):
+                NotificationTextBubble(text: placeholder, isFromSelf: message.sender == .me)
             case .cash(let cash):
                 NotificationCashCard(cash: cash, isFromSelf: message.sender == .me)
             }


### PR DESCRIPTION
Second of four stacked PRs adding edit and delete to chat messages. Stacked on #712 — review that one first; this diff is against it.

Renders what the model from #712 now carries. The transcript can show a tombstone and an edited marker, and knows what each message allows, but nothing yet triggers either.

## Contents

**Tombstone rendering.** A deleted message reuses the plain text cell rather than a cell type of its own, so a delete reconfigures in place instead of forcing a cell swap through the diff. `ChatItem`'s differentiable identity accounts for the deleted and edited state, so a message that changes updates rather than being torn down and rebuilt.

**Edited marker.** A label pinned to the bubble's bottom-trailing corner, with a clear-drawn reservation run appended to the body so the layout reserves space for it. An inline suffix would reflow with the text and could land mid-line. The reservation is what VoiceOver reads, so the label itself is not an accessibility element. `LinkableBubbleView` builds its text through the same `ChatBubbleView.displayText(for:)`, so an edited link message is marked too.

**Capability resolution in the transcript coordinator.** Each message arrives at the UI with its capabilities already resolved, so the view layer reads a value instead of asking a question.

Tests cover the mapping from conversation messages to chat items across tombstones and edit stamps, the reservation being drawn clear, and three marker layouts driven through a real cell: corner placement, staying on a last line with room, and dropping onto its own line when there is none.
