### PR TITLE
fix(deps): resolve shared-core at 0.5.1 to match the requirement

### DIFF
--- a/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bcc0261f97a6d99100c2b9dbc00698c4b2a1da20d91c5862ec899298980b12af",
+  "originHash" : "bfbaca6df065c0441a76cea8f5de36ddcc5deb1584f25cf135fc57d082acd454",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/code-payments/flipcash-shared-core-spm",
       "state" : {
-        "revision" : "5d46c1c9980aed632ed939b017946c0b799649ef",
-        "version" : "0.4.1"
+        "revision" : "c83a57e7b90c169d7aa9f50e1c3358ee76f98bb8",
+        "version" : "0.5.1"
       }
     },
     {


### PR DESCRIPTION
Every Xcode Cloud build off `main` fails at Archive:

```
an out-of-date resolved file was detected at .../Package.resolved, which is not
allowed when automatic dependency resolution is disabled; please make sure to
update the file to reflect the changes in dependencies.
```

#725 raised the `flipcash-shared-core-spm` requirement to `upToNextMinor 0.5.0` but left `Package.resolved` pinned at `0.4.1`. Locally Xcode just re-resolves and the mismatch is invisible; Xcode Cloud archives with automatic resolution disabled, so it stops.

This is the resolution a local build produces against `main` — shared-core `0.5.1`, `originHash` updated to match. Nothing else moves.

Found by build #524.
