### PR TITLE
fix(chat): say "Reply" in the composer hint while replying

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -265,7 +265,7 @@ struct ConversationComposer: View {
 
     var body: some View {
         let field = HStack(alignment: .bottom, spacing: 10) {
-            TextField("Message", text: $composer.draft, axis: .vertical)
+            TextField(fieldPrompt, text: $composer.draft, axis: .vertical)
                 .font(.appTextMessage)
                 .foregroundStyle(Color.textMain)
                 .tint(.white)
@@ -320,6 +320,15 @@ struct ConversationComposer: View {
         .onChange(of: composer.draft) { _, text in
             guard let conversationID else { return }
             conversationController.draftDidChange(text, in: conversationID)
+        }
+    }
+
+    /// The hint names what the field will send. An edit arrives with the existing text already in
+    /// the field, so its hint is never on screen and stays the new-message one.
+    private var fieldPrompt: String {
+        switch composer.mode {
+        case .new, .editing:    "Message"
+        case .replying:         "Reply"
         }
     }
 


### PR DESCRIPTION
The composer's hint read "Message" no matter what the field was aimed at, so an empty field under an open reply strip named the wrong action.

`fieldPrompt` switches on the composer's mode: "Reply" while replying, "Message" otherwise. Editing keeps "Message" because an edit loads the existing text into the field, so its hint never shows.