### PR TITLE
fix(transactions): draw View in Chat as a card, not the primary action

### DIFF
--- a/Flipcash/Core/Screens/Main/Home/TransactionDetailsScreen.swift
+++ b/Flipcash/Core/Screens/Main/Home/TransactionDetailsScreen.swift
@@ -71,8 +71,7 @@ struct TransactionDetailsScreen: View {
                             // here.
                             router.push(.tipConversationForUser(userID))
                         }
-                        .buttonStyle(.filled)
-                        .padding(.top, 4)
+                        .buttonStyle(.filled05)
                     }
                 }
                 .padding(.horizontal, 20)

--- a/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/FilledButtonStyle.swift
+++ b/FlipcashUI/Sources/FlipcashUI/Views/ButtonStyles/FilledButtonStyle.swift
@@ -95,6 +95,18 @@ extension ButtonStyle where Self == FilledButtonStyle {
         )
     }
 
+    /// A full-width filled button at 5% action color opacity — the same tint the
+    /// row and card surfaces carry, for an action that reads as one of them.
+    public static var filled05: FilledButtonStyle {
+        .init(
+            textColor: .textMain,
+            textDisabledColor: .textMain.opacity(0.2),
+            overlayColor: .action.opacity(0.05),
+            overlayDisabledColor: .action.opacity(0.05),
+            isCompact: false
+        )
+    }
+
     /// A full-width filled button at 20% action color opacity (compact variant).
     public static var filled20Compact: FilledButtonStyle {
         .init(


### PR DESCRIPTION
Two fidelity fixes on Transaction Details, both measured against Figma node `9708:105260`.

### The button was the primary-action style

"View in Chat" used `.filled` — solid white background, black text, the style reserved for a screen's primary action. Figma node `9708:118123` fills it with `rgba(255,255,255,0.05)` and white text: the same tint the receipt and ID cards directly above it carry, so it reads as a fourth card in the stack rather than the loudest thing on the screen. Android draws it the same way, via `ButtonState.Filled10`.

`FilledButtonStyle` gains `.filled05`, following the existing `.filled20` pattern. `Metrics.buttonRadius` (6) and `buttonHeight` (60) already match the node.

### The cards sat too far apart

The two cards and the button were spaced at 16pt, one value for the whole screen. Figma node `9708:118142` puts 8pt between them, with a much wider gap above separating them from the header — they read as one stacked group, not four evenly spaced items.

They now sit in their own 8pt stack, with the header left on the outer stack's 16pt. The button also drops its `.padding(.top, 4)`, which had held a prominent primary button off the cards.

### Where Figma and Android disagree

| | Figma | Android | This PR |
|---|---|---|---|
| Button fill | white 5% | white 10% (`White10` = `0x1AFFFFFF`) | 5% |
| Card → card | 8pt | 10dp (`grid.x2` at NORMAL width) | 8pt |
| Header → first card | 43pt | 10dp | unchanged at 16pt |

The first two follow Figma, which is also what `Color.backgroundRow` and the adjacent cards already use. The header gap is left alone: Figma and Android are far apart there, and that is worth settling before either platform moves. Matching the Android side to its own cards is filed separately.
