### PR TITLE
fix(username): drop a leading @ in the validator

### DIFF
--- a/FlipcashCore/Sources/FlipcashCore/Validation/UsernameValidator.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Validation/UsernameValidator.swift
@@ -5,12 +5,12 @@
 
 import Foundation
 
-/// Validates a handle typed into the username field: lowercases the input, then
-/// holds it to the `Username` contract.
+/// Validates a handle typed into the username field: lowercases the input and
+/// drops the `@` a handle is shown with, then holds it to the `Username` contract.
 ///
-/// Lowercasing lives here rather than in `Username.init?` so the model stays
-/// strict — a handle reaching it uppercase is still a caller error. This is the
-/// only place a typed handle is rewritten before it reaches the model.
+/// That normalising lives here rather than in `Username.init?` so the model stays
+/// strict — a handle reaching it uppercase or prefixed is still a caller error.
+/// This is the only place a typed handle is rewritten before it reaches the model.
 public struct UsernameValidator: Validator {
 
     /// Why an input was rejected. The claim screen raises a different dialog for
@@ -54,9 +54,15 @@ public struct UsernameValidator: Validator {
         return .invalidCharacters
     }
 
-    /// Lowercased and stripped of surrounding whitespace. A paste carries both,
-    /// and neither is worth rejecting someone over.
+    /// Lowercased, stripped of surrounding whitespace, and of one leading `@`.
+    /// A paste carries all three — a handle copied out of a profile arrives as
+    /// `@taylor` — and none is worth rejecting someone over. Only one `@` goes:
+    /// `@@taylor` is not a handle anyone has, and the field never adds one.
     private func normalized(_ input: String) -> String {
-        input.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var candidate = input.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if candidate.hasPrefix("@") {
+            candidate.removeFirst()
+        }
+        return candidate
     }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/UsernameValidatorTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/UsernameValidatorTests.swift
@@ -21,6 +21,28 @@ struct UsernameValidatorTests {
         #expect(validator.validate("  taylor ")?.value == "taylor")
     }
 
+    @Test("A leading @ is dropped, so a pasted handle is accepted as its username")
+    func validate_leadingAt_stripped() {
+        #expect(validator.validate("@taylor")?.value == "taylor")
+        #expect(validator.validate(" @Taylor ")?.value == "taylor")
+    }
+
+    @Test("Only one leading @ is dropped; a second is an illegal character")
+    func validate_doubleLeadingAt_rejected() {
+        #expect(validator.validate("@@taylor") == nil)
+        #expect(validator.failure(for: "@@taylor") == .invalidCharacters)
+    }
+
+    @Test("A lone @ is an empty handle, so it reports too short")
+    func failure_loneAt_tooShort() {
+        #expect(validator.failure(for: "@") == .tooShort)
+    }
+
+    @Test("An @ anywhere but the front is an illegal character")
+    func failure_embeddedAt_invalidCharacters() {
+        #expect(validator.failure(for: "tay@lor") == .invalidCharacters)
+    }
+
     @Test("Two characters is the shortest accepted handle")
     func validate_minimumLength_boundary() {
         #expect(validator.validate("ab")?.value == "ab")


### PR DESCRIPTION
Pasting `@taylor` into either username field failed: the claim screen raised Invalid Characters and the lookup screen raised Username Not Found. `UsernameValidator` only trimmed whitespace and lowercased, so the `@` reached `Username.init?` and failed the `^[a-z0-9_]{2,15}$` charset.

`normalized` now also drops one leading `@`. That is the validator's existing job as the one place a typed handle is rewritten before the model, and both `validate` and `failure(for:)` share it, so both screens are covered without touching either. The claim screen's `canSubmit` already compares through the validator, so `@taylor` against a current `taylor` correctly reads as no edit.

Edges, pinned by new tests in `UsernameValidatorTests`:

- `@taylor` and ` @Taylor ` accept as `taylor`
- `@@taylor` and `tay@lor` report invalid characters
- a lone `@` reports too short

The fields still accept the keystroke and show what was typed. Filtering `@` at the field would be the only character-level filter on iOS, and the entry screen's comment explains why it filters nothing beyond case. Android strips the `@` in its field's input transformation instead, so both platforms submit the same value.

Ran `./Scripts/test.sh FlipcashCoreTests/UsernameValidatorTests`: 19 tests pass.
