### PR TITLE
fix(chat): title-case the delete confirmation

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -418,7 +418,7 @@ struct ConversationScreen: View {
         // WhatsApp's sheet offers "Delete for everyone" beside "Delete for me"; we have no
         // delete-for-me, so the one action we do have names its scope and stands alone.
         session.dialogItem = DialogItem.alert(
-            title: "Delete message?",
+            title: "Delete Message?",
             subtitle: "This can't be undone"
         ) {
             DialogAction.destructive("Delete For Everyone") {


### PR DESCRIPTION
The delete confirmation alert titled itself "Delete message?" while its own action button read "Delete For Everyone". Same dialog, two casing conventions. The title now matches the button.