### PR TITLE
fix(tests): unblock the display name smoke test

### DIFF
--- a/FlipcashUITests/Smoke/DisplayNameSmokeTests.swift
+++ b/FlipcashUITests/Smoke/DisplayNameSmokeTests.swift
@@ -75,6 +75,19 @@ final class DisplayNameSmokeTests: BaseUITestCase {
         XCTAssertTrue(save.isEnabled, "Save must enable once the name is valid and changed")
         save.tap()
 
+        // Replacing a name that is already set is confirmed first; only the
+        // first name set during onboarding saves straight through. The editor
+        // stays up behind the dialog until it is answered.
+        let confirmDialog = app.otherElements["Change Display Name?"]
+        XCTAssertTrue(
+            confirmDialog.waitForExistence(timeout: 30),
+            "Expected the rename confirmation dialog. On screen: [\(visibleText())]"
+        )
+        waitUntilHittableAndTap(
+            confirmDialog.buttons["Change Display Name"],
+            "Expected the dialog's Change Display Name action to be tappable"
+        )
+
         // `ProfileNameScreen(completion: .back)` pops itself only once
         // `SetDisplayName` returns, so landing back on My Account is proof the
         // new name was accepted and moderated — a rejection keeps the editor up

--- a/FlipcashUITests/Smoke/DisplayNameSmokeTests.swift
+++ b/FlipcashUITests/Smoke/DisplayNameSmokeTests.swift
@@ -69,7 +69,19 @@ final class DisplayNameSmokeTests: BaseUITestCase {
         let seeded = (field.value as? String) ?? ""
         XCTAssertFalse(seeded.isEmpty, "Expected the editor to be seeded with the current name")
         field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: seeded.count))
-        XCTAssertFalse(save.isEnabled, "Save must stay disabled while the name is empty")
+
+        // Wait for the disabled state rather than sampling it: the emptied field
+        // reaches the button on SwiftUI's next render, which under load lands
+        // after the typing settles. The field is already empty by then — the
+        // instantaneous read just catches the state the button is leaving.
+        let saveDisabled = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "isEnabled == false"),
+            object: save
+        )
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [saveDisabled], timeout: 5), .completed,
+            "Save must stay disabled while the name is empty. Field: [\((field.value as? String) ?? "")]"
+        )
 
         field.typeText("Renamed \(Int.random(in: 1_000...9_999))")
         XCTAssertTrue(save.isEnabled, "Save must enable once the name is valid and changed")


### PR DESCRIPTION
`DisplayNameSmokeTests.testDisplayName_yieldsTipCard_andCanBeChanged` fails on `main`, and fails identically at `06678487` — the commit before the chat edit/delete stack — so it predates that work.

Two separate causes, both in the test.

**The rename confirmation was never answered.** Replacing a display name that is already set raises `Change Display Name?` on Save: `ProfileNameScreen.submit()` only saves straight through when the profile carries no name, which is the onboarding case. The test tapped Save and then waited its full 60s for `ProfileNameScreen(completion: .back)` to pop, with the dialog sitting on screen the whole time. It now taps the dialog's confirm action, scoped to the dialog container the way `AccessKeyBackupSmokeTests` and `BlockUnblockSmokeTests` scope theirs. The assertion behind it is unchanged — landing back on My Account is still what proves the name was accepted.

**`save.isEnabled` was sampled too early.** Once the seeded name is deleted, the emptied field reaches the button on SwiftUI's next render, and under a full-suite load that lands after the typing has settled, so the read caught the state the button was leaving. It now waits for `isEnabled == false`, the way `verifyPhoneIfNeeded` waits for its Confirm button to go away, and names the field's contents if the wait times out. That second failure only surfaced in a full-suite run; the first is deterministic in isolation.
