### PR TITLE
fix(chat): give the reply's close button its own ground

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
+++ b/Flipcash/Core/Screens/Conversation/ComposerReplyStrip.swift
@@ -85,14 +85,19 @@ struct ComposerReplyStrip: View {
             .accessibilityLabel("Replying to \(target.authorName): \(spokenSnippet)")
             .accessibilityIdentifier("composer-reply-quote")
 
-            // WhatsApp's: a large, thin ✕ rather than a small bold one, sized to sit against two
-            // lines of quote without crowding them, in a hit target wider than the glyph.
+            // A disc rather than a bare ✕, because the ground behind it is glass sampling the
+            // transcript: a hairline glyph's contrast changed with whatever message scrolled past.
+            // The fill gives it its own ground and takes that variable out.
             Button(action: onDismiss) {
-                Image(systemName: SystemSymbol.close.rawValue)
-                    // `.system`, not the app face: the stroke weight is the point of the match, and
-                    // an SF Symbol only takes a weight axis from a system font.
-                    .font(.system(size: 18, weight: .light))
-                    .foregroundStyle(Color.textSecondary)
+                Image(systemName: SystemSymbol.closeCircle.rawValue)
+                    // `.system`, not the app face: an SF Symbol only takes its optical axes from a
+                    // system font.
+                    .font(.system(size: 22))
+                    // Palette, not monochrome. A monochrome fill knocks the ✕ out as a hole, which
+                    // over glass fills with the transcript — the thing the disc is here to stop.
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(Color.textMain, Color.textSecondary.opacity(0.35))
+                    // Wider than the disc: the glyph is small enough to miss on its own.
                     .frame(width: 34, height: 34)
                     .contentShape(.rect)
             }

--- a/FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Theme/Image+Symbols.swift
@@ -71,6 +71,9 @@ public enum SystemSymbol: String {
     /// The bare glyph, for dismiss affordances that sit inline with text and
     /// would be overpowered by the filled app-square `xmark`.
     case close = "xmark"
+    /// The dismiss disc, for a control on a glass surface: the fill gives the glyph its
+    /// own ground rather than leaving it to read against whatever the glass samples.
+    case closeCircle = "xmark.circle.fill"
 
     case pencil = "pencil"
     case trash = "trash"


### PR DESCRIPTION
Follow-up to #730, which made the reply quote Liquid Glass over the transcript. That change moved the ground under the quote's dismiss control from an opaque slab to glass sampling whatever is behind it, and the control was still drawn for the slab: an 18pt `.light` `xmark` in `textSecondary`, the least dense thing on the bar. Its contrast now varied with which message had scrolled past.

Drawn as `xmark.circle.fill` instead, so the glyph carries its own ground.

The disc is a plain translucent fill (`textSecondary` at 35%), not a second glass layer. Nesting glass in glass muddies the layering; a control on a glass platter belongs on it, not above it. `CancelEditButton` in the same bar does get its own `glassBackground`, and that stays correct — the bar's surface under it is opaque `backgroundMain`, so that is one glass level rather than two.

Palette rendering rather than monochrome: a monochrome fill knocks the ✕ out as a transparent hole, which over glass fills with the transcript — the exact thing the disc is there to prevent.

`SystemSymbol` gains `closeCircle` so the strip keeps using the app's symbol vocabulary rather than a raw string. `close` is untouched and still used by `CancelEditButton`.

Both candidates were built and compared on device before picking this one; the alternative was matching `CancelEditButton`'s 17pt semibold `xmark` in `textMain`.
