### PR TITLE
feat(account): carry message edit/delete windows on UserFlags

### DIFF
--- a/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/code-payments/ocp-client-protocol",
       "state" : {
-        "revision" : "b08adb951fcaaa463da21a4dfaa775577254d052",
-        "version" : "0.2.0"
+        "revision" : "7c37ecc098d682ccf7ac95e5bd48ef770dbc7962",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/code-payments/flipcash2-client-protocol",
       "state" : {
-        "revision" : "9f6e3805672e955863dc91302bc60e27b7f03977",
-        "version" : "0.2.0"
+        "revision" : "27e3f09a82f6fbd41c03026ee738f943f4ed465e",
+        "version" : "0.4.0"
       }
     },
     {

--- a/FlipcashAPI/Package.swift
+++ b/FlipcashAPI/Package.swift
@@ -34,7 +34,7 @@ let contractDependencies: [Package.Dependency] = protoLocalRoot.map { root in
         .package(path: "\(root)/flipcash2-client-protocol"),
     ]
 } ?? [
-    .package(url: "https://github.com/code-payments/ocp-client-protocol", exact: "0.2.0"),
+    .package(url: "https://github.com/code-payments/ocp-client-protocol", exact: "0.3.0"),
     .package(url: "https://github.com/code-payments/flipcash2-client-protocol", exact: "0.4.0"),
 ]
 

--- a/FlipcashAPI/Package.swift
+++ b/FlipcashAPI/Package.swift
@@ -35,7 +35,7 @@ let contractDependencies: [Package.Dependency] = protoLocalRoot.map { root in
     ]
 } ?? [
     .package(url: "https://github.com/code-payments/ocp-client-protocol", exact: "0.2.0"),
-    .package(url: "https://github.com/code-payments/flipcash2-client-protocol", exact: "0.2.0"),
+    .package(url: "https://github.com/code-payments/flipcash2-client-protocol", exact: "0.4.0"),
 ]
 
 let package = Package(

--- a/FlipcashCore/Sources/FlipcashCore/Models/UserFlags.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/UserFlags.swift
@@ -46,6 +46,14 @@ public struct UserFlags: Codable, Sendable {
     /// Server-defined tip amounts per fiat currency, in major units.
     public let tipPresets: [TipPresets]
 
+    /// Duration after message creation when a message can be edited, or `nil` when the
+    /// server did not send a window.
+    public let messageEditWindow: TimeInterval?
+
+    /// Duration after message creation when a message can be deleted, or `nil` when the
+    /// server did not send a window.
+    public let messageDeleteWindow: TimeInterval?
+
     /// Returns the tip presets for a currency, falling back to the USD row —
     /// mirroring the server's minimum-enforcement fallback — or `nil` when the
     /// server provided no presets at all.
@@ -147,7 +155,9 @@ extension UserFlags {
             enablePhoneNumberSend: proto.enablePhoneNumberSend,
             requireCoinbaseEmailVerification: proto.requireCoinbaseEmailVerification,
             preferredOnrampUsdcLiquidityPool: UsdcLiquidityPool(proto.preferredOnRampUsdcLiquidityPool),
-            tipPresets: proto.tipPresets.compactMap { TipPresets($0) }
+            tipPresets: proto.tipPresets.compactMap { TipPresets($0) },
+            messageEditWindow: proto.hasMessageEditWindow ? TimeInterval(proto.messageEditWindow.seconds) : nil,
+            messageDeleteWindow: proto.hasMessageDeleteWindow ? TimeInterval(proto.messageDeleteWindow.seconds) : nil
         )
     }
 }

--- a/FlipcashTests/Database/Database+ProfileTests.swift
+++ b/FlipcashTests/Database/Database+ProfileTests.swift
@@ -29,7 +29,9 @@ struct DatabaseProfileTests {
         tipPresets: [
             UserFlags.TipPresets(currency: .usd, minimum: 1, low: 5, medium: 10, high: 20),
             UserFlags.TipPresets(currency: .cad, minimum: 2, low: 5, medium: 10, high: 25),
-        ]
+        ],
+        messageEditWindow: 900,
+        messageDeleteWindow: 300
     )
 
     /// Restricted account: no onramp providers, unset timeout, zero fees.
@@ -48,7 +50,9 @@ struct DatabaseProfileTests {
         enablePhoneNumberSend: false,
         requireCoinbaseEmailVerification: false,
         preferredOnrampUsdcLiquidityPool: .unknown,
-        tipPresets: []
+        tipPresets: [],
+        messageEditWindow: nil,
+        messageDeleteWindow: nil
     )
 
     // MARK: - Empty (fresh install) -

--- a/FlipcashTests/SessionTests.swift
+++ b/FlipcashTests/SessionTests.swift
@@ -707,7 +707,9 @@ struct SessionOfflineCacheTests {
             enablePhoneNumberSend: false,
             requireCoinbaseEmailVerification: false,
             preferredOnrampUsdcLiquidityPool: .unknown,
-            tipPresets: []
+            tipPresets: [],
+            messageEditWindow: nil,
+            messageDeleteWindow: nil
         )
     }
 

--- a/FlipcashTests/TestSupport/UserFlags+Fixtures.swift
+++ b/FlipcashTests/TestSupport/UserFlags+Fixtures.swift
@@ -28,7 +28,9 @@ extension UserFlags {
             enablePhoneNumberSend: false,
             requireCoinbaseEmailVerification: requireCoinbaseEmailVerification,
             preferredOnrampUsdcLiquidityPool: .unknown,
-            tipPresets: tipPresets
+            tipPresets: tipPresets,
+            messageEditWindow: nil,
+            messageDeleteWindow: nil
         )
     }
 }

--- a/FlipcashTests/TestSupport/WithdrawViewModel+TestSupport.swift
+++ b/FlipcashTests/TestSupport/WithdrawViewModel+TestSupport.swift
@@ -44,7 +44,9 @@ enum WithdrawViewModelTestHelpers {
             enablePhoneNumberSend: false,
             requireCoinbaseEmailVerification: false,
             preferredOnrampUsdcLiquidityPool: .unknown,
-            tipPresets: []
+            tipPresets: [],
+            messageEditWindow: nil,
+            messageDeleteWindow: nil
         )
 
         return WithdrawViewModel(
@@ -139,7 +141,9 @@ enum WithdrawViewModelTestHelpers {
                 enablePhoneNumberSend: false,
                 requireCoinbaseEmailVerification: false,
                 preferredOnrampUsdcLiquidityPool: .unknown,
-                tipPresets: []
+                tipPresets: [],
+                messageEditWindow: nil,
+                messageDeleteWindow: nil
             )
         }
         let stored = try #require(container.session.balance(for: .usdf))

--- a/FlipcashTests/WithdrawViewModelTests.swift
+++ b/FlipcashTests/WithdrawViewModelTests.swift
@@ -332,7 +332,9 @@ struct WithdrawViewModelTests {
                 enablePhoneNumberSend: false,
                 requireCoinbaseEmailVerification: false,
                 preferredOnrampUsdcLiquidityPool: .unknown,
-                tipPresets: []
+                tipPresets: [],
+                messageEditWindow: nil,
+                messageDeleteWindow: nil
             )
         }
         let stored = try #require(container.session.balance(for: mint))


### PR DESCRIPTION
Carries the two new `UserFlags` durations from [flipcash2-protobuf-api#89](https://github.com/code-payments/flipcash2-protobuf-api/pull/89) into the domain model, and pins the contract package release that carries them.

## Blocked on the release

**Draft until `flipcash2-client-protocol` `0.4.0` is tagged.** That tag does not exist yet — it is pushed by the publish run on [flipcash2-client-protocol#7](https://github.com/code-payments/flipcash2-client-protocol/pull/7), which has to merge first. Until then the `exact: "0.4.0"` requirement has nothing to resolve.

The work was developed and tested against the client checkout directly, via `FLIPCASH_PROTO_LOCAL`. CI never sees that override — it is a shell variable — so it resolves the pin and nothing else.

## Contract change

Two fields appended to `account.v1.UserFlags`, both `google.protobuf.Duration` with explicit presence:

- `message_edit_window = 17` — the window after a message is created during which it can still be edited
- `message_delete_window = 18` — the same, for deletion

Nothing else in the contract moved, and no enum gained or reordered a case, so there is no `Error*(rawValue:)` renumbering hazard here.

## What this does

`UserFlags` gains `messageEditWindow: TimeInterval?` and `messageDeleteWindow: TimeInterval?`, mapped in `init(_ proto:)` behind `proto.hasMessageEditWindow` / `proto.hasMessageDeleteWindow`, so an unset field stays `nil` rather than becoming a zero-length window. That is the same presence pattern the file already uses for `billExchangeDataTimeout`.

No service or wrapper changes were needed: `AccountService.fetchUserFlags` already builds `UserFlags(response.userFlags)`, and the model persists as a JSON blob in `UserFlagsTable`, so `Codable` synthesises `decodeIfPresent` for the new optionals with no schema or `SQLiteVersion` bump.

The remaining diff is the memberwise-init call sites in tests, which the struct's no-default init requires. `Database+ProfileTests` now round-trips one fixture with the windows set and one with them `nil`.

## Scope

No edit or delete behaviour is wired up. `MessagePolicy.editWindow` is the obvious next consumer — it exists and is currently always `nil` — but gating actual UI is left for a follow-up.
