### PR TITLE
fix(chat): make the whole Send Cash pill tappable while it stands alone

### DIFF
--- a/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
+++ b/Flipcash/Core/Screens/Conversation/ConversationBottomBar.swift
@@ -557,6 +557,10 @@ struct SendCashMorphButton: View {
             .frame(minWidth: BarMetrics.contentHeight)
             .frame(maxWidth: standalone && !minimized ? .infinity : nil)
             .frame(height: height)
+            // The label is the only drawn content and the fill is a background on the button, not
+            // on the label, so with `.plain` only the text was the target: alone in the bar the
+            // pill spans the width but "Send a Tip" answered a tap on its centre and nothing else.
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
         }
         .buttonStyle(.plain)
         // White fill above the glass base: fading it out is the white → glass


### PR DESCRIPTION
In a tip DM opened from the username lookup, the full-width "Send a Tip" button only opened the amount screen when the tap landed on its text. The same held for the full-width "Send €" before an ordinary chat exists.

`SendCashMorphButton` uses `.buttonStyle(.plain)`, which hit-tests only what the label draws. The label is the text alone: the white fill and the glass are applied to the Button from outside, because they have to fade during the morph rather than swap views. So the stretched frame around the text was never a target. Once a chat exists the button shrinks to text plus padding, which is why the minimized square never showed it.

The fix is a `contentShape` on the label, the same thing `CancelEditButton` in the same file already does for the same symptom.

The shared button styles (filled, card, icon, subtle, keypad, `CodeButton`) all draw their fill inside the styled label or set a content shape, so nothing built on them has this gap. The one other plain-style site with the same shape is `ChartRangePicker`'s unselected segments, which is left for a separate change.
