### PR TITLE
feat(chat): reply to a message

### DIFF
--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -907,6 +907,15 @@ final class ConversationController {
         windowedMessages(for: conversationID, startingAt: nil, limit: limit)
     }
 
+    /// The locally-stored copy of one message, regardless of whether it is inside the rendered
+    /// window. Reply quotes read through this: a reply can point at a message far above the
+    /// window, and resolving it must not page the server. Observes `messageRevision`, so a quote
+    /// that resolves once history lands re-maps like any other change.
+    func persistedMessage(_ messageID: MessageID, in conversationID: ConversationID) -> ConversationMessage? {
+        _ = messageRevision   // observe: re-read when a confirmed DB write lands
+        return (try? database.message(id: messageID, conversationID: conversationID)) ?? nil
+    }
+
     /// The oldest confirmed id inside the newest-`limit` window — the anchor a first page-back grows
     /// from; nil when nothing is persisted.
     func oldestWindowedMessageID(for conversationID: ConversationID, limit: Int) -> UInt64? {

--- a/Flipcash/Core/Controllers/ConversationController.swift
+++ b/Flipcash/Core/Controllers/ConversationController.swift
@@ -1036,7 +1036,7 @@ final class ConversationController {
     /// server: on success it reconciles to the confirmed message, on failure it stays in the
     /// transcript as `.failed` (never silently dropped).
     @discardableResult
-    func send(_ text: String, to conversationID: ConversationID) async -> Bool {
+    func send(_ text: String, to conversationID: ConversationID, repliedTo: MessageID? = nil) async -> Bool {
         let clientMessageID = UUID()
         let pending = ConversationMessage(
             id: .unassigned,
@@ -1044,13 +1044,14 @@ final class ConversationController {
             content: .text(text),
             date: .now,
             unreadSeq: 0,
+            repliedTo: repliedTo,
             status: .sending,
             clientMessageID: clientMessageID
         )
         let anchor = (try? database.newestMessageID(conversationID: conversationID)).flatMap { $0 }?.value ?? 0
         store.insertPending(pending, anchoredTo: anchor, into: conversationID)
         receiptSettle.hold(clientMessageID.uuidString)
-        return await deliver(clientMessageID: clientMessageID, text: text, to: conversationID)
+        return await deliver(clientMessageID: clientMessageID, text: text, repliedTo: repliedTo, to: conversationID)
     }
 
     /// Re-send a failed optimistic message, reusing its client id so the server (idempotent on it)
@@ -1061,15 +1062,21 @@ final class ConversationController {
               pending.status == .failed,
               case .text(let text) = pending.content else { return }
         store.markPending(clientMessageID: clientMessageID, status: .sending, in: conversationID)
-        _ = await deliver(clientMessageID: clientMessageID, text: text, to: conversationID)
+        _ = await deliver(clientMessageID: clientMessageID, text: text, repliedTo: pending.repliedTo, to: conversationID)
     }
 
-    private func deliver(clientMessageID: UUID, text: String, to conversationID: ConversationID) async -> Bool {
+    private func deliver(clientMessageID: UUID, text: String, repliedTo: MessageID?, to conversationID: ConversationID) async -> Bool {
         // Captured before the send so success and failure report the same
         // conversation kind; an unresolved conversation reports as Unknown.
         let chatType = conversation(withID: conversationID)?.type
         do {
-            let message = try await messaging.sendMessage(owner: owner, conversationID: conversationID, text: text, clientMessageID: clientMessageID)
+            let message = try await messaging.sendMessage(
+                owner: owner,
+                conversationID: conversationID,
+                text: text,
+                repliedTo: repliedTo,
+                clientMessageID: clientMessageID
+            )
             // Persist the row carrying its client id (the server echoes none) so the DB keeps the send's
             // identity across a round-trip. The pending row is dropped only once the confirmed copy is
             // durably readable — a failed write leaves the send visible (the stream echo or a catch-up

--- a/Flipcash/Core/Controllers/Database/Database+Conversations.swift
+++ b/Flipcash/Core/Controllers/Database/Database+Conversations.swift
@@ -420,8 +420,7 @@ nonisolated extension Database {
                 m.unreadSeq      <- message.unreadSeq,
                 m.eventSequence  <- message.eventSequence,
                 m.clientMessageID <- message.clientMessageID,
-                // The reply plan fills this in; the column exists now so the schema bumps once.
-                m.repliedToId    <- nil,
+                m.repliedToId    <- message.repliedTo?.value,
                 m.lastEditedTs   <- message.lastEditedTs?.timeIntervalSinceReferenceDate,
                 m.deletedBy      <- deletedBy,
                 m.deletedAt      <- deletedAt
@@ -504,6 +503,7 @@ nonisolated extension Database {
             unreadSeq: row[m.unreadSeq],
             eventSequence: row[m.eventSequence],
             lastEditedTs: row[m.lastEditedTs].map(Date.init(timeIntervalSinceReferenceDate:)),
+            repliedTo: row[m.repliedToId].map(MessageID.init(value:)),
             clientMessageID: row[m.clientMessageID]
         )
     }

--- a/Flipcash/Core/Controllers/FlipClient+Protocols.swift
+++ b/Flipcash/Core/Controllers/FlipClient+Protocols.swift
@@ -81,7 +81,7 @@ protocol ConversationMessaging: AnyObject, Sendable {
         afterSequence: UInt64,
         onBatch: @MainActor @Sendable @escaping (_ messages: [ConversationMessage], _ checkpoint: UInt64?) -> Void
     ) async throws -> UInt64
-    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID) async throws -> ConversationMessage
+    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, repliedTo: MessageID?, clientMessageID: UUID) async throws -> ConversationMessage
     /// Replaces a message's text. `expectedEventSequence` is the optimistic-concurrency guard: the
     /// server applies the edit only if the message still carries that sequence, and reports a
     /// conflict with the winning state otherwise.

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -54,7 +54,9 @@ extension ChatItem {
         suppressReceiptFor: String? = nil,
         cashBranding: (ExchangedFiat) -> (token: String, iconURL: URL?) = { _ in ("Cash", nil) },
         deletedPresentation: DeletedMessagePresentation = .hidden,
-        capabilities: (ConversationMessage) -> Set<MessageCapability> = { _ in [] }
+        capabilities: (ConversationMessage) -> Set<MessageCapability> = { _ in [] },
+        counterpartName: String = "",
+        quotedMessage: (MessageID) -> ConversationMessage? = { _ in nil }
     ) -> [ChatItem] {
         // Tombstoned (deleted) messages are retained in the store for gapless ordering. Under
         // `.hidden` they are dropped up front so they never skew a date separator, group an adjacent
@@ -138,6 +140,16 @@ extension ChatItem {
                 receipt = .failed("Not Delivered. Tap to retry")
             }
 
+            // Resolved here rather than in the view so all three states — found, never fetched,
+            // deleted — are decided by one pure function and testable without a database.
+            let quote = message.repliedTo.map { repliedTo in
+                Self.quote(
+                    resolving: quotedMessage(repliedTo),
+                    selfUserID: selfUserID,
+                    counterpartName: counterpartName
+                )
+            }
+
             items.append(.message(ChatMessage(
                 id: message.stableID,
                 content: content,
@@ -147,10 +159,54 @@ extension ChatItem {
                 receipt: receipt,
                 linkPreview: linkPreview,
                 isEdited: message.lastEditedTs != nil && !message.isDeleted,
-                actions: orderedActions(capabilities(message))
+                actions: orderedActions(capabilities(message)),
+                quote: quote
             )))
         }
         return items
+    }
+
+    /// The quoted original, for each of the three states it can be in. A message the local database
+    /// has never seen and a tombstone both render as unavailable and both refuse the jump — the
+    /// first because there is no row to land on, the second because `.hidden` filters the tombstone
+    /// out of the transcript entirely.
+    nonisolated private static func quote(
+        resolving original: ConversationMessage?,
+        selfUserID: UserID,
+        counterpartName: String
+    ) -> ChatQuote {
+        guard let original else {
+            return ChatQuote(
+                stableID: nil,
+                authorName: "",
+                snippet: ChatQuote.unavailableSnippet,
+                kind: .unavailable
+            )
+        }
+        let authorName = original.isFromSelf(selfUserID) ? "You" : counterpartName
+        switch original.content {
+        case .text(let text):
+            return ChatQuote(
+                stableID: original.stableID,
+                authorName: authorName,
+                snippet: ChatQuote.snippet(forText: text),
+                kind: .text
+            )
+        case .cash(let fiat):
+            return ChatQuote(
+                stableID: original.stableID,
+                authorName: authorName,
+                snippet: fiat.nativeAmount.formatted(),
+                kind: .cash
+            )
+        case .deleted:
+            return ChatQuote(
+                stableID: nil,
+                authorName: authorName,
+                snippet: ChatQuote.deletedSnippet,
+                kind: .unavailable
+            )
+        }
     }
 
     /// Menu order is fixed here, not at the call site — a `Set` has no order, and the context menu

--- a/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift
@@ -100,13 +100,11 @@ extension ChatItem {
                 content = .text(text)
                 linkPreview = detectedLink(in: text)
             case .cash(let fiat):
-                let currency = fiat.nativeAmount.currency
-                let flagName = currency.region?.rawValue ?? currency.rawValue.uppercased()
                 let branding = cashBranding(fiat)
                 content = .cash(ChatCashContent(
                     amount: fiat.nativeAmount.formatted(),
                     token: branding.token,
-                    flagImageName: flagName,
+                    flagImageName: flagImageName(for: fiat),
                     iconURL: branding.iconURL,
                     isTip: message.cashAction == .tipped
                 ))
@@ -146,7 +144,8 @@ extension ChatItem {
                 Self.quote(
                     resolving: quotedMessage(repliedTo),
                     selfUserID: selfUserID,
-                    counterpartName: counterpartName
+                    counterpartName: counterpartName,
+                    cashBranding: cashBranding
                 )
             }
 
@@ -173,7 +172,8 @@ extension ChatItem {
     nonisolated private static func quote(
         resolving original: ConversationMessage?,
         selfUserID: UserID,
-        counterpartName: String
+        counterpartName: String,
+        cashBranding: (ExchangedFiat) -> (token: String, iconURL: URL?)
     ) -> ChatQuote {
         guard let original else {
             return ChatQuote(
@@ -190,23 +190,37 @@ extension ChatItem {
                 stableID: original.stableID,
                 authorName: authorName,
                 snippet: ChatQuote.snippet(forText: text),
-                kind: .text
+                kind: .text,
+                authorID: original.senderID
             )
         case .cash(let fiat):
+            // Same branding the card carries, so the quote of a payment reads as that payment. The
+            // launchpad icon is deliberately left out: it is a remote fetch, and the flag already
+            // keys the currency at this size.
             return ChatQuote(
                 stableID: original.stableID,
                 authorName: authorName,
                 snippet: fiat.nativeAmount.formatted(),
-                kind: .cash
+                kind: .cash(token: cashBranding(fiat).token, flagImageName: flagImageName(for: fiat)),
+                authorID: original.senderID
             )
         case .deleted:
             return ChatQuote(
                 stableID: nil,
                 authorName: authorName,
                 snippet: ChatQuote.deletedSnippet,
-                kind: .unavailable
+                kind: .unavailable,
+                authorID: original.senderID
             )
         }
+    }
+
+    /// The currency's flag asset: a region flag where the currency has one, else the ticker, which
+    /// is how the crypto flags are named. One derivation for the card and the quote so a payment
+    /// keys the same way wherever it is drawn.
+    nonisolated static func flagImageName(for fiat: ExchangedFiat) -> String {
+        let currency = fiat.nativeAmount.currency
+        return currency.region?.rawValue ?? currency.rawValue.uppercased()
     }
 
     /// Menu order is fixed here, not at the call site — a `Set` has no order, and the context menu

--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -61,6 +61,9 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> ChatScreenViewController {
         let barHost = UIHostingController(rootView: bar(coordinator: context.coordinator))
         barHost.view.backgroundColor = .clear
+        // The bar's content is pinned to the bottom of this view and overhangs the top while the
+        // height constraint catches up, so the overhang has to be allowed to draw.
+        barHost.view.clipsToBounds = false
         let screen = ChatScreenViewController(bar: barHost.view, barController: barHost)
         screen.focusesComposerOnAppear = focusOnAppear
         screen.onReachTop = onReachTop
@@ -168,7 +171,11 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
                 isTipDm: isTipDm
             )
             .environment(conversationController)
-            .modifier(MeasuredBarHeight { coordinator.screen?.setBarHeight($0) })
+            .modifier(
+                MeasuredBarHeight(isReplying: composer.replyTarget != nil) { height, isReplying in
+                    coordinator.screen?.setBarHeight(height, replying: isReplying)
+                }
+            )
         )
     }
 
@@ -186,11 +193,34 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
 /// multiline height — the hosting controller's intrinsic size mis-measures and lets the composer
 /// overflow under the keyboard.
 private struct MeasuredBarHeight: ViewModifier {
-    let report: (CGFloat) -> Void
+    /// Whether a reply is open, reported alongside the height. The bar's clip decides what to do
+    /// with a height from the two together, so this has to arrive from the same layout pass rather
+    /// than be read separately afterwards.
+    let isReplying: Bool
+    let report: (CGFloat, Bool) -> Void
+
+    /// The last height reported, so the reply can be reported without one. A reply that closes does
+    /// not change the bar's height — the strip stays mounted underneath while it fades — and the
+    /// clip still has to be told to close over it.
+    @State private var measured: CGFloat = 0
 
     func body(content: Content) -> some View {
         content
             .fixedSize(horizontal: false, vertical: true)
-            .onGeometryChange(for: CGFloat.self, of: { $0.size.height }, action: report)
+            .onGeometryChange(for: CGFloat.self, of: { $0.size.height }) { height in
+                measured = height
+                report(height, isReplying)
+            }
+            .onChange(of: isReplying) { _, replying in
+                guard measured > 0 else { return }
+                report(measured, replying)
+            }
+            // Sit on the host's bottom edge rather than in the middle of it. The two heights are
+            // never equal mid-change: SwiftUI ramps the content's own height on its spring while the
+            // constraint above chases it on another, and centring turns every point of that gap into
+            // half a point of vertical travel for the whole bar. Bottom-aligned, the gap goes
+            // somewhere nobody looks — the bar grows and shrinks from the top, which is the edge the
+            // reply strip arrives at.
+            .frame(maxHeight: .infinity, alignment: .bottom)
     }
 }

--- a/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
+++ b/Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift
@@ -37,6 +37,8 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
     /// Fired when a context-menu action is chosen on a row, with the row's stable id. Copy never
     /// arrives here — the transcript puts the text on the pasteboard itself.
     let onMessageAction: (String, MessageCapability) -> Void
+    /// Brings the quoted original into the loader's window; the scroll follows here.
+    let onQuoteTap: (String) -> Void
     let showsSendCash: Bool
     let chatExists: Bool
     let conversationID: ConversationID?
@@ -68,6 +70,12 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         screen.onContactAction = onContactAction
         screen.onProfileTap = onProfileTap
         screen.onMessageAction = keyboardFollowing(onMessageAction, screen: screen)
+        screen.onQuoteTap = { [weak screen] stableID in
+            onQuoteTap(stableID)
+            // The reveal may have to move the loader's anchor first, so the scroll records a
+            // pending target when the row is not in the window yet.
+            screen?.scrollToMessage(id: stableID)
+        }
         screen.onCancelEdit = { [composer] in composer.endEditing() }
         screen.update(items: items)
         context.coordinator.barHost = barHost
@@ -87,6 +95,12 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
         screen.onContactAction = onContactAction
         screen.onProfileTap = onProfileTap
         screen.onMessageAction = keyboardFollowing(onMessageAction, screen: screen)
+        screen.onQuoteTap = { [weak screen] stableID in
+            onQuoteTap(stableID)
+            // The reveal may have to move the loader's anchor first, so the scroll records a
+            // pending target when the row is not in the window yet.
+            screen?.scrollToMessage(id: stableID)
+        }
         screen.onCancelEdit = { [composer] in composer.endEditing() }
         // The backdrop is raised from the menu action itself (see `keyboardFollowing`) because it
         // has to claim the menu's blur before the dismissal fades it; it comes down here, whichever
@@ -125,8 +139,10 @@ struct ChatScreenRepresentable: UIViewControllerRepresentable {
             case .edit:
                 screen?.beginEditSpotlight(for: stableID)
                 screen?.focusComposer()
-            case .delete:       screen?.dismissKeyboard()
-            case .copy, .reply: break
+            case .reply:
+                screen?.focusComposer()
+            case .delete:   screen?.dismissKeyboard()
+            case .copy:     break
             }
         }
     }

--- a/Flipcash/Core/Screens/Conversation/ComposerModel.swift
+++ b/Flipcash/Core/Screens/Conversation/ComposerModel.swift
@@ -16,11 +16,21 @@ import FlipcashCore
 @Observable
 final class ComposerModel {
 
+    /// What a reply is composed against — enough to render the strip and to address the send,
+    /// so the composer never reaches back into the transcript for it.
+    struct ReplyTarget: Equatable {
+        let messageID: MessageID
+        let stableID: String
+        let authorName: String
+        let snippet: String
+    }
+
     enum Mode: Equatable {
         case new
         /// `stableID` is the transcript row's identity, kept alongside the message id so the screen
         /// can highlight the row being edited without re-deriving it.
         case editing(messageID: MessageID, stableID: String)
+        case replying(to: ReplyTarget)
     }
 
     private(set) var mode: Mode = .new
@@ -37,7 +47,7 @@ final class ComposerModel {
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         switch mode {
-        case .new:
+        case .new, .replying:
             return trimmed
         case .editing:
             return trimmed == originalText ? nil : trimmed
@@ -50,8 +60,16 @@ final class ComposerModel {
     /// this, so reading it is what ties the backdrop's lifetime to the composer's mode.
     var editingStableID: String? {
         switch mode {
-        case .new:                          nil
+        case .new, .replying:               nil
         case .editing(_, let stableID):     stableID
+        }
+    }
+
+    /// The message this composer is replying to, or `nil` when it is not replying.
+    var replyTarget: ReplyTarget? {
+        switch mode {
+        case .new, .editing:            nil
+        case .replying(let target):     target
         }
     }
 
@@ -59,8 +77,8 @@ final class ComposerModel {
     /// swaps its leading control and its confirm glyph on this.
     var isEditing: Bool {
         switch mode {
-        case .new:     false
-        case .editing: true
+        case .new, .replying:   false
+        case .editing:          true
         }
     }
 
@@ -81,6 +99,19 @@ final class ComposerModel {
         originalText = ""
         draft = stashedDraft
         stashedDraft = ""
+    }
+
+    /// Aims the composer at a message. Unlike an edit, the draft is left alone — a reply adds to
+    /// what you were already typing rather than replacing it.
+    func beginReplying(to target: ReplyTarget) {
+        if isEditing { endEditing() }
+        mode = .replying(to: target)
+    }
+
+    /// Dismisses the reply, keeping the draft — the strip's ⊗ takes back the target, not the text.
+    func endReplying() {
+        guard case .replying = mode else { return }
+        mode = .new
     }
 
     /// Empties the field after a successful send.

--- a/Flipcash/Core/Screens/Conversation/ComposerModel.swift
+++ b/Flipcash/Core/Screens/Conversation/ComposerModel.swift
@@ -22,7 +22,13 @@ final class ComposerModel {
         let messageID: MessageID
         let stableID: String
         let authorName: String
+        /// The author's user id, carried only so the strip can draw them in their own colour — see
+        /// `ComplementaryPalette`.
+        let authorID: UserID?
         let snippet: String
+        /// What the original was, so the strip can draw a payment the way the transcript's quote
+        /// panel does — flag and token beside the amount, rather than the amount alone.
+        var kind: ChatQuote.Kind = .text
     }
 
     enum Mode: Equatable {

--- a/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
+++ b/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
@@ -9,9 +9,10 @@ import SwiftUI
 import FlipcashCore
 import FlipcashUI
 
-/// The quoted original above the composer while a reply is being written. Sits inside the bottom
-/// bar's background rather than on top of it, so the bar reads as one surface that grew, and
-/// dismissing it takes back the target without touching the draft.
+/// The quoted original above the composer while a reply is being written. It paints no background of
+/// its own: the bar draws one opaque surface behind the quote and the controls together, so the two
+/// read as one panel rather than a strip parked above a bar. Dismissing it takes back the target
+/// without touching the draft.
 struct ComposerReplyStrip: View {
 
     let target: ComposerModel.ReplyTarget
@@ -56,7 +57,6 @@ struct ComposerReplyStrip: View {
         .padding(.trailing, 8)
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.white.opacity(0.06))
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("composer-reply-strip")
     }

--- a/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
+++ b/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
@@ -1,0 +1,56 @@
+//
+//  ComposerReplyStrip.swift
+//  Flipcash
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+/// The quoted original above the composer while a reply is being written. Sits inside the bottom
+/// bar's background rather than on top of it, so the bar reads as one surface that grew, and
+/// dismissing it takes back the target without touching the draft.
+struct ComposerReplyStrip: View {
+
+    let target: ComposerModel.ReplyTarget
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            // The leading rule is the quote's whole identity here; the panel has no fill of its own.
+            RoundedRectangle(cornerRadius: 1, style: .continuous)
+                .fill(Color.white.opacity(0.5))
+                .frame(width: 2)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(target.authorName)
+                    .font(.appTextCaption)
+                    .foregroundStyle(Color.textMain)
+                Text(target.snippet)
+                    .font(.appTextCaption)
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: onDismiss) {
+                Image(systemName: SystemSymbol.close.rawValue)
+                    .font(.default(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Cancel reply")
+        }
+        .padding(.leading, 12)
+        .padding(.trailing, 8)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white.opacity(0.06))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Replying to \(target.authorName): \(target.snippet)")
+    }
+}

--- a/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
+++ b/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
@@ -9,55 +9,119 @@ import SwiftUI
 import FlipcashCore
 import FlipcashUI
 
-/// The quoted original above the composer while a reply is being written. It paints no background of
-/// its own: the bar draws one opaque surface behind the quote and the controls together, so the two
-/// read as one panel rather than a strip parked above a bar. Dismissing it takes back the target
-/// without touching the draft.
+/// The quoted original above the composer while a reply is being written: a rule in the author's own
+/// colour flush against the screen's leading edge, their name over one or two lines of what they
+/// said, and the way out on the trailing edge. Dismissing it takes back the target without touching
+/// the draft.
+///
+/// No card and no tinted ground. The strip is not a thing sitting on the bar, it *is* the top of the
+/// bar — the rule runs the full height of the region the bar grew by, edge to edge, which is what
+/// makes the growth read as the bar getting taller rather than as a panel arriving. Matches
+/// WhatsApp, measured: 4pt rule at x=0, text 13pt in, no inset of any kind.
+///
+/// The colour is the person's, not the surface's — `ComplementaryPalette` derives it from their user
+/// id, so the same person is the same colour here, inside a sent bubble, and on Android.
 struct ComposerReplyStrip: View {
 
     let target: ComposerModel.ReplyTarget
     let onDismiss: () -> Void
 
+    /// Flush at the screen's leading edge, so it reads as a citation mark on the bar rather than a
+    /// border on a card.
+    private static let ruleWidth: CGFloat = 4
+
+    /// Sized to the cap height of the amount beside it, so the flag reads as a mark on the line
+    /// rather than as a second element the line has to make room for.
+    private static let flagDiameter: CGFloat = 16
+
     var body: some View {
-        HStack(alignment: .top, spacing: 10) {
-            // The leading rule is the quote's whole identity here; the panel has no fill of its own.
-            RoundedRectangle(cornerRadius: 1, style: .continuous)
-                .fill(Color.white.opacity(0.5))
-                .frame(width: 2)
+        let rule = ComplementaryPalette.color(.start, for: target.authorID)
+        let name = ComplementaryPalette.color(.middle, for: target.authorID)
+
+        HStack(alignment: .center, spacing: 9) {
+            // Unpadded and unclipped: a `Rectangle` is flexible vertically, so in this stack it
+            // takes the strip's whole height, and with no leading padding on the row it starts at
+            // the screen edge.
+            Rectangle()
+                .fill(rule)
+                .frame(width: Self.ruleWidth)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(target.authorName)
-                    .font(.appTextCaption)
-                    .foregroundStyle(Color.textMain)
-                Text(target.snippet)
-                    .font(.appTextCaption)
-                    .foregroundStyle(Color.textSecondary)
-                    .lineLimit(2)
+                    .font(.appTextHeading)
+                    .foregroundStyle(name)
+                quoteLine
             }
+            .padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)
             // Combined here rather than on the row, so the quote reads as one element while the
             // dismiss button stays a button of its own — a row-level combine folds the button into
             // the label and leaves nothing to press.
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("Replying to \(target.authorName): \(target.snippet)")
+            .accessibilityLabel("Replying to \(target.authorName): \(spokenSnippet)")
             .accessibilityIdentifier("composer-reply-quote")
 
+            // WhatsApp's: a large, thin ✕ rather than a small bold one, sized to sit against two
+            // lines of quote without crowding them, in a hit target wider than the glyph.
             Button(action: onDismiss) {
                 Image(systemName: SystemSymbol.close.rawValue)
-                    .font(.default(size: 13, weight: .semibold))
+                    // `.system`, not the app face: the stroke weight is the point of the match, and
+                    // an SF Symbol only takes a weight axis from a system font.
+                    .font(.system(size: 18, weight: .light))
                     .foregroundStyle(Color.textSecondary)
-                    .frame(width: 28, height: 28)
+                    .frame(width: 34, height: 34)
                     .contentShape(.rect)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Cancel reply")
             .accessibilityIdentifier("cancel-reply-button")
         }
-        .padding(.leading, 12)
         .padding(.trailing, 8)
-        .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("composer-reply-strip")
+    }
+
+    /// The quoted original itself. One step under the bubble body's 16, and in the same weight: the
+    /// quote is the subject of the strip, so it is read, not glanced at. `textMain` for the same
+    /// reason — dimming it made it look like placeholder text for the field below.
+    ///
+    /// A payment carries the flag and the mint's name the cash card leads with. The amount alone
+    /// reads as a number; with the flag beside it, it reads as the payment being answered.
+    @ViewBuilder
+    private var quoteLine: some View {
+        switch target.kind {
+        case .cash(let token, let flagImageName):
+            HStack(spacing: 6) {
+                if let flag = flagImageName.flatMap(Image.cashFlag(named:)) {
+                    flag
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: Self.flagDiameter, height: Self.flagDiameter)
+                        .clipShape(.circle)
+                }
+                Text(target.snippet)
+                    .font(.default(size: 14, weight: .medium))
+                    .foregroundStyle(Color.textMain)
+                Text(token)
+                    .font(.default(size: 14, weight: .medium))
+                    .foregroundStyle(Color.textSecondary)
+            }
+            .lineLimit(1)
+        case .text, .unavailable:
+            Text(target.snippet)
+                .font(.default(size: 14, weight: .medium))
+                .foregroundStyle(Color.textMain)
+                .lineLimit(2)
+        }
+    }
+
+    /// What VoiceOver reads for the quote — the mint's name is part of a payment's identity, and it
+    /// is drawn as a separate run that the combined element would otherwise drop.
+    private var spokenSnippet: String {
+        switch target.kind {
+        case .cash(let token, _):  "\(target.snippet) \(token)"
+        case .text, .unavailable:  target.snippet
+        }
     }
 }

--- a/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
+++ b/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
@@ -34,6 +34,12 @@ struct ComposerReplyStrip: View {
                     .lineLimit(2)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            // Combined here rather than on the row, so the quote reads as one element while the
+            // dismiss button stays a button of its own — a row-level combine folds the button into
+            // the label and leaves nothing to press.
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Replying to \(target.authorName): \(target.snippet)")
+            .accessibilityIdentifier("composer-reply-quote")
 
             Button(action: onDismiss) {
                 Image(systemName: SystemSymbol.close.rawValue)
@@ -44,13 +50,14 @@ struct ComposerReplyStrip: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Cancel reply")
+            .accessibilityIdentifier("cancel-reply-button")
         }
         .padding(.leading, 12)
         .padding(.trailing, 8)
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white.opacity(0.06))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Replying to \(target.authorName): \(target.snippet)")
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("composer-reply-strip")
     }
 }

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -20,6 +20,14 @@ import FlipcashUI
 /// appearance when the chat materializes, and the send-arrow pop.
 private let barMorphSpring = ChatMotion.swap.animation
 
+/// The curve the bar grows and shrinks on around the reply strip, and the one the surface changes
+/// colour on. The slab itself is permanent, so nothing mounts or unmounts over the transcript.
+///
+/// Separate from `barMorphSpring` because `swap` overshoots, and the transcript's bottom inset
+/// tracks this height every frame — a bar that overshoots drags the messages past their resting
+/// place and back.
+private let replySpring = ChatMotion.replySurface.animation
+
 /// Metrics shared by the field and the button beside it so their heights can't
 /// desync. Deliberately not `Metrics.buttonHeight`/`buttonRadius` — beside the
 /// field the controls are field-sized, not standard-button-sized.
@@ -60,7 +68,13 @@ struct ConversationBottomBar: View {
             } else if showsSendCash {
                 SendCashMorphButton(
                     symbol: symbol,
-                    composing: model.isComposing,
+                    // Minimized by a reply as well as by focus. Starting a reply from the context
+                    // menu raises the keyboard, and focus — and so `isComposing` — arrives a
+                    // transaction later than the reply target, on its own bouncy spring: the button
+                    // collapsed after the bar had already grown, jolting the field beside it.
+                    // Reading the target directly puts the morph in the reply's own transaction, so
+                    // the two move together and the later focus change finds nothing left to do.
+                    composing: model.isComposing || composer.replyTarget != nil,
                     standalone: !chatExists,
                     // A tip chat sits minimized beside its composer, but before
                     // the first tip there is no composer to sit beside: the
@@ -87,16 +101,147 @@ struct ConversationBottomBar: View {
         // The Send Cash button and the field are separate pills 10pt apart, so
         // they don't need to sample each other.
         return VStack(spacing: 0) {
-            if let target = composer.replyTarget {
-                ComposerReplyStrip(target: target) {
-                    withAnimation(barMorphSpring) { composer.endReplying() }
-                }
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
+            // No `withAnimation` at the dismiss site either: the `.animation(_, value:)` below
+            // already drives this state in both directions, and wrapping the dismissal in a second
+            // transaction gave the exit a curve the entry never had.
+            ComposerReplyReveal(target: composer.replyTarget) { composer.endReplying() }
             content
         }
-        .animation(barMorphSpring, value: composer.replyTarget)
-        .modifier(BarGradientBackground())
+        // Inside the animation modifier, not outside it: the surface is sized by the stack above,
+        // so both its geometry and the strip's height resolve on the one curve.
+        .modifier(BarSurfaceBackground(isReplying: composer.replyTarget != nil))
+        .animation(replySpring, value: composer.replyTarget)
+    }
+}
+
+/// The reply strip's arrival and departure: the quote the bar's top edge uncovers on the way in and
+/// closes back over on the way out.
+///
+/// The travel itself is not here. The bar is hosted in a box that clips it, and that box's edge is
+/// what moves — see `ChatScreenViewController`'s `barClip`. This view only decides *what* height the
+/// bar has to be for the strip to fit, and it takes that height in one step: the strip is laid out
+/// at full size the moment it mounts, behind the clip's edge, and stays there until the edge has
+/// closed over it again. Two animators over one edge is what put the composer row 24pt off its mark.
+///
+/// Height-driven and clipped rather than a transition, because any transition that moves or fades
+/// the quote on its own detaches it from the edge above it: `.move(edge: .bottom).combined(with:
+/// .opacity)` slid the quote down behind the field and dissolved it there while the edge travelled
+/// separately. Clipping welds them — the quote holds still against the field below it while the
+/// edge uncovers it.
+private struct ComposerReplyReveal: View {
+
+    let target: ComposerModel.ReplyTarget?
+    let onDismiss: () -> Void
+
+    /// The strip's own height. Measured rather than declared: a snippet that wraps to a second line
+    /// makes the sheet taller, and the clip has to know by how much.
+    @State private var naturalHeight: CGFloat = 0
+    /// Whether the strip is standing at its full height, 0 or 1 — never anything between.
+    ///
+    /// Kept as a factor of `naturalHeight` rather than a height switched on `target` because the
+    /// strip has to mount before it can be measured: on a first reply it comes up at zero height,
+    /// reports what it wants, and only then takes it. The bar's host reads that second step as the
+    /// opening, so nothing depends on the two landing in one transaction.
+    @State private var progress: CGFloat = 0
+    /// The last target seen, kept after the target clears. A strip that unmounts on the way out has
+    /// nothing to draw while it collapses, and the sheet slides back under the field empty.
+    @State private var retained: ComposerModel.ReplyTarget?
+    /// The quote's own opacity, which only ever moves on the way out.
+    ///
+    /// Asymmetric on purpose. Coming in, the edge uncovering the quote is the whole effect and a
+    /// fade would soften it; going out, a quote that stays fully opaque until the clip eats it reads
+    /// as the text being sliced off, so it dissolves as the sheet closes. `replySurface` has no
+    /// bounce, which is what makes it safe to drive opacity: a spring that overshoots clamps at 0
+    /// and 1 and flickers.
+    @State private var contentOpacity: CGFloat = 1
+
+    /// How much height the strip is asking the bar for. Zero until it has been measured, and held at
+    /// full height right through the exit — the clip closes over the quote, so there has to be a
+    /// quote there to close over.
+    private var revealHeight: CGFloat { naturalHeight * progress }
+
+    var body: some View {
+        Group {
+            if let retained {
+                ComposerReplyStrip(target: retained, onDismiss: onDismiss)
+                    .onGeometryChange(for: CGFloat.self, of: { $0.size.height }) { measured in
+                        measure(measured)
+                    }
+            }
+        }
+        // The strip keeps its own height whatever the frame below proposes, so the frame can clip it
+        // instead of squashing it.
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(height: revealHeight, alignment: .top)
+        .clipped()
+        // Deliberately unanimated, and inside the bar's own `.animation(replySpring,
+        // value: replyTarget)` so it wins: this height is the bar's *requirement*, not the motion.
+        // The clip around the bar travels it, on that same spring, in UIKit.
+        .animation(nil, value: revealHeight)
+        .opacity(contentOpacity)
+        // `clipped()` is a drawing bound, not a hit-testing or accessibility one, so the collapsed
+        // copy stays pressable and findable until the task below unmounts it.
+        .allowsHitTesting(target != nil)
+        // Drop the retained copy once it has finished sliding back under the field. It has to
+        // outlive the target — there is nothing to draw during the collapse otherwise — but only by
+        // the length of the collapse: left mounted, it leaves a zero-height quote in the
+        // accessibility tree that VoiceOver still reads and the UI tests still find. Hiding it
+        // instead of unmounting it does not work; the strip's own `children: .contain` container
+        // survives an ancestor's `accessibilityHidden`.
+        //
+        // `.task(id:)` cancels on the next change, so replying again mid-collapse keeps its strip.
+        .task(id: target) {
+            guard target == nil, retained != nil else { return }
+            try? await Task.sleep(for: .seconds(ChatMotion.replySurface.duration))
+            retained = nil
+            // Only now does the bar stop needing the strip's height. Giving it back any earlier
+            // would shrink the bar out from under a clip that is still closing, and show a band of
+            // the screen behind it above the composer.
+            progress = 0
+            // Back to opaque with nothing mounted, so the next reply starts from a clean state
+            // rather than fading in from wherever the last exit left it.
+            contentOpacity = 1
+        }
+        .onChange(of: target) { _, newValue in
+            guard let newValue else {
+                close()
+                return
+            }
+            retained = newValue
+            // Open from here only when a previous reply already measured the strip. On the first one
+            // the height is still unknown, and `measure(_:)` opens as soon as it arrives.
+            if naturalHeight > 0 { open() }
+        }
+        .onAppear {
+            retained = target
+            // Already replying when the bar appears — there is no arrival to animate.
+            progress = target == nil ? 0 : 1
+            contentOpacity = 1
+        }
+    }
+
+    /// Take the strip's measured height, and open the sheet if it was waiting on this measurement.
+    ///
+    /// A height that changes while the sheet is open is a real change — a one-line snippet replaced
+    /// by a two-line one — so it moves the top edge on the same curve rather than stepping it.
+    private func measure(_ measured: CGFloat) {
+        guard naturalHeight != measured else { return }
+        let wasUnmeasured = naturalHeight == 0
+        naturalHeight = measured
+        if wasUnmeasured, target != nil { open() }
+    }
+
+    private func open() {
+        progress = 1
+        // Only ever a correction: a reply started while the last one was still fading out. A fresh
+        // reply already has this at 1, so nothing animates.
+        withAnimation(ChatMotion.replySurface.animation) { contentOpacity = 1 }
+    }
+
+    /// The quote dissolves; its height stays. The clip is what closes over it, and it needs
+    /// something to close over — `progress` goes back to zero once that has finished.
+    private func close() {
+        withAnimation(ChatMotion.replySurface.animation) { contentOpacity = 0 }
     }
 }
 
@@ -124,6 +269,11 @@ struct ConversationComposer: View {
                 .focused($isFocused)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .frame(minHeight: BarMetrics.fieldMinHeight)
+                // Queried by the UI tests. The placeholder is not usable as a handle: it is gone the
+                // moment there is a draft, so a test that types and then reads the field back finds
+                // nothing. A multiline `TextField(axis:)` also surfaces as a text view wearing a
+                // text-field automation type, so the query has to be identifier-based, not type-based.
+                .accessibilityIdentifier("composer-message-field")
 
             if showsSubmit {
                 Button(action: submit) {
@@ -232,23 +382,114 @@ private struct CancelEditButton: View {
     }
 }
 
-/// Bottom-edge fade so transcript content scrolling under the bar dissolves into
-/// the background.
-private struct BarGradientBackground: ViewModifier {
+/// The bar's own surface: one square-edged, full-bleed slab under the quote and the controls,
+/// running past the safe area to the bottom of the display.
+///
+/// Permanent *geometry*, and that is the point. The reply surface used to be a rounded panel that
+/// appeared behind the bar and left again, and no amount of curve-matching stopped it reading as a
+/// second object crossfading over the messages — because it *was* one. Nothing here mounts or
+/// unmounts: the slab is always drawn, always full width, always pinned to the bottom. A reply
+/// changes two things about it — how tall it is, and what it is painted with — and both resolve on
+/// the one spring, so what moves is the bar itself rather than something arriving over the messages.
+private struct BarSurfaceBackground: ViewModifier {
+
+    /// How far the surface paints below the bar's own bottom edge.
+    ///
+    /// The keyboard's top corners are rounded, and what shows through them is whatever sits behind
+    /// the keyboard — which left a hard-edged notch of chat background at each bottom corner of the
+    /// bar, about 24×25pt on an iPhone 16 Pro. Painting past the bar's edge fills them. Everywhere
+    /// else this is hidden by the keyboard, or by the home-indicator area when the keyboard is down,
+    /// so overshooting the radius costs nothing.
+    private static let keyboardCornerBleed: CGFloat = 32
+
+    let isReplying: Bool
+
     func body(content: Content) -> some View {
-        content.background {
-            LinearGradient(
-                gradient: Gradient(colors: [Color.backgroundMain, Color.backgroundMain, .clear]),
-                startPoint: .bottom,
-                endPoint: .top
-            )
-            // Scope the bleed to the bottom edge only. The bar is a measured,
-            // keyboard-guide-pinned hosted view; an all-edges ignore makes the
-            // bar read as extending to the screen bottom, which collapses the
-            // scroll-content inset by the home-indicator height and drops the
-            // newest message under the bar.
+        // Top-aligned so the negative padding hangs the extra height below the bar rather than
+        // splitting it, which would paint over the transcript.
+        content.background(alignment: .top) {
+            ZStack(alignment: .top) {
+                BarSurface.restingFade
+                // Crossfaded over the fade on identical geometry — same width, same edges, same
+                // bottom — so what changes is the paint, not the cast: there is no second object
+                // to read as arriving over the messages.
+                BarSurface.replyFill
+                    .opacity(isReplying ? 1 : 0)
+            }
+            // Absorbed by the fade's opaque tail, so the dissolve at the top edge keeps its height
+            // whatever the bleed is.
+            .padding(.bottom, -Self.keyboardCornerBleed)
+            // Scope the safe-area bleed to the bottom edge only. The bar is a measured,
+            // keyboard-guide-pinned hosted view; an all-edges ignore makes the bar read as
+            // extending to the screen bottom, which collapses the scroll-content inset by the
+            // home-indicator height and drops the newest message under the bar.
             .ignoresSafeArea(edges: .bottom)
         }
+    }
+}
+
+/// What the bar's surface is made of, which depends on whether a reply is being written.
+///
+/// At rest the slab is not a slab at its top edge: it ramps from the chat background up to nothing
+/// over ``fadeHeight``, so a message scrolling under the bar dissolves into it rather than meeting a
+/// hard line. That dissolve is the composer's resting look and it stays — opaque at rest, the bar
+/// reads as a toolbar bolted across the transcript. Replying paints over it with the
+/// elevated-surface token, which is what draws the top edge and sets the quote apart from the
+/// messages above it.
+///
+/// The reply fill is painted in two places — the bar draws it, and the screen paints the same colour
+/// below the bar so it reaches the bottom of the display. See `BarSurfaceFloor`.
+enum BarSurface {
+
+    /// How far the resting surface takes to ramp from nothing to the chat background — half the
+    /// resting bar, which is where the proportional gradient this replaces put the boundary.
+    ///
+    /// Fixed rather than a fraction of the bar, because a fraction ties the dissolve to the draft: a
+    /// four-line message doubled the fade and softened the transcript twice as far up the screen,
+    /// for no reason a reader can see.
+    static let fadeHeight: CGFloat = 33
+
+    /// The composer at rest: clear at the top edge, chat background below it. The flexible tail is
+    /// what lets the slab bleed past the safe area without stretching the ramp.
+    static var restingFade: some View {
+        VStack(spacing: 0) {
+            LinearGradient(colors: [.clear, .backgroundMain], startPoint: .top, endPoint: .bottom)
+                .frame(height: fadeHeight)
+            Color.backgroundMain
+        }
+    }
+
+    /// The surface a reply lifts the bar to.
+    static let replyFill = Color.backgroundSecondary
+
+    static func fill(isReplying: Bool) -> Color {
+        isReplying ? replyFill : .backgroundMain
+    }
+}
+
+/// The bar surface's continuation below the bar, painted by the screen.
+///
+/// The bar is a hosted view held off the bottom safe area, so its own background stops at the home
+/// indicator. The screen owns the rest; filling it with the same colour is what makes the bar read as
+/// running off the bottom of the display instead of floating above it.
+///
+/// It paints the whole screen, not just the strip, and is placed behind the transcript — which is
+/// opaque — so only the region below the transcript's own bottom edge is ever visible. Sizing it to
+/// the inset instead does not work: `ignoresSafeArea` grows the region offered to a *flexible* view,
+/// and a view already fixed to a height keeps that height and stays inside the safe area.
+///
+/// It carries its own animation because it is a sibling of the bar, not a child: the bar's spring
+/// covers the bar's subtree only, and a floor that snapped to the new colour while the bar eased into
+/// it would put a visible seam across the bottom of the screen.
+struct BarSurfaceFloor: View {
+
+    let isReplying: Bool
+
+    var body: some View {
+        BarSurface.fill(isReplying: isReplying)
+            .ignoresSafeArea(.container, edges: .bottom)
+            .allowsHitTesting(false)
+            .animation(ChatMotion.replySurface.animation, value: isReplying)
     }
 }
 

--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -86,8 +86,17 @@ struct ConversationBottomBar: View {
         // glass above sibling content — drawing the glass over the typed text.
         // The Send Cash button and the field are separate pills 10pt apart, so
         // they don't need to sample each other.
-        return content
-            .modifier(BarGradientBackground())
+        return VStack(spacing: 0) {
+            if let target = composer.replyTarget {
+                ComposerReplyStrip(target: target) {
+                    withAnimation(barMorphSpring) { composer.endReplying() }
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+            content
+        }
+        .animation(barMorphSpring, value: composer.replyTarget)
+        .modifier(BarGradientBackground())
     }
 }
 
@@ -180,6 +189,11 @@ struct ConversationComposer: View {
             composer.clear()
             isFocused = true
             Task { await conversationController.send(text, to: conversationID) }
+        case .replying(let target):
+            guard let text = composer.submission else { return }
+            composer.clear()
+            isFocused = true
+            Task { await conversationController.send(text, to: conversationID, repliedTo: target.messageID) }
         case .editing(let messageID, _):
             // Confirming an edit that changed nothing leaves edit mode rather than round-tripping
             // the same text — the button is always there to be pressed.

--- a/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
@@ -69,6 +69,10 @@ final class ConversationLoadCoordinator {
     /// The reader reached the top — reveal older history.
     func reachedTop() { loader.loadOlder() }
 
+    /// The counterpart's display name as the last mapping resolved it. The composer's reply strip
+    /// reads this so the strip and the sent bubble's quote name the same person the same way.
+    var counterpartName: String { lastInputs?.counterpartName ?? "" }
+
     // Tracks exactly the inputs `map` reads; on the next change to any of them it re-maps off the
     // main thread and re-arms. An unchanged input set short-circuits before spawning any work.
     private func observeInputs() {
@@ -129,6 +133,19 @@ final class ConversationLoadCoordinator {
                 branding[fiat.mint] = .init(token: balance.name, iconURL: balance.imageURL)
             }
         }
+        let counterpartName = conversation?.counterpart(excluding: controller.selfUserID)?.displayName ?? ""
+        // The window first — a reply to a nearby message resolves with no database read at all —
+        // then the table, for a reply pointing above the window. Nothing pages the server: a quote
+        // whose original was never fetched renders as unavailable, by design.
+        var quotedMessages: [UInt64: ConversationMessage] = [:]
+        for message in window {
+            guard let repliedTo = message.repliedTo, quotedMessages[repliedTo.value] == nil else { continue }
+            if let inWindow = window.first(where: { $0.id == repliedTo }) {
+                quotedMessages[repliedTo.value] = inWindow
+            } else if let persisted = controller.persistedMessage(repliedTo, in: conversationID) {
+                quotedMessages[repliedTo.value] = persisted
+            }
+        }
         return Inputs(
             messages: window,
             selfUserID: controller.selfUserID,
@@ -141,6 +158,8 @@ final class ConversationLoadCoordinator {
             profileCard: loader.isEntireHistory(windowCount: window.count) ? profileCard() : nil,
             branding: branding,
             conversation: conversation,
+            counterpartName: counterpartName,
+            quotedMessages: quotedMessages,
             // Read live, so the windows take effect on the same re-map that lands the flags fetch.
             policy: MessagePolicy(userFlags: session.userFlags),
             now: capabilityClock
@@ -171,7 +190,9 @@ final class ConversationLoadCoordinator {
                     policy: inputs.policy,
                     now: inputs.now
                 )
-            }
+            },
+            counterpartName: inputs.counterpartName,
+            quotedMessage: { inputs.quotedMessages[$0.value] }
         )
         if inputs.isTyping {
             items.append(.typingIndicator)
@@ -195,6 +216,11 @@ final class ConversationLoadCoordinator {
         var profileCard: ChatProfileCard?
         var branding: [PublicKey: Branding]
         var conversation: Conversation?
+        /// The counterpart's display name, for a quote whose original they wrote.
+        var counterpartName: String
+        /// Every message quoted by a reply in the window, pre-resolved so `map` stays pure. Keyed
+        /// by raw id because `MessageID` is the natural key and the dictionary must be `Equatable`.
+        var quotedMessages: [UInt64: ConversationMessage]
         var policy: MessagePolicy
         /// The clock capabilities resolve against; advanced only at a window's expiry.
         var now: Date

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -228,11 +228,11 @@ struct ConversationScreen: View {
         // what lets the iOS 26 toolbar scroll-edge effect materialize. The collection view keeps a
         // top content inset (it adjusts for the safe area) so messages stay readable below the bar.
         .ignoresSafeArea(.container, edges: .top)
-        // The bar's panel stops where the hosted view does, at the bottom safe area. This carries
-        // it the rest of the way down, so a reply in progress reads as one surface running off the
-        // bottom of the display rather than a card with an edge above the home indicator.
+        // The bar's surface stops where the hosted view does, at the bottom safe area. This carries
+        // it the rest of the way down, so the bar reads as running off the bottom of the display
+        // rather than as a card with an edge above the home indicator.
         .background {
-            ReplySurfaceFloor(isReplying: composer.replyTarget != nil)
+            BarSurfaceFloor(isReplying: composer.replyTarget != nil)
         }
         .background(Color.backgroundMain)
         .navigationTitle("")
@@ -410,13 +410,16 @@ struct ConversationScreen: View {
         case .copy:
             break
         case .reply:
+            let preview = Self.replyPreview(for: message) { session.balance(for: $0.mint)?.name ?? "Cash" }
             composer.beginReplying(to: ComposerModel.ReplyTarget(
                 messageID: message.id,
                 stableID: stableID,
                 authorName: message.isFromSelf(conversationController.selfUserID)
                     ? "You"
                     : (coordinator?.counterpartName ?? ""),
-                snippet: Self.replySnippet(for: message)
+                authorID: message.senderID,
+                snippet: preview.snippet,
+                kind: preview.kind
             ))
         case .edit:
             guard case .text(let text) = message.content else { return }
@@ -431,11 +434,20 @@ struct ConversationScreen: View {
     ///
     /// A tombstone cannot reach here: `MessageCapability.resolve` grants a deleted message nothing,
     /// so its row has no menu. The branch keeps the switch exhaustive.
-    private static func replySnippet(for message: ConversationMessage) -> String {
+    private static func replyPreview(
+        for message: ConversationMessage,
+        token: (ExchangedFiat) -> String
+    ) -> (snippet: String, kind: ChatQuote.Kind) {
         switch message.content {
-        case .text(let text):   ChatQuote.snippet(forText: text)
-        case .cash(let fiat):   fiat.nativeAmount.formatted()
-        case .deleted:          ChatQuote.deletedSnippet
+        case .text(let text):
+            (ChatQuote.snippet(forText: text), .text)
+        case .cash(let fiat):
+            (
+                fiat.nativeAmount.formatted(),
+                .cash(token: token(fiat), flagImageName: ChatItem.flagImageName(for: fiat))
+            )
+        case .deleted:
+            (ChatQuote.deletedSnippet, .unavailable)
         }
     }
 

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -228,6 +228,12 @@ struct ConversationScreen: View {
         // what lets the iOS 26 toolbar scroll-edge effect materialize. The collection view keeps a
         // top content inset (it adjusts for the safe area) so messages stay readable below the bar.
         .ignoresSafeArea(.container, edges: .top)
+        // The bar's panel stops where the hosted view does, at the bottom safe area. This carries
+        // it the rest of the way down, so a reply in progress reads as one surface running off the
+        // bottom of the display rather than a card with an edge above the home indicator.
+        .background {
+            ReplySurfaceFloor(isReplying: composer.replyTarget != nil)
+        }
         .background(Color.backgroundMain)
         .navigationTitle("")
         .toolbarTitleDisplayMode(.inline)

--- a/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationScreen.swift
@@ -210,6 +210,7 @@ struct ConversationScreen: View {
             onContactAction: openContactCard,
             onProfileTap: profileTapAction,
             onMessageAction: handleMessageAction,
+            onQuoteTap: jumpToQuote,
             showsSendCash: sendTarget != nil,
             chatExists: chatExists,
             conversationID: conversationID,
@@ -403,13 +404,44 @@ struct ConversationScreen: View {
         case .copy:
             break
         case .reply:
-            break // Reply is a separate scope; the menu does not offer it yet.
+            composer.beginReplying(to: ComposerModel.ReplyTarget(
+                messageID: message.id,
+                stableID: stableID,
+                authorName: message.isFromSelf(conversationController.selfUserID)
+                    ? "You"
+                    : (coordinator?.counterpartName ?? ""),
+                snippet: Self.replySnippet(for: message)
+            ))
         case .edit:
             guard case .text(let text) = message.content else { return }
             composer.beginEditing(messageID: message.id, stableID: stableID, currentText: text)
         case .delete:
             confirmDelete(message.id)
         }
+    }
+
+    /// The composer strip's preview of the message being answered — the same three-way split the
+    /// transcript's quote panel uses, so the strip and the sent bubble read alike.
+    ///
+    /// A tombstone cannot reach here: `MessageCapability.resolve` grants a deleted message nothing,
+    /// so its row has no menu. The branch keeps the switch exhaustive.
+    private static func replySnippet(for message: ConversationMessage) -> String {
+        switch message.content {
+        case .text(let text):   ChatQuote.snippet(forText: text)
+        case .cash(let fiat):   fiat.nativeAmount.formatted()
+        case .deleted:          ChatQuote.deletedSnippet
+        }
+    }
+
+    /// Brings the quoted original into the window when the local database has it. Returns without
+    /// effect otherwise — history that was never fetched is out of scope, and the panel that
+    /// points at it is already non-tappable.
+    ///
+    /// A pending row's stable id is a UUID string, so the conversion fails and the jump is a no-op —
+    /// correct, since an unconfirmed message is by definition at the bottom of the window already.
+    private func jumpToQuote(_ stableID: String) {
+        guard let value = UInt64(stableID) else { return }
+        _ = coordinator?.loader.reveal(MessageID(value: value))
     }
 
     private func confirmDelete(_ messageID: MessageID) {

--- a/Flipcash/Core/Screens/Conversation/MessageLoader.swift
+++ b/Flipcash/Core/Screens/Conversation/MessageLoader.swift
@@ -44,6 +44,19 @@ final class MessageLoader {
         startID == nil && windowCount < Self.initialWindow
     }
 
+    /// Brings `messageID` into the rendered window, returning whether it is now there.
+    ///
+    /// One anchor move, not a paging loop: an anchored window reads every message from `startID`
+    /// forward, so pointing the anchor at the target is enough. Nothing is fetched — a message the
+    /// local database has never seen returns `false` and the caller leaves the transcript alone.
+    @discardableResult
+    func reveal(_ messageID: MessageID) -> Bool {
+        if messages.contains(where: { $0.id == messageID }) { return true }
+        guard controller.persistedMessage(messageID, in: conversationID) != nil else { return false }
+        startID = messageID.value
+        return true
+    }
+
     /// Reveals an older step: moves the anchor back over already-persisted history, or pages the next
     /// older batch from the server (which persists it) once the local history is exhausted.
     func loadOlder() {

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Chat/ChatNotificationClient.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Chat/ChatNotificationClient.swift
@@ -109,6 +109,9 @@ public final class ChatNotificationClient: Sendable {
                 owner: owner,
                 conversationID: conversationID,
                 text: text,
+                // A notification quick-reply is a plain message: the extension has no transcript
+                // to quote from.
+                repliedTo: nil,
                 clientMessageID: clientMessageID
             ) { continuation.resume(with: $0) }
         }

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift
@@ -55,9 +55,9 @@ extension FlipClient {
     }
 
     @discardableResult
-    public func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID) async throws -> ConversationMessage {
+    public func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, repliedTo: MessageID?, clientMessageID: UUID) async throws -> ConversationMessage {
         try await withCheckedThrowingContinuation { c in
-            chatMessagingService.sendMessage(owner: owner, conversationID: conversationID, text: text, clientMessageID: clientMessageID) { c.resume(with: $0) }
+            chatMessagingService.sendMessage(owner: owner, conversationID: conversationID, text: text, repliedTo: repliedTo, clientMessageID: clientMessageID) { c.resume(with: $0) }
         }
     }
 

--- a/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift
@@ -124,10 +124,21 @@ final class ChatMessagingService: Sendable {
         }
     }
 
-    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID, completion: @Sendable @escaping (Result<ConversationMessage, ErrorSendMessage>) -> Void) {
+    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, repliedTo: MessageID?, clientMessageID: UUID, completion: @Sendable @escaping (Result<ConversationMessage, ErrorSendMessage>) -> Void) {
         let request = Flipcash_Messaging_V1_SendMessageRequest.with {
             $0.chatID = conversationID.proto
-            $0.content = [.with { $0.text = .with { $0.text = text } }]
+            // A reply wraps the same text one level deeper on the wire. The domain model keeps it
+            // flat — see `ConversationMessage.init?(_:)`, which unwraps it back.
+            if let repliedTo {
+                $0.content = [.with {
+                    $0.reply = .with {
+                        $0.repliedMessageID = repliedTo.proto
+                        $0.content = [.with { $0.text = .with { $0.text = text } }]
+                    }
+                }]
+            } else {
+                $0.content = [.with { $0.text = .with { $0.text = text } }]
+            }
             $0.clientMessageID = .with { $0.value = clientMessageID.data }
             $0.auth = owner.authFor(message: $0)
         }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift
@@ -50,6 +50,9 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
     public let isEdited: Bool
     /// What the context menu offers for this row, already ordered. Empty means no menu.
     public let actions: [MessageCapability]
+    /// The original this row replies to, already resolved for display, or `nil` when the row is
+    /// not a reply.
+    public let quote: ChatQuote?
 
     public init(
         id: String,
@@ -60,7 +63,8 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
         receipt: ChatReceipt? = nil,
         linkPreview: LinkPreview? = nil,
         isEdited: Bool = false,
-        actions: [MessageCapability] = []
+        actions: [MessageCapability] = [],
+        quote: ChatQuote? = nil
     ) {
         self.id = id
         self.content = content
@@ -71,6 +75,7 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
         self.linkPreview = linkPreview
         self.isEdited = isEdited
         self.actions = actions
+        self.quote = quote
     }
 
     /// Convenience for text rows.
@@ -83,7 +88,8 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
         receipt: ChatReceipt? = nil,
         linkPreview: LinkPreview? = nil,
         isEdited: Bool = false,
-        actions: [MessageCapability] = []
+        actions: [MessageCapability] = [],
+        quote: ChatQuote? = nil
     ) {
         self.init(
             id: id,
@@ -94,7 +100,8 @@ public struct ChatMessage: Hashable, Sendable, Codable, Identifiable {
             receipt: receipt,
             linkPreview: linkPreview,
             isEdited: isEdited,
-            actions: actions
+            actions: actions,
+            quote: quote
         )
     }
 }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatQuote.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatQuote.swift
@@ -15,8 +15,11 @@ public struct ChatQuote: Hashable, Sendable, Codable {
     /// What the original was, which selects the panel's presentation.
     public enum Kind: Hashable, Sendable, Codable {
         case text
-        /// A payment. The snippet is the formatted amount.
-        case cash
+        /// A payment. The snippet is the formatted amount; the branding is the same pair the cash
+        /// card itself draws, so a quote of a payment is recognisable as that payment rather than
+        /// as a bare number — `token` is the mint's name ("Cash" for USDF) and `flagImageName` is
+        /// the currency's asset name, `nil` when the currency has no flag.
+        case cash(token: String, flagImageName: String?)
         /// The original is not in the local database, or it has been deleted. The panel renders
         /// the placeholder copy and the row is not tappable.
         case unavailable
@@ -29,12 +32,17 @@ public struct ChatQuote: Hashable, Sendable, Codable {
     public let authorName: String
     public let snippet: String
     public let kind: Kind
+    /// The author's user id, carried only so the panel can draw them in their own colour — see
+    /// `ComplementaryPalette`. `nil` for an original whose author is unknown, which is the same
+    /// case that leaves ``authorName`` empty.
+    public let authorID: UserID?
 
-    public init(stableID: String?, authorName: String, snippet: String, kind: Kind) {
+    public init(stableID: String?, authorName: String, snippet: String, kind: Kind, authorID: UserID? = nil) {
         self.stableID = stableID
         self.authorName = authorName
         self.snippet = snippet
         self.kind = kind
+        self.authorID = authorID
     }
 
     /// Whether tapping the panel goes anywhere.

--- a/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatQuote.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatQuote.swift
@@ -1,0 +1,62 @@
+//
+//  ChatQuote.swift
+//  FlipcashCore
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The quoted original shown above a reply's body — display-ready, like everything else a chat row
+/// draws. The transcript mapper resolves the replied-to id into one of these; the panel that draws
+/// it knows nothing about the database or which messages happen to be loaded.
+public struct ChatQuote: Hashable, Sendable, Codable {
+
+    /// What the original was, which selects the panel's presentation.
+    public enum Kind: Hashable, Sendable, Codable {
+        case text
+        /// A payment. The snippet is the formatted amount.
+        case cash
+        /// The original is not in the local database, or it has been deleted. The panel renders
+        /// the placeholder copy and the row is not tappable.
+        case unavailable
+    }
+
+    /// The transcript row to jump to, or `nil` when there is nothing to jump to.
+    public let stableID: String?
+    /// "You" for the viewer's own message, the counterpart's display name otherwise. Empty for an
+    /// unavailable original, whose author is not known.
+    public let authorName: String
+    public let snippet: String
+    public let kind: Kind
+
+    public init(stableID: String?, authorName: String, snippet: String, kind: Kind) {
+        self.stableID = stableID
+        self.authorName = authorName
+        self.snippet = snippet
+        self.kind = kind
+    }
+
+    /// Whether tapping the panel goes anywhere.
+    public var isJumpable: Bool { stableID != nil }
+
+    /// Copy for an original the client cannot show.
+    public static let unavailableSnippet = "Original message unavailable"
+
+    /// Copy for an original that has since been deleted.
+    public static let deletedSnippet = "This message was deleted"
+
+    /// Longest snippet the panel renders. Past this the panel would wrap to a third line and the
+    /// bubble would grow around a preview rather than the message.
+    public static let snippetLimit = 120
+
+    /// One line of preview text: newlines collapsed to spaces, truncated at ``snippetLimit``.
+    public static func snippet(forText text: String) -> String {
+        let flattened = text
+            .split(whereSeparator: \.isNewline)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
+        guard flattened.count > snippetLimit else { return flattened }
+        return flattened.prefix(snippetLimit) + "…"
+    }
+}

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift
@@ -65,6 +65,12 @@ public struct ConversationMessage: Identifiable, Hashable, Sendable {
     public let eventSequence: UInt64
     /// When the sender last edited this message, or `nil` if it has never been edited.
     public let lastEditedTs: Date?
+    /// The message this one replies to, or `nil` when it replies to nothing. A reply is a
+    /// decoration on a text message rather than a content kind of its own: the wire nests the
+    /// body inside `ReplyContent`, and the initializer below unwraps it so every `case .text`
+    /// path — link detection, the transcript mapper, the bubble, edit — sees the shape it
+    /// always saw.
+    public let repliedTo: MessageID?
     /// Delivery state. `.sent` for every server/cache message; `.sending`/`.failed` only for an
     /// in-flight optimistic message.
     public var status: SendStatus
@@ -83,6 +89,7 @@ public struct ConversationMessage: Identifiable, Hashable, Sendable {
         unreadSeq: UInt64,
         eventSequence: UInt64 = 0,
         lastEditedTs: Date? = nil,
+        repliedTo: MessageID? = nil,
         status: SendStatus = .sent,
         clientMessageID: UUID? = nil
     ) {
@@ -94,6 +101,7 @@ public struct ConversationMessage: Identifiable, Hashable, Sendable {
         self.unreadSeq = unreadSeq
         self.eventSequence = eventSequence
         self.lastEditedTs = lastEditedTs
+        self.repliedTo = repliedTo
         self.status = status
         self.clientMessageID = clientMessageID
     }
@@ -125,6 +133,7 @@ extension ConversationMessage {
             unreadSeq: unreadSeq,
             eventSequence: eventSequence,
             lastEditedTs: lastEditedTs,
+            repliedTo: repliedTo,
             status: status,
             clientMessageID: clientMessageID
         )
@@ -145,10 +154,12 @@ extension ConversationMessage {
     /// it converges the same way across the stream, `GetMessages`, and `GetDelta`
     /// and can't leave the pre-delete content on screen.
     public init?(_ proto: Flipcash_Messaging_V1_Message) {
+        let repliedTo: MessageID?
         switch proto.content.first?.type {
         case .text(let textContent):
             self.content = .text(textContent.text)
             self.cashAction = nil
+            repliedTo = nil
         case .cash(let cashContent):
             guard let amount = try? ExchangedFiat(cashContent.amount) else {
                 return nil
@@ -156,6 +167,7 @@ extension ConversationMessage {
             self.content = .cash(amount)
             // Unrecognized verbs fall back to `.sent`, per the proto contract.
             self.cashAction = cashContent.verb == .tipped ? .tipped : .sent
+            repliedTo = nil
         case .deleted(let deletedContent):
             self.content = .deleted(
                 Deletion(
@@ -164,7 +176,20 @@ extension ConversationMessage {
                 )
             )
             self.cashAction = nil
-        case .reply, .media, .system, .none:
+            repliedTo = nil
+        case .reply(let replyContent):
+            // The wire nests the body one level down; unwrap it so the message is a text message
+            // that happens to point at another, not a second shape every `case .text` must learn.
+            // `content` is repeated on the wire but carries exactly one entry in practice — a
+            // reply with nothing inside has no body to draw, so it is dropped like any other
+            // content the client cannot represent.
+            guard case .text(let textContent)? = replyContent.content.first?.type else {
+                return nil
+            }
+            self.content = .text(textContent.text)
+            self.cashAction = nil
+            repliedTo = replyContent.hasRepliedMessageID ? MessageID(replyContent.repliedMessageID) : nil
+        case .media, .system, .none:
             return nil
         }
 
@@ -174,6 +199,7 @@ extension ConversationMessage {
         self.unreadSeq = proto.unreadSeq
         self.eventSequence = proto.eventSequence
         self.lastEditedTs = proto.hasLastEditedTs ? proto.lastEditedTs.date : nil
+        self.repliedTo = repliedTo
         self.status = .sent
         self.clientMessageID = nil
     }

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/MessageCapability.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/MessageCapability.swift
@@ -61,14 +61,16 @@ extension MessageCapability {
             // Nothing is left to act on, and a tombstone must not be re-deleted.
             return []
         case .cash:
-            // Reply is a cash message's only capability, and reply is not built yet.
-            return []
+            // Reply is a cash message's only capability: there is no text to copy, the server
+            // authored it so there is nothing to edit, and delete is deliberately withheld from
+            // a payment record.
+            return [.reply]
         case .text:
             break
         }
 
         guard message.isFromSelf(selfUserID) else {
-            return [.copy]
+            return [.copy, .reply]
         }
 
         // An unconfirmed message has no `eventSequence` to send as `expected_event_sequence`, so no
@@ -78,7 +80,7 @@ extension MessageCapability {
             return []
         }
 
-        var capabilities: Set<MessageCapability> = [.copy]
+        var capabilities: Set<MessageCapability> = [.copy, .reply]
         if isWithin(policy.editWindow, of: message, at: now) {
             capabilities.insert(.edit)
         }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ChatQuoteTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ChatQuoteTests.swift
@@ -1,0 +1,49 @@
+//
+//  ChatQuoteTests.swift
+//  FlipcashCoreTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import FlipcashCore
+
+@Suite("ChatQuote")
+struct ChatQuoteTests {
+
+    @Test("A short snippet is left alone")
+    func shortSnippet_isUnchanged() {
+        #expect(ChatQuote.snippet(forText: "on my way") == "on my way")
+    }
+
+    @Test("A long snippet is truncated with an ellipsis at the limit")
+    func longSnippet_isTruncated() {
+        let text = String(repeating: "a", count: ChatQuote.snippetLimit + 40)
+        let snippet = ChatQuote.snippet(forText: text)
+        #expect(snippet.count == ChatQuote.snippetLimit + 1)
+        #expect(snippet.hasSuffix("…"))
+    }
+
+    @Test("Newlines collapse so the snippet stays one line")
+    func newlines_collapse() {
+        #expect(ChatQuote.snippet(forText: "line one\nline two") == "line one line two")
+    }
+
+    @Test("A quote with no target cannot be jumped to")
+    func unresolvedQuote_hasNoTarget() {
+        let quote = ChatQuote(stableID: nil, authorName: "", snippet: ChatQuote.unavailableSnippet, kind: .unavailable)
+        #expect(quote.isJumpable == false)
+    }
+
+    @Test("A resolved quote can be jumped to")
+    func resolvedQuote_hasTarget() {
+        let quote = ChatQuote(stableID: "7", authorName: "You", snippet: "hi", kind: .text)
+        #expect(quote.isJumpable)
+    }
+
+    @Test("A message carries no quote by default")
+    func chatMessage_defaultsToNoQuote() {
+        #expect(ChatMessage(id: "1", text: "hi", sender: .me).quote == nil)
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
@@ -417,3 +417,67 @@ struct ConversationMessageMetadataTests {
         #expect(edited.lastEditedTs == Date(timeIntervalSince1970: 200))
     }
 }
+
+@Suite("Reply proto mapping")
+struct ConversationMessageReplyMappingTests {
+
+    private func replyProto(repliedTo: UInt64, text: String) -> Flipcash_Messaging_V1_Message {
+        .with {
+            $0.messageID = .with { $0.value = 42 }
+            $0.content = [
+                .with { content in
+                    content.reply = .with { reply in
+                        reply.repliedMessageID = .with { $0.value = repliedTo }
+                        reply.content = [.with { inner in inner.text = .with { $0.text = text } }]
+                    }
+                }
+            ]
+        }
+    }
+
+    @Test("A reply proto maps to a text message carrying the replied-to id")
+    func replyProto_unwrapsToText() throws {
+        let message = try #require(ConversationMessage(replyProto(repliedTo: 7, text: "on my way")))
+        #expect(message.content == .text("on my way"))
+        #expect(message.repliedTo == MessageID(value: 7))
+    }
+
+    @Test("A plain text proto carries no replied-to id")
+    func textProto_hasNoRepliedTo() throws {
+        let proto = Flipcash_Messaging_V1_Message.with {
+            $0.messageID = .with { $0.value = 43 }
+            $0.content = [.with { $0.text = .with { $0.text = "hi" } }]
+        }
+        let message = try #require(ConversationMessage(proto))
+        #expect(message.repliedTo == nil)
+    }
+
+    @Test("A reply whose inner content is empty is dropped rather than rendered blank")
+    func replyProto_withoutInnerContent_isDropped() {
+        let proto = Flipcash_Messaging_V1_Message.with {
+            $0.messageID = .with { $0.value = 44 }
+            $0.content = [
+                .with { content in
+                    content.reply = .with { reply in
+                        reply.repliedMessageID = .with { $0.value = 7 }
+                    }
+                }
+            ]
+        }
+        #expect(ConversationMessage(proto) == nil)
+    }
+
+    @Test("replacingContent preserves the replied-to id")
+    func replacingContent_preservesRepliedTo() {
+        let message = ConversationMessage(
+            id: MessageID(value: 1),
+            senderID: nil,
+            content: .text("first"),
+            date: Date(timeIntervalSince1970: 0),
+            unreadSeq: 0,
+            repliedTo: MessageID(value: 9)
+        )
+        let edited = message.replacingContent(.text("second"), lastEditedTs: Date(timeIntervalSince1970: 1))
+        #expect(edited.repliedTo == MessageID(value: 9))
+    }
+}

--- a/FlipcashCore/Tests/FlipcashCoreTests/MessageCapabilityTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/MessageCapabilityTests.swift
@@ -30,7 +30,7 @@ struct MessageCapabilityTests {
 
     @Test("My own confirmed text can be copied, edited, and deleted")
     func ownTextIsFullyActionable() {
-        #expect(resolve(text("hi", from: me)) == [.copy, .edit, .delete])
+        #expect(resolve(text("hi", from: me)) == [.copy, .reply, .edit, .delete])
     }
 
     @Test("An unconfirmed message of mine offers nothing — it has no sequence to send as expected")
@@ -40,7 +40,7 @@ struct MessageCapabilityTests {
 
     @Test("Someone else's text can only be copied")
     func otherPersonsTextIsCopyOnly() {
-        #expect(resolve(text("hi", from: them)) == [.copy])
+        #expect(resolve(text("hi", from: them)) == [.copy, .reply])
     }
 
     @Test("A tombstone offers nothing")
@@ -53,14 +53,14 @@ struct MessageCapabilityTests {
         #expect(resolve(tombstone).isEmpty)
     }
 
-    @Test("A cash message offers nothing in this scope — reply is the only capability it will ever have")
-    func cashMessageOffersNothingYet() {
+    @Test("A cash message offers Reply and nothing else")
+    func cashMessageOffersReplyOnly() {
         let cash = ConversationMessage(
             id: MessageID(value: 3), senderID: me,
             content: .cash(ExchangedFiat(nativeAmount: .usd(20), rate: .oneToOne)),
             cashAction: .sent, date: now, unreadSeq: 1, eventSequence: 2
         )
-        #expect(resolve(cash).isEmpty)
+        #expect(resolve(cash) == [.reply])
     }
 
     // MARK: - Windows -
@@ -72,19 +72,19 @@ struct MessageCapabilityTests {
     @Test("A message inside both windows keeps every action")
     func messageInsideBothWindowsIsFullyActionable() {
         let policy = windows(edit: 900, delete: 172_800)
-        #expect(resolve(text("hi", from: me, sentAgo: 600), policy: policy) == [.copy, .edit, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 600), policy: policy) == [.copy, .reply, .edit, .delete])
     }
 
     @Test("A message past the edit window but inside the delete window can still be deleted")
     func messagePastEditWindowIsDeleteOnly() {
         let policy = windows(edit: 900, delete: 172_800)
-        #expect(resolve(text("hi", from: me, sentAgo: 1_200), policy: policy) == [.copy, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 1_200), policy: policy) == [.copy, .reply, .delete])
     }
 
     @Test("A message past both windows can only be copied")
     func messagePastBothWindowsIsCopyOnly() {
         let policy = windows(edit: 900, delete: 172_800)
-        #expect(resolve(text("hi", from: me, sentAgo: 200_000), policy: policy) == [.copy])
+        #expect(resolve(text("hi", from: me, sentAgo: 200_000), policy: policy) == [.copy, .reply])
     }
 
     @Test("A message past the delete window loses delete even while it is still editable")
@@ -92,27 +92,27 @@ struct MessageCapabilityTests {
         // A delete window shorter than the edit window is not the configuration we ship, but it is
         // what proves the two gates are independent rather than one implying the other.
         let policy = windows(edit: 900, delete: 60)
-        #expect(resolve(text("hi", from: me, sentAgo: 300), policy: policy) == [.copy, .edit])
+        #expect(resolve(text("hi", from: me, sentAgo: 300), policy: policy) == [.copy, .reply, .edit])
     }
 
     @Test("At exactly the window length both actions are still offered — the boundary is inclusive")
     func boundaryIsInclusive() {
         let policy = windows(edit: 900, delete: 172_800)
-        #expect(resolve(text("hi", from: me, sentAgo: 900), policy: policy) == [.copy, .edit, .delete])
-        #expect(resolve(text("hi", from: me, sentAgo: 172_800), policy: policy) == [.copy, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 900), policy: policy) == [.copy, .reply, .edit, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 172_800), policy: policy) == [.copy, .reply, .delete])
     }
 
     @Test("A hair past the boundary the action is gone")
     func justPastBoundaryDropsTheAction() {
         let policy = windows(edit: 900, delete: 172_800)
-        #expect(resolve(text("hi", from: me, sentAgo: 900.001), policy: policy) == [.copy, .delete])
-        #expect(resolve(text("hi", from: me, sentAgo: 172_800.001), policy: policy) == [.copy])
+        #expect(resolve(text("hi", from: me, sentAgo: 900.001), policy: policy) == [.copy, .reply, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 172_800.001), policy: policy) == [.copy, .reply])
     }
 
     @Test("A nil window never lapses")
     func nilWindowNeverLapses() {
         let policy = windows(edit: nil, delete: nil)
-        #expect(resolve(text("hi", from: me, sentAgo: 10_000_000), policy: policy) == [.copy, .edit, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 10_000_000), policy: policy) == [.copy, .reply, .edit, .delete])
     }
 
     // MARK: - Fallbacks -
@@ -132,9 +132,9 @@ struct MessageCapabilityTests {
         // assigns — so this is the no-flags path, and it must not be more permissive than the
         // fallback.
         let policy = MessagePolicy(userFlags: nil)
-        #expect(resolve(text("hi", from: me, sentAgo: 600), policy: policy) == [.copy, .edit, .delete])
-        #expect(resolve(text("hi", from: me, sentAgo: 1_200), policy: policy) == [.copy, .delete])
-        #expect(resolve(text("hi", from: me, sentAgo: 200_000), policy: policy) == [.copy])
+        #expect(resolve(text("hi", from: me, sentAgo: 600), policy: policy) == [.copy, .reply, .edit, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 1_200), policy: policy) == [.copy, .reply, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 200_000), policy: policy) == [.copy, .reply])
     }
 
     @Test("Flags that arrived with both windows unset fall back too")
@@ -157,14 +157,14 @@ struct MessageCapabilityTests {
         let policy = MessagePolicy(userFlags: flags)
         #expect(policy.editWindow == 60)
         #expect(policy.deleteWindow == 120)
-        #expect(resolve(text("hi", from: me, sentAgo: 90), policy: policy) == [.copy, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 90), policy: policy) == [.copy, .reply, .delete])
     }
 
     @Test("The default policy is the fallback policy")
     func defaultPolicyCarriesTheFallbacks() {
         #expect(MessagePolicy.default.editWindow == MessagePolicy.fallbackEditWindow)
         #expect(MessagePolicy.default.deleteWindow == MessagePolicy.fallbackDeleteWindow)
-        #expect(resolve(text("hi", from: me, sentAgo: 86_400)) == [.copy, .delete])
+        #expect(resolve(text("hi", from: me, sentAgo: 86_400)) == [.copy, .reply, .delete])
     }
 
     // MARK: - Expiry scheduling -

--- a/FlipcashTests/Chat/ChatBubbleViewTests.swift
+++ b/FlipcashTests/Chat/ChatBubbleViewTests.swift
@@ -54,25 +54,29 @@ struct ChatBubbleViewCornerTests {
 @Suite("ChatMessageCell alignment")
 struct ChatMessageCellAlignmentTests {
 
-    private func laidOutCell(sender: ChatMessage.Sender) -> (cell: ChatMessageCell, bubble: UIView) {
+    /// Returns the bubble's frame *in the content view's* coordinate space. `contentView.subviews[0]`
+    /// is the column stack view, which spans the whole row by design and hugs the sender's edge
+    /// through its `alignment` — so measuring that against the content view's edges asserts nothing.
+    private func laidOutCell(sender: ChatMessage.Sender) -> (cell: ChatMessageCell, bubble: CGRect) {
         let cell = ChatMessageCell(frame: CGRect(x: 0, y: 0, width: 320, height: 80))
         cell.configure(with: ChatMessage(id: "1", text: "hi", sender: sender), maxWidth: 250)
         cell.layoutIfNeeded()
-        return (cell, cell.contentView.subviews[0])
+        let bubble = cell.bubbleView
+        return (cell, bubble.convert(bubble.bounds, to: cell.contentView))
     }
 
     @Test("A self message hugs the trailing edge")
     func selfMessage_hugsTrailing() {
         let (cell, bubble) = laidOutCell(sender: .me)
-        #expect(abs(bubble.frame.maxX - (cell.contentView.bounds.width - 12)) < 0.5)
-        #expect(bubble.frame.minX > 12) // does not span the full width
+        #expect(abs(bubble.maxX - (cell.contentView.bounds.width - 12)) < 0.5)
+        #expect(bubble.minX > 12) // does not span the full width
     }
 
     @Test("An other message hugs the leading edge")
     func otherMessage_hugsLeading() {
         let (cell, bubble) = laidOutCell(sender: .other)
-        #expect(abs(bubble.frame.minX - 12) < 0.5)
-        #expect(bubble.frame.maxX < cell.contentView.bounds.width - 12)
+        #expect(abs(bubble.minX - 12) < 0.5)
+        #expect(bubble.maxX < cell.contentView.bounds.width - 12)
     }
 }
 

--- a/FlipcashTests/Chat/ChatQuoteBubbleTests.swift
+++ b/FlipcashTests/Chat/ChatQuoteBubbleTests.swift
@@ -1,0 +1,154 @@
+//
+//  ChatQuoteBubbleTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import UIKit
+import FlipcashCore
+@testable import FlipcashUI
+
+@Suite("Reply bubble quote panel")
+@MainActor
+struct ChatQuoteBubbleTests {
+
+    private static let maxWidth: CGFloat = 250
+
+    private let quote = ChatQuote(stableID: "7", authorName: "Ada", snippet: "dinner at 7?", kind: .text)
+
+    private func laidOutCell(quote: ChatQuote?) -> ChatMessageCell {
+        let cell = ChatMessageCell(frame: CGRect(x: 0, y: 0, width: 320, height: 80))
+        cell.configure(
+            with: ChatMessage(id: "1", content: .text("works"), sender: .me, quote: quote),
+            maxWidth: Self.maxWidth
+        )
+        let fitted = cell.contentView.systemLayoutSizeFitting(
+            CGSize(width: 320, height: 0),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        cell.frame = CGRect(x: 0, y: 0, width: 320, height: fitted.height)
+        cell.layoutIfNeeded()
+        return cell
+    }
+
+    @Test("A quote makes the bubble taller")
+    func quote_growsTheBubble() {
+        let plain = laidOutCell(quote: nil).bubbleView.frame.height
+        let quoted = laidOutCell(quote: quote).bubbleView.frame.height
+        #expect(quoted > plain)
+    }
+
+    @Test("A message with no quote reserves no height for the panel")
+    func noQuote_reservesNothing() {
+        let bubble = laidOutCell(quote: nil).bubbleView
+        #expect(bubble.quotePanel.isHidden)
+        #expect(bubble.quotePanel.frame.height == 0)
+    }
+
+    @Test("Reusing a bubble drops the previous quote")
+    func reuse_dropsTheQuote() {
+        let cell = laidOutCell(quote: quote)
+        cell.configure(with: ChatMessage(id: "2", content: .text("hi"), sender: .me), maxWidth: Self.maxWidth)
+        cell.layoutIfNeeded()
+        #expect(cell.bubbleView.quotePanel.isHidden)
+    }
+
+    @Test("The panel reports the row it jumps to")
+    func panel_reportsItsTarget() {
+        var tapped: String?
+        let cell = laidOutCell(quote: quote)
+        cell.bubbleView.onQuoteTap = { tapped = $0 }
+        cell.bubbleView.quotePanel.simulateTap()
+        #expect(tapped == "7")
+    }
+
+    @Test("An unavailable quote is not tappable")
+    func unavailableQuote_doesNotJump() {
+        var tapped: String?
+        let unavailable = ChatQuote(
+            stableID: nil, authorName: "", snippet: ChatQuote.unavailableSnippet, kind: .unavailable
+        )
+        let cell = laidOutCell(quote: unavailable)
+        cell.bubbleView.onQuoteTap = { tapped = $0 }
+        cell.bubbleView.quotePanel.simulateTap()
+        #expect(tapped == nil)
+    }
+}
+
+@Suite("Reply bubble geometry")
+@MainActor
+struct ChatQuoteBubbleGeometryTests {
+
+    private static let maxWidth: CGFloat = 250
+
+    private let shortQuote = ChatQuote(stableID: "7", authorName: "Ada", snippet: "ok", kind: .text)
+    private let longQuote = ChatQuote(
+        stableID: "7",
+        authorName: "Ada",
+        snippet: String(repeating: "long enough to wrap ", count: 6),
+        kind: .text
+    )
+
+    /// Lays out a real cell and returns the bubble's frame *in the content view's* coordinate
+    /// space. The bubble sits inside the column stack view, so its own `frame` is relative to that
+    /// stack — comparing it against the content view's edges without converting measures the wrong
+    /// box, which is what makes the assertions below meaningful.
+    private func laidOutCell(
+        sender: ChatMessage.Sender,
+        quote: ChatQuote?,
+        text: String = "works"
+    ) -> (cell: ChatMessageCell, bubbleFrame: CGRect) {
+        let cell = ChatMessageCell(frame: CGRect(x: 0, y: 0, width: 320, height: 80))
+        cell.configure(
+            with: ChatMessage(id: "1", content: .text(text), sender: sender, quote: quote),
+            maxWidth: Self.maxWidth
+        )
+        let fitted = cell.contentView.systemLayoutSizeFitting(
+            CGSize(width: 320, height: 0),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        cell.frame = CGRect(x: 0, y: 0, width: 320, height: fitted.height)
+        cell.layoutIfNeeded()
+        let bubble = cell.bubbleView
+        return (cell, bubble.convert(bubble.bounds, to: cell.contentView))
+    }
+
+    @Test("A quoted reply from me still hugs the trailing edge")
+    func selfReply_hugsTrailing() {
+        let (cell, bubble) = laidOutCell(sender: .me, quote: shortQuote)
+        #expect(abs(bubble.maxX - (cell.contentView.bounds.width - 12)) < 0.5)
+        #expect(bubble.minX > 12)
+    }
+
+    @Test("A quoted reply from them still hugs the leading edge")
+    func otherReply_hugsLeading() {
+        let (cell, bubble) = laidOutCell(sender: .other, quote: shortQuote)
+        #expect(abs(bubble.minX - 12) < 0.5)
+        #expect(bubble.maxX < cell.contentView.bounds.width - 12)
+    }
+
+    @Test("A quote wider than the body does not push the bubble past maxWidth")
+    func longQuote_respectsMaxWidth() {
+        let (_, bubble) = laidOutCell(sender: .me, quote: longQuote, text: "ok")
+        #expect(bubble.width <= Self.maxWidth + 0.5)
+    }
+
+    @Test("Adding a quote does not move the bubble sideways")
+    func quote_doesNotShiftTheBubble() {
+        let plain = laidOutCell(sender: .me, quote: nil)
+        let quoted = laidOutCell(sender: .me, quote: shortQuote)
+        // The height changes; the trailing edge must not.
+        #expect(abs(plain.bubbleFrame.maxX - quoted.bubbleFrame.maxX) < 0.5)
+    }
+
+    @Test("A quote wider than the body widens the bubble to hold it")
+    func longQuote_widensTheBubble() {
+        let narrow = laidOutCell(sender: .me, quote: nil, text: "ok")
+        let (_, wide) = laidOutCell(sender: .me, quote: longQuote, text: "ok")
+        #expect(wide.width > narrow.bubbleFrame.width)
+    }
+}

--- a/FlipcashTests/Chat/ChatQuoteBubbleTests.swift
+++ b/FlipcashTests/Chat/ChatQuoteBubbleTests.swift
@@ -65,6 +65,24 @@ struct ChatQuoteBubbleTests {
         #expect(tapped == "7")
     }
 
+    @Test("A quoted payment reads out its amount and the mint's name")
+    func cashQuote_speaksTheToken() {
+        let cash = ChatQuote(
+            stableID: "7",
+            authorName: "Ada",
+            snippet: "$5.00",
+            kind: .cash(token: "Launch It", flagImageName: "us")
+        )
+        let panel = laidOutCell(quote: cash).bubbleView.quotePanel
+        #expect(panel.accessibilityLabel == "Replying to Ada: $5.00 Launch It")
+    }
+
+    @Test("A quoted sentence reads out only what was said")
+    func textQuote_speaksTheSnippet() {
+        let panel = laidOutCell(quote: quote).bubbleView.quotePanel
+        #expect(panel.accessibilityLabel == "Replying to Ada: dinner at 7?")
+    }
+
     @Test("An unavailable quote is not tappable")
     func unavailableQuote_doesNotJump() {
         var tapped: String?

--- a/FlipcashTests/Chat/ChatQuoteMappingTests.swift
+++ b/FlipcashTests/Chat/ChatQuoteMappingTests.swift
@@ -1,0 +1,120 @@
+//
+//  ChatQuoteMappingTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+import FlipcashCore
+import FlipcashUI
+@testable import Flipcash
+
+@Suite("Reply quote mapping")
+struct ChatQuoteMappingTests {
+
+    private let me = UUID()
+    private let them = UUID()
+    private let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func message(
+        id: UInt64,
+        from sender: UUID?,
+        content: ConversationMessage.Content,
+        repliedTo: UInt64? = nil,
+        offset: TimeInterval = 0
+    ) -> ConversationMessage {
+        ConversationMessage(
+            id: MessageID(value: id),
+            senderID: sender,
+            content: content,
+            date: start.addingTimeInterval(offset),
+            unreadSeq: id,
+            eventSequence: id,
+            repliedTo: repliedTo.map { MessageID(value: $0) }
+        )
+    }
+
+    private func quotes(
+        _ messages: [ConversationMessage],
+        resolving pool: [ConversationMessage] = []
+    ) -> [ChatQuote?] {
+        let byID = Dictionary(uniqueKeysWithValues: (messages + pool).map { ($0.id, $0) })
+        return ChatItem.from(
+            messages,
+            selfUserID: me,
+            counterpartName: "Ada",
+            quotedMessage: { byID[$0] }
+        ).compactMap { item in
+            if case .message(let message) = item { return message.quote } else { return nil }
+        }
+    }
+
+    @Test("A reply to a message in the window quotes its author and text")
+    func replyToWindowedMessage_resolves() throws {
+        let original = message(id: 1, from: them, content: .text("dinner at 7?"))
+        let reply = message(id: 2, from: me, content: .text("works"), repliedTo: 1, offset: 5)
+        let quote = try #require(quotes([original, reply]).last ?? nil)
+        #expect(quote.authorName == "Ada")
+        #expect(quote.snippet == "dinner at 7?")
+        #expect(quote.kind == .text)
+        #expect(quote.stableID == original.stableID)
+    }
+
+    @Test("A reply to my own message names me")
+    func replyToOwnMessage_namesMe() throws {
+        let original = message(id: 1, from: me, content: .text("dinner at 7?"))
+        let reply = message(id: 2, from: them, content: .text("works"), repliedTo: 1, offset: 5)
+        let quote = try #require(quotes([original, reply]).last ?? nil)
+        #expect(quote.authorName == "You")
+    }
+
+    @Test("A reply to a message outside the local database renders as unavailable and cannot be jumped to")
+    func replyToUnknownMessage_isUnavailable() throws {
+        let reply = message(id: 2, from: me, content: .text("works"), repliedTo: 99, offset: 5)
+        let quote = try #require(quotes([reply]).last ?? nil)
+        #expect(quote.kind == .unavailable)
+        #expect(quote.snippet == ChatQuote.unavailableSnippet)
+        #expect(quote.isJumpable == false)
+    }
+
+    @Test("A reply to a deleted message says so and cannot be jumped to")
+    func replyToDeletedMessage_isUnavailable() throws {
+        let original = message(
+            id: 1, from: them,
+            content: .deleted(ConversationMessage.Deletion(deletedBy: them, deletedAt: start))
+        )
+        let reply = message(id: 2, from: me, content: .text("works"), repliedTo: 1, offset: 5)
+        // The tombstone itself is filtered out of the transcript under `.hidden`, so it is supplied
+        // through the resolution pool rather than the window.
+        let quote = try #require(quotes([reply], resolving: [original]).last ?? nil)
+        #expect(quote.kind == .unavailable)
+        #expect(quote.snippet == ChatQuote.deletedSnippet)
+        #expect(quote.isJumpable == false)
+    }
+
+    private func fiat(_ amount: Decimal) -> ExchangedFiat {
+        ExchangedFiat(
+            onChainAmount: TokenAmount(quarks: 0, mint: .usdf),
+            nativeAmount: FiatAmount(value: amount, currency: .usd),
+            currencyRate: Rate(fx: 1, currency: .usd)
+        )
+    }
+
+    @Test("A reply to a payment quotes the formatted amount")
+    func replyToCashMessage_quotesAmount() throws {
+        let fiat = fiat(5)
+        let original = message(id: 1, from: them, content: .cash(fiat))
+        let reply = message(id: 2, from: me, content: .text("thanks!"), repliedTo: 1, offset: 5)
+        let quote = try #require(quotes([original, reply]).last ?? nil)
+        #expect(quote.kind == .cash)
+        #expect(quote.snippet == fiat.nativeAmount.formatted())
+    }
+
+    @Test("A message that is not a reply carries no quote")
+    func plainMessage_hasNoQuote() {
+        let plain = message(id: 1, from: me, content: .text("hi"))
+        #expect(quotes([plain]).last ?? nil == nil)
+    }
+}

--- a/FlipcashTests/Chat/ChatQuoteMappingTests.swift
+++ b/FlipcashTests/Chat/ChatQuoteMappingTests.swift
@@ -38,12 +38,14 @@ struct ChatQuoteMappingTests {
 
     private func quotes(
         _ messages: [ConversationMessage],
-        resolving pool: [ConversationMessage] = []
+        resolving pool: [ConversationMessage] = [],
+        cashBranding: @escaping (ExchangedFiat) -> (token: String, iconURL: URL?) = { _ in ("Cash", nil) }
     ) -> [ChatQuote?] {
         let byID = Dictionary(uniqueKeysWithValues: (messages + pool).map { ($0.id, $0) })
         return ChatItem.from(
             messages,
             selfUserID: me,
+            cashBranding: cashBranding,
             counterpartName: "Ada",
             quotedMessage: { byID[$0] }
         ).compactMap { item in
@@ -102,14 +104,24 @@ struct ChatQuoteMappingTests {
         )
     }
 
-    @Test("A reply to a payment quotes the formatted amount")
+    @Test("A reply to a payment quotes the amount with the currency's flag and the mint's name")
     func replyToCashMessage_quotesAmount() throws {
         let fiat = fiat(5)
         let original = message(id: 1, from: them, content: .cash(fiat))
         let reply = message(id: 2, from: me, content: .text("thanks!"), repliedTo: 1, offset: 5)
         let quote = try #require(quotes([original, reply]).last ?? nil)
-        #expect(quote.kind == .cash)
+        #expect(quote.kind == .cash(token: "Cash", flagImageName: "us"))
         #expect(quote.snippet == fiat.nativeAmount.formatted())
+    }
+
+    @Test("A quoted payment carries the mint's own branding, not the USDF default")
+    func replyToBondedCashMessage_quotesTheMintsName() throws {
+        let original = message(id: 1, from: them, content: .cash(fiat(1.99)))
+        let reply = message(id: 2, from: me, content: .text("nice"), repliedTo: 1, offset: 5)
+        let quote = try #require(
+            quotes([original, reply], cashBranding: { _ in ("Launch It", nil) }).last ?? nil
+        )
+        #expect(quote.kind == .cash(token: "Launch It", flagImageName: "us"))
     }
 
     @Test("A message that is not a reply carries no quote")

--- a/FlipcashTests/Chat/ChatSwipeToReplyTests.swift
+++ b/FlipcashTests/Chat/ChatSwipeToReplyTests.swift
@@ -1,0 +1,207 @@
+//
+//  ChatSwipeToReplyTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import UIKit
+import FlipcashCore
+@testable import FlipcashUI
+
+@Suite("Swipe to reply")
+@MainActor
+struct ChatSwipeToReplyTests {
+
+    @Test("A mostly-horizontal drag may begin")
+    func horizontalDrag_begins() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: 300, y: 40), isBlocked: false))
+    }
+
+    @Test("A mostly-vertical drag is left to the scroll view")
+    func verticalDrag_doesNotBegin() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: 40, y: -300), isBlocked: false) == false)
+    }
+
+    @Test("A diagonal drag with more vertical than horizontal is left to the scroll view")
+    func diagonalDrag_doesNotBegin() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: 120, y: -160), isBlocked: false) == false)
+    }
+
+    @Test("A drag towards the leading edge is not a reply swipe")
+    func leadingDrag_doesNotBegin() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: -300, y: 10), isBlocked: false) == false)
+    }
+
+    @Test("Nothing begins while the transcript is blocked")
+    func blocked_doesNotBegin() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: 300, y: 40), isBlocked: true) == false)
+    }
+
+    @Test("Translation past the maximum is bounded")
+    func translation_isBounded() {
+        let bound = ChatSwipeToReply.maxTranslation * 2
+        #expect(ChatSwipeToReply.offset(forTranslation: 500) < bound)
+        #expect(ChatSwipeToReply.offset(forTranslation: 5_000) < bound)
+        // Bounded, but not a dead stop: a longer drag still moves the row further.
+        #expect(ChatSwipeToReply.offset(forTranslation: 500) > ChatSwipeToReply.offset(forTranslation: 200))
+    }
+
+    @Test("A drag towards the leading edge does not move the row")
+    func leadingTranslation_isIgnored() {
+        #expect(ChatSwipeToReply.offset(forTranslation: -80) == 0)
+    }
+
+    @Test("Translation past the threshold resists")
+    func translation_resistsPastThreshold() {
+        let offset = ChatSwipeToReply.offset(forTranslation: 120)
+        #expect(offset > ChatSwipeToReply.triggerThreshold)
+        #expect(offset < 120)
+    }
+
+    @Test("Releasing past the threshold triggers the reply")
+    func pastThreshold_triggers() {
+        #expect(ChatSwipeToReply.triggers(offset: ChatSwipeToReply.triggerThreshold + 1))
+    }
+
+    @Test("Releasing short of the threshold does not trigger")
+    func shortOfThreshold_doesNotTrigger() {
+        #expect(ChatSwipeToReply.triggers(offset: ChatSwipeToReply.triggerThreshold - 1) == false)
+    }
+
+    @Test("A drag starting on the leading edge is left to back-navigation")
+    func leadingEdgeDrag_defersToBack() {
+        #expect(ChatSwipeToReply.defersToBackGesture(startX: 0))
+        #expect(ChatSwipeToReply.defersToBackGesture(startX: ChatSwipeToReply.backGestureInset - 1))
+    }
+
+    @Test("A drag starting anywhere else on the row is a reply swipe")
+    func restOfRow_doesNotDeferToBack() {
+        #expect(ChatSwipeToReply.defersToBackGesture(startX: ChatSwipeToReply.backGestureInset) == false)
+        // The empty space beside a bubble is as swipeable as the bubble itself.
+        #expect(ChatSwipeToReply.defersToBackGesture(startX: 120) == false)
+        #expect(ChatSwipeToReply.defersToBackGesture(startX: 380) == false)
+    }
+
+    @Test("The edge left to back-navigation is a strip, not a third of the row")
+    func backGestureInset_staysNarrow() {
+        #expect(ChatSwipeToReply.backGestureInset < 40)
+    }
+
+    @Test("The arrow rests off the leading edge, out of frame")
+    func arrow_restsOffTheEdge() {
+        let center = ChatSwipeToReply.affordanceCenter(inRowOfHeight: 48)
+        #expect(center.x < 0)
+        #expect(center.y == 24)
+    }
+
+    @Test("The arrow rides the row into the gap the drag opens")
+    func arrow_landsInsideTheRow() {
+        let center = ChatSwipeToReply.affordanceCenter(inRowOfHeight: 48)
+        // At full travel the row carries it back over the leading edge, clear of the bubble that
+        // has moved out of the way by the same distance.
+        let travelled = ChatSwipeToReply.affordanceCenter(
+            inRowOfHeight: 48, offset: ChatSwipeToReply.maxTranslation
+        ).x
+        #expect(travelled > 0)
+        #expect(travelled < ChatSwipeToReply.maxTranslation)
+    }
+
+    @Test("The arrow moves with the row, offset for offset")
+    func arrow_tracksTheDrag() {
+        let rest = ChatSwipeToReply.affordanceCenter(inRowOfHeight: 48).x
+        let dragged = ChatSwipeToReply.affordanceCenter(inRowOfHeight: 48, offset: 30).x
+        #expect(dragged - rest == 30)
+    }
+}
+
+@Suite("Swipe offset on a row")
+@MainActor
+struct ChatColumnCellSwipeOffsetTests {
+
+    private func laidOutCell() -> ChatMessageCell {
+        let cell = ChatMessageCell(frame: CGRect(x: 0, y: 0, width: 320, height: 60))
+        cell.configure(with: ChatMessage(id: "1", text: "hi", sender: .me), maxWidth: 250)
+        cell.layoutIfNeeded()
+        return cell
+    }
+
+    private func bubbleX(_ cell: ChatMessageCell) -> CGFloat {
+        cell.bubbleView.convert(cell.bubbleView.bounds, to: cell).minX
+    }
+
+    @Test("A swipe offset moves the row's content sideways")
+    func offset_movesTheContent() {
+        let cell = laidOutCell()
+        let before = bubbleX(cell)
+        cell.swipeOffset = 40
+        #expect(bubbleX(cell) - before == 40)
+    }
+
+    @Test("A swipe offset survives a layout pass")
+    func offset_survivesLayout() {
+        // The regression this guards: the offset used to live on `contentView.transform`, which
+        // `UICollectionViewCell.layoutSubviews` cancels by reassigning `contentView.frame` — so the
+        // row read as motionless however far the finger travelled.
+        let cell = laidOutCell()
+        let before = bubbleX(cell)
+        cell.swipeOffset = 40
+        cell.setNeedsLayout()
+        cell.layoutIfNeeded()
+        #expect(bubbleX(cell) - before == 40)
+    }
+
+    @Test("Reuse clears the offset")
+    func reuse_clearsTheOffset() {
+        let cell = laidOutCell()
+        let before = bubbleX(cell)
+        cell.swipeOffset = 40
+        cell.prepareForReuse()
+        cell.layoutIfNeeded()
+        #expect(cell.swipeOffset == 0)
+        #expect(bubbleX(cell) == before)
+    }
+}
+
+@Suite("Swipe offset in the live transcript")
+@MainActor
+struct ChatTranscriptSwipeOffsetTests {
+
+    /// The cell-level test proves the offset survives `UICollectionViewCell.layoutSubviews`. This one
+    /// proves it survives the layout that actually runs under it: ChatLayout re-measures self-sizing
+    /// rows and writes cell frames, which is what cancelled the previous `contentView.transform`.
+    @Test("The offset survives the transcript's own layout pass")
+    func offset_survivesChatLayout() {
+        let controller = ChatViewController()
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
+        window.rootViewController = controller
+        window.isHidden = false
+        controller.view.layoutIfNeeded()
+
+        controller.update(
+            items: (1...8).map { index in
+                .message(ChatMessage(
+                    id: "\(index)",
+                    text: "message \(index)",
+                    sender: index.isMultiple(of: 2) ? .me : .other
+                ))
+            },
+            animated: false
+        )
+        controller.view.layoutIfNeeded()
+
+        guard let cell = controller.collectionView.visibleCells.compactMap({ $0 as? ChatMessageCell }).first else {
+            Issue.record("no bubble row on screen")
+            return
+        }
+        let bubble = cell.bubbleView
+        let before = bubble.convert(bubble.bounds, to: window).minX
+
+        cell.swipeOffset = 40
+        controller.collectionView.setNeedsLayout()
+        controller.collectionView.layoutIfNeeded()
+
+        #expect(abs(bubble.convert(bubble.bounds, to: window).minX - before - 40) < 0.5)
+    }
+}

--- a/FlipcashTests/Chat/ComplementaryPaletteTests.swift
+++ b/FlipcashTests/Chat/ComplementaryPaletteTests.swift
@@ -1,0 +1,67 @@
+//
+//  ComplementaryPaletteTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+import SwiftUI
+import FlipcashCore
+@testable import FlipcashUI
+
+/// Pins the port of Android's `generateComplementaryColorPalette` to exact colours.
+///
+/// The expected values are not read back from this implementation — they were computed
+/// independently from Android's arithmetic (SHA-512 the id's bytes, hue from the sum of the first
+/// three, brightness wobble from the fourth, 20° to the next stop). That is the whole point of the
+/// suite: it fails if the Swift side drifts from the Kotlin side, which is the one thing a person
+/// looking at both apps would notice.
+@MainActor
+@Suite("ComplementaryPalette")
+struct ComplementaryPaletteTests {
+
+    private let ada = UUID(uuidString: "8B3D4E1A-0000-4000-8000-000000000007")!
+    private let zeroes = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+
+    @Test("A user id lands on Android's colours")
+    func matchesAndroidArithmetic() {
+        #expect(ComplementaryPalette.color(.start, for: ada).hexString == "#D69336")
+        #expect(ComplementaryPalette.color(.middle, for: ada).hexString == "#D9CC3E")
+        #expect(ComplementaryPalette.color(.start, for: zeroes).hexString == "#D936CB")
+        #expect(ComplementaryPalette.color(.middle, for: zeroes).hexString == "#D93E98")
+    }
+
+    @Test("The same person is the same colour every time")
+    func isStable() {
+        // Swift's own `hashValue` is seeded per process, so a palette built on it would repaint
+        // every quote on the next launch. This is the assertion that catches that mistake.
+        #expect(
+            ComplementaryPalette.color(.start, for: ada).hexString
+                == ComplementaryPalette.color(.start, for: ada).hexString
+        )
+    }
+
+    @Test("Two people are two colours")
+    func separatesPeople() {
+        #expect(
+            ComplementaryPalette.color(.start, for: ada).hexString
+                != ComplementaryPalette.color(.start, for: zeroes).hexString
+        )
+    }
+
+    @Test("An author we have no id for falls back to the neutral")
+    func fallsBackWithoutAnID() {
+        #expect(ComplementaryPalette.color(.start, for: nil).hexString == Color.textSecondary.hexString)
+        #expect(ComplementaryPalette.color(.middle, for: nil).hexString == Color.textSecondary.hexString)
+    }
+
+    @Test("The UIKit form agrees with the SwiftUI one")
+    func uiColorAgrees() {
+        #expect(
+            Color(ComplementaryPalette.uiColor(.start, for: ada)).hexString
+                == ComplementaryPalette.color(.start, for: ada).hexString
+        )
+    }
+}

--- a/FlipcashTests/Chat/ComposerModelTests.swift
+++ b/FlipcashTests/Chat/ComposerModelTests.swift
@@ -81,6 +81,7 @@ struct ComposerModelTests {
             messageID: MessageID(value: 7),
             stableID: "7",
             authorName: "Ada",
+            authorID: UUID(uuidString: "8B3D4E1A-0000-4000-8000-000000000007"),
             snippet: "dinner at 7?"
         )
     }

--- a/FlipcashTests/Chat/ComposerModelTests.swift
+++ b/FlipcashTests/Chat/ComposerModelTests.swift
@@ -75,4 +75,78 @@ struct ComposerModelTests {
         #expect(composer.draft.isEmpty)
         #expect(composer.mode == .new)
     }
+
+    private var replyTarget: ComposerModel.ReplyTarget {
+        ComposerModel.ReplyTarget(
+            messageID: MessageID(value: 7),
+            stableID: "7",
+            authorName: "Ada",
+            snippet: "dinner at 7?"
+        )
+    }
+
+    @Test("Starting a reply keeps what is already typed")
+    func beginReplying_keepsDraft() {
+        let composer = ComposerModel()
+        composer.draft = "half a thought"
+        composer.beginReplying(to: replyTarget)
+        #expect(composer.draft == "half a thought")
+        #expect(composer.replyTarget == replyTarget)
+    }
+
+    @Test("A reply submits its trimmed draft")
+    func replying_submitsTrimmedDraft() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.draft = "  works  "
+        #expect(composer.submission == "works")
+        #expect(composer.canSubmit)
+    }
+
+    @Test("An empty reply cannot be submitted")
+    func replyingWithEmptyDraft_cannotSubmit() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.draft = "   "
+        #expect(composer.submission == nil)
+        #expect(composer.canSubmit == false)
+    }
+
+    @Test("Dismissing the reply keeps the draft and clears the target")
+    func endReplying_keepsDraft() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.draft = "works"
+        composer.endReplying()
+        #expect(composer.replyTarget == nil)
+        #expect(composer.draft == "works")
+    }
+
+    @Test("A reply is not an edit")
+    func replying_isNotEditing() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        #expect(composer.isEditing == false)
+        #expect(composer.editingStableID == nil)
+    }
+
+    @Test("Starting an edit while replying drops the reply")
+    func beginEditing_whileReplying_dropsReply() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.beginEditing(messageID: MessageID(value: 9), stableID: "9", currentText: "old")
+        #expect(composer.replyTarget == nil)
+        #expect(composer.isEditing)
+        #expect(composer.draft == "old")
+    }
+
+    @Test("Clearing after a send drops the reply")
+    func clear_dropsReply() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.draft = "works"
+        composer.clear()
+        #expect(composer.replyTarget == nil)
+        #expect(composer.draft.isEmpty)
+    }
 }

--- a/FlipcashTests/Chat/ConversationReplySendTests.swift
+++ b/FlipcashTests/Chat/ConversationReplySendTests.swift
@@ -1,0 +1,96 @@
+//
+//  ConversationReplySendTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Sending a reply")
+struct ConversationReplySendTests {
+
+    /// Mirrors `ConversationControllerTests.makeController` — the same four mocks and a temp DB.
+    private func makeController(_ mock: MockConversations, selfUserID: UserID = UUID()) -> ConversationController {
+        ConversationController(
+            fetching: mock, messaging: mock, streaming: mock,
+            contactNaming: MockDMContactNaming(),
+            database: try! Database.makeTemp().database,
+            owner: .generate()!, selfUserID: selfUserID,
+            typingHeartbeatInterval: .seconds(3), incomingTypingExpiry: .seconds(10)
+        )
+    }
+
+    @Test("A reply carries the replied-to id to the service")
+    func send_carriesRepliedTo() async throws {
+        let mock = MockConversations()
+        mock.sendResult = ConversationMessage(
+            id: MessageID(value: 8), senderID: nil, content: .text("works"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0, repliedTo: MessageID(value: 7)
+        )
+        let controller = makeController(mock)
+
+        #expect(await controller.send("works", to: ConversationID.test(1), repliedTo: MessageID(value: 7)))
+
+        let sent = try #require(mock.sent.last)
+        #expect(sent.text == "works")
+        #expect(sent.repliedTo == MessageID(value: 7))
+    }
+
+    @Test("A plain send carries no replied-to id")
+    func send_withoutReply_carriesNothing() async throws {
+        let mock = MockConversations()
+        mock.sendResult = ConversationMessage(
+            id: MessageID(value: 8), senderID: nil, content: .text("hi"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0
+        )
+        let controller = makeController(mock)
+
+        #expect(await controller.send("hi", to: ConversationID.test(1)))
+
+        let sent = try #require(mock.sent.last)
+        #expect(sent.repliedTo == nil)
+    }
+
+    @Test("The optimistic row quotes the original before the server confirms")
+    func failedReply_keepsRepliedTo() async throws {
+        // A failed send leaves the optimistic row in the transcript, which is the same row the
+        // successful path shows while it is in flight — so this reads the pending copy directly.
+        let me = UUID()
+        let mock = MockConversations()
+        mock.sendError = ErrorSendMessage.transportFailure
+        let controller = makeController(mock, selfUserID: me)
+
+        _ = await controller.send("works", to: ConversationID.test(1), repliedTo: MessageID(value: 7))
+
+        let pending = try #require(controller.messages(for: ConversationID.test(1)).first)
+        #expect(pending.status == .failed)
+        #expect(pending.repliedTo == MessageID(value: 7))
+    }
+
+    @Test("Retrying a failed reply keeps the replied-to id")
+    func retry_keepsRepliedTo() async throws {
+        let me = UUID()
+        let mock = MockConversations()
+        mock.sendError = ErrorSendMessage.transportFailure
+        let controller = makeController(mock, selfUserID: me)
+
+        _ = await controller.send("works", to: ConversationID.test(1), repliedTo: MessageID(value: 7))
+        let failed = try #require(controller.messages(for: ConversationID.test(1)).first)
+        let clientID = try #require(failed.clientMessageID)
+
+        mock.sendError = nil
+        mock.sendResult = ConversationMessage(
+            id: MessageID(value: 9), senderID: me, content: .text("works"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0, repliedTo: MessageID(value: 7)
+        )
+        await controller.retry(clientMessageID: clientID, in: ConversationID.test(1))
+
+        let sent = try #require(mock.sent.last)
+        #expect(sent.repliedTo == MessageID(value: 7))
+    }
+}

--- a/FlipcashTests/Chat/MessageLoaderRevealTests.swift
+++ b/FlipcashTests/Chat/MessageLoaderRevealTests.swift
@@ -1,0 +1,70 @@
+//
+//  MessageLoaderRevealTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Revealing a quoted message")
+struct MessageLoaderRevealTests {
+
+    /// The same construction `MessageLoaderTests` uses — four mocks over a real temp database.
+    private func makeController(_ database: Database) -> ConversationController {
+        ConversationController(
+            fetching: MockConversations(), messaging: MockConversations(), streaming: MockConversations(),
+            contactNaming: MockDMContactNaming(),
+            database: database,
+            owner: .generate()!, selfUserID: UUID(),
+            typingHeartbeatInterval: .seconds(3), incomingTypingExpiry: .seconds(10)
+        )
+    }
+
+    private func message(_ id: UInt64) -> ConversationMessage {
+        ConversationMessage(
+            id: MessageID(value: id), senderID: nil, content: .text("m\(id)"),
+            date: Date(timeIntervalSince1970: TimeInterval(id)), unreadSeq: id
+        )
+    }
+
+    private func makeLoader(messageCount: Int) throws -> (loader: MessageLoader, url: URL) {
+        let (database, url) = try Database.makeTemp()
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages((1...messageCount).map { message(UInt64($0)) }, conversationID: id)
+        return (MessageLoader(conversationID: id, controller: makeController(database)), url)
+    }
+
+    @Test("A message already in the window needs no anchor move")
+    func revealWindowed_keepsAnchor() throws {
+        let (loader, url) = try makeLoader(messageCount: 10)
+        defer { Database.removeTemp(at: url) }
+        let target = try #require(loader.messages.first?.id)
+
+        #expect(loader.reveal(target))
+        #expect(loader.messages.contains { $0.id == target })
+    }
+
+    @Test("A message above the window is brought into it")
+    func revealOlderMessage_movesAnchor() throws {
+        let (loader, url) = try makeLoader(messageCount: 200)
+        defer { Database.removeTemp(at: url) }
+        // The initial window is the newest 60 (141...200), so 3 is well above it.
+        let target = MessageID(value: 3)
+        #expect(loader.messages.contains { $0.id == target } == false)
+
+        #expect(loader.reveal(target))
+        #expect(loader.messages.contains { $0.id == target })
+    }
+
+    @Test("A message the database has never seen cannot be revealed")
+    func revealUnknownMessage_fails() throws {
+        let (loader, url) = try makeLoader(messageCount: 10)
+        defer { Database.removeTemp(at: url) }
+        #expect(loader.reveal(MessageID(value: 9_999)) == false)
+    }
+}

--- a/FlipcashTests/Database/Database+ConversationsTests.swift
+++ b/FlipcashTests/Database/Database+ConversationsTests.swift
@@ -766,4 +766,24 @@ struct DatabaseConversationsTests {
         #expect(try database.message(id: MessageID(value: 99), conversationID: conversationID) == nil)
     }
 
+    @Test("A reply round-trips its replied-to id through the database")
+    func replyMessage_roundTripsRepliedTo() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let conversationID = ConversationID.test(1)
+        let original = ConversationMessage(
+            id: MessageID(value: 1), senderID: nil, content: .text("original"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0
+        )
+        let reply = ConversationMessage(
+            id: MessageID(value: 2), senderID: nil, content: .text("replying"),
+            date: Date(timeIntervalSince1970: 1), unreadSeq: 1,
+            repliedTo: MessageID(value: 1)
+        )
+        try database.upsertConversationMessages([original, reply], conversationID: conversationID)
+
+        let stored = try database.getConversationMessages(conversationID: conversationID)
+        #expect(stored.first { $0.id == MessageID(value: 1) }?.repliedTo == nil)
+        #expect(stored.first { $0.id == MessageID(value: 2) }?.repliedTo == MessageID(value: 1))
+    }
 }

--- a/FlipcashTests/TestSupport/MockConversations.swift
+++ b/FlipcashTests/TestSupport/MockConversations.swift
@@ -11,7 +11,11 @@ import FlipcashCore
 /// every call; the test sets scripted responses before driving the controller.
 final class MockConversations: ConversationFetching, ConversationMessaging, ConversationEventStreaming, @unchecked Sendable {
 
-    struct Sent: Sendable { let conversationID: ConversationID; let text: String }
+    struct Sent: Sendable {
+        let conversationID: ConversationID
+        let text: String
+        let repliedTo: MessageID?
+    }
     struct TypingCall: Sendable { let conversationID: ConversationID; let state: TypingState }
     /// A scripted `GetDelta` batch: one `onBatch` call with these messages + checkpoint.
     struct DeltaBatch: Sendable { let messages: [ConversationMessage]; let checkpoint: UInt64? }
@@ -183,15 +187,15 @@ final class MockConversations: ConversationFetching, ConversationMessaging, Conv
         return olderMessages
     }
 
-    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, clientMessageID: UUID) async throws -> ConversationMessage {
+    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, repliedTo: MessageID?, clientMessageID: UUID) async throws -> ConversationMessage {
         lock.withLock {
-            _sent.append(Sent(conversationID: conversationID, text: text))
+            _sent.append(Sent(conversationID: conversationID, text: text, repliedTo: repliedTo))
             _sentClientIDs.append(clientMessageID)
         }
         if let error = sendError { throw error }
         return sendResult ?? ConversationMessage(
             id: MessageID(value: 1), senderID: nil, content: .text(text),
-            date: Date(timeIntervalSince1970: 0), unreadSeq: 0
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0, repliedTo: repliedTo
         )
     }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatBubbleView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatBubbleView.swift
@@ -18,6 +18,20 @@ public final class ChatBubbleView: UIView {
     private let background = BubbleBackgroundView()
     private let label = UILabel()
     private let editedLabel = EditedMarker.makeLabel()
+    private(set) var quotePanel = ChatQuotePanelView()
+
+    /// Forwarded from the panel: the stable id of the message to jump to.
+    var onQuoteTap: ((String) -> Void)? {
+        get { quotePanel.onTap }
+        set { quotePanel.onTap = newValue }
+    }
+
+    /// Body pinned to the bubble's top, for a message with no quote.
+    private var labelTopToBubble: NSLayoutConstraint!
+    /// Body pinned below the quote panel, for a reply.
+    private var labelTopToQuote: NSLayoutConstraint!
+    /// Collapses the panel when there is no quote, so a hidden view consumes no height.
+    private var quoteZeroHeight: NSLayoutConstraint!
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -37,13 +51,27 @@ public final class ChatBubbleView: UIView {
 
         addSubview(editedLabel)
 
+        quotePanel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(quotePanel)
+
+        labelTopToBubble = label.topAnchor.constraint(equalTo: topAnchor, constant: 9)
+        labelTopToQuote = label.topAnchor.constraint(
+            equalTo: quotePanel.bottomAnchor,
+            constant: ChatQuotePanelView.bottomSpacing
+        )
+        quoteZeroHeight = quotePanel.heightAnchor.constraint(equalToConstant: 0)
+
         NSLayoutConstraint.activate([
             background.topAnchor.constraint(equalTo: topAnchor),
             background.bottomAnchor.constraint(equalTo: bottomAnchor),
             background.leadingAnchor.constraint(equalTo: leadingAnchor),
             background.trailingAnchor.constraint(equalTo: trailingAnchor),
 
-            label.topAnchor.constraint(equalTo: topAnchor, constant: 9),
+            quotePanel.topAnchor.constraint(equalTo: topAnchor, constant: 9),
+            quotePanel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: ChatQuotePanelView.horizontalInset),
+            quotePanel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -ChatQuotePanelView.horizontalInset),
+            labelTopToBubble,
+            quoteZeroHeight,
             label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -9),
             label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
@@ -62,6 +90,21 @@ public final class ChatBubbleView: UIView {
     public func configure(with message: ChatMessage) {
         label.attributedText = Self.displayText(for: message)
         editedLabel.isHidden = !Self.showsEditedMarker(for: message)
+
+        // Deactivate before activating: with both top constraints live the layout is
+        // unsatisfiable, and UIKit resolves that by breaking one at random.
+        if let quote = message.quote {
+            quotePanel.isHidden = false
+            quotePanel.configure(with: quote)
+            quoteZeroHeight.isActive = false
+            labelTopToBubble.isActive = false
+            labelTopToQuote.isActive = true
+        } else {
+            quotePanel.isHidden = true
+            labelTopToQuote.isActive = false
+            labelTopToBubble.isActive = true
+            quoteZeroHeight.isActive = true
+        }
 
         background.apply(
             fill: BubbleBackgroundView.fill(isFromSelf: message.sender == .me),

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
@@ -154,6 +154,13 @@ public final class ChatCashCardCell: ChatColumnCell {
     }
 }
 
+extension ChatCashCardCell: BubbleCarrying {
+    /// The card, not the cell: the cell spans the full row, so lifting it would raise a
+    /// full-width rectangle out of the transcript.
+    var liftPreviewView: UIView { card }
+    var liftPreviewMaskingPath: UIBezierPath? { card.maskingPath }
+}
+
 #Preview("Cash cards") {
     let layout = UICollectionViewFlowLayout()
     layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatColumnCell.swift
@@ -71,6 +71,18 @@ public class ChatColumnCell: UICollectionViewCell {
         ])
     }
 
+    /// How far the row's content is dragged towards the trailing edge by the reply swipe.
+    ///
+    /// It moves the column, not the content view. `UICollectionViewCell.layoutSubviews` assigns
+    /// `contentView.frame` on every pass, which cancels a transform there — and between ChatLayout's
+    /// invalidations and the subview the swipe parents to the row, that pass runs often enough during
+    /// a drag that the row never visibly moves. Auto Layout positions the column through `center` and
+    /// `bounds`, which a transform composes with rather than fights.
+    var swipeOffset: CGFloat {
+        get { column.transform.tx }
+        set { column.transform = newValue == 0 ? .identity : CGAffineTransform(translationX: newValue, y: 0) }
+    }
+
     /// Self-sizes on height alone, at the width the layout asked for. The column spans the row, so
     /// the default implementation's compressed horizontal fit measures the cell at its content width
     /// instead — a width the layout then discards, having already forced the row to full width.
@@ -87,6 +99,9 @@ public class ChatColumnCell: UICollectionViewCell {
 
     public override func prepareForReuse() {
         super.prepareForReuse()
+        // A row recycled mid-swipe (or while the swipe's settle animation is still running) would
+        // otherwise be dequeued still translated sideways, and draw its new message offset.
+        swipeOffset = 0
         currentMessageID = nil
         retryID = nil
         retryTap?.isEnabled = false

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatLinkMessageCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatLinkMessageCell.swift
@@ -24,6 +24,14 @@ public final class ChatLinkMessageCell: ChatColumnCell {
         didSet { bubble.onOpenURL = onOpenURL }
     }
 
+    var bubbleView: LinkableBubbleView { bubble }
+
+    /// Forwarded from the bubble's quote panel: the stable id of the row to jump to.
+    var onQuoteTap: ((String) -> Void)? {
+        get { bubbleView.onQuoteTap }
+        set { bubbleView.onQuoteTap = newValue }
+    }
+
     /// The view + shape the context-menu lift clips to.
     var liftPreviewView: UIView { bubble }
     var liftPreviewMaskingPath: UIBezierPath? { bubble.maskingPath }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift
@@ -25,6 +25,12 @@ public final class ChatMessageCell: ChatColumnCell {
     /// to the bubble shape.
     var bubbleView: ChatBubbleView { bubble }
 
+    /// Forwarded from the bubble's quote panel: the stable id of the row to jump to.
+    var onQuoteTap: ((String) -> Void)? {
+        get { bubbleView.onQuoteTap }
+        set { bubbleView.onQuoteTap = newValue }
+    }
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         installColumn(content: bubble)

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatMotion.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatMotion.swift
@@ -111,9 +111,16 @@ public nonisolated enum ChatMotion {
     /// The keyboard case inherits the system curve directly (see
     /// `ChatViewController.scrollViewDidChangeAdjustedContentInset`) rather than this spring, which
     /// is the same intent the zero bounce encodes: any overshoot would fight the keyboard. The bar
-    /// case has no curve to inherit, so `ChatScreenViewController.setBarHeight` uses this one — and
-    /// wants the same stillness, since a send runs it alongside `insertion` and `scroll`.
+    /// case wants the same stillness, since a send runs it alongside `insertion` and `scroll`.
     public static let keyboardScroll = ChatSpring(duration: 0.30, bounce: 0)
+    /// The bar growing and shrinking around the reply strip.
+    ///
+    /// The one spring in this file taken from a reference rather than the prototype: WhatsApp's
+    /// reply surface, measured frame by frame off a 60fps capture — 13 frames out, 14 back,
+    /// monotonic, no overshoot in either direction. Bounce is zero for the same reason
+    /// `keyboardScroll`'s is: the transcript's bottom inset tracks this height every frame, and a bar
+    /// that overshoots drags the messages past their resting place and back.
+    public static let replySurface = ChatSpring(duration: 0.22, bounce: 0)
     /// The "Delivered" line appearing under a sent bubble. Slow and gentle: it arrives after the
     /// message has landed and shouldn't compete with it.
     public static let delivered = ChatSpring(duration: 0.40, bounce: 0.12)

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift
@@ -1,0 +1,113 @@
+//
+//  ChatQuotePanelView.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+import FlipcashCore
+
+/// The quoted original drawn inside a reply's bubble, above the body: a leading rule, the author,
+/// and one or two lines of the original. Tapping it asks to jump to that message — but only when
+/// there is a row to jump to, which `ChatQuote.isJumpable` decides.
+final class ChatQuotePanelView: UIView {
+
+    /// Called with the target row's stable id when the panel is tapped. Silent for a quote that
+    /// cannot be jumped to.
+    var onTap: ((String) -> Void)?
+
+    private var targetStableID: String?
+
+    private let rule = UIView()
+    private let authorLabel = UILabel()
+    private let snippetLabel = UILabel()
+
+    /// The panel's own inset from the bubble's edges — the body's leading inset, so the quote's
+    /// rule and the text below it share one margin.
+    static let horizontalInset: CGFloat = 12
+    /// Gap between the panel and the body beneath it.
+    static let bottomSpacing: CGFloat = 6
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUp()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setUp() {
+        backgroundColor = UIColor.white.withAlphaComponent(0.10)
+        layer.cornerRadius = 8
+        layer.cornerCurve = .continuous
+        clipsToBounds = true
+
+        rule.backgroundColor = UIColor.white.withAlphaComponent(0.5)
+        rule.layer.cornerRadius = 1
+        rule.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(rule)
+
+        authorLabel.font = .default(size: 12, weight: .bold)
+        authorLabel.textColor = .white
+        authorLabel.numberOfLines = 1
+        authorLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(authorLabel)
+
+        snippetLabel.font = .default(size: 12, weight: .medium)
+        snippetLabel.textColor = UIColor.white.withAlphaComponent(0.55)
+        // One line in the bubble, per the spec: the panel is a citation, not a second message, and
+        // a two-line panel over a one-line reply reads as the wrong thing being the point. The
+        // composer's strip allows two, because there the quote *is* the subject.
+        snippetLabel.numberOfLines = 1
+        snippetLabel.lineBreakMode = .byTruncatingTail
+        snippetLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(snippetLabel)
+
+        NSLayoutConstraint.activate([
+            rule.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            rule.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            rule.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+            rule.widthAnchor.constraint(equalToConstant: 2),
+
+            authorLabel.leadingAnchor.constraint(equalTo: rule.trailingAnchor, constant: 8),
+            authorLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            authorLabel.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+
+            snippetLabel.leadingAnchor.constraint(equalTo: authorLabel.leadingAnchor),
+            snippetLabel.trailingAnchor.constraint(equalTo: authorLabel.trailingAnchor),
+            snippetLabel.topAnchor.constraint(equalTo: authorLabel.bottomAnchor, constant: 1),
+            snippetLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+        ])
+
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+    }
+
+    func configure(with quote: ChatQuote) {
+        targetStableID = quote.stableID
+        // An unavailable original has no author to name, so the author line collapses rather than
+        // rendering an empty run.
+        authorLabel.text = quote.authorName
+        authorLabel.isHidden = quote.authorName.isEmpty
+        snippetLabel.text = quote.snippet
+        isUserInteractionEnabled = quote.isJumpable
+        accessibilityLabel = quote.authorName.isEmpty
+            ? quote.snippet
+            : "Replying to \(quote.authorName): \(quote.snippet)"
+    }
+
+    @objc private func handleTap() {
+        guard let targetStableID else { return }
+        onTap?(targetStableID)
+    }
+
+    /// Drives the tap path from tests, which cannot deliver a real touch to a detached view.
+    func simulateTap() {
+        guard isUserInteractionEnabled else { return }
+        handleTap()
+    }
+}
+#endif

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift
@@ -84,6 +84,7 @@ final class ChatQuotePanelView: UIView {
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
         isAccessibilityElement = true
         accessibilityTraits = .button
+        accessibilityIdentifier = "chat-quote-panel"
     }
 
     func configure(with quote: ChatQuote) {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift
@@ -23,12 +23,28 @@ final class ChatQuotePanelView: UIView {
     private let rule = UIView()
     private let authorLabel = UILabel()
     private let snippetLabel = UILabel()
+    /// Drawn only for a quoted payment: the currency's flag and the mint's name around the amount,
+    /// the same pair the cash card itself leads with. A bare "$5.00" in a quote reads as a number
+    /// rather than as the payment it points at.
+    private let flagView = UIImageView()
+    private let tokenLabel = UILabel()
+    private let detailRow = UIStackView()
+    /// Takes the slack so the flag, amount and token stay clustered at the leading edge instead of
+    /// the amount stretching and pushing the token to the far side of the panel.
+    private let detailSpacer = UIView()
 
     /// The panel's own inset from the bubble's edges — the body's leading inset, so the quote's
     /// rule and the text below it share one margin.
     static let horizontalInset: CGFloat = 12
     /// Gap between the panel and the body beneath it.
     static let bottomSpacing: CGFloat = 6
+
+    /// Sized to the cap height of the amount beside it, so the flag reads as a mark on the line
+    /// rather than as a second element the line has to make room for.
+    private static let flagDiameter: CGFloat = 14
+
+    /// The preview grey a quoted sentence is drawn in.
+    private static let snippetColor = UIColor.white.withAlphaComponent(0.55)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -38,47 +54,71 @@ final class ChatQuotePanelView: UIView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
+    /// The cell's tint behind the author's colour. Low enough that the name keeps its contrast —
+    /// the colour is at full strength in the rule and the name, and this is the ground they sit on.
+    private static let cellTint: CGFloat = 0.14
+
     private func setUp() {
-        backgroundColor = UIColor.white.withAlphaComponent(0.10)
         layer.cornerRadius = 8
         layer.cornerCurve = .continuous
         clipsToBounds = true
 
-        rule.backgroundColor = UIColor.white.withAlphaComponent(0.5)
-        rule.layer.cornerRadius = 1
         rule.translatesAutoresizingMaskIntoConstraints = false
         addSubview(rule)
 
-        authorLabel.font = .default(size: 12, weight: .bold)
-        authorLabel.textColor = .white
+        authorLabel.font = .appTextHeading
         authorLabel.numberOfLines = 1
         authorLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(authorLabel)
 
         snippetLabel.font = .default(size: 12, weight: .medium)
-        snippetLabel.textColor = UIColor.white.withAlphaComponent(0.55)
+        snippetLabel.textColor = Self.snippetColor
         // One line in the bubble, per the spec: the panel is a citation, not a second message, and
         // a two-line panel over a one-line reply reads as the wrong thing being the point. The
         // composer's strip allows two, because there the quote *is* the subject.
         snippetLabel.numberOfLines = 1
         snippetLabel.lineBreakMode = .byTruncatingTail
-        snippetLabel.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(snippetLabel)
+
+        flagView.contentMode = .scaleAspectFill
+        flagView.clipsToBounds = true
+        flagView.layer.cornerRadius = Self.flagDiameter / 2
+
+        tokenLabel.font = .default(size: 12, weight: .medium)
+        tokenLabel.textColor = UIColor.white.withAlphaComponent(0.35)
+        tokenLabel.numberOfLines = 1
+
+        detailSpacer.setContentHuggingPriority(.init(1), for: .horizontal)
+        detailSpacer.setContentCompressionResistancePriority(.init(1), for: .horizontal)
+
+        detailRow.axis = .horizontal
+        detailRow.alignment = .center
+        detailRow.spacing = 5
+        detailRow.translatesAutoresizingMaskIntoConstraints = false
+        detailRow.addArrangedSubview(flagView)
+        detailRow.addArrangedSubview(snippetLabel)
+        detailRow.addArrangedSubview(tokenLabel)
+        detailRow.addArrangedSubview(detailSpacer)
+        addSubview(detailRow)
 
         NSLayoutConstraint.activate([
-            rule.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
-            rule.topAnchor.constraint(equalTo: topAnchor, constant: 6),
-            rule.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
-            rule.widthAnchor.constraint(equalToConstant: 2),
+            // Flush against the cell's leading edge and the full height of it, so the cell reads as
+            // a quote rather than a card with a line drawn near it. The corner radius clips it.
+            rule.leadingAnchor.constraint(equalTo: leadingAnchor),
+            rule.topAnchor.constraint(equalTo: topAnchor),
+            rule.bottomAnchor.constraint(equalTo: bottomAnchor),
+            rule.widthAnchor.constraint(equalToConstant: 3),
 
             authorLabel.leadingAnchor.constraint(equalTo: rule.trailingAnchor, constant: 8),
             authorLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
             authorLabel.topAnchor.constraint(equalTo: topAnchor, constant: 6),
 
-            snippetLabel.leadingAnchor.constraint(equalTo: authorLabel.leadingAnchor),
-            snippetLabel.trailingAnchor.constraint(equalTo: authorLabel.trailingAnchor),
-            snippetLabel.topAnchor.constraint(equalTo: authorLabel.bottomAnchor, constant: 1),
-            snippetLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+            detailRow.leadingAnchor.constraint(equalTo: authorLabel.leadingAnchor),
+            detailRow.trailingAnchor.constraint(equalTo: authorLabel.trailingAnchor),
+            detailRow.topAnchor.constraint(equalTo: authorLabel.bottomAnchor, constant: 1),
+            detailRow.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+
+            flagView.widthAnchor.constraint(equalToConstant: Self.flagDiameter),
+            flagView.heightAnchor.constraint(equalToConstant: Self.flagDiameter),
         ])
 
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
@@ -89,15 +129,41 @@ final class ChatQuotePanelView: UIView {
 
     func configure(with quote: ChatQuote) {
         targetStableID = quote.stableID
+        // The author's own colour, derived from their user id — the same colour the composer's strip
+        // draws them in, and the same one Android does. An original with no known author falls back
+        // to the neutral secondary, which is what `ComplementaryPalette` returns for a nil id.
+        let ruleColor = ComplementaryPalette.uiColor(.start, for: quote.authorID)
+        rule.backgroundColor = ruleColor
+        authorLabel.textColor = ComplementaryPalette.uiColor(.middle, for: quote.authorID)
+        backgroundColor = ruleColor.withAlphaComponent(Self.cellTint)
         // An unavailable original has no author to name, so the author line collapses rather than
         // rendering an empty run.
         authorLabel.text = quote.authorName
         authorLabel.isHidden = quote.authorName.isEmpty
         snippetLabel.text = quote.snippet
+        switch quote.kind {
+        case .cash(let token, let flagImageName):
+            let flag = flagImageName.flatMap { UIImage(named: $0, in: .module, compatibleWith: nil) }
+            flagView.image = flag
+            flagView.isHidden = flag == nil
+            tokenLabel.text = token
+            tokenLabel.isHidden = false
+            // A payment's amount is the whole of what was said, so it is read rather than glanced
+            // at — a step brighter than the preview grey a quoted sentence gets.
+            snippetLabel.textColor = UIColor.white.withAlphaComponent(0.75)
+        case .text, .unavailable:
+            flagView.isHidden = true
+            tokenLabel.isHidden = true
+            snippetLabel.textColor = Self.snippetColor
+        }
+        let spoken = switch quote.kind {
+        case .cash(let token, _):  "\(quote.snippet) \(token)"
+        case .text, .unavailable:  quote.snippet
+        }
         isUserInteractionEnabled = quote.isJumpable
         accessibilityLabel = quote.authorName.isEmpty
-            ? quote.snippet
-            : "Replying to \(quote.authorName): \(quote.snippet)"
+            ? spoken
+            : "Replying to \(quote.authorName): \(spoken)"
     }
 
     @objc private func handleTap() {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -397,6 +397,9 @@ public final class ChatScreenViewController: UIViewController {
     public func update(items: [ChatItem]) { transcript.update(items: items) }
     public func scrollToBottom(animated: Bool = true) { transcript.scrollToBottom(animated: animated) }
 
+    /// Brings a row into view, deferring until the update that contains it lands.
+    public func scrollToMessage(id: String) { transcript.scrollToMessage(id: id) }
+
     // MARK: - Bar inset
 
     public override func viewDidLayoutSubviews() {

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -118,6 +118,12 @@ public final class ChatScreenViewController: UIViewController {
         set { transcript.onMessageAction = newValue }
     }
 
+    /// Forwards a tap on a reply's quote panel, with the quoted row's id.
+    public var onQuoteTap: ((String) -> Void)? {
+        get { transcript.onQuoteTap }
+        set { transcript.onQuoteTap = newValue }
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor(Color.backgroundMain)

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift
@@ -24,10 +24,25 @@ public final class ChatScreenViewController: UIViewController {
     private let transcript = ChatViewController()
     private let bar: UIView
     private let barController: UIViewController?
+    /// The box the bar is seen through: the bar sits at its *bottom* edge and is clipped by it.
+    ///
+    /// The reply strip is the reason there are two views rather than one. The bar's own height has
+    /// to be its content's height exactly, and that height jumps the moment the strip mounts; the
+    /// visible box has to travel to the same number over the strip's spring. Those are different
+    /// numbers at the same instant, and a single view cannot hold both — animating one view's height
+    /// leaves its hosted SwiftUI content laid out for the destination while the layer is still on the
+    /// way there, and the content is drawn off its mark by the whole difference. Measured on a 60fps
+    /// capture, that put the composer row 24pt — half the strip's 48 — from where it belongs. Pinned
+    /// to the bottom of a box that clips it, the bar's frame can jump to the strip's full height
+    /// while the box uncovers it, and the composer row does not move at all.
+    private let barClip = UIView()
     /// The bar's height is driven by its *measured* SwiftUI height, so the frame matches its
     /// content exactly — a hosting controller's intrinsic size mis-measures multiline growth and
-    /// lets the composer overflow below its frame, under the keyboard.
+    /// lets the composer overflow below its frame, under the keyboard. Always applied unanimated.
     private var barHeightConstraint: NSLayoutConstraint!
+    /// The clip's height — what the screen and the transcript actually see as the bar. Equal to the
+    /// bar's own height except while the reply strip is arriving or leaving.
+    private var barClipHeightConstraint: NSLayoutConstraint!
     /// Keeps the bar above the keyboard. Not `view.keyboardLayoutGuide`: see `KeyboardFloor`.
     private var keyboardFloor: KeyboardFloor!
     /// Fades the transcript into the navigation bar. See `TranscriptTopFade`.
@@ -59,6 +74,13 @@ public final class ChatScreenViewController: UIViewController {
     private static let spotlightAttempts = 8
     /// Whether a measured bar height has landed yet — the first one is applied without animation.
     private var didMeasureBar = false
+
+    /// Whether the last measured bar height included the reply strip.
+    private var barShowsReply = false
+    /// What the strip added to the bar when it opened, so the clip knows what to close back over.
+    /// The bar itself still reports the taller height on the way out — the strip stays mounted under
+    /// the clip while it fades — so the closed height cannot be read off the measurement.
+    private var replyStripHeight: CGFloat = 0
     /// The pop gestures switched off for the length of an edit, kept so only those are switched back
     /// on and one that was already off stays off.
     private var suspendedPopGestures: [UIGestureRecognizer] = []
@@ -151,6 +173,7 @@ public final class ChatScreenViewController: UIViewController {
 
         let constraints = addBar(bar, controller: barController)
         barHeightConstraint = constraints.height
+        barClipHeightConstraint = constraints.clipHeight
         keyboardFloor = KeyboardFloor(view: view, bottomConstraint: constraints.bottom)
         lowerComposerOnResignActive()
         handOffComposerFocusAroundContextMenu()
@@ -197,7 +220,7 @@ public final class ChatScreenViewController: UIViewController {
     public func beginEditSpotlight(for stableID: String) {
         editedStableID = stableID
         backdrop.present(over: contextMenuBackdropHost, animator: nil)
-        backdrop.hold(clearing: bar, under: hostNavigationController?.navigationBar)
+        backdrop.hold(clearing: barClip, under: hostNavigationController?.navigationBar)
         setPopGesturesSuspended(true)
         transcript.afterContextMenu { [weak self] in
             self?.spotlightAttemptsRemaining = Self.spotlightAttempts
@@ -280,27 +303,37 @@ public final class ChatScreenViewController: UIViewController {
         hostNavigationController?.view ?? view
     }
 
-    /// Adds a hosted bar pinned to the view's width and bottom; returns the height constraint
-    /// (driven later by the bar's measured SwiftUI content height) and the bottom constraint
-    /// (driven by the keyboard).
+    /// Adds a hosted bar sitting on the bottom edge of a clip box that spans the view's width;
+    /// returns the bar's own height constraint and the clip's (both driven later by the bar's
+    /// measured SwiftUI content height) and the clip's bottom constraint (driven by the keyboard).
     private func addBar(
         _ bar: UIView,
         controller: UIViewController?
-    ) -> (height: NSLayoutConstraint, bottom: NSLayoutConstraint) {
+    ) -> (height: NSLayoutConstraint, clipHeight: NSLayoutConstraint, bottom: NSLayoutConstraint) {
         if let controller { addChild(controller) }
+        barClip.translatesAutoresizingMaskIntoConstraints = false
+        barClip.clipsToBounds = true
+        view.addSubview(barClip)
         bar.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(bar)
+        barClip.addSubview(bar)
         controller?.didMove(toParent: self)
 
         let heightConstraint = bar.heightAnchor.constraint(equalToConstant: 80)
-        let bottomConstraint = bar.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let clipHeightConstraint = barClip.heightAnchor.constraint(equalToConstant: 80)
+        let bottomConstraint = barClip.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         NSLayoutConstraint.activate([
-            bar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            bar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            barClip.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            barClip.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bottomConstraint,
+            clipHeightConstraint,
+            bar.leadingAnchor.constraint(equalTo: barClip.leadingAnchor),
+            bar.trailingAnchor.constraint(equalTo: barClip.trailingAnchor),
+            // Bottom, not top: the bar grows upward out of the clip, so the composer row keeps its
+            // place on the keyboard while the strip above it is uncovered.
+            bar.bottomAnchor.constraint(equalTo: barClip.bottomAnchor),
             heightConstraint,
         ])
-        return (heightConstraint, bottomConstraint)
+        return (heightConstraint, clipHeightConstraint, bottomConstraint)
     }
 
     /// Drops the composer's focus as the app leaves the foreground.
@@ -375,30 +408,70 @@ public final class ChatScreenViewController: UIViewController {
         }
     }
 
-    /// Set the bar's height to its measured SwiftUI content height.
-    public func setBarHeight(_ height: CGFloat) {
-        guard barHeightConstraint != nil, barHeightConstraint.constant != height else { return }
-        // First measurement (or off-screen): apply it flat, so the push doesn't animate the bar in.
+    /// Set the bar's height to its measured SwiftUI content height. `replying` says whether a reply
+    /// is open, which decides what the clip around the bar does with that height.
+    ///
+    /// The bar always takes the height flat. It is pinned to the bottom of the clip, so its own
+    /// frame can change by the strip's whole height without moving anything that is on screen.
+    public func setBarHeight(_ height: CGFloat, replying: Bool) {
+        // Read before the early exits: a reply closing has to move the clip even though the measured
+        // height does not change — the strip stays mounted under the clip while it fades.
+        let opensReply = replying && !barShowsReply
+        let closesReply = !replying && barShowsReply
+        barShowsReply = replying
+        guard barHeightConstraint != nil else { return }
+
+        // A reply's own height is not known when it opens. On a first reply the strip mounts at zero
+        // height, reports what it wants, and takes it a pass later; re-replying while the last one is
+        // still fading keeps the strip it already has and never reports again. So the opening is
+        // whichever pass actually makes the bar taller after the target changed, not the target
+        // change itself — and once that height is known, later ones are ordinary bar growth.
+        if opensReply { replyStripHeight = 0 }
+        let previousClip = barClipHeightConstraint.constant
+        let clipHeight: CGFloat
+        let travels: Bool
+        if replying {
+            clipHeight = height
+            travels = replyStripHeight == 0 && clipHeight != previousClip
+            if travels { replyStripHeight = clipHeight - previousClip }
+        } else {
+            // Closing, the strip is still in the measurement and has to come back off it.
+            clipHeight = closesReply ? height - replyStripHeight : height
+            travels = closesReply
+            if !closesReply { replyStripHeight = 0 }
+        }
+
         let isFirst = !didMeasureBar
         didMeasureBar = true
+        guard !isFirst, view.window != nil, travels else {
+            guard barHeightConstraint.constant != height || barClipHeightConstraint.constant != clipHeight else { return }
+            barHeightConstraint.constant = height
+            barClipHeightConstraint.constant = clipHeight
+            // Every other height — a draft wrapping to a second line, the send arrow appearing — is
+            // one the content has *already* laid itself out at by the time the number arrives. Clip
+            // and bar match it in the same frame; the transcript's inset comes with them, since
+            // `viewDidLayoutSubviews` reads the clip's frame during this pass.
+            UIView.performWithoutAnimation {
+                self.view.layoutIfNeeded()
+            }
+            return
+        }
+
+        // Two passes, deliberately. The bar takes its new height first, with the clip still at the
+        // old one, so the strip is laid out at full size behind the clip's edge and the composer row
+        // is already standing where it will stay.
         barHeightConstraint.constant = height
-        guard !isFirst, view.window != nil else { return }
-        // Lay out inside the animation so the transcript's inset change — `viewDidLayoutSubviews`
-        // feeds the new bar height to `setBottomInset` — rides the same curve and the content
-        // scrolls up with the bar, instead of snapping on whatever layout pass happens to run next.
-        //
-        // The transcript's own spring, not the bar's: a height change moves the content, and a send
-        // collapses a multiline field at the same moment the insertion and the settle-to-bottom are
-        // running. `swap` is the bounciest spring in the vocabulary bar one, and three curves
-        // overshooting the same pixels by different amounts is what read as the bar and the
-        // transcript coming apart. Zero bounce keeps this one out of the other two's way.
-        let spring = ChatMotion.keyboardScroll
-        UIView.animate(springDuration: spring.duration, bounce: spring.bounce) {
+        UIView.performWithoutAnimation {
+            self.view.layoutIfNeeded()
+        }
+        // Then the clip's edge travels, and that edge is the whole animation: it uncovers the strip
+        // on the way in and closes back over it on the way out. The transcript's inset is read inside
+        // this pass too, so the bubbles are pushed by the edge rather than teleporting ahead of it.
+        barClipHeightConstraint.constant = clipHeight
+        ChatMotion.replySurface.animate {
             self.view.layoutIfNeeded()
         }
     }
-
-    // MARK: - Data passthrough
 
     public func update(items: [ChatItem]) { transcript.update(items: items) }
     public func scrollToBottom(animated: Bool = true) { transcript.scrollToBottom(animated: animated) }
@@ -420,7 +493,7 @@ public final class ChatScreenViewController: UIViewController {
         // Reserve only the bar's own height. On-device the system already grows the collection
         // view's adjusted content inset by the keyboard when it's up, so adding the keyboard here
         // too (via the bar's risen position) double-counts it and overscrolls by a whole keyboard.
-        transcript.setBottomInset(bar.frame.height)
+        transcript.setBottomInset(barClip.frame.height)
     }
 }
 

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatSwipeToReply.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatSwipeToReply.swift
@@ -1,0 +1,204 @@
+//
+//  ChatSwipeToReply.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+
+/// Drag a row towards the trailing edge to reply to it.
+///
+/// Owns the whole gesture — the recognizer, the row being dragged, its offset, and whether the
+/// trigger has already fired — because those four move together and splitting them across the
+/// transcript's fields would make the coexistence rules impossible to follow. The transcript keeps
+/// one `let` and answers two questions: which row is under a point, and whether it can be replied to.
+@MainActor
+final class ChatSwipeToReply: NSObject {
+
+    /// Furthest a row travels. Past this the drag resists rather than stopping dead, so a hard
+    /// swipe still feels connected to the finger.
+    nonisolated static let maxTranslation: CGFloat = 64
+    /// Offset at which the reply fires on release.
+    nonisolated static let triggerThreshold: CGFloat = 48
+    /// Width of the leading strip left to the system's interactive-pop gesture. The reply swipe runs
+    /// in the same direction as back-navigation, so the two would otherwise fight over every drag
+    /// that starts at the screen edge — and the row would win, leaving no way back.
+    nonisolated static let backGestureInset: CGFloat = 24
+    /// Where the affordance comes to rest at full travel, measured from the row's leading edge.
+    nonisolated private static let affordanceInset: CGFloat = 20
+    nonisolated private static let affordanceDiameter: CGFloat = 32
+
+    let recognizer = UIPanGestureRecognizer()
+
+    /// The row under a point, if it can be replied to. The transcript answers this; the gesture
+    /// does not know what a message is.
+    var rowForSwipe: ((CGPoint) -> (cell: ChatColumnCell, stableID: String)?)?
+    /// Whether the transcript is busy — mid-update, or showing a context menu.
+    var isBlocked: (() -> Bool)?
+    /// Called once, when the drag crosses the threshold.
+    var onTrigger: ((String) -> Void)?
+
+    private var draggedCell: ChatColumnCell?
+    private var draggedStableID: String?
+    /// Latched once per drag, so the threshold's haptic fires on the way past and not on every
+    /// frame beyond it. It gates the feedback only — the reply fires from `.ended`.
+    private var hasPassedThreshold = false
+    private let affordance = UIView()
+    private let affordanceIcon = UIImageView()
+    private let haptics = UIImpactFeedbackGenerator(style: .light)
+
+    override init() {
+        super.init()
+        recognizer.addTarget(self, action: #selector(handlePan))
+        recognizer.delegate = self
+        recognizer.maximumNumberOfTouches = 1
+
+        affordance.bounds = CGRect(x: 0, y: 0, width: Self.affordanceDiameter, height: Self.affordanceDiameter)
+        affordance.backgroundColor = UIColor.white.withAlphaComponent(0.12)
+        affordance.layer.cornerRadius = Self.affordanceDiameter / 2
+        affordance.alpha = 0
+
+        affordanceIcon.image = UIImage(systemName: SystemSymbol.replyArrow.rawValue)
+        affordanceIcon.tintColor = UIColor.white.withAlphaComponent(0.75)
+        affordanceIcon.contentMode = .scaleAspectFit
+        affordanceIcon.frame = affordance.bounds.insetBy(dx: 8, dy: 8)
+        affordance.addSubview(affordanceIcon)
+    }
+
+    /// Whether a drag with this velocity is a reply swipe rather than a scroll.
+    ///
+    /// Horizontal dominance is the whole rule: a diagonal drag belongs to the scroll view, which
+    /// would otherwise lose it to a recognizer that only ever moves sideways. Only trailing-ward
+    /// drags qualify — the leading direction is left free for anything that wants it later.
+    nonisolated static func shouldBegin(velocity: CGPoint, isBlocked: Bool) -> Bool {
+        guard !isBlocked else { return false }
+        guard velocity.x > 0 else { return false }
+        return abs(velocity.x) > abs(velocity.y)
+    }
+
+    /// Whether a drag starting at this x belongs to back-navigation rather than to the row. Kept
+    /// separate from `shouldBegin` because it is a rule about where the finger landed, not about
+    /// which way it moved, and the two fail for different reasons.
+    nonisolated static func defersToBackGesture(startX: CGFloat) -> Bool {
+        startX < backGestureInset
+    }
+
+    /// How far the row actually moves for a raw translation: clamped, with resistance past the max.
+    nonisolated static func offset(forTranslation translation: CGFloat) -> CGFloat {
+        guard translation > 0 else { return 0 }
+        guard translation > maxTranslation else { return translation }
+        // Rubber band: past the max the row keeps following the finger, but with diminishing
+        // returns that approach one more `maxTranslation` of travel and never exceed it — so a hard
+        // swipe still feels connected without running the row off under the bubble beside it.
+        let overshoot = translation - maxTranslation
+        return maxTranslation + maxTranslation * overshoot / (overshoot + maxTranslation)
+    }
+
+    /// Whether releasing at this offset fires the reply. Consulted only from `.ended` — crossing
+    /// the threshold mid-drag arms the gesture, it does not send.
+    nonisolated static func triggers(offset: CGFloat) -> Bool {
+        offset > triggerThreshold
+    }
+
+    /// Where the affordance sits in the row's own coordinates at a given drag offset. It starts off
+    /// the leading edge and rides the row by the same offset the row moves, which is why it needs no
+    /// knowledge of which edge the bubble hugs: at rest it is out of frame for either sender, and at
+    /// full travel it lands in space the bubble has just left.
+    ///
+    /// The offset is carried here rather than in a transform because the affordance's transform is
+    /// spent on the scale, and it is parented to the content view rather than to the column the row's
+    /// own translation moves.
+    nonisolated static func affordanceCenter(inRowOfHeight height: CGFloat, offset: CGFloat = 0) -> CGPoint {
+        CGPoint(x: affordanceInset + affordanceDiameter / 2 - maxTranslation + offset, y: height / 2)
+    }
+
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+            begin(at: gesture.location(in: gesture.view))
+        case .changed:
+            let offset = Self.offset(forTranslation: gesture.translation(in: gesture.view).x)
+            apply(offset: offset)
+            // The haptic at the threshold only announces that a release from here will reply. The
+            // reply itself waits for the finger to lift, so a drag that passes the threshold and
+            // comes back sends nothing.
+            if !hasPassedThreshold, Self.triggers(offset: offset) {
+                hasPassedThreshold = true
+                haptics.impactOccurred()
+            }
+        case .ended:
+            let offset = Self.offset(forTranslation: gesture.translation(in: gesture.view).x)
+            let stableID = draggedStableID
+            settle()
+            if Self.triggers(offset: offset), let stableID { onTrigger?(stableID) }
+        case .cancelled, .failed:
+            settle()
+        case .possible, .recognized:
+            break
+        @unknown default:
+            settle()
+        }
+    }
+
+    private func begin(at point: CGPoint) {
+        guard let row = rowForSwipe?(point) else {
+            recognizer.state = .cancelled
+            return
+        }
+        draggedCell = row.cell
+        draggedStableID = row.stableID
+        hasPassedThreshold = false
+        haptics.prepare()
+
+        affordance.alpha = 0
+        affordance.transform = CGAffineTransform(scaleX: 0.6, y: 0.6)
+        affordance.center = Self.affordanceCenter(inRowOfHeight: row.cell.bounds.height)
+        row.cell.contentView.addSubview(affordance)
+    }
+
+    private func apply(offset: CGFloat) {
+        guard let draggedCell else { return }
+        draggedCell.swipeOffset = offset
+        // The arrow rides the row by the same offset, and grows in over the run-up to the trigger, so
+        // the gesture announces itself before it fires rather than after.
+        let progress = min(1, offset / Self.triggerThreshold)
+        affordance.center = Self.affordanceCenter(inRowOfHeight: draggedCell.bounds.height, offset: offset)
+        affordance.alpha = progress
+        affordance.transform = CGAffineTransform(scaleX: 0.6 + 0.4 * progress, y: 0.6 + 0.4 * progress)
+    }
+
+    private func settle() {
+        let cell = draggedCell
+        let restingCenter = Self.affordanceCenter(inRowOfHeight: cell?.bounds.height ?? 0)
+        draggedCell = nil
+        draggedStableID = nil
+        hasPassedThreshold = false
+        ChatMotion.swap.animate {
+            cell?.swipeOffset = 0
+            self.affordance.center = restingCenter
+            self.affordance.alpha = 0
+            self.affordance.transform = CGAffineTransform(scaleX: 0.6, y: 0.6)
+        } completion: { _ in
+            // Only when no newer drag has claimed it: the arrow is one shared view, so an unguarded
+            // removal here tears it out of the row a second swipe has already started on.
+            if self.draggedCell == nil { self.affordance.removeFromSuperview() }
+        }
+    }
+}
+
+extension ChatSwipeToReply: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let pan = gestureRecognizer as? UIPanGestureRecognizer else { return false }
+        guard Self.shouldBegin(velocity: pan.velocity(in: pan.view), isBlocked: isBlocked?() ?? false) else {
+            return false
+        }
+        // Measured against the window, not the scroll view: the row's own x origin drifts with the
+        // transform of whatever is mid-settle, and the strip we are avoiding is a screen edge.
+        let edgeReference = pan.view?.window ?? pan.view
+        guard !Self.defersToBackGesture(startX: pan.location(in: edgeReference).x) else { return false }
+        return rowForSwipe?(pan.location(in: pan.view)) != nil
+    }
+}
+#endif

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -51,6 +51,9 @@ public final class ChatViewController: UICollectionViewController {
 
     /// Fired when a context-menu action other than Copy is chosen, with the row's id. Copy is handled
     /// here — it needs nothing the transcript does not already hold.
+    /// Called with a quoted message's stable id when its panel is tapped.
+    public var onQuoteTap: ((String) -> Void)?
+
     public var onMessageAction: ((String, MessageCapability) -> Void)?
 
     /// The widest a bubble may grow, as a share of the collection view's width.
@@ -76,6 +79,10 @@ public final class ChatViewController: UICollectionViewController {
     /// A row asked for before it was in `items` — the loader's window has to move first. The next
     /// update carrying it performs the scroll.
     private var pendingScrollTargetID: String?
+
+    /// Drag a row towards the leading edge to reply to it. Owns its own recognizer and state — see
+    /// `ChatSwipeToReply` for why it is exclusive with every other gesture here.
+    private let swipeToReply = ChatSwipeToReply()
     /// Breathing room kept below the last item, above the bar, so a trailing receipt doesn't sit
     /// flush against the bar.
     private static let bottomContentPadding: CGFloat = 12
@@ -169,6 +176,25 @@ public final class ChatViewController: UICollectionViewController {
         collectionView.register(ChatDateSeparatorCell.self, forCellWithReuseIdentifier: ChatDateSeparatorCell.reuseIdentifier)
         collectionView.register(ChatTypingIndicatorCell.self, forCellWithReuseIdentifier: ChatTypingIndicatorCell.reuseIdentifier)
         collectionView.register(ChatProfileCardCell.self, forCellWithReuseIdentifier: ChatProfileCardCell.reuseIdentifier)
+
+        swipeToReply.isBlocked = { [weak self] in
+            guard let self else { return true }
+            return self.isShowingContextMenu || self.isUpdating
+        }
+        swipeToReply.rowForSwipe = { [weak self] point in
+            guard let self,
+                  let indexPath = self.collectionView.indexPathForItem(at: point),
+                  let cell = self.collectionView.cellForItem(at: indexPath) as? ChatColumnCell,
+                  case .message(let message) = self.items[indexPath.item],
+                  message.actions.contains(.reply)
+            else { return nil }
+            return (cell, message.id)
+        }
+        swipeToReply.onTrigger = { [weak self] stableID in
+            self?.onMessageAction?(stableID, .reply)
+        }
+        collectionView.addGestureRecognizer(swipeToReply.recognizer)
+
         collectionView.reloadData()
     }
 
@@ -232,6 +258,10 @@ public final class ChatViewController: UICollectionViewController {
         if wasEmpty || newItems.isEmpty || !animated {
             if !animated { needsInitialScroll = true }
             items = newItems
+            // Toggling `isEnabled` cancels the gesture, which settles the row — a recycled cell must
+            // never inherit a translation from the row that was dragged before it.
+            swipeToReply.recognizer.isEnabled = false
+            swipeToReply.recognizer.isEnabled = true
             collectionView.reloadData()
             performInitialScrollIfNeeded()
             performPendingScrollIfLanded()
@@ -311,9 +341,11 @@ public final class ChatViewController: UICollectionViewController {
                 cell.configure(with: message, maxWidth: maxWidth)
                 cell.onRetry = { [weak self] id in self?.onRetry?(id) }
                 cell.onOpenURL = { [weak self] url in self?.onOpenURL?(url) }
+                cell.onQuoteTap = { [weak self] id in self?.onQuoteTap?(id) }
             case let cell as ChatMessageCell:
                 cell.configure(with: message, maxWidth: maxWidth)
                 cell.onRetry = { [weak self] id in self?.onRetry?(id) }
+                cell.onQuoteTap = { [weak self] id in self?.onQuoteTap?(id) }
             case let cell as ChatCashCardCell:
                 cell.configure(with: message)
             default:
@@ -584,8 +616,15 @@ extension ChatViewController: ChatLayoutDelegate {
 extension ChatViewController: UIGestureRecognizerDelegate {
     /// Lets the tap-to-dismiss recognizer fire alongside the collection view's own scroll and
     /// selection recognizers, so lowering the keyboard never pre-empts a cell tap.
+    ///
+    /// Swipe-to-reply is the exception: it translates a cell, so running it beside the scroll would
+    /// drag a row sideways mid-scroll, and running it beside the long-press would slide the row out
+    /// from under its own lift preview. It is exclusive in both directions.
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        true
+        if gestureRecognizer === swipeToReply.recognizer || otherGestureRecognizer === swipeToReply.recognizer {
+            return false
+        }
+        return true
     }
 }
 
@@ -813,7 +852,7 @@ private extension MessageCapability {
     var menuSymbol: SystemSymbol {
         switch self {
         case .copy:   .doc
-        case .reply:  .arrowLeft
+        case .reply:  .replyArrow
         case .edit:   .pencil
         case .delete: .trash
         }

--- a/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift
@@ -72,6 +72,10 @@ public final class ChatViewController: UICollectionViewController {
     /// True until the first non-empty content has been scrolled to the bottom. The open is
     /// deferred to `viewDidLayoutSubviews` so it runs once the collection view has real bounds.
     private var needsInitialScroll = false
+
+    /// A row asked for before it was in `items` — the loader's window has to move first. The next
+    /// update carrying it performs the scroll.
+    private var pendingScrollTargetID: String?
     /// Breathing room kept below the last item, above the bar, so a trailing receipt doesn't sit
     /// flush against the bar.
     private static let bottomContentPadding: CGFloat = 12
@@ -200,6 +204,9 @@ public final class ChatViewController: UICollectionViewController {
     /// `keepContentOffsetAtBottomOnBatchUpdates` keeps a new arrival pinned to the bottom (and a
     /// prepended older page anchored in place) with no hand-rolled scrolling.
     public func update(items newItems: [ChatItem], animated: Bool = true) {
+        // A window that jumped hundreds of rows must not animate: it would draw a scroll through
+        // content the user never asked to see.
+        let animated = animated && pendingScrollTargetID == nil
         // While a context menu is lifted, hold pushed updates: reloading the transcript now (e.g. an
         // arriving message) would reflow the content out from under the lifted preview. The latest
         // push is applied when the menu closes. Mirrors ChatLayout deferring updates during a preview.
@@ -227,6 +234,7 @@ public final class ChatViewController: UICollectionViewController {
             items = newItems
             collectionView.reloadData()
             performInitialScrollIfNeeded()
+            performPendingScrollIfLanded()
             return
         }
 
@@ -260,6 +268,7 @@ public final class ChatViewController: UICollectionViewController {
                         pendingBottomInset = nil
                         setBottomInset(inset)
                     }
+                    performPendingScrollIfLanded()
                 },
                 setData: { [weak self] data in
                     self?.items = data
@@ -366,6 +375,36 @@ public final class ChatViewController: UICollectionViewController {
         guard needsInitialScroll, !items.isEmpty, collectionView.bounds.height > 0 else { return }
         needsInitialScroll = false
         scrollToBottom(animated: false)
+    }
+
+    /// Scrolls the given row into view, or waits for the update that brings it in.
+    public func scrollToMessage(id: String) {
+        guard items.contains(where: { $0.differenceIdentifier.hasSuffix(":\(id)") }) else {
+            pendingScrollTargetID = id
+            return
+        }
+        scrollToRow(id: id, animated: true)
+    }
+
+    /// Performs a deferred jump once the update that brought the row in has been applied.
+    private func performPendingScrollIfLanded() {
+        guard let target = pendingScrollTargetID,
+              items.contains(where: { $0.differenceIdentifier.hasSuffix(":\(target)") }) else { return }
+        pendingScrollTargetID = nil
+        scrollToRow(id: target, animated: false)
+    }
+
+    /// Centers a row that is already in `items`.
+    private func scrollToRow(id: String, animated: Bool) {
+        guard let index = items.firstIndex(where: { $0.differenceIdentifier.hasSuffix(":\(id)") }) else { return }
+        let indexPath = IndexPath(item: index, section: 0)
+        guard animated else {
+            collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+            return
+        }
+        ChatMotion.scroll.animate {
+            self.collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+        }
     }
 
     /// Scroll to the newest message by re-anchoring the layout to the last item's bottom edge.

--- a/FlipcashUI/Sources/FlipcashUI/Chat/LinkableBubbleView.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Chat/LinkableBubbleView.swift
@@ -21,6 +21,21 @@ public final class LinkableBubbleView: UIView {
     /// Called when the user taps a detected link.
     var onOpenURL: ((URL) -> Void)?
 
+    private(set) var quotePanel = ChatQuotePanelView()
+
+    /// Forwarded from the panel: the stable id of the message to jump to.
+    var onQuoteTap: ((String) -> Void)? {
+        get { quotePanel.onTap }
+        set { quotePanel.onTap = newValue }
+    }
+
+    /// Body pinned to the bubble's top, for a message with no quote.
+    private var textTopToBubble: NSLayoutConstraint!
+    /// Body pinned below the quote panel, for a reply.
+    private var textTopToQuote: NSLayoutConstraint!
+    /// Collapses the panel when there is no quote, so a hidden view consumes no height.
+    private var quoteZeroHeight: NSLayoutConstraint!
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setUp()
@@ -51,13 +66,27 @@ public final class LinkableBubbleView: UIView {
 
         addSubview(editedLabel)
 
+        quotePanel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(quotePanel)
+
+        textTopToBubble = textView.topAnchor.constraint(equalTo: topAnchor, constant: 9)
+        textTopToQuote = textView.topAnchor.constraint(
+            equalTo: quotePanel.bottomAnchor,
+            constant: ChatQuotePanelView.bottomSpacing
+        )
+        quoteZeroHeight = quotePanel.heightAnchor.constraint(equalToConstant: 0)
+
         NSLayoutConstraint.activate([
             background.topAnchor.constraint(equalTo: topAnchor),
             background.bottomAnchor.constraint(equalTo: bottomAnchor),
             background.leadingAnchor.constraint(equalTo: leadingAnchor),
             background.trailingAnchor.constraint(equalTo: trailingAnchor),
 
-            textView.topAnchor.constraint(equalTo: topAnchor, constant: 9),
+            quotePanel.topAnchor.constraint(equalTo: topAnchor, constant: 9),
+            quotePanel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: ChatQuotePanelView.horizontalInset),
+            quotePanel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -ChatQuotePanelView.horizontalInset),
+            textTopToBubble,
+            quoteZeroHeight,
             textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -9),
             textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
             textView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
@@ -73,6 +102,7 @@ public final class LinkableBubbleView: UIView {
 
     func prepareForReuse() {
         textView.resignFirstResponder()
+        quotePanel.onTap = nil
     }
 
     public func configure(with message: ChatMessage) {
@@ -81,6 +111,21 @@ public final class LinkableBubbleView: UIView {
         // text view is non-editable, so it detects over `attributedText` as it did over `text`.
         textView.attributedText = ChatBubbleView.displayText(for: message)
         editedLabel.isHidden = !ChatBubbleView.showsEditedMarker(for: message)
+
+        // Deactivate before activating: with both top constraints live the layout is
+        // unsatisfiable, and UIKit resolves that by breaking one at random.
+        if let quote = message.quote {
+            quotePanel.isHidden = false
+            quotePanel.configure(with: quote)
+            quoteZeroHeight.isActive = false
+            textTopToBubble.isActive = false
+            textTopToQuote.isActive = true
+        } else {
+            quotePanel.isHidden = true
+            textTopToQuote.isActive = false
+            textTopToBubble.isActive = true
+            quoteZeroHeight.isActive = true
+        }
 
         background.apply(
             fill: BubbleBackgroundView.fill(isFromSelf: message.sender == .me),

--- a/FlipcashUI/Sources/FlipcashUI/Theme/ComplementaryPalette.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/ComplementaryPalette.swift
@@ -1,0 +1,80 @@
+//
+//  ComplementaryPalette.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import SwiftUI
+import CryptoKit
+import FlipcashCore
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// The colour a person is drawn in, derived from their user id.
+///
+/// A port of Android's `generateComplementaryColorPalette`
+/// (`ui/components/.../utils/ComplementaryGradient.kt`), arithmetic for arithmetic: SHA-512 the id's
+/// bytes, take the hue from the sum of the first three, wobble the brightness by the fourth, and
+/// shift 20° for each further stop. Ported rather than re-derived because both apps show the same
+/// conversations — a person who is teal on Android and amber here reads as two people.
+///
+/// Android's third stop carries a WCAG contrast correction that only the anonymous-avatar gradient
+/// needs. Nothing here draws that gradient, so the correction is not ported; bring it over with the
+/// stop if an avatar ever needs it.
+///
+/// Not memoized, where Android keeps a map. One SHA-512 over sixteen bytes is cheaper than the lock
+/// a shared cache would need to be safe off the main actor.
+public enum ComplementaryPalette {
+
+    /// Which stop to take. Android names them by position; a quote uses the first for its rule and
+    /// the second — the lighter of the two — for the author's name.
+    public enum Stop {
+        case start
+        case middle
+    }
+
+    /// Fixed on Android: the id chooses the hue and a small brightness wobble, nothing else.
+    private static let saturation = 0.75
+    private static let baseBrightness = 0.85
+    /// Degrees between one stop and the next.
+    private static let hueShift = 20.0
+
+    /// The person's colour, or the neutral secondary text colour when there is no id to derive one
+    /// from — an original the local database has never seen has no author, let alone a colour.
+    /// Android falls back the same way, to its `tertiary`.
+    public static func color(_ stop: Stop, for id: UserID?) -> Color {
+        guard let hsb = components(stop, for: id) else { return .textSecondary }
+        return Color(hue: hsb.hue, saturation: hsb.saturation, brightness: hsb.brightness)
+    }
+
+    #if canImport(UIKit)
+    /// See ``color(_:for:)``. The transcript draws its quote panel in UIKit.
+    public static func uiColor(_ stop: Stop, for id: UserID?) -> UIColor {
+        guard let hsb = components(stop, for: id) else { return UIColor(Color.textSecondary) }
+        return UIColor(hue: hsb.hue, saturation: hsb.saturation, brightness: hsb.brightness, alpha: 1)
+    }
+    #endif
+
+    /// Hue normalized to 0...1 for both colour types, which take it that way where Compose takes
+    /// degrees. The saturation and brightness are Android's numbers untouched.
+    private static func components(
+        _ stop: Stop,
+        for id: UserID?
+    ) -> (hue: Double, saturation: Double, brightness: Double)? {
+        guard let id else { return nil }
+        let digest = Array(SHA512.hash(data: withUnsafeBytes(of: id.uuid) { Data($0) }))
+        let hue = Double((Int(digest[0]) + Int(digest[1]) + Int(digest[2])) % 360)
+        let variation = Double(Int(digest[3]) % 10) / 100
+        switch stop {
+        case .start:
+            return (hue / 360, saturation, baseBrightness - variation)
+        case .middle:
+            return ((hue + hueShift).truncatingRemainder(dividingBy: 360) / 360,
+                    saturation * 0.95,
+                    baseBrightness)
+        }
+    }
+}

--- a/FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift
@@ -54,6 +54,7 @@ public enum SystemSymbol: String {
     case arrowDown = "arrow.down"
     case arrowRight = "arrow.right"
     case arrowLeft = "arrow.left"
+    case replyArrow = "arrowshape.turn.up.left.fill"
     
     case info = "info.circle"
     case doc = "doc.on.doc"

--- a/FlipcashUITests/Smoke/ChatReplySmokeTests.swift
+++ b/FlipcashUITests/Smoke/ChatReplySmokeTests.swift
@@ -1,0 +1,160 @@
+//
+//  ChatReplySmokeTests.swift
+//  FlipcashUITests
+//
+
+import XCTest
+
+/// Drives replying to a chat message end to end: both entry points (the context menu and the
+/// leading swipe), the composer strip that names the target, dismissing it without losing the
+/// draft, and the quote panel the sent bubble carries.
+///
+/// Every message is one the test account sends into an existing DM, so the suite needs no second
+/// device — a message you sent carries `.reply` like any other.
+///
+/// **Prerequisites:** the `FLIPCASH_UI_TEST_ACCESS_KEY` account needs at least one chat
+/// conversation. With none, each test skips rather than fails.
+///
+/// **Not covered here:** the anchor move behind "tap a quote to jump to the original". Proving it
+/// needs the original far enough off-screen that a jump is observable, which costs a dozen network
+/// sends per run. `MessageLoaderRevealTests` covers the reveal itself; this suite checks the panel
+/// is tappable and that tapping it leaves the transcript intact.
+@MainActor
+final class ChatReplySmokeTests: BaseUITestCase {
+
+    override var requiresAuthentication: Bool { true }
+
+    private var conversation: ConversationUIScreen { ConversationUIScreen(app: app) }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Several round-trip sends per test run past XCTest's 2-minute default.
+        executionTimeAllowance = 600
+    }
+
+    /// Long-pressing a sent message offers Reply, and choosing it opens the composer on that
+    /// message — the strip naming what is being answered.
+    func testMessageMenu_offersReplyAndAimsTheComposer() throws {
+        try openConversation()
+
+        let original = Self.uniqueText("original")
+        conversation.sendMessage(original, from: self)
+        conversation.assertMessageDelivered(original)
+
+        conversation.beginReply(to: original, from: self)
+    }
+
+    /// Swiping a row towards the trailing edge is the same entry as the menu's Reply, without the
+    /// menu — the gesture's own coexistence with scrolling and the long-press lift is what makes
+    /// this worth driving on a real transcript.
+    func testSwipingARow_opensTheReplyStrip() throws {
+        try openConversation()
+
+        let original = Self.uniqueText("swiped")
+        conversation.sendMessage(original, from: self)
+        conversation.assertMessageDelivered(original)
+
+        conversation.swipeToReply(on: original, from: self)
+        conversation.assertReplyStripQuotes(original)
+    }
+
+    /// The strip's ⊗ takes back the target and leaves the draft alone — a reply abandoned
+    /// mid-sentence must not also lose the sentence.
+    func testCancellingAReply_keepsTheDraft() throws {
+        try openConversation()
+
+        let original = Self.uniqueText("kept")
+        conversation.sendMessage(original, from: self)
+        conversation.assertMessageDelivered(original)
+
+        conversation.beginReply(to: original, from: self)
+
+        let draft = "half a thought"
+        waitUntilHittableAndTap(conversation.messageField)
+        conversation.messageField.typeText(draft)
+
+        waitAndTap(conversation.cancelReplyButton)
+        conversation.assertNoReplyStrip()
+
+        let value = conversation.messageField.value as? String ?? ""
+        XCTAssertTrue(
+            value.contains(draft),
+            "Expected the draft to survive dismissing the reply, got '\(value)'"
+        )
+        XCTAssertTrue(
+            conversation.composerSendButton.exists,
+            "Expected the send button to stay up — there is still text to send"
+        )
+    }
+
+    /// A sent reply lands as an ordinary delivered message whose bubble embeds the original it
+    /// answers, and the composer returns to writing a new message.
+    func testSendingAReply_quotesTheOriginalAndClearsTheStrip() throws {
+        try openConversation()
+
+        let original = Self.uniqueText("quoted")
+        conversation.sendMessage(original, from: self)
+        conversation.assertMessageDelivered(original)
+
+        let answer = Self.uniqueText("answer")
+        conversation.sendReply(answer, to: original, from: self)
+
+        conversation.assertNoReplyStrip(timeout: 15)
+        conversation.assertMessageDelivered(answer)
+        conversation.assertBubbleQuotes(original)
+    }
+
+    /// The quote panel inside a reply is a button, and pressing it leaves the transcript on the
+    /// conversation with both rows still rendered — the jump's landing, not its paging.
+    func testTappingAQuote_staysOnTheOriginal() throws {
+        try openConversation()
+
+        let original = Self.uniqueText("target")
+        conversation.sendMessage(original, from: self)
+        conversation.assertMessageDelivered(original)
+
+        let answer = Self.uniqueText("pointer")
+        conversation.sendReply(answer, to: original, from: self)
+        conversation.assertBubbleQuotes(original)
+
+        let panel = conversation.quotePanels.allElementsBoundByIndex.first { $0.label.contains(original) }
+        let quote = try XCTUnwrap(panel, "Expected the reply's quote panel")
+        waitUntilHittableAndTap(quote)
+
+        XCTAssertTrue(
+            conversation.messageBubble(original).waitForExistence(timeout: 15),
+            "Expected the quoted original on screen after tapping its quote"
+        )
+        XCTAssertTrue(
+            conversation.messageField.exists,
+            "Expected to stay in the conversation after the jump"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Opens the account's first chat, skipping the test when it has none — the suite drives an
+    /// existing conversation rather than creating one, so an empty list is a missing fixture and
+    /// not a defect.
+    private func openConversation() throws {
+        assertMainScreenReached()
+
+        let chats = TipsUIScreen(app: app)
+        chats.open(from: self)
+
+        guard let row = chats.firstConversationRow(timeout: 30) else {
+            throw XCTSkip("The test account has no chat conversation — skipping the reply suite")
+        }
+        row.tap()
+
+        XCTAssertTrue(
+            conversation.messageField.waitForExistence(timeout: 30),
+            "Expected the conversation's composer. On screen: [\(visibleText())]"
+        )
+    }
+
+    /// A per-run body, so a bubble query can never match a message left behind by an earlier run.
+    private static func uniqueText(_ prefix: String) -> String {
+        "\(prefix) \(Int(Date().timeIntervalSince1970 * 1000) % 1_000_000)"
+    }
+}

--- a/FlipcashUITests/Support/Screens/ConversationUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/ConversationUIScreen.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 /// Page object for a DM conversation. Drives Send Cash, the message composer,
-/// and the delivery receipts.
+/// the delivery receipts, and the reply affordances (menu, swipe, quote panel).
 @MainActor
 struct ConversationUIScreen {
 
@@ -29,6 +29,26 @@ struct ConversationUIScreen {
 
     func messageBubble(_ text: String) -> XCUIElement { app.staticTexts[text] }
 
+    // MARK: - Reply elements
+
+    /// The quoted original above the composer, present only while a reply is open.
+    var replyStrip: XCUIElement { app.otherElements["composer-reply-strip"] }
+
+    /// The strip's quote text, combined into one element so VoiceOver reads it as a citation.
+    var replyStripQuote: XCUIElement { app.otherElements["composer-reply-quote"] }
+
+    /// The strip's dismiss control — takes back the target, not the draft.
+    var cancelReplyButton: XCUIElement { app.buttons["cancel-reply-button"] }
+
+    /// The context menu's Reply row. Scoped to `firstMatch` because the menu is hosted in a
+    /// platter whose container type has moved between iOS versions.
+    var replyMenuItem: XCUIElement { app.buttons["Reply"].firstMatch }
+
+    /// The quote panels drawn inside sent reply bubbles.
+    var quotePanels: XCUIElementQuery {
+        app.buttons.matching(identifier: "chat-quote-panel")
+    }
+
     // MARK: - Actions
 
     /// Opens the Send amount sheet on top of the conversation.
@@ -40,6 +60,49 @@ struct ConversationUIScreen {
     func sendMessage(_ text: String, from testCase: BaseUITestCase) {
         testCase.waitUntilHittableAndTap(messageField)
         messageField.typeText(text)
+        testCase.waitAndTap(composerSendButton)
+    }
+
+    // MARK: - Reply actions
+
+    /// Long-presses `text`'s bubble and waits for its context menu.
+    ///
+    /// The press is delivered through `press(forDuration:)` rather than a tap so the transcript's
+    /// long-press recognizer fires; `pressForDuration` shorter than ~1s lands as a tap on some
+    /// hosts, which selects nothing and leaves no menu.
+    func openMenu(on text: String, from testCase: BaseUITestCase) {
+        let bubble = messageBubble(text)
+        XCTAssertTrue(
+            bubble.waitForExistence(timeout: 30),
+            "Expected '\(text)' in the transcript before opening its menu"
+        )
+        testCase.waitForStableFrame(bubble)
+        bubble.press(forDuration: 1.2)
+    }
+
+    /// Opens `text`'s menu and taps Reply, leaving the composer aimed at that message.
+    func beginReply(to text: String, from testCase: BaseUITestCase) {
+        openMenu(on: text, from: testCase)
+        testCase.waitAndTap(replyMenuItem, timeout: 15, "Expected a Reply row in the message menu")
+        assertReplyStripQuotes(text)
+    }
+
+    /// Swipes `text`'s bubble towards the trailing edge, the gesture shortcut for Reply.
+    func swipeToReply(on text: String, from testCase: BaseUITestCase) {
+        let bubble = messageBubble(text)
+        XCTAssertTrue(
+            bubble.waitForExistence(timeout: 30),
+            "Expected '\(text)' in the transcript before swiping it"
+        )
+        testCase.waitForStableFrame(bubble)
+        bubble.swipeRight()
+    }
+
+    /// Aims the composer at `original` through the menu, then sends `reply` as an answer to it.
+    func sendReply(_ reply: String, to original: String, from testCase: BaseUITestCase) {
+        beginReply(to: original, from: testCase)
+        testCase.waitUntilHittableAndTap(messageField)
+        messageField.typeText(reply)
         testCase.waitAndTap(composerSendButton)
     }
 
@@ -66,6 +129,43 @@ struct ConversationUIScreen {
             waitForReceipt(atOrBelow: bubble, timeout: timeout),
             "Expected the message to be marked 'Delivered'"
         )
+    }
+
+    /// Asserts the composer is open on a reply whose strip cites `text`.
+    func assertReplyStripQuotes(_ text: String, timeout: TimeInterval = 15) {
+        XCTAssertTrue(
+            replyStrip.waitForExistence(timeout: timeout),
+            "Expected the composer's reply strip after choosing Reply"
+        )
+        XCTAssertTrue(
+            replyStripQuote.label.contains(text),
+            "Expected the strip to cite '\(text)', got '\(replyStripQuote.label)'"
+        )
+    }
+
+    /// Asserts no reply is open on the composer.
+    func assertNoReplyStrip(timeout: TimeInterval = 5) {
+        let gone = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: gone, object: replyStrip)
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [expectation], timeout: timeout), .completed,
+            "Expected the reply strip to be dismissed"
+        )
+    }
+
+    /// Asserts a sent bubble carries a quote panel citing `original`.
+    ///
+    /// Scans every panel rather than resolving one: a transcript may hold earlier replies, and a
+    /// single-element query over several matches raises "multiple matching elements".
+    func assertBubbleQuotes(_ original: String, timeout: TimeInterval = 30) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if quotePanels.allElementsBoundByIndex.contains(where: { $0.label.contains(original) }) {
+                return
+            }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        XCTFail("Expected a reply bubble quoting '\(original)'. On screen: [\(app.staticTexts.allElementsBoundByIndex.prefix(15).map(\.label).joined(separator: " | "))]")
     }
 
     // MARK: - Helpers

--- a/FlipcashUITests/Support/Screens/ConversationUIScreen.swift
+++ b/FlipcashUITests/Support/Screens/ConversationUIScreen.swift
@@ -19,7 +19,10 @@ struct ConversationUIScreen {
     // MARK: - Elements
 
     var sendCashButton: XCUIElement { app.buttons["send-cash-button"] }
-    var messageField: XCUIElement { app.textFields["Message"] }
+    /// The composer's text field, found by identifier rather than by placeholder — the placeholder
+    /// disappears as soon as there is a draft, and a multiline `TextField(axis:)` reports a text-view
+    /// base type, so neither `textFields["Message"]` nor a type-scoped query survives typing.
+    var messageField: XCUIElement { app.descendants(matching: .any)["composer-message-field"].firstMatch }
 
     /// The composer's send arrow. A dedicated identifier avoids the same-labelled
     /// back button and ScanBottomBar "Send".
@@ -35,7 +38,11 @@ struct ConversationUIScreen {
     var replyStrip: XCUIElement { app.otherElements["composer-reply-strip"] }
 
     /// The strip's quote text, combined into one element so VoiceOver reads it as a citation.
-    var replyStripQuote: XCUIElement { app.otherElements["composer-reply-quote"] }
+    ///
+    /// Queried without a type because `.accessibilityElement(children: .combine)` decides the
+    /// element's type from what it folded up — a name over a snippet surfaces as static text, not as
+    /// the container `otherElements` would match.
+    var replyStripQuote: XCUIElement { app.descendants(matching: .any)["composer-reply-quote"].firstMatch }
 
     /// The strip's dismiss control — takes back the target, not the draft.
     var cancelReplyButton: XCUIElement { app.buttons["cancel-reply-button"] }

--- a/docs/superpowers/plans/2026-09-04-chat-message-reply.md
+++ b/docs/superpowers/plans/2026-09-04-chat-message-reply.md
@@ -1,0 +1,2837 @@
+# Chat Message Reply Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a person reply to any chat message — from the context menu or a swipe — see the quoted original above the composer and inside the sent bubble, and tap that quote to jump back to the original when it is in the local database.
+
+**Architecture:** A reply is a decoration on a text message, not a new content kind. `ConversationMessage` gains `repliedTo: MessageID?`; the proto initializer unwraps `ReplyContent` so the inner `TextContent` still lands in `.text`, which means every existing `case .text` path (link detection, mapper, bubble, edit) is untouched. The pure mapper resolves that id into a display-ready `ChatQuote` (author, snippet, kind, target stable id) using a pre-resolved dictionary carried on `ConversationLoadCoordinator.Inputs`, so `map` stays pure and off-main. The UI is three additions: a strip above the composer's input row, a tinted panel inside the bubble above the body, and a pan recognizer on the transcript. Jump-to-original is one anchor move on `MessageLoader` plus a pending-target scroll on `ChatViewController` — no paging loop, no network call.
+
+**Tech Stack:** Swift 6.1, SwiftUI + UIKit, ChatLayout + DifferenceKit, SQLite.swift, gRPC-Swift 2 via `FlipcashAPI` (`flipcash2-client-protocol` 0.2.0), Swift Testing.
+
+---
+
+## Scope
+
+**In:** reply send, reply render (composer strip + in-bubble quote panel), reply entry from the context menu and from a swipe, tap-to-jump when the original is in the local database, `Reply`-only menus on cash and tip rows, persistence of `repliedToId`.
+
+**Out:** proto work (`ReplyContent` already ships in `flipcash2-client-protocol` 0.2.0); fetching history that was never fetched in order to resolve a quote (renders as unavailable, tap does nothing); replying to a cash message with a cash message; group-chat author colors.
+
+**No `SQLiteVersion` bump.** `Schema.swift:279` already declares `let repliedToId = Expression<UInt64?>("repliedToId")` and `Schema.swift:534` already adds the column; `Database+Conversations.swift:424` writes `nil` into it with the comment "The reply plan fills this in; the column exists now so the schema bumps once." Task 2 fills it in. **Do not add another column** (a cached quote snippet, an author name) — that would force a bump and rebuild every user's database. Everything the quote needs is derived at map time from a message already in the window or already in the table.
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatQuote.swift` | Display-ready quote value: author name, snippet, kind, target stable id. Pure data, no behavior. |
+| `FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift` | The tinted quote panel drawn inside a bubble, above the body. Accent rule + two labels + a tap target. |
+| `FlipcashUI/Sources/FlipcashUI/Chat/ChatSwipeToReply.swift` | Owns the reply pan recognizer and everything it tracks (target index path, translated cell, trigger latch). One named unit, per the hard rule. |
+| `Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift` | The strip above the composer's input row: accent rule, author, snippet, dismiss. |
+| `FlipcashTests/Chat/ChatQuoteMappingTests.swift` | Mapper quote resolution in all three states. |
+| `FlipcashTests/Chat/ChatQuoteBubbleTests.swift` | Bubble geometry with and without a quote panel. |
+| `FlipcashTests/Chat/ChatSwipeToReplyTests.swift` | The swipe's begin conditions and trigger threshold. |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `FlipcashCore/.../Models/Conversation/ConversationMessage.swift` | `repliedTo: MessageID?` on the struct, `init`, `replacingContent`, and the proto init's `.reply` unwrap. |
+| `FlipcashCore/.../Models/Conversation/MessageCapability.swift` | `resolve` emits `.reply`; cash returns `[.reply]` instead of `[]`. |
+| `FlipcashCore/.../Models/Chat/ChatMessage.swift` | `quote: ChatQuote?` on the struct and both inits. |
+| `FlipcashCore/.../Clients/Flip API/Services/ChatMessagingService.swift` | `sendMessage` takes `repliedTo`, builds `ReplyContent` when set. |
+| `FlipcashCore/.../Clients/Flip API/FlipClient+Chat.swift` | `sendMessage` signature. |
+| `Flipcash/Core/Controllers/FlipClient+Protocols.swift` | `ConversationMessaging.sendMessage` signature. |
+| `Flipcash/Core/Controllers/ConversationController.swift` | `repliedTo` through `send`/`retry`/`deliver`; new `persistedMessage(_:in:)`. |
+| `Flipcash/Core/Controllers/Database/Database+Conversations.swift` | Write and read `repliedToId`. |
+| `Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift` | `counterpartName` + `quotedMessage` parameters; builds `ChatQuote`. |
+| `Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift` | `counterpartName` + `quotedMessages` on `Inputs`, pre-resolved in `currentInputs()`. |
+| `Flipcash/Core/Screens/Conversation/MessageLoader.swift` | `reveal(_:)` — the one anchor move. |
+| `Flipcash/Core/Screens/Conversation/ComposerModel.swift` | `Mode.replying(to:)` + `ReplyTarget`. |
+| `Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift` | Hosts the reply strip above the input row; submit sends with `repliedTo`. |
+| `Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift` | `.reply` focuses the composer; `onQuoteTap` wiring. |
+| `Flipcash/Core/Screens/Conversation/ConversationScreen.swift` | `.reply` branch; `jumpToQuote`. |
+| `FlipcashUI/.../Chat/ChatBubbleView.swift` | Quote panel above the label, conditional top constraint. |
+| `FlipcashUI/.../Chat/LinkableBubbleView.swift` | Same panel, same constraints. |
+| `FlipcashUI/.../Chat/ChatMessageCell.swift`, `ChatLinkMessageCell.swift` | `onQuoteTap` passthrough. |
+| `FlipcashUI/.../Chat/ChatCashCardCell.swift` | Conforms to `BubbleCarrying` so the lift clips to the card. |
+| `FlipcashUI/.../Chat/ChatViewController.swift` | `onQuoteTap`, `scrollToMessage(id:)`, pending scroll target, the reply pan, discriminating `shouldRecognizeSimultaneouslyWith`. |
+| `FlipcashUI/.../Chat/ChatScreenViewController.swift` | `onQuoteTap` and `scrollToMessage(id:)` passthroughs. |
+| `FlipcashUI/.../Theme/Image+Symbols.swift` | `replyArrow` symbol for the swipe affordance. |
+| `FlipcashTests/TestSupport/MockConversations.swift` | `Sent` records `repliedTo`. |
+| `FlipcashCore/Tests/.../MessageCapabilityTests.swift` | Rewrite the "cash offers nothing" test. |
+
+---
+
+## Task 1: `ConversationMessage` carries the replied-to id
+
+Two things are wrong today. `ConversationMessage` has nowhere to put a replied-to id, and `init?(_ proto:)` returns `nil` for `case .reply` — so a reply sent from Android or the web **vanishes from the transcript entirely**. That is a live defect, and this task fixes it.
+
+`Flipcash_Messaging_V1_ReplyContent` is `{ repliedMessageID: Flipcash_Messaging_V1_MessageId, hasRepliedMessageID: Bool, content: [Flipcash_Messaging_V1_Content] }`. The inner `content` is repeated, so the unwrap reads `replyContent.content.first?.type` and lands the inner text in `.text`.
+
+**Files:**
+- Modify: `FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift`
+- Test: `FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift`:
+
+```swift
+@Suite("Reply proto mapping")
+struct ConversationMessageReplyMappingTests {
+
+    private func replyProto(repliedTo: UInt64, text: String) -> Flipcash_Messaging_V1_Message {
+        .with {
+            $0.messageID = .with { $0.value = 42 }
+            $0.content = [
+                .with { content in
+                    content.reply = .with { reply in
+                        reply.repliedMessageID = .with { $0.value = repliedTo }
+                        reply.content = [.with { inner in inner.text = .with { $0.text = text } }]
+                    }
+                }
+            ]
+        }
+    }
+
+    @Test("A reply proto maps to a text message carrying the replied-to id")
+    func replyProto_unwrapsToText() throws {
+        let message = try #require(ConversationMessage(replyProto(repliedTo: 7, text: "on my way")))
+        #expect(message.content == .text("on my way"))
+        #expect(message.repliedTo == MessageID(value: 7))
+    }
+
+    @Test("A plain text proto carries no replied-to id")
+    func textProto_hasNoRepliedTo() throws {
+        let proto = Flipcash_Messaging_V1_Message.with {
+            $0.messageID = .with { $0.value = 43 }
+            $0.content = [.with { $0.text = .with { $0.text = "hi" } }]
+        }
+        let message = try #require(ConversationMessage(proto))
+        #expect(message.repliedTo == nil)
+    }
+
+    @Test("A reply whose inner content is empty is dropped rather than rendered blank")
+    func replyProto_withoutInnerContent_isDropped() {
+        let proto = Flipcash_Messaging_V1_Message.with {
+            $0.messageID = .with { $0.value = 44 }
+            $0.content = [
+                .with { content in
+                    content.reply = .with { reply in
+                        reply.repliedMessageID = .with { $0.value = 7 }
+                    }
+                }
+            ]
+        }
+        #expect(ConversationMessage(proto) == nil)
+    }
+
+    @Test("replacingContent preserves the replied-to id")
+    func replacingContent_preservesRepliedTo() {
+        let message = ConversationMessage(
+            id: MessageID(value: 1),
+            senderID: nil,
+            content: .text("first"),
+            date: Date(timeIntervalSince1970: 0),
+            unreadSeq: 0,
+            repliedTo: MessageID(value: 9)
+        )
+        let edited = message.replacingContent(.text("second"), lastEditedTs: Date(timeIntervalSince1970: 1))
+        #expect(edited.repliedTo == MessageID(value: 9))
+    }
+}
+```
+
+Add `import FlipcashAPI` at the top of that file if it is not already there.
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./Scripts/test.sh FlipcashCoreTests/ConversationMessageReplyMappingTests
+```
+
+Expected: compile failure — `ConversationMessage` has no `repliedTo` parameter or property.
+
+- [ ] **Step 3: Add the property, the init parameter, and the unwrap**
+
+In `ConversationMessage.swift`, add the stored property after `lastEditedTs`:
+
+```swift
+    /// The message this one replies to, or `nil` when it replies to nothing. A reply is a
+    /// decoration on a text message rather than a content kind of its own: the wire nests the
+    /// body inside `ReplyContent`, and the initializer below unwraps it so every `case .text`
+    /// path — link detection, the transcript mapper, the bubble, edit — sees the shape it
+    /// always saw.
+    public let repliedTo: MessageID?
+```
+
+Add the parameter to `init`, after `lastEditedTs`:
+
+```swift
+        lastEditedTs: Date? = nil,
+        repliedTo: MessageID? = nil,
+        status: SendStatus = .sent,
+```
+
+and the assignment, after `self.lastEditedTs = lastEditedTs`:
+
+```swift
+        self.repliedTo = repliedTo
+```
+
+In `replacingContent(_:lastEditedTs:)`, add to the constructed value after `lastEditedTs: lastEditedTs`:
+
+```swift
+            repliedTo: repliedTo,
+```
+
+In `init?(_ proto:)`, replace the `.reply, .media, .system, .none` case and set `repliedTo` for the other cases. The switch becomes:
+
+```swift
+        let repliedTo: MessageID?
+        switch proto.content.first?.type {
+        case .text(let textContent):
+            self.content = .text(textContent.text)
+            self.cashAction = nil
+            repliedTo = nil
+        case .cash(let cashContent):
+            guard let amount = try? ExchangedFiat(cashContent.amount) else {
+                return nil
+            }
+            self.content = .cash(amount)
+            // Unrecognized verbs fall back to `.sent`, per the proto contract.
+            self.cashAction = cashContent.verb == .tipped ? .tipped : .sent
+            repliedTo = nil
+        case .deleted(let deletedContent):
+            self.content = .deleted(
+                Deletion(
+                    deletedBy: deletedContent.hasDeletedBy ? try? UUID(data: deletedContent.deletedBy.value) : nil,
+                    deletedAt: deletedContent.hasDeletedTs ? deletedContent.deletedTs.date : proto.ts.date
+                )
+            )
+            self.cashAction = nil
+            repliedTo = nil
+        case .reply(let replyContent):
+            // The wire nests the body one level down; unwrap it so the message is a text message
+            // that happens to point at another, not a second shape every `case .text` must learn.
+            // `content` is repeated on the wire but carries exactly one entry in practice — a
+            // reply with nothing inside has no body to draw, so it is dropped like any other
+            // content the client cannot represent.
+            guard case .text(let textContent)? = replyContent.content.first?.type else {
+                return nil
+            }
+            self.content = .text(textContent.text)
+            self.cashAction = nil
+            repliedTo = replyContent.hasRepliedMessageID ? MessageID(replyContent.repliedMessageID) : nil
+        case .media, .system, .none:
+            return nil
+        }
+```
+
+and set the property alongside the others at the bottom of the initializer, after `self.lastEditedTs = ...`:
+
+```swift
+        self.repliedTo = repliedTo
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+./Scripts/test.sh FlipcashCoreTests/ConversationMessageReplyMappingTests FlipcashCoreTests/ConversationModelMappingTests FlipcashCoreTests/ConversationStoreTests
+```
+
+Expected: PASS. The existing suites are run too because `ConversationMessage`'s memberwise init gained a parameter.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add FlipcashCore/Sources/FlipcashCore/Models/Conversation/ConversationMessage.swift FlipcashCore/Tests/FlipcashCoreTests/ConversationModelMappingTests.swift
+git commit -m "feat(chat): carry the replied-to id on ConversationMessage
+
+A reply proto returned nil from the message initializer, so a reply sent from
+another client never appeared in the transcript. Unwrap ReplyContent into the
+text case it already is and keep the replied-to id beside it."
+```
+
+---
+
+## Task 2: Persist `repliedToId`
+
+The column already exists — `Schema.swift:279` declares it and `Schema.swift:534` adds it. `Database+Conversations.swift:424` writes `nil` into it today. **`SQLiteVersion` in `Info.plist` stays at 35**: no column is added, no type changes, and a row written before this task decodes as `repliedTo: nil`, which is exactly right for a message that was not a reply.
+
+**Files:**
+- Modify: `Flipcash/Core/Controllers/Database/Database+Conversations.swift:424` and `:507`
+- Test: `FlipcashTests/Database/Database+ConversationsTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `FlipcashTests/Database/Database+ConversationsTests.swift`, inside the existing conversation-messages suite:
+
+```swift
+    @Test("A reply round-trips its replied-to id through the database")
+    func replyMessage_roundTripsRepliedTo() throws {
+        let (database, url) = try Database.makeTemp()
+        defer { Database.removeTemp(at: url) }
+        let conversationID = ConversationID.test(1)
+        let original = ConversationMessage(
+            id: MessageID(value: 1), senderID: nil, content: .text("original"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0
+        )
+        let reply = ConversationMessage(
+            id: MessageID(value: 2), senderID: nil, content: .text("replying"),
+            date: Date(timeIntervalSince1970: 1), unreadSeq: 1,
+            repliedTo: MessageID(value: 1)
+        )
+        try database.upsertConversationMessages([original, reply], conversationID: conversationID)
+
+        let stored = try database.getConversationMessages(conversationID: conversationID)
+        #expect(stored.first { $0.id == MessageID(value: 1) }?.repliedTo == nil)
+        #expect(stored.first { $0.id == MessageID(value: 2) }?.repliedTo == MessageID(value: 1))
+    }
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+./Scripts/test.sh FlipcashTests/DatabaseConversationsTests/replyMessage_roundTripsRepliedTo
+```
+
+Expected: FAIL — the reply's `repliedTo` decodes as `nil`, because the write hard-codes `nil`.
+
+- [ ] **Step 3: Write and read the column**
+
+In `Database+Conversations.swift`, replace the write at `:423-424`:
+
+```swift
+                m.clientMessageID <- message.clientMessageID,
+                m.repliedToId    <- message.repliedTo?.value,
+```
+
+(The comment above it goes with the `nil`.)
+
+In the decoder's returned value, add after `lastEditedTs:`:
+
+```swift
+            lastEditedTs: row[m.lastEditedTs].map(Date.init(timeIntervalSinceReferenceDate:)),
+            repliedTo: row[m.repliedToId].map(MessageID.init(value:)),
+            clientMessageID: row[m.clientMessageID]
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+```bash
+./Scripts/test.sh FlipcashTests/DatabaseConversationsTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Flipcash/Core/Controllers/Database/Database+Conversations.swift FlipcashTests/Database/Database+ConversationsTests.swift
+git commit -m "feat(chat): persist a reply's replied-to message id
+
+The column was added with the edit/delete schema bump and written as nil since.
+Fill it in and read it back; no SQLiteVersion bump, because nothing about the
+schema changes."
+```
+
+---
+
+## Task 3: The menu offers Reply
+
+Two changes to `MessageCapability.resolve`. Text messages gain `.reply` on both sides. Cash and tip messages return `[.reply]` instead of `[]` — today those rows offer no menu at all, because edit is impossible by contract and delete is deliberately excluded, which left the set empty.
+
+`nextExpiry` needs no change: it skips any capability whose `policy.window(for:)` is `nil`, and `.reply` has no window.
+
+**Files:**
+- Modify: `FlipcashCore/Sources/FlipcashCore/Models/Conversation/MessageCapability.swift`
+- Test: `FlipcashCore/Tests/FlipcashCoreTests/MessageCapabilityTests.swift`
+
+- [ ] **Step 1: Rewrite the cash test and add the reply tests**
+
+In `MessageCapabilityTests.swift`, find and **delete** the test named
+`"A cash message offers nothing in this scope — reply is the only capability it will ever have"`,
+and add:
+
+```swift
+    @Test("A cash message offers Reply and nothing else")
+    func cashMessage_offersReplyOnly() {
+        let message = ConversationMessage(
+            id: MessageID(value: 1), senderID: selfUserID, content: .cash(sampleFiat),
+            cashAction: .sent, date: now, unreadSeq: 0, eventSequence: 1
+        )
+        let capabilities = MessageCapability.resolve(
+            for: message, in: nil, as: selfUserID, policy: .init(editWindow: 900, deleteWindow: 900), now: now
+        )
+        #expect(capabilities == [.reply])
+    }
+
+    @Test("A received text message offers Copy and Reply")
+    func receivedText_offersCopyAndReply() {
+        let message = ConversationMessage(
+            id: MessageID(value: 1), senderID: otherUserID, content: .text("hi"),
+            date: now, unreadSeq: 0, eventSequence: 1
+        )
+        let capabilities = MessageCapability.resolve(
+            for: message, in: nil, as: selfUserID, policy: .init(editWindow: 900, deleteWindow: 900), now: now
+        )
+        #expect(capabilities == [.copy, .reply])
+    }
+
+    @Test("An own text message inside both windows offers all four")
+    func ownText_insideWindows_offersEverything() {
+        let message = ConversationMessage(
+            id: MessageID(value: 1), senderID: selfUserID, content: .text("hi"),
+            date: now, unreadSeq: 0, eventSequence: 1
+        )
+        let capabilities = MessageCapability.resolve(
+            for: message, in: nil, as: selfUserID, policy: .init(editWindow: 900, deleteWindow: 900), now: now
+        )
+        #expect(capabilities == [.copy, .reply, .edit, .delete])
+    }
+
+    @Test("An unconfirmed own message still offers nothing, so the menu does not grow rows mid-send")
+    func unconfirmedOwnText_offersNothing() {
+        let message = ConversationMessage(
+            id: .unassigned, senderID: selfUserID, content: .text("hi"),
+            date: now, unreadSeq: 0, eventSequence: 0, status: .sending, clientMessageID: UUID()
+        )
+        let capabilities = MessageCapability.resolve(
+            for: message, in: nil, as: selfUserID, policy: .init(editWindow: 900, deleteWindow: 900), now: now
+        )
+        #expect(capabilities.isEmpty)
+    }
+
+    @Test("A tombstone still offers nothing")
+    func tombstone_offersNothing() {
+        let message = ConversationMessage(
+            id: MessageID(value: 1), senderID: selfUserID,
+            content: .deleted(.init(deletedBy: selfUserID, deletedAt: now)),
+            date: now, unreadSeq: 0, eventSequence: 2
+        )
+        let capabilities = MessageCapability.resolve(
+            for: message, in: nil, as: selfUserID, policy: .init(editWindow: 900, deleteWindow: 900), now: now
+        )
+        #expect(capabilities.isEmpty)
+    }
+```
+
+Reuse the suite's existing `selfUserID` / `otherUserID` / `now` / `sampleFiat` fixtures and its `MessagePolicy` construction — if the suite builds a policy some other way, use that way rather than `.init(editWindow:deleteWindow:)`.
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./Scripts/test.sh FlipcashCoreTests/MessageCapabilityTests
+```
+
+Expected: FAIL — cash resolves to `[]`, and text sets are missing `.reply`.
+
+- [ ] **Step 3: Emit `.reply`**
+
+In `MessageCapability.resolve`, replace the cash case:
+
+```swift
+        case .cash:
+            // Reply is a cash message's only capability: there is no text to copy, the server
+            // authored it so there is nothing to edit, and delete is deliberately withheld from
+            // a payment record.
+            return [.reply]
+```
+
+Replace the received-message early return:
+
+```swift
+        guard message.isFromSelf(selfUserID) else {
+            return [.copy, .reply]
+        }
+```
+
+Replace the base set for own messages:
+
+```swift
+        var capabilities: Set<MessageCapability> = [.copy, .reply]
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+./Scripts/test.sh FlipcashCoreTests/MessageCapabilityTests FlipcashTests/MessageCapabilityMenuTests
+```
+
+Expected: PASS. `MessageCapabilityMenuTests` may need its expected menus updated to include the Reply row — update the expectations, not the ordering (`ChatItem.orderedActions` already fixes `[.copy, .reply, .edit, .delete]`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add FlipcashCore/Sources/FlipcashCore/Models/Conversation/MessageCapability.swift FlipcashCore/Tests/FlipcashCoreTests/MessageCapabilityTests.swift FlipcashTests/MessageCapabilityMenuTests.swift
+git commit -m "feat(chat): offer Reply on text, cash, and tip rows
+
+Cash and tip rows resolved to an empty capability set, so they carried no
+context menu at all. Reply is the one thing they can offer, and it is now the
+one thing they do."
+```
+
+---
+
+## Task 4: `ChatQuote` and `ChatMessage.quote`
+
+The display-ready quote. Everything the panel draws is resolved here at map time — the views stay dumb, and all three quote states are testable off a pure function.
+
+`stableID` is `nil` for a quote that cannot be jumped to: an original outside the local database, or a tombstoned one (under `.hidden` the tombstone row is filtered out of the transcript, so there would be no row to land on).
+
+**Files:**
+- Create: `FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatQuote.swift`
+- Modify: `FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift`
+- Test: `FlipcashCore/Tests/FlipcashCoreTests/ChatQuoteTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `FlipcashCore/Tests/FlipcashCoreTests/ChatQuoteTests.swift`:
+
+```swift
+//
+//  ChatQuoteTests.swift
+//  FlipcashCoreTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import FlipcashCore
+
+@Suite("ChatQuote")
+struct ChatQuoteTests {
+
+    @Test("A short snippet is left alone")
+    func shortSnippet_isUnchanged() {
+        #expect(ChatQuote.snippet(forText: "on my way") == "on my way")
+    }
+
+    @Test("A long snippet is truncated with an ellipsis at the limit")
+    func longSnippet_isTruncated() {
+        let text = String(repeating: "a", count: ChatQuote.snippetLimit + 40)
+        let snippet = ChatQuote.snippet(forText: text)
+        #expect(snippet.count == ChatQuote.snippetLimit + 1)
+        #expect(snippet.hasSuffix("…"))
+    }
+
+    @Test("Newlines collapse so the snippet stays one line")
+    func newlines_collapse() {
+        #expect(ChatQuote.snippet(forText: "line one\nline two") == "line one line two")
+    }
+
+    @Test("A quote with no target cannot be jumped to")
+    func unresolvedQuote_hasNoTarget() {
+        let quote = ChatQuote(stableID: nil, authorName: "", snippet: ChatQuote.unavailableSnippet, kind: .unavailable)
+        #expect(quote.isJumpable == false)
+    }
+
+    @Test("A resolved quote can be jumped to")
+    func resolvedQuote_hasTarget() {
+        let quote = ChatQuote(stableID: "7", authorName: "You", snippet: "hi", kind: .text)
+        #expect(quote.isJumpable)
+    }
+
+    @Test("A message carries no quote by default")
+    func chatMessage_defaultsToNoQuote() {
+        #expect(ChatMessage(id: "1", text: "hi", sender: .me).quote == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+./Scripts/test.sh FlipcashCoreTests/ChatQuoteTests
+```
+
+Expected: compile failure — no `ChatQuote`.
+
+- [ ] **Step 3: Write `ChatQuote`**
+
+Create `FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatQuote.swift`:
+
+```swift
+//
+//  ChatQuote.swift
+//  FlipcashCore
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The quoted original shown above a reply's body — display-ready, like everything else a chat row
+/// draws. The transcript mapper resolves the replied-to id into one of these; the panel that draws
+/// it knows nothing about the database or which messages happen to be loaded.
+public struct ChatQuote: Hashable, Sendable, Codable {
+
+    /// What the original was, which selects the panel's presentation.
+    public enum Kind: Hashable, Sendable, Codable {
+        case text
+        /// A payment. The snippet is the formatted amount.
+        case cash
+        /// The original is not in the local database, or it has been deleted. The panel renders
+        /// the placeholder copy and the row is not tappable.
+        case unavailable
+    }
+
+    /// The transcript row to jump to, or `nil` when there is nothing to jump to.
+    public let stableID: String?
+    /// "You" for the viewer's own message, the counterpart's display name otherwise. Empty for an
+    /// unavailable original, whose author is not known.
+    public let authorName: String
+    public let snippet: String
+    public let kind: Kind
+
+    public init(stableID: String?, authorName: String, snippet: String, kind: Kind) {
+        self.stableID = stableID
+        self.authorName = authorName
+        self.snippet = snippet
+        self.kind = kind
+    }
+
+    /// Whether tapping the panel goes anywhere.
+    public var isJumpable: Bool { stableID != nil }
+
+    /// Copy for an original the client cannot show.
+    public static let unavailableSnippet = "Original message unavailable"
+
+    /// Copy for an original that has since been deleted.
+    public static let deletedSnippet = "This message was deleted"
+
+    /// Longest snippet the panel renders. Past this the panel would wrap to a third line and the
+    /// bubble would grow around a preview rather than the message.
+    public static let snippetLimit = 120
+
+    /// One line of preview text: newlines collapsed to spaces, truncated at ``snippetLimit``.
+    public static func snippet(forText text: String) -> String {
+        let flattened = text
+            .split(whereSeparator: \.isNewline)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
+        guard flattened.count > snippetLimit else { return flattened }
+        return flattened.prefix(snippetLimit) + "…"
+    }
+}
+```
+
+- [ ] **Step 4: Add `quote` to `ChatMessage`**
+
+In `ChatMessage.swift`, add the stored property after `actions`:
+
+```swift
+    /// The original this row replies to, already resolved for display, or `nil` when the row is
+    /// not a reply.
+    public let quote: ChatQuote?
+```
+
+Add `quote: ChatQuote? = nil` as the last parameter of **both** initializers (after `actions:`), assign it in the full one:
+
+```swift
+        self.quote = quote
+```
+
+and forward it from the text convenience initializer:
+
+```swift
+            actions: actions,
+            quote: quote
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+./Scripts/test.sh FlipcashCoreTests/ChatQuoteTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatQuote.swift FlipcashCore/Sources/FlipcashCore/Models/Chat/ChatMessage.swift FlipcashCore/Tests/FlipcashCoreTests/ChatQuoteTests.swift
+git commit -m "feat(chat): add the display-ready quote a reply row draws"
+```
+
+---
+
+## Task 5: The mapper resolves the quote
+
+`ChatItem.from` stays pure. It takes the counterpart's name and a lookup closure; the caller pre-resolves the messages. All three states — resolved, unavailable, deleted — are decided here, so all three are testable without a database.
+
+**Files:**
+- Modify: `Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift`
+- Test: `FlipcashTests/Chat/ChatQuoteMappingTests.swift` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `FlipcashTests/Chat/ChatQuoteMappingTests.swift`:
+
+```swift
+//
+//  ChatQuoteMappingTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+import FlipcashCore
+import FlipcashUI
+@testable import Flipcash
+
+@Suite("Reply quote mapping")
+struct ChatQuoteMappingTests {
+
+    private let me = UUID()
+    private let them = UUID()
+    private let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func message(
+        id: UInt64,
+        from sender: UUID?,
+        content: ConversationMessage.Content,
+        repliedTo: UInt64? = nil,
+        offset: TimeInterval = 0
+    ) -> ConversationMessage {
+        ConversationMessage(
+            id: MessageID(value: id),
+            senderID: sender,
+            content: content,
+            date: start.addingTimeInterval(offset),
+            unreadSeq: id,
+            eventSequence: id,
+            repliedTo: repliedTo.map { MessageID(value: $0) }
+        )
+    }
+
+    private func quotes(
+        _ messages: [ConversationMessage],
+        resolving pool: [ConversationMessage] = []
+    ) -> [ChatQuote?] {
+        let byID = Dictionary(uniqueKeysWithValues: (messages + pool).map { ($0.id, $0) })
+        return ChatItem.from(
+            messages,
+            selfUserID: me,
+            counterpartName: "Ada",
+            quotedMessage: { byID[$0] }
+        ).compactMap { item in
+            if case .message(let message) = item { return message.quote } else { return nil }
+        }
+    }
+
+    @Test("A reply to a message in the window quotes its author and text")
+    func replyToWindowedMessage_resolves() throws {
+        let original = message(id: 1, from: them, content: .text("dinner at 7?"))
+        let reply = message(id: 2, from: me, content: .text("works"), repliedTo: 1, offset: 5)
+        let quote = try #require(quotes([original, reply]).last ?? nil)
+        #expect(quote.authorName == "Ada")
+        #expect(quote.snippet == "dinner at 7?")
+        #expect(quote.kind == .text)
+        #expect(quote.stableID == original.stableID)
+    }
+
+    @Test("A reply to my own message names me")
+    func replyToOwnMessage_namesMe() throws {
+        let original = message(id: 1, from: me, content: .text("dinner at 7?"))
+        let reply = message(id: 2, from: them, content: .text("works"), repliedTo: 1, offset: 5)
+        let quote = try #require(quotes([original, reply]).last ?? nil)
+        #expect(quote.authorName == "You")
+    }
+
+    @Test("A reply to a message outside the local database renders as unavailable and cannot be jumped to")
+    func replyToUnknownMessage_isUnavailable() throws {
+        let reply = message(id: 2, from: me, content: .text("works"), repliedTo: 99, offset: 5)
+        let quote = try #require(quotes([reply]).last ?? nil)
+        #expect(quote.kind == .unavailable)
+        #expect(quote.snippet == ChatQuote.unavailableSnippet)
+        #expect(quote.isJumpable == false)
+    }
+
+    @Test("A reply to a deleted message says so and cannot be jumped to")
+    func replyToDeletedMessage_isUnavailable() throws {
+        let original = message(
+            id: 1, from: them,
+            content: .deleted(ConversationMessage.Deletion(deletedBy: them, deletedAt: start))
+        )
+        let reply = message(id: 2, from: me, content: .text("works"), repliedTo: 1, offset: 5)
+        // The tombstone itself is filtered out of the transcript under `.hidden`, so it is supplied
+        // through the resolution pool rather than the window.
+        let quote = try #require(quotes([reply], resolving: [original]).last ?? nil)
+        #expect(quote.kind == .unavailable)
+        #expect(quote.snippet == ChatQuote.deletedSnippet)
+        #expect(quote.isJumpable == false)
+    }
+
+    private func fiat(_ amount: Decimal) -> ExchangedFiat {
+        ExchangedFiat(
+            onChainAmount: TokenAmount(quarks: 0, mint: .usdf),
+            nativeAmount: FiatAmount(value: amount, currency: .usd),
+            currencyRate: Rate(fx: 1, currency: .usd)
+        )
+    }
+
+    @Test("A reply to a payment quotes the formatted amount")
+    func replyToCashMessage_quotesAmount() throws {
+        let fiat = fiat(5)
+        let original = message(id: 1, from: them, content: .cash(fiat))
+        let reply = message(id: 2, from: me, content: .text("thanks!"), repliedTo: 1, offset: 5)
+        let quote = try #require(quotes([original, reply]).last ?? nil)
+        #expect(quote.kind == .cash)
+        #expect(quote.snippet == fiat.nativeAmount.formatted())
+    }
+
+    @Test("A message that is not a reply carries no quote")
+    func plainMessage_hasNoQuote() {
+        let plain = message(id: 1, from: me, content: .text("hi"))
+        #expect(quotes([plain]).last ?? nil == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./Scripts/test.sh FlipcashTests/ChatQuoteMappingTests
+```
+
+Expected: compile failure — `ChatItem.from` has no `counterpartName` or `quotedMessage` parameter.
+
+- [ ] **Step 3: Add the parameters and build the quote**
+
+In `ChatItem+Conversation.swift`, add two parameters to `from(_:...)` after `capabilities:`:
+
+```swift
+        capabilities: (ConversationMessage) -> Set<MessageCapability> = { _ in [] },
+        counterpartName: String = "",
+        quotedMessage: (MessageID) -> ConversationMessage? = { _ in nil }
+    ) -> [ChatItem] {
+```
+
+Inside the loop, after the `receipt` switch and before `items.append(.message(...))`:
+
+```swift
+            // Resolved here rather than in the view so all three states — found, never fetched,
+            // deleted — are decided by one pure function and testable without a database.
+            let quote = message.repliedTo.map { repliedTo in
+                Self.quote(
+                    resolving: quotedMessage(repliedTo),
+                    selfUserID: selfUserID,
+                    counterpartName: counterpartName
+                )
+            }
+```
+
+Add `quote: quote` as the last argument of the `ChatMessage(...)` construction:
+
+```swift
+                actions: orderedActions(capabilities(message)),
+                quote: quote
+            )))
+```
+
+Add the resolver beside `orderedActions`:
+
+```swift
+    /// The quoted original, for each of the three states it can be in. A message the local database
+    /// has never seen and a tombstone both render as unavailable and both refuse the jump — the
+    /// first because there is no row to land on, the second because `.hidden` filters the tombstone
+    /// out of the transcript entirely.
+    nonisolated private static func quote(
+        resolving original: ConversationMessage?,
+        selfUserID: UserID,
+        counterpartName: String
+    ) -> ChatQuote {
+        guard let original else {
+            return ChatQuote(
+                stableID: nil,
+                authorName: "",
+                snippet: ChatQuote.unavailableSnippet,
+                kind: .unavailable
+            )
+        }
+        let authorName = original.isFromSelf(selfUserID) ? "You" : counterpartName
+        switch original.content {
+        case .text(let text):
+            return ChatQuote(
+                stableID: original.stableID,
+                authorName: authorName,
+                snippet: ChatQuote.snippet(forText: text),
+                kind: .text
+            )
+        case .cash(let fiat):
+            return ChatQuote(
+                stableID: original.stableID,
+                authorName: authorName,
+                snippet: fiat.nativeAmount.formatted(),
+                kind: .cash
+            )
+        case .deleted:
+            return ChatQuote(
+                stableID: nil,
+                authorName: authorName,
+                snippet: ChatQuote.deletedSnippet,
+                kind: .unavailable
+            )
+        }
+    }
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+./Scripts/test.sh FlipcashTests/ChatQuoteMappingTests FlipcashTests/ChatMessageMappingTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Flipcash/Core/Screens/Conversation/ChatItem+Conversation.swift FlipcashTests/Chat/ChatQuoteMappingTests.swift
+git commit -m "feat(chat): resolve a reply's quoted original in the transcript mapper"
+```
+
+---
+
+## Task 6: Feed the mapper its quotes
+
+The coordinator pre-resolves every quoted message before mapping: from the window first, then from the local database. Both go on `Inputs`, so `map` stays pure and the equality short-circuit keeps working — a quote appearing because history was paged in changes `Inputs` and re-maps; an unrelated tick does not.
+
+**Files:**
+- Modify: `Flipcash/Core/Controllers/ConversationController.swift`
+- Modify: `Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift`
+
+- [ ] **Step 1: Add the persisted-message accessor**
+
+In `ConversationController.swift`, beside `windowedMessages(for:startingAt:limit:)`:
+
+```swift
+    /// The locally-stored copy of one message, regardless of whether it is inside the rendered
+    /// window. Reply quotes read through this: a reply can point at a message far above the
+    /// window, and resolving it must not page the server. Observes `messageRevision`, so a quote
+    /// that resolves once history lands re-maps like any other change.
+    func persistedMessage(_ messageID: MessageID, in conversationID: ConversationID) -> ConversationMessage? {
+        _ = messageRevision   // observe: re-read when a confirmed DB write lands
+        return (try? database.message(id: messageID, conversationID: conversationID)) ?? nil
+    }
+```
+
+- [ ] **Step 2: Carry the quotes on `Inputs`**
+
+In `ConversationLoadCoordinator.swift`, add to `struct Inputs` after `conversation`:
+
+```swift
+        /// The counterpart's display name, for a quote whose original they wrote.
+        var counterpartName: String
+        /// Every message quoted by a reply in the window, pre-resolved so `map` stays pure. Keyed
+        /// by raw id because `MessageID` is the natural key and the dictionary must be `Equatable`.
+        var quotedMessages: [UInt64: ConversationMessage]
+```
+
+In `currentInputs()`, after the branding loop:
+
+```swift
+        let counterpartName = conversation?.counterpart(excluding: controller.selfUserID)?.displayName ?? ""
+        // The window first — a reply to a nearby message resolves with no database read at all —
+        // then the table, for a reply pointing above the window. Nothing pages the server: a quote
+        // whose original was never fetched renders as unavailable, by design.
+        var quotedMessages: [UInt64: ConversationMessage] = [:]
+        for message in window {
+            guard let repliedTo = message.repliedTo, quotedMessages[repliedTo.value] == nil else { continue }
+            if let inWindow = window.first(where: { $0.id == repliedTo }) {
+                quotedMessages[repliedTo.value] = inWindow
+            } else if let persisted = controller.persistedMessage(repliedTo, in: conversationID) {
+                quotedMessages[repliedTo.value] = persisted
+            }
+        }
+```
+
+and pass them, after `conversation: conversation,`:
+
+```swift
+            counterpartName: counterpartName,
+            quotedMessages: quotedMessages,
+```
+
+In `map(_:)`, add after the `capabilities:` closure:
+
+```swift
+            counterpartName: inputs.counterpartName,
+            quotedMessage: { inputs.quotedMessages[$0.value] }
+```
+
+Expose the resolved name so the composer strip names the author exactly as the bubble's panel
+does — one source, not two:
+
+```swift
+    /// The counterpart's display name as the last mapping resolved it. The composer's reply strip
+    /// reads this so the strip and the sent bubble's quote name the same person the same way.
+    var counterpartName: String { lastInputs?.counterpartName ?? "" }
+```
+
+- [ ] **Step 3: Build**
+
+Build the app scheme in Xcode (or via your usual build command) and confirm it compiles. There is no new behavior to unit-test here — the resolution logic under test lives in Task 5's pure mapper, and this task only supplies it.
+
+- [ ] **Step 4: Run the surrounding suites**
+
+```bash
+./Scripts/test.sh FlipcashTests/ChatQuoteMappingTests FlipcashTests/MessageLoaderTests FlipcashTests/ConversationMutationTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Flipcash/Core/Controllers/ConversationController.swift Flipcash/Core/Screens/Conversation/ConversationLoadCoordinator.swift
+git commit -m "feat(chat): pre-resolve quoted originals for the transcript mapper
+
+A reply can point above the rendered window, so resolution reads the window
+first and the local table second. Neither pages the server."
+```
+
+---
+
+## Task 7: `ComposerModel` learns to reply
+
+A third mode beside `.new` and `.editing`. Two differences from editing, both deliberate:
+
+- **The draft survives.** Starting a reply keeps whatever is already typed — WhatsApp does not throw it away, and unlike an edit there is no other text to swap in. So there is no stash.
+- **`submission` behaves exactly like `.new`** — the trimmed draft, non-empty. There is no "unchanged" case to suppress.
+
+`isEditing` and `editingStableID` stay false/nil in reply mode: they drive the cancel-edit morph and the edit spotlight, neither of which applies.
+
+**Files:**
+- Modify: `Flipcash/Core/Screens/Conversation/ComposerModel.swift`
+- Test: `FlipcashTests/Chat/ComposerModelTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `ComposerModelTests` suite:
+
+```swift
+    private var replyTarget: ComposerModel.ReplyTarget {
+        ComposerModel.ReplyTarget(
+            messageID: MessageID(value: 7),
+            stableID: "7",
+            authorName: "Ada",
+            snippet: "dinner at 7?"
+        )
+    }
+
+    @Test("Starting a reply keeps what is already typed")
+    func beginReplying_keepsDraft() {
+        let composer = ComposerModel()
+        composer.draft = "half a thought"
+        composer.beginReplying(to: replyTarget)
+        #expect(composer.draft == "half a thought")
+        #expect(composer.replyTarget == replyTarget)
+    }
+
+    @Test("A reply submits its trimmed draft")
+    func replying_submitsTrimmedDraft() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.draft = "  works  "
+        #expect(composer.submission == "works")
+        #expect(composer.canSubmit)
+    }
+
+    @Test("An empty reply cannot be submitted")
+    func replyingWithEmptyDraft_cannotSubmit() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.draft = "   "
+        #expect(composer.submission == nil)
+        #expect(composer.canSubmit == false)
+    }
+
+    @Test("Dismissing the reply keeps the draft and clears the target")
+    func endReplying_keepsDraft() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.draft = "works"
+        composer.endReplying()
+        #expect(composer.replyTarget == nil)
+        #expect(composer.draft == "works")
+    }
+
+    @Test("A reply is not an edit")
+    func replying_isNotEditing() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        #expect(composer.isEditing == false)
+        #expect(composer.editingStableID == nil)
+    }
+
+    @Test("Starting an edit while replying drops the reply")
+    func beginEditing_whileReplying_dropsReply() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.beginEditing(messageID: MessageID(value: 9), stableID: "9", currentText: "old")
+        #expect(composer.replyTarget == nil)
+        #expect(composer.isEditing)
+        #expect(composer.draft == "old")
+    }
+
+    @Test("Clearing after a send drops the reply")
+    func clear_dropsReply() {
+        let composer = ComposerModel()
+        composer.beginReplying(to: replyTarget)
+        composer.draft = "works"
+        composer.clear()
+        #expect(composer.replyTarget == nil)
+        #expect(composer.draft.isEmpty)
+    }
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./Scripts/test.sh FlipcashTests/ComposerModelTests
+```
+
+Expected: compile failure — no `beginReplying`.
+
+- [ ] **Step 3: Add the mode**
+
+In `ComposerModel.swift`, add the target type above `Mode`:
+
+```swift
+    /// What a reply is composed against — enough to render the strip and to address the send,
+    /// so the composer never reaches back into the transcript for it.
+    struct ReplyTarget: Equatable {
+        let messageID: MessageID
+        let stableID: String
+        let authorName: String
+        let snippet: String
+    }
+```
+
+Add the case:
+
+```swift
+    enum Mode: Equatable {
+        case new
+        case editing(messageID: MessageID, stableID: String)
+        case replying(to: ReplyTarget)
+    }
+```
+
+Add the accessors beside `editingStableID`:
+
+```swift
+    /// The message this composer is replying to, or `nil` when it is not replying.
+    var replyTarget: ReplyTarget? {
+        switch mode {
+        case .new, .editing:            nil
+        case .replying(let target):     target
+        }
+    }
+```
+
+Extend `submission`'s switch with the reply case, which behaves like `.new`:
+
+```swift
+        case .new, .replying:
+            let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+```
+
+Extend `editingStableID` and `isEditing` — a reply is not an edit:
+
+```swift
+    var editingStableID: String? {
+        switch mode {
+        case .new, .replying:               nil
+        case .editing(_, let stableID):     stableID
+        }
+    }
+
+    var isEditing: Bool {
+        switch mode {
+        case .new, .replying:   false
+        case .editing:          true
+        }
+    }
+```
+
+Add the transitions beside `beginEditing`/`endEditing`:
+
+```swift
+    /// Aims the composer at a message. Unlike an edit, the draft is left alone — a reply adds to
+    /// what you were already typing rather than replacing it.
+    func beginReplying(to target: ReplyTarget) {
+        if isEditing { endEditing() }
+        mode = .replying(to: target)
+    }
+
+    /// Dismisses the reply, keeping the draft — the strip's ⊗ takes back the target, not the text.
+    func endReplying() {
+        guard case .replying = mode else { return }
+        mode = .new
+    }
+```
+
+In `beginEditing`, the existing body already assigns `mode = .editing(...)`, which drops a reply target. Confirm it also stashes the draft as it does today — the `beginEditing_whileReplying_dropsReply` test covers the ordering.
+
+In `clear()`, the existing `if mode != .new { mode = .new }` guard already drops a reply target; no change needed.
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+./Scripts/test.sh FlipcashTests/ComposerModelTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Flipcash/Core/Screens/Conversation/ComposerModel.swift FlipcashTests/Chat/ComposerModelTests.swift
+git commit -m "feat(chat): give the composer a reply mode
+
+Unlike an edit, a reply keeps the draft: it adds to what you were typing
+rather than replacing it, so there is nothing to stash."
+```
+
+---
+
+## Task 8: The composer's reply strip
+
+A quote strip above the input row, inside the bar's gradient background so it reads as one surface: full-bleed, a leading accent rule, the author on the first line, the snippet muted below, and a ⊗ at the trailing edge that clears back to `.new`.
+
+The theme is monochrome — there is no green accent to borrow. The rule and the author line use the same white-opacity family the rest of the chat chrome uses.
+
+**Files:**
+- Create: `Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift`
+- Modify: `Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift`
+
+- [ ] **Step 1: Write the strip**
+
+Create `Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift`:
+
+```swift
+//
+//  ComposerReplyStrip.swift
+//  Flipcash
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import SwiftUI
+import FlipcashCore
+import FlipcashUI
+
+/// The quoted original above the composer while a reply is being written. Sits inside the bottom
+/// bar's background rather than on top of it, so the bar reads as one surface that grew, and
+/// dismissing it takes back the target without touching the draft.
+struct ComposerReplyStrip: View {
+
+    let target: ComposerModel.ReplyTarget
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            // The leading rule is the quote's whole identity here; the panel has no fill of its own.
+            RoundedRectangle(cornerRadius: 1, style: .continuous)
+                .fill(Color.white.opacity(0.5))
+                .frame(width: 2)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(target.authorName)
+                    .font(.appTextCaption)
+                    .foregroundStyle(Color.textMain)
+                Text(target.snippet)
+                    .font(.appTextCaption)
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: onDismiss) {
+                Image(systemName: SystemSymbol.close.rawValue)
+                    .font(.default(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Cancel reply")
+        }
+        .padding(.leading, 12)
+        .padding(.trailing, 8)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white.opacity(0.06))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Replying to \(target.authorName): \(target.snippet)")
+    }
+}
+```
+
+- [ ] **Step 2: Mount it in the bar**
+
+In `ConversationBottomBar.swift`, inside `ConversationBottomBar.body`, wrap the existing `content` so the strip sits above the input row and inside the gradient. Replace:
+
+```swift
+        return content.modifier(BarGradientBackground())
+```
+
+with:
+
+```swift
+        return VStack(spacing: 0) {
+            if let target = composer.replyTarget {
+                ComposerReplyStrip(target: target) {
+                    withAnimation(barMorphSpring) { composer.endReplying() }
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+            content
+        }
+        .animation(barMorphSpring, value: composer.replyTarget)
+        .modifier(BarGradientBackground())
+```
+
+The strip is full-bleed by construction — the horizontal padding lives on `content`, not on the `VStack`.
+
+- [ ] **Step 3: Report the taller bar**
+
+The bar's height feeds the transcript's bottom inset through `setBarHeight(_:)`. Confirm the existing height measurement is a `GeometryReader`/`onGeometryChange` over the whole bar rather than a constant derived from `BarMetrics.contentHeight`: if it reads the rendered height, the strip is already accounted for and the transcript keeps its last message visible. If it is computed from `BarMetrics`, switch it to the measured height — a hard-coded height would leave the strip covering the newest row.
+
+- [ ] **Step 4: Verify by hand**
+
+Build and run. In a conversation:
+- Long-press a message, choose Reply. The strip animates up, the keyboard raises, and the transcript scrolls so the last message stays above the taller bar.
+- Type something, then tap ⊗. The strip animates away and **the text stays**.
+- Type something, start a reply, then start an edit. The strip disappears, the draft becomes the edited message's text, and the cancel-edit button appears.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+git commit -m "feat(chat): show the quoted original above the composer"
+```
+
+---
+
+## Task 9: Send the reply
+
+`ReplyContent` wraps the text on the wire; the id rides beside it. Four signatures carry the replied-to id from the composer to the request, and the optimistic pending message carries it too so the quote is on the bubble the instant it appears rather than after the server confirms.
+
+**Files:**
+- Modify: `FlipcashCore/Sources/FlipcashCore/Clients/Flip API/Services/ChatMessagingService.swift`
+- Modify: `FlipcashCore/Sources/FlipcashCore/Clients/Flip API/FlipClient+Chat.swift`
+- Modify: `Flipcash/Core/Controllers/FlipClient+Protocols.swift`
+- Modify: `Flipcash/Core/Controllers/ConversationController.swift`
+- Modify: `Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift`
+- Modify: `FlipcashTests/TestSupport/MockConversations.swift`
+- Test: `FlipcashTests/Chat/ConversationReplySendTests.swift` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `FlipcashTests/Chat/ConversationReplySendTests.swift`:
+
+```swift
+//
+//  ConversationReplySendTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Sending a reply")
+struct ConversationReplySendTests {
+
+    /// Mirrors `ConversationControllerTests.makeController` — the same four mocks and a temp DB.
+    private func makeController(_ mock: MockConversations, selfUserID: UserID = UUID()) -> ConversationController {
+        ConversationController(
+            fetching: mock, messaging: mock, streaming: mock,
+            contactNaming: MockDMContactNaming(),
+            database: try! Database.makeTemp().database,
+            owner: .generate()!, selfUserID: selfUserID,
+            typingHeartbeatInterval: .seconds(3), incomingTypingExpiry: .seconds(10)
+        )
+    }
+
+    @Test("A reply carries the replied-to id to the service")
+    func send_carriesRepliedTo() async throws {
+        let mock = MockConversations()
+        mock.sendResult = ConversationMessage(
+            id: MessageID(value: 8), senderID: nil, content: .text("works"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0, repliedTo: MessageID(value: 7)
+        )
+        let controller = makeController(mock)
+
+        #expect(await controller.send("works", to: ConversationID.test(1), repliedTo: MessageID(value: 7)))
+
+        let sent = try #require(mock.sent.last)
+        #expect(sent.text == "works")
+        #expect(sent.repliedTo == MessageID(value: 7))
+    }
+
+    @Test("A plain send carries no replied-to id")
+    func send_withoutReply_carriesNothing() async throws {
+        let mock = MockConversations()
+        mock.sendResult = ConversationMessage(
+            id: MessageID(value: 8), senderID: nil, content: .text("hi"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0
+        )
+        let controller = makeController(mock)
+
+        #expect(await controller.send("hi", to: ConversationID.test(1)))
+
+        let sent = try #require(mock.sent.last)
+        #expect(sent.repliedTo == nil)
+    }
+
+    @Test("The optimistic row quotes the original before the server confirms")
+    func failedReply_keepsRepliedTo() async throws {
+        // A failed send leaves the optimistic row in the transcript, which is the same row the
+        // successful path shows while it is in flight — so this reads the pending copy directly.
+        let me = UUID()
+        let mock = MockConversations()
+        mock.sendError = ErrorSendMessage.transportFailure
+        let controller = makeController(mock, selfUserID: me)
+
+        _ = await controller.send("works", to: ConversationID.test(1), repliedTo: MessageID(value: 7))
+
+        let pending = try #require(controller.messages(for: ConversationID.test(1)).first)
+        #expect(pending.status == .failed)
+        #expect(pending.repliedTo == MessageID(value: 7))
+    }
+
+    @Test("Retrying a failed reply keeps the replied-to id")
+    func retry_keepsRepliedTo() async throws {
+        let me = UUID()
+        let mock = MockConversations()
+        mock.sendError = ErrorSendMessage.transportFailure
+        let controller = makeController(mock, selfUserID: me)
+
+        _ = await controller.send("works", to: ConversationID.test(1), repliedTo: MessageID(value: 7))
+        let failed = try #require(controller.messages(for: ConversationID.test(1)).first)
+        let clientID = try #require(failed.clientMessageID)
+
+        mock.sendError = nil
+        mock.sendResult = ConversationMessage(
+            id: MessageID(value: 9), senderID: me, content: .text("works"),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0, repliedTo: MessageID(value: 7)
+        )
+        await controller.retry(clientMessageID: clientID, in: ConversationID.test(1))
+
+        let sent = try #require(mock.sent.last)
+        #expect(sent.repliedTo == MessageID(value: 7))
+    }
+}
+```
+
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./Scripts/test.sh FlipcashTests/ConversationReplySendTests
+```
+
+Expected: compile failure — `send` has no `repliedTo` parameter.
+
+- [ ] **Step 3: Build the wire request**
+
+In `ChatMessagingService.swift`, change the signature and the content construction:
+
+```swift
+    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, repliedTo: MessageID?, clientMessageID: UUID, completion: @Sendable @escaping (Result<ConversationMessage, ErrorSendMessage>) -> Void) {
+        let request = Flipcash_Messaging_V1_SendMessageRequest.with {
+            $0.chatID = conversationID.proto
+            // A reply wraps the same text one level deeper on the wire. The domain model keeps it
+            // flat — see `ConversationMessage.init?(_:)`, which unwraps it back.
+            if let repliedTo {
+                $0.content = [.with {
+                    $0.reply = .with {
+                        $0.repliedMessageID = repliedTo.proto
+                        $0.content = [.with { $0.text = .with { $0.text = text } }]
+                    }
+                }]
+            } else {
+                $0.content = [.with { $0.text = .with { $0.text = text } }]
+            }
+            $0.clientMessageID = .with { $0.value = clientMessageID.data }
+            $0.auth = owner.authFor(message: $0)
+        }
+```
+
+- [ ] **Step 4: Thread the parameter through the other three signatures**
+
+In `FlipClient+Chat.swift`, add `repliedTo: MessageID?` to the `sendMessage` wrapper and forward it to the service call.
+
+In `FlipClient+Protocols.swift`, update the `ConversationMessaging` requirement to match:
+
+```swift
+    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, repliedTo: MessageID?, clientMessageID: UUID) async throws -> ConversationMessage
+```
+
+In `MockConversations.swift`, add the field to the record and the parameter to the method:
+
+```swift
+    struct Sent: Sendable {
+        let conversationID: ConversationID
+        let text: String
+        let repliedTo: MessageID?
+    }
+```
+
+and the method records it:
+
+```swift
+    func sendMessage(owner: KeyPair, conversationID: ConversationID, text: String, repliedTo: MessageID?, clientMessageID: UUID) async throws -> ConversationMessage {
+        lock.withLock {
+            _sent.append(Sent(conversationID: conversationID, text: text, repliedTo: repliedTo))
+            _sentClientIDs.append(clientMessageID)
+        }
+        if let error = sendError { throw error }
+        return sendResult ?? ConversationMessage(
+            id: MessageID(value: 1), senderID: nil, content: .text(text),
+            date: Date(timeIntervalSince1970: 0), unreadSeq: 0, repliedTo: repliedTo
+        )
+    }
+```
+
+- [ ] **Step 5: Thread it through the controller**
+
+In `ConversationController.swift`, `send` takes the id, puts it on the optimistic message, and passes it down:
+
+```swift
+    @discardableResult
+    func send(_ text: String, to conversationID: ConversationID, repliedTo: MessageID? = nil) async -> Bool {
+        let clientMessageID = UUID()
+        let pending = ConversationMessage(
+            id: .unassigned, senderID: selfUserID, content: .text(text),
+            date: .now, unreadSeq: 0, status: .sending, clientMessageID: clientMessageID,
+            repliedTo: repliedTo
+        )
+```
+
+(keep the rest of the body, changing only the final call:)
+
+```swift
+        return await deliver(clientMessageID: clientMessageID, text: text, repliedTo: repliedTo, to: conversationID)
+```
+
+`retry` reads the id back off the pending message rather than being handed it, so a retry after a relaunch still quotes the right original:
+
+```swift
+        store.markPending(clientMessageID: clientMessageID, status: .sending, in: conversationID)
+        _ = await deliver(clientMessageID: clientMessageID, text: text, repliedTo: pending.repliedTo, to: conversationID)
+```
+
+`deliver` takes it and forwards it:
+
+```swift
+    private func deliver(clientMessageID: UUID, text: String, repliedTo: MessageID?, to conversationID: ConversationID) async -> Bool {
+```
+
+with the messaging call becoming:
+
+```swift
+            let confirmed = try await messaging.sendMessage(
+                owner: owner,
+                conversationID: conversationID,
+                text: text,
+                repliedTo: repliedTo,
+                clientMessageID: clientMessageID
+            )
+```
+
+- [ ] **Step 6: Send from the composer**
+
+In `ConversationBottomBar.swift`, extend `ConversationComposer.submit()`'s switch:
+
+```swift
+        switch composer.mode {
+        case .new:
+            guard let text = composer.submission else { return }
+            composer.clear()
+            isFocused = true
+            Task { await conversationController.send(text, to: conversationID) }
+        case .replying(let target):
+            guard let text = composer.submission else { return }
+            composer.clear()
+            isFocused = true
+            Task { await conversationController.send(text, to: conversationID, repliedTo: target.messageID) }
+        case .editing(let messageID, _):
+```
+
+(the `.editing` body is unchanged.)
+
+- [ ] **Step 7: Run the tests and watch them pass**
+
+```bash
+./Scripts/test.sh FlipcashTests/ConversationReplySendTests FlipcashTests/ConversationMutationTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add FlipcashCore/Sources/FlipcashCore/Clients/Flip\ API/Services/ChatMessagingService.swift FlipcashCore/Sources/FlipcashCore/Clients/Flip\ API/FlipClient+Chat.swift Flipcash/Core/Controllers/FlipClient+Protocols.swift Flipcash/Core/Controllers/ConversationController.swift Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift FlipcashTests/TestSupport/MockConversations.swift FlipcashTests/Chat/ConversationReplySendTests.swift
+git commit -m "feat(chat): send a reply with the id of the message it answers
+
+The optimistic row carries the id too, so the quote is on the bubble the
+moment it appears rather than after the server confirms."
+```
+
+---
+
+## Task 10: The quote panel inside the bubble
+
+A tinted panel above the body, inside the same bubble background: its own leading rule, the author, the snippet. It is the jump target.
+
+Two constraints that matter more than they look:
+
+- **The cell class must not change.** `ChatItem+Differentiable.cellReuseIdentifier` picks the cell from the content kind and the link preview; a quote is not part of that decision. If a quote changed the identifier, DifferenceKit would delete and re-insert the row instead of updating it, and the send animation would flicker.
+- **A hidden panel must occupy no height.** The panel is hidden *and* pinned to zero height when there is no quote, and the body's top constraint is swapped, not just deactivated — leaving both active makes the layout unsatisfiable.
+
+**Files:**
+- Create: `FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift`
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/ChatBubbleView.swift`
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/LinkableBubbleView.swift`
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift`
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/ChatLinkMessageCell.swift`
+- Test: `FlipcashTests/Chat/ChatQuoteBubbleTests.swift` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `FlipcashTests/Chat/ChatQuoteBubbleTests.swift`:
+
+```swift
+//
+//  ChatQuoteBubbleTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import UIKit
+import FlipcashCore
+@testable import FlipcashUI
+
+@Suite("Reply bubble quote panel")
+@MainActor
+struct ChatQuoteBubbleTests {
+
+    private static let maxWidth: CGFloat = 250
+
+    private let quote = ChatQuote(stableID: "7", authorName: "Ada", snippet: "dinner at 7?", kind: .text)
+
+    private func laidOutCell(quote: ChatQuote?) -> ChatMessageCell {
+        let cell = ChatMessageCell(frame: CGRect(x: 0, y: 0, width: 320, height: 80))
+        cell.configure(
+            with: ChatMessage(id: "1", content: .text("works"), sender: .me, quote: quote),
+            maxWidth: Self.maxWidth
+        )
+        let fitted = cell.contentView.systemLayoutSizeFitting(
+            CGSize(width: 320, height: 0),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        cell.frame = CGRect(x: 0, y: 0, width: 320, height: fitted.height)
+        cell.layoutIfNeeded()
+        return cell
+    }
+
+    @Test("A quote makes the bubble taller")
+    func quote_growsTheBubble() {
+        let plain = laidOutCell(quote: nil).bubbleView.frame.height
+        let quoted = laidOutCell(quote: quote).bubbleView.frame.height
+        #expect(quoted > plain)
+    }
+
+    @Test("A message with no quote reserves no height for the panel")
+    func noQuote_reservesNothing() {
+        let bubble = laidOutCell(quote: nil).bubbleView
+        #expect(bubble.quotePanel.isHidden)
+        #expect(bubble.quotePanel.frame.height == 0)
+    }
+
+    @Test("Reusing a bubble drops the previous quote")
+    func reuse_dropsTheQuote() {
+        let cell = laidOutCell(quote: quote)
+        cell.configure(with: ChatMessage(id: "2", content: .text("hi"), sender: .me), maxWidth: Self.maxWidth)
+        cell.layoutIfNeeded()
+        #expect(cell.bubbleView.quotePanel.isHidden)
+    }
+
+    @Test("The panel reports the row it jumps to")
+    func panel_reportsItsTarget() {
+        var tapped: String?
+        let cell = laidOutCell(quote: quote)
+        cell.bubbleView.onQuoteTap = { tapped = $0 }
+        cell.bubbleView.quotePanel.simulateTap()
+        #expect(tapped == "7")
+    }
+
+    @Test("An unavailable quote is not tappable")
+    func unavailableQuote_doesNotJump() {
+        var tapped: String?
+        let unavailable = ChatQuote(
+            stableID: nil, authorName: "", snippet: ChatQuote.unavailableSnippet, kind: .unavailable
+        )
+        let cell = laidOutCell(quote: unavailable)
+        cell.bubbleView.onQuoteTap = { tapped = $0 }
+        cell.bubbleView.quotePanel.simulateTap()
+        #expect(tapped == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./Scripts/test.sh FlipcashTests/ChatQuoteBubbleTests
+```
+
+Expected: compile failure — no `quotePanel`.
+
+- [ ] **Step 3: Write the panel**
+
+Create `FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift`:
+
+```swift
+//
+//  ChatQuotePanelView.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+import FlipcashCore
+
+/// The quoted original drawn inside a reply's bubble, above the body: a leading rule, the author,
+/// and one or two lines of the original. Tapping it asks to jump to that message — but only when
+/// there is a row to jump to, which `ChatQuote.isJumpable` decides.
+final class ChatQuotePanelView: UIView {
+
+    /// Called with the target row's stable id when the panel is tapped. Silent for a quote that
+    /// cannot be jumped to.
+    var onTap: ((String) -> Void)?
+
+    private var targetStableID: String?
+
+    private let rule = UIView()
+    private let authorLabel = UILabel()
+    private let snippetLabel = UILabel()
+
+    /// The panel's own inset from the bubble's edges — the body's leading inset, so the quote's
+    /// rule and the text below it share one margin.
+    static let horizontalInset: CGFloat = 12
+    /// Gap between the panel and the body beneath it.
+    static let bottomSpacing: CGFloat = 6
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUp()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setUp() {
+        backgroundColor = UIColor.white.withAlphaComponent(0.10)
+        layer.cornerRadius = 8
+        layer.cornerCurve = .continuous
+        clipsToBounds = true
+
+        rule.backgroundColor = UIColor.white.withAlphaComponent(0.5)
+        rule.layer.cornerRadius = 1
+        rule.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(rule)
+
+        authorLabel.font = .default(size: 12, weight: .bold)
+        authorLabel.textColor = .white
+        authorLabel.numberOfLines = 1
+        authorLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(authorLabel)
+
+        snippetLabel.font = .default(size: 12, weight: .medium)
+        snippetLabel.textColor = UIColor.white.withAlphaComponent(0.55)
+        // One line in the bubble, per the spec: the panel is a citation, not a second message, and
+        // a two-line panel over a one-line reply reads as the wrong thing being the point. The
+        // composer's strip allows two, because there the quote *is* the subject.
+        snippetLabel.numberOfLines = 1
+        snippetLabel.lineBreakMode = .byTruncatingTail
+        snippetLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(snippetLabel)
+
+        NSLayoutConstraint.activate([
+            rule.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            rule.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            rule.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+            rule.widthAnchor.constraint(equalToConstant: 2),
+
+            authorLabel.leadingAnchor.constraint(equalTo: rule.trailingAnchor, constant: 8),
+            authorLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            authorLabel.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+
+            snippetLabel.leadingAnchor.constraint(equalTo: authorLabel.leadingAnchor),
+            snippetLabel.trailingAnchor.constraint(equalTo: authorLabel.trailingAnchor),
+            snippetLabel.topAnchor.constraint(equalTo: authorLabel.bottomAnchor, constant: 1),
+            snippetLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+        ])
+
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+    }
+
+    func configure(with quote: ChatQuote) {
+        targetStableID = quote.stableID
+        // An unavailable original has no author to name, so the author line collapses rather than
+        // rendering an empty run.
+        authorLabel.text = quote.authorName
+        authorLabel.isHidden = quote.authorName.isEmpty
+        snippetLabel.text = quote.snippet
+        isUserInteractionEnabled = quote.isJumpable
+        accessibilityLabel = quote.authorName.isEmpty
+            ? quote.snippet
+            : "Replying to \(quote.authorName): \(quote.snippet)"
+    }
+
+    @objc private func handleTap() {
+        guard let targetStableID else { return }
+        onTap?(targetStableID)
+    }
+
+    /// Drives the tap path from tests, which cannot deliver a real touch to a detached view.
+    func simulateTap() {
+        guard isUserInteractionEnabled else { return }
+        handleTap()
+    }
+}
+#endif
+```
+
+The author line's `isHidden` collapses it because `authorLabel` has no explicit height and `snippetLabel` pins to its bottom — a hidden label with an empty string still lays out at zero height, which is what is wanted here.
+
+- [ ] **Step 4: Mount it in `ChatBubbleView`**
+
+In `ChatBubbleView.swift`, add the panel and the swap constraints:
+
+```swift
+    private(set) var quotePanel = ChatQuotePanelView()
+
+    /// Forwarded from the panel: the stable id of the message to jump to.
+    var onQuoteTap: ((String) -> Void)? {
+        get { quotePanel.onTap }
+        set { quotePanel.onTap = newValue }
+    }
+
+    /// Body pinned to the bubble's top, for a message with no quote.
+    private var labelTopToBubble: NSLayoutConstraint!
+    /// Body pinned below the quote panel, for a reply.
+    private var labelTopToQuote: NSLayoutConstraint!
+    /// Collapses the panel when there is no quote, so a hidden view consumes no height.
+    private var quoteZeroHeight: NSLayoutConstraint!
+```
+
+In `setUp()`, after the label is added and before `NSLayoutConstraint.activate([...])`:
+
+```swift
+        quotePanel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(quotePanel)
+
+        labelTopToBubble = label.topAnchor.constraint(equalTo: topAnchor, constant: 9)
+        labelTopToQuote = label.topAnchor.constraint(
+            equalTo: quotePanel.bottomAnchor,
+            constant: ChatQuotePanelView.bottomSpacing
+        )
+        quoteZeroHeight = quotePanel.heightAnchor.constraint(equalToConstant: 0)
+```
+
+Replace the label's top constraint in the activation list with the panel's constraints plus the default top:
+
+```swift
+            quotePanel.topAnchor.constraint(equalTo: topAnchor, constant: 9),
+            quotePanel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: ChatQuotePanelView.horizontalInset),
+            quotePanel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -ChatQuotePanelView.horizontalInset),
+            labelTopToBubble,
+            quoteZeroHeight,
+```
+
+(the label's `bottomAnchor`, `leadingAnchor`, `trailingAnchor` and the `editedLabel` constraints are unchanged.)
+
+In `configure(with:)`, before the `background.apply(...)` call:
+
+```swift
+        // Deactivate before activating: with both top constraints live the layout is
+        // unsatisfiable, and UIKit resolves that by breaking one at random.
+        if let quote = message.quote {
+            quotePanel.isHidden = false
+            quotePanel.configure(with: quote)
+            quoteZeroHeight.isActive = false
+            labelTopToBubble.isActive = false
+            labelTopToQuote.isActive = true
+        } else {
+            quotePanel.isHidden = true
+            labelTopToQuote.isActive = false
+            labelTopToBubble.isActive = true
+            quoteZeroHeight.isActive = true
+        }
+```
+
+- [ ] **Step 5: Mount it in `LinkableBubbleView`**
+
+Apply the same five edits to `LinkableBubbleView.swift`, with `textView` in place of `label`: the same `quotePanel`/`onQuoteTap`/three constraints, the same activation list swap (the text view's top constant is also `9`), and the same block in `configure(with:)`. Add the panel reset to `prepareForReuse()`:
+
+```swift
+    func prepareForReuse() {
+        textView.resignFirstResponder()
+        quotePanel.onTap = nil
+    }
+```
+
+- [ ] **Step 6: Expose it on the cells**
+
+`ChatMessageCell` and `ChatLinkMessageCell` already surface `bubbleView` for the alignment tests. Add the forwarding callback to both so the transcript can wire it in Task 13:
+
+```swift
+    var onQuoteTap: ((String) -> Void)? {
+        get { bubbleView.onQuoteTap }
+        set { bubbleView.onQuoteTap = newValue }
+    }
+```
+
+- [ ] **Step 7: Run the tests and watch them pass**
+
+```bash
+./Scripts/test.sh FlipcashTests/ChatQuoteBubbleTests FlipcashTests/ChatBubbleViewTests
+```
+
+Expected: PASS. `ChatBubbleViewTests` passing unchanged is the point — a quote must not have disturbed the plain bubble's metrics.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add FlipcashUI/Sources/FlipcashUI/Chat/ChatQuotePanelView.swift FlipcashUI/Sources/FlipcashUI/Chat/ChatBubbleView.swift FlipcashUI/Sources/FlipcashUI/Chat/LinkableBubbleView.swift FlipcashUI/Sources/FlipcashUI/Chat/ChatMessageCell.swift FlipcashUI/Sources/FlipcashUI/Chat/ChatLinkMessageCell.swift FlipcashTests/Chat/ChatQuoteBubbleTests.swift
+git commit -m "feat(chat): draw the quoted original inside a reply's bubble"
+```
+
+---
+
+## Task 11: Verify the reply bubble's geometry
+
+A quote panel changes a bubble's height and its intrinsic width. The row's horizontal placement is set by the stack view's alignment over a full-width message column, and the last regression there was a sideways shift on rows whose height changed. So the check is the one that caught it: lay out a real cell, and assert the bubble still hugs its sender's edge and still respects `maxWidth`, with a quote attached.
+
+This task adds no production code. If an assertion fails, the fix belongs in Task 10's constraints — do not relax the assertion.
+
+**Files:**
+- Test: `FlipcashTests/Chat/ChatQuoteBubbleTests.swift` (extend)
+
+- [ ] **Step 1: Write the geometry tests**
+
+Add a second suite to `ChatQuoteBubbleTests.swift`:
+
+```swift
+@Suite("Reply bubble geometry")
+@MainActor
+struct ChatQuoteBubbleGeometryTests {
+
+    private static let maxWidth: CGFloat = 250
+
+    private let shortQuote = ChatQuote(stableID: "7", authorName: "Ada", snippet: "ok", kind: .text)
+    private let longQuote = ChatQuote(
+        stableID: "7",
+        authorName: "Ada",
+        snippet: String(repeating: "long enough to wrap ", count: 6),
+        kind: .text
+    )
+
+    private func laidOutCell(sender: ChatMessage.Sender, quote: ChatQuote?, text: String = "works") -> (cell: ChatMessageCell, bubble: UIView) {
+        let cell = ChatMessageCell(frame: CGRect(x: 0, y: 0, width: 320, height: 80))
+        cell.configure(
+            with: ChatMessage(id: "1", content: .text(text), sender: sender, quote: quote),
+            maxWidth: Self.maxWidth
+        )
+        let fitted = cell.contentView.systemLayoutSizeFitting(
+            CGSize(width: 320, height: 0),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        cell.frame = CGRect(x: 0, y: 0, width: 320, height: fitted.height)
+        cell.layoutIfNeeded()
+        return (cell, cell.contentView.subviews[0])
+    }
+
+    @Test("A quoted reply from me still hugs the trailing edge")
+    func selfReply_hugsTrailing() {
+        let (cell, bubble) = laidOutCell(sender: .me, quote: shortQuote)
+        #expect(abs(bubble.frame.maxX - (cell.contentView.bounds.width - 12)) < 0.5)
+        #expect(bubble.frame.minX > 12)
+    }
+
+    @Test("A quoted reply from them still hugs the leading edge")
+    func otherReply_hugsLeading() {
+        let (cell, bubble) = laidOutCell(sender: .other, quote: shortQuote)
+        #expect(abs(bubble.frame.minX - 12) < 0.5)
+        #expect(bubble.frame.maxX < cell.contentView.bounds.width - 12)
+    }
+
+    @Test("A quote wider than the body does not push the bubble past maxWidth")
+    func longQuote_respectsMaxWidth() {
+        let (_, bubble) = laidOutCell(sender: .me, quote: longQuote, text: "ok")
+        #expect(bubble.frame.width <= Self.maxWidth + 0.5)
+    }
+
+    @Test("Adding a quote does not move the bubble sideways")
+    func quote_doesNotShiftTheBubble() {
+        let plain = laidOutCell(sender: .me, quote: nil)
+        let quoted = laidOutCell(sender: .me, quote: shortQuote)
+        // The height changes; the trailing edge must not.
+        #expect(abs(plain.bubble.frame.maxX - quoted.bubble.frame.maxX) < 0.5)
+    }
+
+    @Test("A quote wider than the body widens the bubble to hold it")
+    func longQuote_widensTheBubble() {
+        let narrow = laidOutCell(sender: .me, quote: nil, text: "ok")
+        let (_, wide) = laidOutCell(sender: .me, quote: longQuote, text: "ok")
+        #expect(wide.frame.width > narrow.bubble.frame.width)
+    }
+}
+```
+
+- [ ] **Step 2: Run them**
+
+```bash
+./Scripts/test.sh FlipcashTests/ChatQuoteBubbleGeometryTests
+```
+
+Expected: PASS with Task 10's constraints as written. A failure on `quote_doesNotShiftTheBubble` or `longQuote_respectsMaxWidth` means the panel's leading/trailing constraints are fighting the bubble's width — fix the constraints in `ChatBubbleView`/`LinkableBubbleView`, not the test.
+
+- [ ] **Step 3: Verify the animation by hand**
+
+Build and run. Send a reply into a conversation with a screenful of history and watch the insert:
+- The new row rises into place with the same spring as a plain send; the bubble does not slide horizontally as it settles.
+- The rows above it do not jump when the taller row lands.
+- Scroll up past the reply and back down — the row's height is stable across recycling.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add FlipcashTests/Chat/ChatQuoteBubbleTests.swift
+git commit -m "test(chat): pin the reply bubble's alignment and width"
+```
+
+---
+
+## Task 12: The cash lift clips to the card
+
+Cash and tip rows get a context menu for the first time in Task 3. `ChatCashCardCell` does not conform to `BubbleCarrying`, so the lift would raise the whole full-width cell instead of the card — visible as a full-width rectangle lifting out of the transcript.
+
+**Files:**
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift`
+
+- [ ] **Step 1: Conform**
+
+At the bottom of `ChatCashCardCell.swift`, inside the `#if canImport(UIKit)` block:
+
+```swift
+extension ChatCashCardCell: BubbleCarrying {
+    /// The card, not the cell: the cell spans the full row, so lifting it would raise a
+    /// full-width rectangle out of the transcript.
+    var liftPreviewView: UIView { card }
+    var liftPreviewMaskingPath: UIBezierPath? { card.maskingPath }
+}
+```
+
+- [ ] **Step 2: Verify by hand**
+
+Build and run. Long-press a cash bubble and a tip bubble:
+- The lift raises the card alone, clipped to its rounded shape — matching a text bubble's lift.
+- The menu shows one item, Reply.
+- Choosing it opens the composer strip quoting the amount.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add FlipcashUI/Sources/FlipcashUI/Chat/ChatCashCardCell.swift
+git commit -m "fix(chat): clip the cash row's menu lift to the card
+
+Cash rows gain a context menu with reply, and the cell spans the full row —
+without this the lift raises a full-width rectangle."
+```
+
+---
+
+## Task 13: Wire the menu and the quote tap
+
+Two chains. The menu's Reply aims the composer and raises the keyboard, the way Edit already does. The quote tap travels cell → transcript → screen → representable → `ConversationScreen`.
+
+**Files:**
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift`
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift`
+- Modify: `Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift`
+- Modify: `Flipcash/Core/Screens/Conversation/ConversationScreen.swift`
+
+- [ ] **Step 1: Add the transcript's callback**
+
+In `ChatViewController.swift`, beside `onMessageAction`:
+
+```swift
+    /// Called with a quoted message's stable id when its panel is tapped.
+    public var onQuoteTap: ((String) -> Void)?
+```
+
+In `cellForItemAt`'s message branch, forward it on both text cells:
+
+```swift
+            case let cell as ChatLinkMessageCell:
+                cell.configure(with: message, maxWidth: maxWidth)
+                cell.onRetry = { [weak self] id in self?.onRetry?(id) }
+                cell.onOpenURL = { [weak self] url in self?.onOpenURL?(url) }
+                cell.onQuoteTap = { [weak self] id in self?.onQuoteTap?(id) }
+            case let cell as ChatMessageCell:
+                cell.configure(with: message, maxWidth: maxWidth)
+                cell.onRetry = { [weak self] id in self?.onRetry?(id) }
+                cell.onQuoteTap = { [weak self] id in self?.onQuoteTap?(id) }
+```
+
+- [ ] **Step 2: Pass it through the screen**
+
+In `ChatScreenViewController.swift`, beside the other passthrough properties:
+
+```swift
+    public var onQuoteTap: ((String) -> Void)? {
+        get { transcript.onQuoteTap }
+        set { transcript.onQuoteTap = newValue }
+    }
+```
+
+- [ ] **Step 3: Focus the composer on Reply**
+
+In `ChatScreenRepresentable.swift`, extend `keyboardFollowing`'s switch — reply raises the keyboard like an edit, but takes no spotlight (the spotlight marks the row being rewritten; a reply's target is not being rewritten):
+
+```swift
+            switch action {
+            case .edit:
+                screen?.beginEditSpotlight(for: stableID)
+                screen?.focusComposer()
+            case .reply:
+                screen?.focusComposer()
+            case .delete:   screen?.dismissKeyboard()
+            case .copy:     break
+            }
+```
+
+- [ ] **Step 4: Add the representable's quote-tap parameter**
+
+In `ChatScreenRepresentable`, add the stored closure beside the others:
+
+```swift
+    let onQuoteTap: (String) -> Void
+```
+
+and in **both** `makeUIViewController` and `updateUIViewController`, set it alongside the other callbacks:
+
+```swift
+        screen.onQuoteTap = { [weak screen] stableID in
+            onQuoteTap(stableID)
+            // The reveal may have to move the loader's anchor first, so the scroll records a
+            // pending target when the row is not in the window yet.
+            screen?.scrollToMessage(id: stableID)
+        }
+```
+
+`scrollToMessage(id:)` is added in Task 14. **Do Task 14 before building this one** — this line does not compile without it. The two tasks are separated because they are separately reviewable, not because they land independently.
+
+- [ ] **Step 5: Fill in the screen's reply branch**
+
+In `ConversationScreen.swift`, replace the `.reply` stub in `handleMessageAction`:
+
+```swift
+        case .reply:
+            composer.beginReplying(to: ComposerModel.ReplyTarget(
+                messageID: message.id,
+                stableID: stableID,
+                authorName: message.isFromSelf(conversationController.selfUserID)
+                    ? "You"
+                    : (coordinator?.counterpartName ?? ""),
+                snippet: Self.replySnippet(for: message)
+            ))
+```
+
+with the snippet helper beside the other private helpers:
+
+```swift
+    /// The composer strip's preview of the message being answered — the same three-way split the
+    /// transcript's quote panel uses, so the strip and the sent bubble read alike.
+    private static func replySnippet(for message: ConversationMessage) -> String {
+        switch message.content {
+        case .text(let text):   ChatQuote.snippet(forText: text)
+        case .cash(let fiat):   fiat.nativeAmount.formatted()
+        case .deleted:          ChatQuote.deletedSnippet
+        }
+    }
+```
+
+A `.deleted` message cannot reach here: Task 3's `resolve` returns no capabilities for a tombstone, so its row has no menu. The branch exists to keep the switch exhaustive.
+
+- [ ] **Step 6: Add the jump handler and pass it in**
+
+Beside `handleMessageAction`:
+
+```swift
+    /// Brings the quoted original into the window when the local database has it. Returns without
+    /// effect otherwise — history that was never fetched is out of scope, and the panel that
+    /// points at it is already non-tappable.
+    private func jumpToQuote(_ stableID: String) {
+        guard let value = UInt64(stableID) else { return }
+        _ = coordinator?.loader.reveal(MessageID(value: value))
+    }
+```
+
+A pending row's stable id is a UUID string, so `UInt64(stableID)` fails and the jump is a no-op — correct, since an unconfirmed message is by definition at the bottom of the window already.
+
+At the `ChatScreenRepresentable(...)` call site, add:
+
+```swift
+            onQuoteTap: jumpToQuote,
+```
+
+- [ ] **Step 7: Build and verify by hand**
+
+Build and run:
+- Long-press a message, choose Reply. The keyboard raises, the strip appears, and no row is spotlighted.
+- Send it. The bubble shows the quote panel.
+- Choose Reply on a cash bubble. The strip quotes the amount.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift Flipcash/Core/Screens/Conversation/ChatScreenRepresentable.swift Flipcash/Core/Screens/Conversation/ConversationScreen.swift
+git commit -m "feat(chat): start a reply from the message menu"
+```
+
+---
+
+## Task 14: Jump to the quoted original
+
+One anchor move, not a paging loop. `windowedMessages(for:startingAt:limit:)` with a `startID` reads every message from that id forward, so pointing the loader's anchor at the quoted id brings it into the window in a single step — no loop, no network call.
+
+The remap lands asynchronously, so the scroll cannot happen inline. `ChatViewController` records the target and performs the scroll on the next update that contains it, applying that update without animation: animating a window that jumped hundreds of rows would draw a scroll through content the user never asked to see.
+
+**Files:**
+- Modify: `Flipcash/Core/Screens/Conversation/MessageLoader.swift`
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift`
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift`
+- Test: `FlipcashTests/Chat/MessageLoaderRevealTests.swift` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `FlipcashTests/Chat/MessageLoaderRevealTests.swift`:
+
+```swift
+//
+//  MessageLoaderRevealTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import Foundation
+import FlipcashCore
+@testable import Flipcash
+
+@MainActor
+@Suite("Revealing a quoted message")
+struct MessageLoaderRevealTests {
+
+    /// The same construction `MessageLoaderTests` uses — four mocks over a real temp database.
+    private func makeController(_ database: Database) -> ConversationController {
+        ConversationController(
+            fetching: MockConversations(), messaging: MockConversations(), streaming: MockConversations(),
+            contactNaming: MockDMContactNaming(),
+            database: database,
+            owner: .generate()!, selfUserID: UUID(),
+            typingHeartbeatInterval: .seconds(3), incomingTypingExpiry: .seconds(10)
+        )
+    }
+
+    private func message(_ id: UInt64) -> ConversationMessage {
+        ConversationMessage(
+            id: MessageID(value: id), senderID: nil, content: .text("m\(id)"),
+            date: Date(timeIntervalSince1970: TimeInterval(id)), unreadSeq: id
+        )
+    }
+
+    private func makeLoader(messageCount: Int) throws -> (loader: MessageLoader, url: URL) {
+        let (database, url) = try Database.makeTemp()
+        let id = ConversationID.test(1)
+        try database.upsertConversationMessages((1...messageCount).map { message(UInt64($0)) }, conversationID: id)
+        return (MessageLoader(conversationID: id, controller: makeController(database)), url)
+    }
+
+    @Test("A message already in the window needs no anchor move")
+    func revealWindowed_keepsAnchor() throws {
+        let (loader, url) = try makeLoader(messageCount: 10)
+        defer { Database.removeTemp(at: url) }
+        let target = try #require(loader.messages.first?.id)
+
+        #expect(loader.reveal(target))
+        #expect(loader.messages.contains { $0.id == target })
+    }
+
+    @Test("A message above the window is brought into it")
+    func revealOlderMessage_movesAnchor() throws {
+        let (loader, url) = try makeLoader(messageCount: 200)
+        defer { Database.removeTemp(at: url) }
+        // The initial window is the newest 60 (141...200), so 3 is well above it.
+        let target = MessageID(value: 3)
+        #expect(loader.messages.contains { $0.id == target } == false)
+
+        #expect(loader.reveal(target))
+        #expect(loader.messages.contains { $0.id == target })
+    }
+
+    @Test("A message the database has never seen cannot be revealed")
+    func revealUnknownMessage_fails() throws {
+        let (loader, url) = try makeLoader(messageCount: 10)
+        defer { Database.removeTemp(at: url) }
+        #expect(loader.reveal(MessageID(value: 9_999)) == false)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./Scripts/test.sh FlipcashTests/MessageLoaderRevealTests
+```
+
+Expected: compile failure — no `reveal`.
+
+- [ ] **Step 3: Add `reveal`**
+
+In `MessageLoader.swift`:
+
+```swift
+    /// Brings `messageID` into the rendered window, returning whether it is now there.
+    ///
+    /// One anchor move, not a paging loop: an anchored window reads every message from `startID`
+    /// forward, so pointing the anchor at the target is enough. Nothing is fetched — a message the
+    /// local database has never seen returns `false` and the caller leaves the transcript alone.
+    @discardableResult
+    func reveal(_ messageID: MessageID) -> Bool {
+        if messages.contains(where: { $0.id == messageID }) { return true }
+        guard controller.persistedMessage(messageID, in: conversationID) != nil else { return false }
+        startID = messageID.value
+        return true
+    }
+```
+
+`startID` is currently `private`; `reveal` lives in the same type, so no access change is needed.
+
+- [ ] **Step 4: Add the pending-target scroll**
+
+In `ChatViewController.swift`, beside the other private state:
+
+```swift
+    /// A row asked for before it was in `items` — the loader's window has to move first. The next
+    /// update carrying it performs the scroll.
+    private var pendingScrollTargetID: String?
+```
+
+Add the public entry point beside `scrollToBottom(animated:)`:
+
+```swift
+    /// Scrolls the given row into view, or waits for the update that brings it in.
+    public func scrollToMessage(id: String) {
+        guard items.contains(where: { $0.differenceIdentifier.hasSuffix(":\(id)") }) else {
+            pendingScrollTargetID = id
+            return
+        }
+        scrollToRow(id: id, animated: true)
+    }
+
+    /// Centers a row that is already in `items`.
+    private func scrollToRow(id: String, animated: Bool) {
+        guard let index = items.firstIndex(where: { $0.differenceIdentifier.hasSuffix(":\(id)") }) else { return }
+        let indexPath = IndexPath(item: index, section: 0)
+        if animated {
+            ChatMotion.scroll.animate {
+                self.collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+            }
+        } else {
+            collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+        }
+    }
+```
+
+Matching on the identifier's suffix is deliberate: `differenceIdentifier` is `"<cellClass>:<id>"`, and the caller knows only the id.
+
+In `update(items:animated:)`, suppress the animation for the update that lands the target, and perform the scroll once it has:
+
+```swift
+    public func update(items newItems: [ChatItem], animated: Bool = true) {
+        // A window that jumped hundreds of rows must not animate: it would draw a scroll through
+        // content the user never asked to see.
+        let animated = animated && pendingScrollTargetID == nil
+```
+
+and at the end of the method's completion — the same place `performInitialScrollIfNeeded()` is called on the non-animated path, and inside the staged-changeset `completion:` on the animated one:
+
+```swift
+        if let target = pendingScrollTargetID,
+           self.items.contains(where: { $0.differenceIdentifier.hasSuffix(":\(target)") }) {
+            self.pendingScrollTargetID = nil
+            self.scrollToRow(id: target, animated: false)
+        }
+```
+
+Add the same block to both paths — the target can land on either.
+
+- [ ] **Step 5: Pass it through the screen**
+
+In `ChatScreenViewController.swift`, beside `scrollToBottom`:
+
+```swift
+    public func scrollToMessage(id: String) { transcript.scrollToMessage(id: id) }
+```
+
+- [ ] **Step 6: Run the tests and watch them pass**
+
+```bash
+./Scripts/test.sh FlipcashTests/MessageLoaderRevealTests FlipcashTests/MessageLoaderTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Verify by hand**
+
+Build and run in a conversation with several hundred messages:
+- Reply to a recent message, then tap the quote in the sent bubble. The transcript centers the original.
+- Scroll to the bottom, then tap a quote whose original is far above the window. The window jumps to it without a visible scroll-through, and the original is centered.
+- Scroll up to the very top and keep going. `loadOlder` still fetches past the moved anchor — the anchor moved, it was not pinned.
+- Tap a quote panel that reads "Original message unavailable". Nothing happens, and nothing is fetched.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Flipcash/Core/Screens/Conversation/MessageLoader.swift FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift FlipcashUI/Sources/FlipcashUI/Chat/ChatScreenViewController.swift FlipcashTests/Chat/MessageLoaderRevealTests.swift
+git commit -m "feat(chat): jump to a quoted message that is already stored
+
+An anchored window reads from its start id forward, so revealing a message
+above the window is one anchor move rather than a paging loop."
+```
+
+---
+
+## Task 15: Swipe to reply — the riskiest task in this plan
+
+**Read this section before writing any of it.**
+
+A horizontal pan on the transcript has to coexist with two recognizers that already work:
+
+1. **The collection view's own vertical scroll.** A pan that begins on any horizontal drift steals diagonal scrolls and the transcript feels sticky.
+2. **The long-press lift.** `ChatViewController` currently returns unconditional `true` from `gestureRecognizer(_:shouldRecognizeSimultaneouslyWith:)` — written so the tap-to-dismiss recognizer never pre-empts a cell tap. Under that rule the new pan would run **during** a context-menu lift: the cell would slide sideways underneath its own floating preview.
+
+So the fix is to make that method discriminating rather than to add a recognizer under it. The pan is the one recognizer that never runs simultaneously with anything.
+
+The pan, the tracked index path, the translated cell, and the trigger latch are four pieces of state for one concern, so they live in their own type (`ChatSwipeToReply`) rather than as loose fields on the view controller.
+
+**Files:**
+- Create: `FlipcashUI/Sources/FlipcashUI/Chat/ChatSwipeToReply.swift`
+- Modify: `FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift`
+- Modify: `FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift`
+- Test: `FlipcashTests/Chat/ChatSwipeToReplyTests.swift` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+The gesture's *decisions* are testable without a touch: whether it may begin, and whether a translation has crossed the trigger. Create `FlipcashTests/Chat/ChatSwipeToReplyTests.swift`:
+
+```swift
+//
+//  ChatSwipeToReplyTests.swift
+//  FlipcashTests
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+import Testing
+import UIKit
+import FlipcashCore
+@testable import FlipcashUI
+
+@Suite("Swipe to reply")
+@MainActor
+struct ChatSwipeToReplyTests {
+
+    @Test("A mostly-horizontal drag may begin")
+    func horizontalDrag_begins() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: -300, y: 40), isBlocked: false))
+    }
+
+    @Test("A mostly-vertical drag is left to the scroll view")
+    func verticalDrag_doesNotBegin() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: -40, y: -300), isBlocked: false) == false)
+    }
+
+    @Test("A diagonal drag with more vertical than horizontal is left to the scroll view")
+    func diagonalDrag_doesNotBegin() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: 120, y: -160), isBlocked: false) == false)
+    }
+
+    @Test("A drag towards the trailing edge is not a reply swipe")
+    func trailingDrag_doesNotBegin() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: 300, y: 10), isBlocked: false) == false)
+    }
+
+    @Test("Nothing begins while the transcript is blocked")
+    func blocked_doesNotBegin() {
+        #expect(ChatSwipeToReply.shouldBegin(velocity: CGPoint(x: -300, y: 40), isBlocked: true) == false)
+    }
+
+    @Test("Translation is clamped to the maximum")
+    func translation_isClamped() {
+        #expect(ChatSwipeToReply.offset(forTranslation: -500) == -ChatSwipeToReply.maxTranslation)
+    }
+
+    @Test("A drag towards the trailing edge does not move the row")
+    func trailingTranslation_isIgnored() {
+        #expect(ChatSwipeToReply.offset(forTranslation: 80) == 0)
+    }
+
+    @Test("Translation past the threshold resists")
+    func translation_resistsPastThreshold() {
+        let offset = ChatSwipeToReply.offset(forTranslation: -120)
+        #expect(offset < -ChatSwipeToReply.triggerThreshold)
+        #expect(offset > -120)
+    }
+
+    @Test("Crossing the threshold triggers the reply")
+    func pastThreshold_triggers() {
+        #expect(ChatSwipeToReply.triggers(offset: -ChatSwipeToReply.triggerThreshold - 1))
+    }
+
+    @Test("Releasing short of the threshold does not trigger")
+    func shortOfThreshold_doesNotTrigger() {
+        #expect(ChatSwipeToReply.triggers(offset: -ChatSwipeToReply.triggerThreshold + 1) == false)
+    }
+}
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+./Scripts/test.sh FlipcashTests/ChatSwipeToReplyTests
+```
+
+Expected: compile failure — no `ChatSwipeToReply`.
+
+- [ ] **Step 3: Add the affordance symbol**
+
+In `Image+Symbols.swift`, add to `SystemSymbol`:
+
+```swift
+    case replyArrow = "arrowshape.turn.up.left.fill"
+```
+
+- [ ] **Step 4: Write the gesture**
+
+Create `FlipcashUI/Sources/FlipcashUI/Chat/ChatSwipeToReply.swift`:
+
+```swift
+//
+//  ChatSwipeToReply.swift
+//  FlipcashUI
+//
+//  Copyright © 2026 Code Inc. All rights reserved.
+//
+
+#if canImport(UIKit)
+import UIKit
+
+/// Drag a row towards the leading edge to reply to it.
+///
+/// Owns the whole gesture — the recognizer, the row being dragged, its offset, and whether the
+/// trigger has already fired — because those four move together and splitting them across the
+/// transcript's fields would make the coexistence rules impossible to follow. The transcript keeps
+/// one `let` and answers two questions: which row is under a point, and whether it can be replied to.
+@MainActor
+final class ChatSwipeToReply: NSObject {
+
+    /// Furthest a row travels. Past this the drag resists rather than stopping dead, so a hard
+    /// swipe still feels connected to the finger.
+    static let maxTranslation: CGFloat = 64
+    /// Offset at which the reply fires on release.
+    static let triggerThreshold: CGFloat = 48
+
+    let recognizer = UIPanGestureRecognizer()
+
+    /// The row under a point, if it can be replied to. The transcript answers this; the gesture
+    /// does not know what a message is.
+    var rowForSwipe: ((CGPoint) -> (cell: UICollectionViewCell, stableID: String)?)?
+    /// Whether the transcript is busy — mid-update, or showing a context menu.
+    var isBlocked: (() -> Bool)?
+    /// Called once, when the drag crosses the threshold.
+    var onTrigger: ((String) -> Void)?
+
+    private var draggedCell: UICollectionViewCell?
+    private var draggedStableID: String?
+    private var hasTriggered = false
+    private let affordance = UIImageView()
+    private let haptics = UIImpactFeedbackGenerator(style: .light)
+
+    override init() {
+        super.init()
+        recognizer.addTarget(self, action: #selector(handlePan))
+        recognizer.delegate = self
+        recognizer.maximumNumberOfTouches = 1
+
+        affordance.image = UIImage(systemName: SystemSymbol.replyArrow.rawValue)
+        affordance.tintColor = UIColor.white.withAlphaComponent(0.55)
+        affordance.contentMode = .scaleAspectFit
+        affordance.alpha = 0
+    }
+
+    /// Whether a drag with this velocity is a reply swipe rather than a scroll.
+    ///
+    /// Horizontal dominance is the whole rule: a diagonal drag belongs to the scroll view, which
+    /// would otherwise lose it to a recognizer that only ever moves sideways. Only leading-ward
+    /// drags qualify — the trailing direction is left free for anything that wants it later.
+    nonisolated static func shouldBegin(velocity: CGPoint, isBlocked: Bool) -> Bool {
+        guard !isBlocked else { return false }
+        guard velocity.x < 0 else { return false }
+        return abs(velocity.x) > abs(velocity.y)
+    }
+
+    /// How far the row actually moves for a raw translation: clamped, with resistance past the max.
+    nonisolated static func offset(forTranslation translation: CGFloat) -> CGFloat {
+        guard translation < 0 else { return 0 }
+        let distance = -translation
+        guard distance > maxTranslation else { return translation }
+        // Rubber band: everything past the max moves at a third speed, so the row keeps following
+        // the finger without running off under the bubble beside it.
+        return -(maxTranslation + (distance - maxTranslation) / 3)
+    }
+
+    /// Whether releasing at this offset fires the reply.
+    nonisolated static func triggers(offset: CGFloat) -> Bool {
+        offset < -triggerThreshold
+    }
+
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+            begin(at: gesture.location(in: gesture.view))
+        case .changed:
+            let offset = Self.offset(forTranslation: gesture.translation(in: gesture.view).x)
+            apply(offset: offset)
+            if !hasTriggered, Self.triggers(offset: offset) {
+                hasTriggered = true
+                haptics.impactOccurred()
+                if let draggedStableID { onTrigger?(draggedStableID) }
+            }
+        case .ended, .cancelled, .failed:
+            settle()
+        case .possible, .recognized:
+            break
+        @unknown default:
+            settle()
+        }
+    }
+
+    private func begin(at point: CGPoint) {
+        guard let row = rowForSwipe?(point) else {
+            recognizer.state = .cancelled
+            return
+        }
+        draggedCell = row.cell
+        draggedStableID = row.stableID
+        hasTriggered = false
+        haptics.prepare()
+
+        affordance.alpha = 0
+        affordance.frame = CGRect(x: row.cell.bounds.width - 34, y: (row.cell.bounds.height - 20) / 2, width: 20, height: 20)
+        row.cell.contentView.addSubview(affordance)
+    }
+
+    private func apply(offset: CGFloat) {
+        guard let draggedCell else { return }
+        draggedCell.contentView.transform = CGAffineTransform(translationX: offset, y: 0)
+        // The arrow fades in over the run-up to the trigger, so the gesture announces itself before
+        // it fires rather than after.
+        affordance.alpha = min(1, -offset / Self.triggerThreshold)
+    }
+
+    private func settle() {
+        let cell = draggedCell
+        draggedCell = nil
+        draggedStableID = nil
+        hasTriggered = false
+        ChatMotion.swap.animate {
+            cell?.contentView.transform = .identity
+            self.affordance.alpha = 0
+        } completion: { _ in
+            self.affordance.removeFromSuperview()
+        }
+    }
+}
+
+extension ChatSwipeToReply: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let pan = gestureRecognizer as? UIPanGestureRecognizer else { return false }
+        guard Self.shouldBegin(velocity: pan.velocity(in: pan.view), isBlocked: isBlocked?() ?? false) else {
+            return false
+        }
+        return rowForSwipe?(pan.location(in: pan.view)) != nil
+    }
+}
+#endif
+```
+
+- [ ] **Step 5: Mount it, and narrow the simultaneity rule**
+
+In `ChatViewController.swift`, add the property beside the other private state:
+
+```swift
+    private let swipeToReply = ChatSwipeToReply()
+```
+
+In `viewDidLoad` (after the collection view is installed), wire it:
+
+```swift
+        swipeToReply.isBlocked = { [weak self] in
+            guard let self else { return true }
+            return self.isShowingContextMenu || self.isUpdating
+        }
+        swipeToReply.rowForSwipe = { [weak self] point in
+            guard let self,
+                  let indexPath = self.collectionView.indexPathForItem(at: point),
+                  let cell = self.collectionView.cellForItem(at: indexPath),
+                  case .message(let message) = self.items[indexPath.item],
+                  message.actions.contains(.reply)
+            else { return nil }
+            return (cell, message.id)
+        }
+        swipeToReply.onTrigger = { [weak self] stableID in
+            self?.onMessageAction?(stableID, .reply)
+        }
+        collectionView.addGestureRecognizer(swipeToReply.recognizer)
+```
+
+**Then narrow the simultaneity rule.** Replace the existing extension:
+
+```swift
+extension ChatViewController: UIGestureRecognizerDelegate {
+    /// Lets the tap-to-dismiss recognizer fire alongside the collection view's own scroll and
+    /// selection recognizers, so lowering the keyboard never pre-empts a cell tap.
+    ///
+    /// Swipe-to-reply is the exception: it translates a cell, so running it beside the scroll would
+    /// drag a row sideways mid-scroll, and running it beside the long-press would slide the row out
+    /// from under its own lift preview. It is exclusive in both directions.
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        if gestureRecognizer === swipeToReply.recognizer || otherGestureRecognizer === swipeToReply.recognizer {
+            return false
+        }
+        return true
+    }
+}
+```
+
+Reset any in-flight translation when the transcript reloads. In `update(items:animated:)`, on the non-animated path where `reloadData()` is called, add:
+
+```swift
+        swipeToReply.recognizer.isEnabled = false
+        swipeToReply.recognizer.isEnabled = true
+```
+
+Toggling `isEnabled` cancels the gesture, which runs `settle()` and clears the cell's transform — a recycled cell must never inherit a translation.
+
+- [ ] **Step 6: Run the tests and watch them pass**
+
+```bash
+./Scripts/test.sh FlipcashTests/ChatSwipeToReplyTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Verification — coexistence with scrolling**
+
+This is the half the unit tests cannot reach. Build, run, open a conversation with a few hundred messages, and check each:
+
+- [ ] Flick vertically, hard, several times. Scrolling is as smooth as before; no row twitches sideways.
+- [ ] Drag diagonally — down-and-left, up-and-left — at a shallow angle. The transcript scrolls; no row moves sideways.
+- [ ] Drag slowly, almost straight left. The row follows the finger and the arrow fades in.
+- [ ] Drag left past the maximum. The row resists rather than stopping dead, and never travels far enough to overlap the row beside it.
+- [ ] Release short of the threshold. The row springs back with no reply started.
+- [ ] Release past the threshold. One haptic, the strip appears, the row springs back.
+- [ ] Drag right. Nothing moves.
+- [ ] Start a leading drag and reverse direction mid-drag back past zero. The row does not travel to the trailing side.
+
+- [ ] **Step 8: Verification — coexistence with the lift**
+
+- [ ] Long-press a message to raise the menu, then drag sideways while the preview is lifted. The row underneath does not move.
+- [ ] Long-press, dismiss the menu, then immediately swipe. The swipe works.
+- [ ] Swipe past the threshold and, without lifting, keep the finger down. Only one haptic fires and only one strip appears — the latch holds.
+
+- [ ] **Step 9: Verification — coexistence with updates and recycling**
+
+- [ ] Swipe a row while a message arrives (send from another device, or let a poll land). The incoming row inserts and the swiped row still springs back to its own position, not to an offset one.
+- [ ] Swipe a row, then scroll it off screen without releasing. Scroll back: no row is stuck at an offset.
+- [ ] Swipe a cash bubble. It moves and starts a reply, like a text row.
+- [ ] Swipe a deleted-message tombstone under a `.visible` policy. Nothing moves — it carries no `.reply` action.
+- [ ] Swipe while a failed message is retrying. Nothing breaks.
+
+- [ ] **Step 10: Verification — the keyboard**
+
+- [ ] With the keyboard up and a draft typed, swipe a row. The strip appears, the draft survives, the keyboard stays up.
+- [ ] With the composer already replying to A, swipe B. The strip retargets to B; the draft survives.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add FlipcashUI/Sources/FlipcashUI/Chat/ChatSwipeToReply.swift FlipcashUI/Sources/FlipcashUI/Chat/ChatViewController.swift FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift FlipcashTests/Chat/ChatSwipeToReplyTests.swift
+git commit -m "feat(chat): swipe a row towards the leading edge to reply
+
+The pan is exclusive with every other recognizer. It translates a cell, so
+running it beside the scroll would drag a row sideways mid-scroll, and
+beside the long-press it would slide the row out from under its own lift."
+```
+
+---
+
+## Final verification
+
+- [ ] Run the chat suites:
+
+```bash
+./Scripts/test.sh FlipcashTests/ChatQuoteMappingTests FlipcashTests/ChatQuoteBubbleTests FlipcashTests/ChatQuoteBubbleGeometryTests FlipcashTests/ChatSwipeToReplyTests FlipcashTests/MessageLoaderRevealTests FlipcashTests/ComposerModelTests FlipcashTests/ConversationReplySendTests FlipcashTests/MessageCapabilityMenuTests
+```
+
+- [ ] Run the full suite from Xcode (`Product → Test`) — `Scripts/test.sh` deliberately does not run the whole plan.
+
+- [ ] End-to-end, on device or simulator, against a real conversation:
+  - Reply to a text message from the menu; the bubble quotes it; tap the quote and land on the original.
+  - Reply by swipe; same result.
+  - Reply to a cash bubble and to a tip bubble.
+  - Reply to a message far above the window, scroll to the bottom, then tap the quote.
+  - Receive a reply sent from Android and confirm it renders with its quote — this is the path that silently dropped the message before Task 1.


### PR DESCRIPTION
A reply proto returned nil from the message initializer, so a reply sent from another client never appeared in the transcript at all. This builds out the whole feature from there.

Reply is a decoration on a text message, not a new content kind: the initializer unwraps `ReplyContent` into the text case it already is and keeps the replied-to id beside it, so every existing `.text` path is untouched. The id was already in the database schema — added with the edit/delete bump and written as nil since — so there is no `SQLiteVersion` bump here.

## What's in it

- The replied-to id is carried and persisted, and Reply joins the capability set for text, cash, and tip rows. Cash and tip resolved to an empty set before this, so they carried no context menu at all.
- `ChatQuote`, the display-ready citation a reply draws, resolved by the transcript mapper from the window first and the local table second. Neither pages the server.
- The composer gains a reply mode. Unlike an edit it keeps the draft, and the optimistic row carries the id, so the quote is on the bubble the moment it appears.
- A reply starts from the context menu or from dragging the row towards the trailing edge. The first 24pt defer to back-navigation, which the swipe would otherwise make unreachable from the transcript.
- Tapping a quote jumps to the original whenever it is in the local table — one anchor move rather than a paging loop.
- Quoted payments draw the mint's name and the currency's flag, the same pair the cash card leads with.
- Sender colours are ported from Android's `generateComplementaryColorPalette`, arithmetic for arithmetic, so a person is the same colour on both platforms.

## Reviewing

Commit by commit — each one is a single concern and builds on its own. `.claude/plans/2026-09-04-chat-message-reply.md` has the analysis the work was planned from, and accounts for 2837 of the diff's lines.

Tests: 13 Swift Testing suites across `FlipcashCore` and `FlipcashTests` — quote model, mapping, capabilities, bubble geometry, swipe offset, palette, reply send, reveal — plus 5 XCUITest cases in `ChatReplySmokeTests` driving the flow over an existing DM.
