### PR TITLE
fix(deps): move shared-core to 0.4.1, which has the KikCode figure API

### DIFF
--- a/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1a7a324f799454c1f9bc947515e8d2ac6fcab8cea18f3cca99c1c1cb94e663bb",
+  "originHash" : "bcc0261f97a6d99100c2b9dbc00698c4b2a1da20d91c5862ec899298980b12af",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/code-payments/flipcash-shared-core-spm",
       "state" : {
-        "revision" : "d478eb223c2f1e0076babf1a1447fbe4155a31fb",
-        "version" : "0.4.0"
+        "revision" : "5d46c1c9980aed632ed939b017946c0b799649ef",
+        "version" : "0.4.1"
       }
     },
     {

--- a/FlipcashUI/Package.swift
+++ b/FlipcashUI/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/ekazaev/ChatLayout", from: "2.4.2"),
         .package(url: "https://github.com/ra1028/DifferenceKit", from: "1.3.0"),
         .package(url: "https://github.com/onevcat/Kingfisher", from: "8.3.0"),
-        .package(url: "https://github.com/code-payments/flipcash-shared-core-spm", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/code-payments/flipcash-shared-core-spm", .upToNextMinor(from: "0.4.1")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
`main` has not built since the 0.4.0 bump:

```
error: type 'KikCode' has no member 'figure'
```

The CGPath figure wrappers only ever existed on the branch 0.3.1 was published from, and that
branch never merged. 0.4.0 was published from `code/cash`, where the publish workflow stages the
Swift package by deleting `Sources` and `Tests` and re-copying from the checkout — so cutting it
removed the API rather than carrying it forward. Details in
[code-android-app#1401](https://github.com/code-payments/code-android-app/pull/1401), which restores
the sources; 0.4.1 is cut from `code/cash` with them in.

Pinning back to 0.3.1 was never available — `FlipcashCore` uses `SharedCoreKit.Base58`,
`SharedEd25519` and the Hashes wrappers, none of which exist there.

The floor moves to 0.4.1 rather than letting `.upToNextMinor(from: "0.4.0")` pick it up, so a fresh
resolve cannot land back on the one published version missing the API.
