### PR TITLE
feat(chat): declare the payment action on tip DM payments

### DIFF
--- a/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/code-payments/flipcash2-client-protocol",
       "state" : {
-        "revision" : "27e3f09a82f6fbd41c03026ee738f943f4ed465e",
-        "version" : "0.4.0"
+        "revision" : "524cfbee86388ee0b13078d6159e4d2961fe130a",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
+++ b/Flipcash/Core/Screens/Send/SendAmountViewModel.swift
@@ -83,12 +83,17 @@ final class SendAmountViewModel {
     /// Where this send reports as coming from, which is not always the surface
     /// that composed it.
     ///
-    /// `CHAT` means "sent from a thread that already exists": the server rejects
-    /// it with `tip dm has not been initialized` when no DM is there yet. The
-    /// payment that opens the DM therefore always reports as `TIPCARD`, however
-    /// it was composed — a scanned card, or the chat the username lookup pushes
-    /// before the thread is real. Matches Android's rule, which reads the same
-    /// flag off a bottom bar still showing "Send a Tip".
+    /// The payment that opens the DM always reports as `TIPCARD`, however it was
+    /// composed — a scanned card, or the chat the username lookup pushes before
+    /// the thread is real. Matches Android's rule, which reads the same flag off
+    /// a bottom bar still showing "Send a Tip".
+    ///
+    /// What the server actually enforces is the verb, not this field: a send is
+    /// denied with `tip dm has not been initialized` unless the chat already
+    /// exists, and only a tip may open one. Since `action` is derived from this
+    /// value, keeping it `TIPCARD` here is what makes the opening payment
+    /// resolve to a tip on a server that reads `action` and on one that predates
+    /// it alike.
     private var effectiveTipOrigin: TipOrigin? {
         guard case .tip(let recipient) = target else { return nil }
         return opensTipDM ? .tipcard : recipient.origin
@@ -351,19 +356,19 @@ final class SendAmountViewModel {
                 return .failed
             }
 
-            // Only a tip card payment is a tip — the same line the activity feed
-            // draws, from `ChatMetadata.TipDmPayment.Location`. Both the scanned
-            // tipcard flow and the Send Cash action inside a tip thread submit
-            // here, and the latter reports as a plain cash send.
-            let isTip = effectiveTipOrigin == .tipcard
-            let transferEvent: Analytics.TransferEvent = isTip ? .sentTip : .sentCash
+            // Both the scanned tipcard flow and the Send Cash action inside a tip
+            // thread submit here; `chat` is the single source for whether this
+            // reports as a tip, so the wire `action` and the analytics event
+            // never drift apart.
+            let chat = chatPaymentMetadata()
+            let transferEvent: Analytics.TransferEvent = (chat?.isTip ?? false) ? .sentTip : .sentCash
 
             do {
                 try await sender.send(
                     amount: amountToSend,
                     verifiedState: pinnedState,
                     to: recipient,
-                    chat: chatPaymentMetadata()
+                    chat: chat
                 )
                 Analytics.transfer(event: transferEvent, exchangedFiat: amountToSend, grabTime: nil, successful: true, error: nil)
                 return .success
@@ -392,9 +397,11 @@ final class SendAmountViewModel {
                 destinationPhoneE164: contact.phoneE164
             )
         case .tip(let recipient):
+            let origin = effectiveTipOrigin ?? recipient.origin
             return .tipDm(
                 chatID: .tipDm(between: session.userID, and: recipient.userID),
-                origin: effectiveTipOrigin ?? recipient.origin
+                origin: origin,
+                action: origin == .tipcard ? .tip : .send
             )
         }
     }

--- a/FlipcashAPI/Package.swift
+++ b/FlipcashAPI/Package.swift
@@ -35,7 +35,7 @@ let contractDependencies: [Package.Dependency] = protoLocalRoot.map { root in
     ]
 } ?? [
     .package(url: "https://github.com/code-payments/ocp-client-protocol", exact: "0.3.0"),
-    .package(url: "https://github.com/code-payments/flipcash2-client-protocol", exact: "0.4.0"),
+    .package(url: "https://github.com/code-payments/flipcash2-client-protocol", exact: "0.5.0"),
 ]
 
 let package = Package(

--- a/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ChatPaymentMetadata.swift
+++ b/FlipcashCore/Sources/FlipcashCore/Models/Conversation/ChatPaymentMetadata.swift
@@ -16,15 +16,27 @@ import SwiftProtobuf
 public enum ChatPaymentMetadata: Sendable {
 
     case contactDm(chatID: ConversationID, sourcePhoneE164: String, destinationPhoneE164: String)
-    case tipDm(chatID: ConversationID, origin: TipOrigin)
+    case tipDm(chatID: ConversationID, origin: TipOrigin, action: TipDmAction)
 
     /// The DM chat this payment posts into.
     public var chatID: ConversationID {
         switch self {
         case .contactDm(let chatID, _, _):
             return chatID
-        case .tipDm(let chatID, _):
+        case .tipDm(let chatID, _, _):
             return chatID
+        }
+    }
+
+    /// Whether this payment reports as a tip. Mirrors the `action` serialized
+    /// below, so a caller reporting analytics reads the same value the wire
+    /// carries instead of re-deriving it.
+    public var isTip: Bool {
+        switch self {
+        case .contactDm:
+            return false
+        case .tipDm(_, _, let action):
+            return action == .tip
         }
     }
 
@@ -40,8 +52,11 @@ public enum ChatPaymentMetadata: Sendable {
                         $0.source = .with { $0.value = sourcePhoneE164 }
                         $0.destination = .with { $0.value = destinationPhoneE164 }
                     }
-                case .tipDm(_, let origin):
-                    $0.tipDmPayment = .with { $0.location = origin.proto }
+                case .tipDm(_, let origin, let action):
+                    $0.tipDmPayment = .with {
+                        $0.location = origin.proto
+                        $0.action = action.proto
+                    }
                 }
             }
         }.serializedData()
@@ -63,6 +78,32 @@ public enum TipOrigin: Sendable {
         switch self {
         case .tipcard: return .tipcard
         case .chat:    return .chat
+        }
+    }
+}
+
+/// The verb a tip DM payment reports to the server, alongside `TipOrigin`.
+///
+/// The proto's `Action.default` means "infer from location," which only
+/// exists so the server can stay compatible with clients built before this
+/// field shipped. This client has no such clients to be compatible with, so
+/// `.default` has no local representation here: every `TipDmPayment` this
+/// client builds sets `action` explicitly. That matters because proto3 gives
+/// `Location` a zero value too (`TIPCARD`), so an unset `action` alongside a
+/// `TIPCARD` location would be indistinguishable on the wire from a client
+/// that deliberately declared a tip — `DEFAULT` and `TIPCARD` are both 0.
+public enum TipDmAction: Sendable, CaseIterable {
+
+    /// A Send Cash payment inside an already-initialized tip DM.
+    case send
+
+    /// A payment from a tip card, or the payment that opens the tip DM.
+    case tip
+
+    var proto: Flipcash_Intent_V1_ChatMetadata.TipDmPayment.Action {
+        switch self {
+        case .send: return .send
+        case .tip:  return .tip
         }
     }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/ChatPaymentMetadataTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/ChatPaymentMetadataTests.swift
@@ -27,9 +27,9 @@ struct ChatPaymentMetadataTests {
         #expect(payment.destination.value == "+15551230002")
     }
 
-    @Test("Tip DM payments carry the chat id and the tipcard origin")
+    @Test("Tip DM payments carry the chat id, the tipcard origin, and the tip action")
     func tipDmTipcardSerialization() throws {
-        let metadata = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .tipcard)
+        let metadata = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .tipcard, action: .tip)
 
         let decoded = try Flipcash_Intent_V1_AppMetadata(serializedBytes: metadata.serializedAppMetadata())
 
@@ -39,11 +39,12 @@ struct ChatPaymentMetadataTests {
             return
         }
         #expect(payment.location == .tipcard)
+        #expect(payment.action == .tip)
     }
 
-    @Test("Tip DM payments carry the chat origin when sent from a chat")
+    @Test("Tip DM payments carry the chat origin and send action when sent from a chat")
     func tipDmChatSerialization() throws {
-        let metadata = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .chat)
+        let metadata = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .chat, action: .send)
 
         let decoded = try Flipcash_Intent_V1_AppMetadata(serializedBytes: metadata.serializedAppMetadata())
 
@@ -53,6 +54,7 @@ struct ChatPaymentMetadataTests {
             return
         }
         #expect(payment.location == .chat)
+        #expect(payment.action == .send)
     }
 
     @Test("Each variant exposes its chat id uniformly")
@@ -62,9 +64,22 @@ struct ChatPaymentMetadataTests {
             sourcePhoneE164: "+15551230001",
             destinationPhoneE164: "+15551230002"
         )
-        let tip = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .tipcard)
+        let tip = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .tipcard, action: .tip)
 
         #expect(contact.chatID == chatID)
         #expect(tip.chatID == chatID)
+    }
+
+    @Test("The local action type never serializes the proto's DEFAULT case", arguments: TipDmAction.allCases)
+    func actionNeverSerializesDefault(action: TipDmAction) throws {
+        let metadata = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .tipcard, action: action)
+
+        let decoded = try Flipcash_Intent_V1_AppMetadata(serializedBytes: metadata.serializedAppMetadata())
+
+        guard case .tipDmPayment(let payment) = decoded.chat.type else {
+            Issue.record("Expected tipDmPayment, got \(String(describing: decoded.chat.type))")
+            return
+        }
+        #expect(payment.action != .default)
     }
 }

--- a/FlipcashCore/Tests/FlipcashCoreTests/IntentTransferTests.swift
+++ b/FlipcashCore/Tests/FlipcashCoreTests/IntentTransferTests.swift
@@ -121,6 +121,25 @@ extension IntentTransferTests {
         #expect(chatMetadata.contactDmPayment.destination.value == "+14155550101")
     }
 
+    @Test("Metadata carries serialized tip DM app metadata that round-trips location and action")
+    func metadataCarriesTipDmAppMetadata() throws {
+        let chatID = ConversationID.tipDm(between: UUID(), and: UUID())
+        let chat = ChatPaymentMetadata.tipDm(chatID: chatID, origin: .chat, action: .send)
+        let intent = try makeIntent(appMetadata: chat.serializedAppMetadata())
+
+        let metadata = intent.metadata()
+        #expect(metadata.hasAppMetadata)
+
+        let decoded = try Flipcash_Intent_V1_AppMetadata(serializedBytes: metadata.appMetadata.value)
+        guard case .chat(let chatMetadata)? = decoded.domain else {
+            Issue.record("Expected chat domain metadata")
+            return
+        }
+        #expect(chatMetadata.chatID.value == chatID.data)
+        #expect(chatMetadata.tipDmPayment.location == .chat)
+        #expect(chatMetadata.tipDmPayment.action == .send)
+    }
+
     private func makeIntent(
         sourceCluster: AccountCluster = .mock,
         destination: PublicKey = .generate()!,

--- a/FlipcashTests/SendAmountViewModelTests.swift
+++ b/FlipcashTests/SendAmountViewModelTests.swift
@@ -598,12 +598,13 @@ struct SendAmountViewModelTests {
         #expect(mock.resolveUserIDCalls == [recipientID])
         #expect(mock.resolveContactCalls.isEmpty)
         let chat = try #require(mock.sendCalls.first?.chat)
-        guard case .tipDm(let chatID, let origin) = chat else {
+        guard case .tipDm(let chatID, let origin, let action) = chat else {
             Issue.record("Expected tipDm metadata, got \(chat)")
             return
         }
         #expect(chatID == ConversationID.tipDm(between: container.session.userID, and: recipientID))
         #expect(origin == .tipcard)
+        #expect(action == .tip)
     }
 
     @Test("The tip that opens the DM reports as tipcard even when it's composed in a chat")
@@ -622,13 +623,16 @@ struct SendAmountViewModelTests {
 
         #expect(outcome == .success)
         let chat = try #require(mock.sendCalls.first?.chat)
-        guard case .tipDm(_, let origin) = chat else {
+        guard case .tipDm(_, let origin, let action) = chat else {
             Issue.record("Expected tipDm metadata, got \(chat)")
             return
         }
-        // `CHAT` here is what the server rejects with "tip dm has not been
-        // initialized" — there is no thread yet for this payment to be sent from.
+        // A send is what the server rejects with "tip dm has not been
+        // initialized" — there is no thread yet for this payment to be sent
+        // from, so the opening payment has to resolve to a tip.
         #expect(origin == .tipcard)
+        // The DM-opening payment is always a tip, however it was composed.
+        #expect(action == .tip)
     }
 
     @Test("Once the DM exists, an in-chat send still reports as chat")
@@ -646,11 +650,12 @@ struct SendAmountViewModelTests {
 
         #expect(outcome == .success)
         let chat = try #require(mock.sendCalls.first?.chat)
-        guard case .tipDm(_, let origin) = chat else {
+        guard case .tipDm(_, let origin, let action) = chat else {
             Issue.record("Expected tipDm metadata, got \(chat)")
             return
         }
         #expect(origin == .chat)
+        #expect(action == .send)
     }
 
     @Test("A tip below the server minimum is blocked before submission")


### PR DESCRIPTION
`flipcash2-client-protocol` 0.5.0 adds `action` to
`intent.v1.ChatMetadata.TipDmPayment`. This pins 0.5.0 and sets the field. The
Android side is code-payments/code-android-app#1442.

## Who decides the verb

The recipient's "You tipped" / "You sent" comes from `messaging.v1.CashContent.verb`,
which the server writes. Neither client ever sets it — iOS reads it once, at
`ConversationMessage.swift:163-169`; Android reads it at `ProtobufToLocal.kt:159-170`,
and the one `setVerb` it has (`LocalToProtobuf.kt:127-141`) is unreachable because
nothing builds outbound `CashContent`.

Server side that resolution is `intent.GetDmPaymentVerb` (`flipcash2-server`,
`intent/chat.go:117-138`). It prefers `action`, and falls back to `location` only when
`action` is `DEFAULT`. `location` has exactly one reader in the whole server — that
fallback. `action` has exactly one reader — the switch above it.

The resolved verb drives three things, which is why it is worth getting right:

- the cash message injected into the DM (`task/chat.go:89`),
- the sender's activity feed title (`activity/localization.go:30`),
- and the tip DM validation rules (`intent/chat.go:258`).

## `action` is not optional here

Validation keys off the same verb (`validateTipDmAppMetadata`, `intent/chat.go:252-308`):
a tip may target a chat that does not exist yet and must clear the per-currency
minimum plus the recipient's initialization fee; a send has no minimum but is denied
with "tip dm has not been initialized" unless the chat is already there.

So the payment that opens a tip DM must resolve to `TIPPED`. Sending `action = SEND`
on that path would be rejected outright. This is the constraint both clients had
already discovered from the outside and recorded imprecisely as a rule about
`location` (`SendAmountViewModel.swift:86-95`, `ChatViewModel.kt:1073`).

## What each app sends

| Situation | `location` | `action` |
|---|---|---|
| Payment from a scanned or linked tip card | `TIPCARD` | `TIP` |
| The payment that opens the tip DM | `TIPCARD` | `TIP` |
| Send Cash inside an initialized tip DM | `CHAT` | `SEND` |
| Contact (phone) DM payment | n/a | n/a |

Same rule on both platforms. `ContactDmPayment` has no `action` field.

## `DEFAULT` is never sent

Each app models the action locally with two values, so `DEFAULT` is unrepresentable
rather than merely avoided. `Location`'s zero value is `TIPCARD`, not an unknown, so a
message that leaves `action` unset is indistinguishable on the wire from one
deliberately declaring a tip — the server's own comment at `intent/chat.go:130-133`
spells that out. Leaving the field at `DEFAULT` hands the verb back to the inference
this field exists to replace.

## `location` does not move

Not one `location` byte changes on any path, and that is deliberate: it is the
compatibility path. Server support for `action` landed on 2026-09-09
(`flipcash2-server#196`), one day before `flipcash2-client-protocol` 0.5.0 was cut. A
server without that commit reads `location` alone.

Because `action` is set to exactly the verb `location` already implied, both server
versions resolve the same verb, so these clients are correct against either. Make
`location` honest at the same time — send `CHAT` for a chat-composed payment that
opens the DM — and the two versions disagree: the new one allows it, the old one
denies it as an uninitialized send. That cleanup is worth doing once `#196` is
confirmed deployed everywhere, and it is a one-line change on each platform then.

## On iOS specifically

`ChatPaymentMetadata.tipDm` gains an `action`, and a new `TipDmAction` with two
cases serializes it. `SendAmountViewModel` picks the action from the origin it
already computes, so the two cannot disagree.

The tip analytics event moves onto the same value. It previously re-derived
tip-ness from the recipient case, which meant the scanned tip card and the Send
Cash action inside a tip thread both reported `sentTip` regardless of what the
wire said. It now reads `ChatPaymentMetadata.isTip`, which is the `action` being
sent.

Two doc comments described the old inference as the server's rule. They now say
what the server actually does with each field.
