### PR TITLE
feat(derive): route key derivation through SharedCoreKit

### DIFF
--- a/Code.xcodeproj/project.pbxproj
+++ b/Code.xcodeproj/project.pbxproj
@@ -1766,7 +1766,7 @@
 			repositoryURL = "https://github.com/code-payments/flipcash-shared-core-spm";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.5.0;
 			};
 		};
 		9ACE172927E6287C00ACA047 /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {

--- a/CrossPlatformVectors/Package.swift
+++ b/CrossPlatformVectors/Package.swift
@@ -11,16 +11,17 @@ import PackageDescription
 //
 // iOS only, and run on a simulator rather than `swift test` on the host: the implementation under
 // test is no longer a host-buildable C package but the shared Kotlin reached through
-// `SharedCoreKit`, whose XCFramework ships iOS slices only. That is the point of the gate now —
-// it exercises the framework exactly as FlipcashCore consumes it, which the Kotlin-side
-// `Ed25519VectorTest` on the same fixtures does not.
+// `SharedCoreKit`. Exercising the framework exactly as FlipcashCore consumes it on iOS is the
+// point of the gate — the Kotlin-side `Ed25519VectorTest` on the same fixtures does not do that.
+// (The XCFramework also ships a macOS slice now, used by `FlipcashCoreVectors`; this target stays
+// iOS-only by design, not for lack of one.)
 let package = Package(
     name: "CrossPlatformVectors",
     platforms: [
         .iOS(.v15),
     ],
     dependencies: [
-        .package(url: "https://github.com/code-payments/flipcash-shared-core-spm", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/code-payments/flipcash-shared-core-spm", .upToNextMinor(from: "0.5.0")),
     ],
     targets: [
         .testTarget(

--- a/FlipcashCore/Package.swift
+++ b/FlipcashCore/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(path: "../FlipcashAPI"),
-        .package(url: "https://github.com/code-payments/flipcash-shared-core-spm", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/code-payments/flipcash-shared-core-spm", .upToNextMinor(from: "0.5.0")),
     ],
     targets: [
         .target(

--- a/FlipcashCore/Package.swift
+++ b/FlipcashCore/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "FlipcashCore",
     platforms: [
         .iOS(.v18),
+        .macOS(.v15),
     ],
     products: [
         .library(

--- a/FlipcashCore/Sources/FlipcashCore/Solana/Keys/Derive.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Solana/Keys/Derive.swift
@@ -7,85 +7,19 @@
 //
 
 import Foundation
+import SharedCoreKit
 
-public typealias KeyDescriptor = (key: Data, chain: Data)
-
-/// Deterministic wallet generation for ED25519 curve using SLIP-0010 spec
-/// Reference: https://github.com/satoshilabs/slips/blob/master/slip-0010.md
-///
 public enum Derive {
-    
-    private static let curve: Data = Data("ed25519 seed".utf8)
-    private static let hardenedOffset: UInt32 = 0x80000000
-    
-    static func masterKey(seed: Data) -> KeyDescriptor {
-        seed.hmac(using: curve).split32()
-    }
-    
-    static func path(path: Path, seed: Data) -> (keyPair: KeyPair, chaincode: Data) {
-        var descriptor = masterKey(seed: seed)
-        
-        path.indexes.forEach { index in
-            descriptor = CKDPriv(keyDescriptor: descriptor, index: hardenedOffset + index.value)
-        }
-        
-        return (
-            KeyPair(seed: try! Seed32(descriptor.key)),
-            descriptor.chain
-        )
-    }
-    
-    private static func CKDPriv(keyDescriptor: KeyDescriptor, index: UInt32) -> KeyDescriptor {
-        var entropy = Data()
-        entropy.append(0x00)
-        entropy.append(keyDescriptor.key)
-        entropy.append(contentsOf: index.bigEndian.bytes)
-        
-        return entropy.hmac(using: keyDescriptor.chain).split32()
-    }
-}
+    private static let hardenedOffset: Int64 = 0x8000_0000
 
-/// Deterministic key derivation using BIP39
-/// Reference: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
-///
-extension Derive {
-    
     static func seedUsingBIP39(phrase: [String], password: String = "") -> Key64 {
-        let phrase = phrase.joined(separator: " ")
-        let salt = "mnemonic\(password)"
-        
-        let bytes = PBKDF.deriveKey(
-            algorithm: .sha512,
-            password: phrase,
-            salt: salt
-        )
-        
-        return try! Key64(bytes)
+        try! Key64(SharedDerivation.seed(mnemonic: phrase, passphrase: password))
     }
-    
+
     public static func keyPairUsingBIP39(path: Path, phrase: [String], password: String = "") -> KeyPair {
-        let key64 = seedUsingBIP39(
-            phrase: phrase,
-            password: password
-        )
-        
-        return Derive.path(path: path, seed: key64.data).keyPair
-    }
-}
-
-// MARK: - Data -
-
-private extension Data {
-    
-    func split32() -> (Data, Data) {
-        let lhs = Data(self[0..<32])
-        let rhs = Data(self[32..<64])
-        return (lhs, rhs)
-    }
-    
-    func hmac(using key: Data) -> Data {
-        var hmac = HMAC(algorithm: .sha512, key: key)
-        hmac.update(self)
-        return hmac.digestData()
+        let seed = seedUsingBIP39(phrase: phrase, password: password)
+        let hardenedIndexes = path.indexes.map { hardenedOffset + Int64($0.value) }
+        let derivedKey = SharedDerivation.derivedKey(seed: seed.data, hardenedIndexes: hardenedIndexes)
+        return KeyPair(seed: try! Seed32(derivedKey))
     }
 }

--- a/FlipcashCoreVectors/Package.swift
+++ b/FlipcashCoreVectors/Package.swift
@@ -13,7 +13,7 @@ import PackageDescription
 let package = Package(
     name: "FlipcashCoreVectors",
     platforms: [
-        .macOS("14.0"), // FlipcashCore's transitive deps (BigDecimal 13.3, grpc/nio) need >= 13.3
+        .macOS("15.0"), // FlipcashCore's transitive deps (BigDecimal 13.3, grpc/nio) need >= 13.3
         .iOS("18.0"),
     ],
     dependencies: [

--- a/FlipcashUI/Package.swift
+++ b/FlipcashUI/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/ekazaev/ChatLayout", from: "2.4.2"),
         .package(url: "https://github.com/ra1028/DifferenceKit", from: "1.3.0"),
         .package(url: "https://github.com/onevcat/Kingfisher", from: "8.3.0"),
-        .package(url: "https://github.com/code-payments/flipcash-shared-core-spm", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/code-payments/flipcash-shared-core-spm", .upToNextMinor(from: "0.5.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

Routes `Derive.seedUsingBIP39` and `Derive.keyPairUsingBIP39` through `SharedCoreKit`'s `SharedDerivation` instead of the Swift-only BIP-39/SLIP-10 implementation, so key derivation is shared with Android via `:libs:encryption:mnemonic` in KMP commonMain.

Declaring a macOS platform on `FlipcashCore`/`FlipcashCoreVectors` (needed to exercise `Slip10DerivationVectorTests`, see below) surfaced two pre-existing gaps unrelated to this change: `FlipcashCore/Package.swift` had never declared macOS at all, and once it could build for macOS, `ChatNotificationClient`'s `GRPCClient` usage turned out to need macOS 15, not the 13.3/14.0 floor `BigDecimal`/grpc-nio need. Both manifests are now pinned to macOS 15.

**Draft because:** this depends on a `flipcash-shared-core-spm` release that hasn't shipped yet. The macOS Kotlin/Native targets it needs are in [code-android-app#1402](https://github.com/code-payments/code-android-app/pull/1402); until that lands and a release is cut, CI here can't resolve `SharedCoreKit` for macOS and `FlipcashCoreVectors` will fail to build.

## Test plan
- [x] `FlipcashCoreVectors`' full suite (6 tests, including `Slip10DerivationVectorTests`) passes locally against a macOS-slice build of `SharedCore.xcframework` via `FLIPCASH_SHARED_CORE_LOCAL`
- [ ] Re-verify against a real `flipcash-shared-core-spm` release once cut, then mark ready for review
